### PR TITLE
feat: prune control for old embedded-DB snapshots

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1889,7 +1889,13 @@ checksummed and applied once). Schema changes add the next `NNN_*.sql`; data tra
 SQL can't express add a **code migration** TS module under `src/db/migrations/code/`
 (shared `NNN_` ordering, same per-migration transaction). On startup the runner migrates a
 **copy** of the DB (`<dataDir>/.migrate-tmp`) and **atomically swaps** it in on success; on
-failure the live `pgdata` is untouched, so downgrading to the previous binary just works.
+failure the live `pgdata` is untouched, so downgrading to the previous binary just works. The
+renamed-aside originals are kept as `pgdata.superseded.<timestamp>` (the swap auto-retains the
+newest 5 — `db/superseded.ts`). A superuser can reclaim them on demand: `GET
+/api/database-info/superseded` reports the on-disk size and `POST
+/api/database-info/prune-superseded` deletes **all** of them (no rollback retained; the live
+`pgdata` is untouched). Both are surfaced in the Database card on General settings and are
+embedded-only — external Postgres migrates in place and produces no snapshots.
 An **external Postgres** migrates **in place** instead: per-migration transactions under a
 session `pg_advisory_lock` (`applyPendingMigrationsExternal`), with the downgrade guard
 re-checked under the lock, so concurrent startups can't double-migrate and a failed

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -79,3 +79,13 @@ process is deliberately cautious:
 
 The net effect: upgrades are safe by default, and your data is preserved across them
 without any manual migration work on your part.
+
+## Reclaiming disk from old database versions
+
+Each embedded upgrade leaves the previous database copy behind in the data directory as a
+rollback point, and Hezo keeps the few most recent ones automatically. On a long-running
+instance these can add up to gigabytes. When you're confident you won't need to roll back,
+open **Settings → General → Database** (superuser only): it shows how much disk the retained
+copies are using next to a **Prune** button that deletes them all. Your current database is
+untouched — but once pruned, you can no longer roll back to an earlier version. This applies
+to the embedded database only; an external Postgres keeps no such copies.

--- a/packages/server/src/db/migrate-swap.ts
+++ b/packages/server/src/db/migrate-swap.ts
@@ -1,14 +1,13 @@
-import { cp, mkdir, readdir, rename, rm } from 'node:fs/promises';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { logger } from '../logger';
+import { pruneSuperseded, SUPERSEDED_PREFIX } from './superseded';
 
 const log = logger.child('migrate-swap');
 
 /** Temp data dir (sibling of `pgdata`) where migrations run against a copy. */
 const MIGRATE_TMP = '.migrate-tmp';
-/** Prefix for the previous `pgdata`, kept aside after a successful swap. */
-const SUPERSEDED_PREFIX = 'pgdata.superseded.';
-/** How many superseded `pgdata` directories to retain. */
+/** How many superseded `pgdata` directories the migration swap retains. */
 const KEEP_SUPERSEDED = 5;
 
 function pgDataPath(dataDir: string): string {
@@ -48,19 +47,11 @@ export async function promoteMigrationCopy(dataDir: string): Promise<void> {
 	await rename(join(tmp, 'pgdata'), pgDataPath(dataDir));
 	await rm(tmp, { recursive: true, force: true });
 
-	await pruneSuperseded(dataDir);
+	await pruneSuperseded(dataDir, KEEP_SUPERSEDED);
 	log.info(`Swapped in migrated database; previous pgdata kept at ${supersededPath}`);
 }
 
 /** Remove the temp copy after a failed migration. The original is untouched. */
 export async function discardMigrationCopy(dataDir: string): Promise<void> {
 	await rm(tmpDataDir(dataDir), { recursive: true, force: true });
-}
-
-async function pruneSuperseded(dataDir: string): Promise<void> {
-	const entries = (await readdir(dataDir)).filter((e) => e.startsWith(SUPERSEDED_PREFIX)).sort();
-	const excess = entries.slice(0, Math.max(0, entries.length - KEEP_SUPERSEDED));
-	for (const e of excess) {
-		await rm(join(dataDir, e), { recursive: true, force: true });
-	}
 }

--- a/packages/server/src/db/superseded.ts
+++ b/packages/server/src/db/superseded.ts
@@ -1,0 +1,92 @@
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Helpers for the pre-migration snapshots the copy-migrate-swap leaves behind.
+ *
+ * On every embedded-DB migration the runner renames the old cluster aside to
+ * `pgdata.superseded.<timestamp>` (`migrate-swap.ts`) so a failed upgrade can be
+ * rolled back. Those directories accumulate; the swap auto-retains the newest
+ * `KEEP_SUPERSEDED`, and the General-settings "Prune" control lets a superuser
+ * reclaim them all on demand. Both paths share the logic here.
+ */
+
+/** Prefix for a previous `pgdata`, kept aside after a successful migration swap. */
+export const SUPERSEDED_PREFIX = 'pgdata.superseded.';
+
+/**
+ * List the `pgdata.superseded.<timestamp>` directories in `dataDir` as full
+ * paths, sorted oldest-first (the timestamp format sorts chronologically). A
+ * missing or unreadable data dir yields an empty list.
+ */
+export async function listSupersededDirs(dataDir: string): Promise<string[]> {
+	let entries: string[];
+	try {
+		entries = await readdir(dataDir);
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((e) => e.startsWith(SUPERSEDED_PREFIX))
+		.sort()
+		.map((e) => join(dataDir, e));
+}
+
+/** Recursively sum the on-disk size, in bytes, of everything under `dir`. */
+async function dirSize(dir: string): Promise<number> {
+	// A missing/unreadable dir contributes nothing (e.g. raced with a delete).
+	const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+	let total = 0;
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			total += await dirSize(full);
+		} else {
+			try {
+				total += (await stat(full)).size;
+			} catch {
+				// Raced with a concurrent delete (e.g. a migration swap) — skip it.
+			}
+		}
+	}
+	return total;
+}
+
+export interface SupersededUsage {
+	/** Number of superseded snapshot directories. */
+	count: number;
+	/** Total on-disk size of those directories, in bytes. */
+	bytes: number;
+}
+
+/** Count the superseded snapshot directories and their total on-disk size. */
+export async function measureSuperseded(dataDir: string): Promise<SupersededUsage> {
+	const dirs = await listSupersededDirs(dataDir);
+	let bytes = 0;
+	for (const dir of dirs) bytes += await dirSize(dir);
+	return { count: dirs.length, bytes };
+}
+
+export interface SupersededPruneResult {
+	/** Number of snapshot directories removed. */
+	removed: number;
+	/** Total on-disk bytes freed. */
+	bytes: number;
+}
+
+/**
+ * Remove superseded snapshot directories, keeping the `keep` newest. `keep = 0`
+ * (the default) removes them all — the on-demand "reclaim everything" path;
+ * the migration swap passes `KEEP_SUPERSEDED` to preserve its rollback window.
+ * Returns how many directories were removed and the bytes freed.
+ */
+export async function pruneSuperseded(dataDir: string, keep = 0): Promise<SupersededPruneResult> {
+	const dirs = await listSupersededDirs(dataDir); // oldest-first
+	const victims = keep > 0 ? dirs.slice(0, Math.max(0, dirs.length - keep)) : dirs;
+	let bytes = 0;
+	for (const dir of victims) {
+		bytes += await dirSize(dir);
+		await rm(dir, { recursive: true, force: true });
+	}
+	return { removed: victims.length, bytes };
+}

--- a/packages/server/src/routes/database-info.ts
+++ b/packages/server/src/routes/database-info.ts
@@ -1,25 +1,62 @@
 import { Hono } from 'hono';
+import { measureSuperseded, pruneSuperseded } from '../db/superseded';
 import type { StorageInfo } from '../lib/db-info';
-import { ok } from '../lib/response';
+import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
+import { logger } from '../logger';
 import { requireSuperuser } from '../middleware/auth';
 
+const log = logger.child('database-info');
+
 /**
- * Storage metadata for the General settings page. Superuser-only: even
+ * Storage metadata for the General settings page, plus maintenance of the
+ * pre-migration snapshots the embedded DB leaves behind. Superuser-only: even
  * redacted, the connection target (host/port/database) is infrastructure
- * detail — the same posture as the updates download/apply routes.
+ * detail — the same posture as the updates download/apply routes — and pruning
+ * permanently deletes data.
  *
  * The `StorageInfo` handed to this factory is computed ONCE at startup with
  * the connection URL already redacted server-side (`redactDatabaseUrl`); the
  * raw URL is never set on the request context, so no handler — this one or
- * any future one — can echo it to a client.
+ * any future one — can echo it to a client. `dataDir` is where the embedded
+ * cluster and its `pgdata.superseded.*` snapshots live.
  */
-export function buildDatabaseInfoRoutes(info: StorageInfo): Hono<Env> {
+export function buildDatabaseInfoRoutes(info: StorageInfo, dataDir: string): Hono<Env> {
 	const routes = new Hono<Env>();
+
 	routes.get('/database-info', (c) => {
 		const denied = requireSuperuser(c);
 		if (denied) return denied;
 		return ok(c, info);
 	});
+
+	// On-disk size of the retained pre-migration snapshots (`pgdata.superseded.*`).
+	// Embedded-only: external Postgres migrates in place and produces none, so it
+	// always reports zero and the UI hides the prune control.
+	routes.get('/database-info/superseded', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		if (info.backend === 'external') return ok(c, { count: 0, bytes: 0 });
+		return ok(c, await measureSuperseded(dataDir));
+	});
+
+	// Reclaim disk by deleting ALL superseded snapshots. Destructive and
+	// irreversible — the current database is untouched, but no rollback to a
+	// prior version remains.
+	routes.post('/database-info/prune-superseded', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		if (info.backend === 'external') {
+			return err(c, 'UNSUPPORTED', 'Snapshots only exist for the embedded database.', 409);
+		}
+		try {
+			const result = await pruneSuperseded(dataDir, 0);
+			return ok(c, { removed: result.removed, freed_bytes: result.bytes });
+		} catch (e) {
+			log.error(`Failed to prune superseded snapshots: ${e instanceof Error ? e.message : e}`);
+			return err(c, 'PRUNE_FAILED', 'Failed to prune old database snapshots.', 500);
+		}
+	});
+
 	return routes;
 }

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -679,6 +679,7 @@ export function buildApp(
 		'/api',
 		buildDatabaseInfoRoutes(
 			config.storageInfo ?? { backend: 'embedded', display: join(config.dataDir, 'pgdata') },
+			config.dataDir,
 		),
 	);
 	app.route(

--- a/packages/server/test/database-superseded.test.ts
+++ b/packages/server/test/database-superseded.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { AuthType } from '@hezo/shared';
+import { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { buildDatabaseInfoRoutes } from '../src/routes/database-info';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+// Three snapshot dirs, each PG_VERSION ('16\n' = 3 bytes) + base/data (500 bytes)
+// = 503 bytes, so 3 total 1509 bytes. Names are real timestamped forms so the
+// oldest-first sort is exercised.
+const SNAPSHOTS = [
+	'pgdata.superseded.2026-07-20T07-16-44-887Z',
+	'pgdata.superseded.2026-07-21T03-58-39-807Z',
+	'pgdata.superseded.2026-07-22T09-06-19-601Z',
+];
+const BYTES_PER_SNAPSHOT = 503;
+
+describe('database superseded snapshots', () => {
+	let app: Hono<Env>;
+	let db: Db;
+	let token: string;
+	let masterKeyManager: MasterKeyManager;
+	let dataDir: string;
+
+	function seedSnapshot(name: string): void {
+		const dir = join(dataDir, name);
+		mkdirSync(join(dir, 'base'), { recursive: true });
+		writeFileSync(join(dir, 'PG_VERSION'), '16\n'); // 3 bytes
+		writeFileSync(join(dir, 'base', 'data'), 'x'.repeat(500)); // 500 bytes, nested
+	}
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		token = ctx.token;
+		masterKeyManager = ctx.masterKeyManager;
+		dataDir = ctx.dataDir;
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+		rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it('reports zero when there are no snapshots', async () => {
+		const res = await app.request('/api/database-info/superseded', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: { count: number; bytes: number } };
+		expect(data).toEqual({ count: 0, bytes: 0 });
+	});
+
+	it('measures the count and total on-disk size of the snapshots', async () => {
+		for (const name of SNAPSHOTS) seedSnapshot(name);
+
+		const res = await app.request('/api/database-info/superseded', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: { count: number; bytes: number } };
+		expect(data.count).toBe(SNAPSHOTS.length);
+		expect(data.bytes).toBe(SNAPSHOTS.length * BYTES_PER_SNAPSHOT);
+	});
+
+	it('requires superuser for both the size lookup and the prune', async () => {
+		const nonSuper = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Member', false) RETURNING id",
+		);
+		const memberToken = await signAdminJwt(masterKeyManager, nonSuper.rows[0].id);
+
+		const sizeRes = await app.request('/api/database-info/superseded', {
+			headers: authHeader(memberToken),
+		});
+		expect(sizeRes.status).toBe(403);
+
+		const pruneRes = await app.request('/api/database-info/prune-superseded', {
+			method: 'POST',
+			headers: authHeader(memberToken),
+		});
+		expect(pruneRes.status).toBe(403);
+
+		// The 403 must not have deleted anything.
+		const stillThere = await app.request('/api/database-info/superseded', {
+			headers: authHeader(token),
+		});
+		const { data } = (await stillThere.json()) as { data: { count: number } };
+		expect(data.count).toBe(SNAPSHOTS.length);
+	});
+
+	it('prunes every snapshot and reports the disk it freed', async () => {
+		const res = await app.request('/api/database-info/prune-superseded', {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: { removed: number; freed_bytes: number } };
+		expect(data.removed).toBe(SNAPSHOTS.length);
+		expect(data.freed_bytes).toBe(SNAPSHOTS.length * BYTES_PER_SNAPSHOT);
+
+		// Nothing left to reclaim afterwards.
+		const after = await app.request('/api/database-info/superseded', {
+			headers: authHeader(token),
+		});
+		const body = (await after.json()) as { data: { count: number; bytes: number } };
+		expect(body.data).toEqual({ count: 0, bytes: 0 });
+	});
+});
+
+// The external-Postgres backend produces no snapshots. Build the routes directly
+// with an external StorageInfo behind a stub superuser auth so the branch is
+// covered without provisioning a real external database.
+describe('database superseded snapshots — external backend', () => {
+	function externalApp(dataDir: string): Hono<Env> {
+		const app = new Hono<Env>();
+		app.use('*', async (c, next) => {
+			c.set('auth', { type: AuthType.Admin, userId: 'stub', isSuperuser: true });
+			await next();
+		});
+		app.route(
+			'/api',
+			buildDatabaseInfoRoutes({ backend: 'external', display: 'postgres://x' }, dataDir),
+		);
+		return app;
+	}
+
+	it('reports zero and refuses to prune', async () => {
+		const app = externalApp('/nonexistent-data-dir');
+
+		const size = await app.request('/api/database-info/superseded');
+		expect(size.status).toBe(200);
+		const { data } = (await size.json()) as { data: { count: number; bytes: number } };
+		expect(data).toEqual({ count: 0, bytes: 0 });
+
+		const prune = await app.request('/api/database-info/prune-superseded', { method: 'POST' });
+		expect(prune.status).toBe(409);
+	});
+});

--- a/packages/web/src/components/asset-icon.tsx
+++ b/packages/web/src/components/asset-icon.tsx
@@ -34,5 +34,6 @@ export function formatBytes(bytes: number): string {
 	if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }

--- a/packages/web/src/components/database-section.tsx
+++ b/packages/web/src/components/database-section.tsx
@@ -1,23 +1,94 @@
-import { Database, Server } from 'lucide-react';
+import { Database, Server, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 import { type DatabaseInfo, useDatabaseInfo } from '../hooks/use-database-info';
 import { useMe } from '../hooks/use-me';
+import { usePruneSuperseded, useSupersededData } from '../hooks/use-superseded-data';
+import { toast } from '../hooks/use-toast';
+import { formatBytes } from './asset-icon';
+import { ConfirmDialog } from './ui/confirm-dialog';
 
 /**
  * Database storage card, rendered side-by-side with the asset-storage card
  * inside {@link StorageSection}. Superuser-only, matching the endpoint's gate.
  * The connection string arrives pre-redacted from the server — this component
  * never sees, stores, or reveals the raw URL.
+ *
+ * For the embedded backend it also surfaces the on-disk size of the retained
+ * pre-migration snapshots (`pgdata.superseded.*`) with a control to prune them.
+ * That footer is shown only when there is something to reclaim — hidden for
+ * external Postgres (no snapshots) and when zero snapshots remain.
  */
 export function DatabaseSection() {
 	const { data: me } = useMe();
 	const isSuperuser = me?.is_superuser === true;
 	const { data: info } = useDatabaseInfo(isSuperuser);
+	const isEmbedded = info?.backend === 'embedded';
+	const { data: superseded } = useSupersededData(isSuperuser && isEmbedded);
+	const prune = usePruneSuperseded();
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	if (!isSuperuser) return null;
+
+	const hasSnapshots = isEmbedded && superseded !== undefined && superseded.count > 0;
 
 	return (
 		<div className="border border-border rounded-md p-3 bg-surface" data-testid="settings-database">
 			{info === undefined ? null : <DatabaseDetails info={info} />}
+			{hasSnapshots && (
+				<div
+					className="mt-3 pt-3 border-t border-border flex items-center justify-between gap-3"
+					data-testid="settings-database-superseded"
+				>
+					<div className="min-w-0">
+						<div className="text-[12px] font-medium">Previous versions</div>
+						<div
+							className="text-[12px] text-text-3 mt-0.5"
+							data-testid="settings-database-superseded-size"
+						>
+							{superseded.count} {superseded.count === 1 ? 'snapshot' : 'snapshots'} ·{' '}
+							{formatBytes(superseded.bytes)} on disk
+						</div>
+					</div>
+					<button
+						type="button"
+						onClick={() => setConfirmOpen(true)}
+						data-testid="settings-database-prune"
+						className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1.5 text-[12px] font-medium text-danger transition-colors hover:border-danger-soft hover:bg-danger-soft hover:text-danger-soft-fg"
+					>
+						<Trash2 className="h-3 w-3" />
+						Prune…
+					</button>
+				</div>
+			)}
+			{hasSnapshots && (
+				<ConfirmDialog
+					open={confirmOpen}
+					onOpenChange={setConfirmOpen}
+					title="Prune old database versions?"
+					variant="danger"
+					confirmLabel={`Prune ${formatBytes(superseded.bytes)}`}
+					description={
+						<>
+							Hezo keeps a copy of your previous database after each upgrade so it can roll back a
+							failed one. You have{' '}
+							<strong className="font-medium text-text-1">
+								{superseded.count} previous {superseded.count === 1 ? 'version' : 'versions'}
+							</strong>{' '}
+							using{' '}
+							<strong className="font-medium text-text-1">{formatBytes(superseded.bytes)}</strong>{' '}
+							of disk. This can’t be undone — your current database is untouched, but you won’t be
+							able to roll back to an earlier version.
+						</>
+					}
+					onConfirm={async () => {
+						try {
+							await prune.mutateAsync();
+						} catch (e) {
+							toast.error(e instanceof Error ? e.message : 'Failed to prune old database versions');
+						}
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/hooks/use-superseded-data.ts
+++ b/packages/web/src/hooks/use-superseded-data.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+export interface SupersededData {
+	/** Number of `pgdata.superseded.*` snapshot directories. */
+	count: number;
+	/** Total on-disk size of those directories, in bytes. */
+	bytes: number;
+}
+
+/**
+ * Size of the embedded DB's retained pre-migration snapshots. Superuser +
+ * embedded-only — pass `enabled: false` otherwise so the fetch is skipped
+ * (external Postgres has none; other users would 403).
+ */
+export function useSupersededData(enabled: boolean) {
+	return useQuery({
+		queryKey: queryKeys.supersededData(),
+		queryFn: () => api.get<SupersededData>('/api/database-info/superseded'),
+		enabled,
+	});
+}
+
+export interface PruneSupersededResult {
+	removed: number;
+	freed_bytes: number;
+}
+
+/**
+ * Delete every `pgdata.superseded.*` snapshot. Destructive and irreversible, so
+ * it invalidates + refetches rather than updating optimistically — the
+ * refreshed size (the footer disappearing) is the confirmation. Mirrors the
+ * security-sensitive credential mutations.
+ */
+export function usePruneSuperseded() {
+	return useMutation({
+		mutationFn: () => api.post<PruneSupersededResult>('/api/database-info/prune-superseded'),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.supersededData() });
+			queryClient.invalidateQueries({ queryKey: queryKeys.databaseInfo() });
+		},
+	});
+}

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -32,6 +32,12 @@ export const queryKeys = {
 	instanceSettings: () => ['instance', 'settings'],
 	/** Storage backend metadata (server-side redacted) for the General settings page. */
 	databaseInfo: () => ['instance', 'database'],
+	/**
+	 * On-disk size of the embedded DB's pre-migration snapshots
+	 * (`pgdata.superseded.*`). Under the `databaseInfo` prefix so its invalidation
+	 * cascades here too.
+	 */
+	supersededData: () => ['instance', 'database', 'superseded'],
 	/** Asset storage backend metadata (server-side redacted) for the General settings page. */
 	assetStorageInfo: () => ['instance', 'asset-storage'],
 	/** Instance-wide mention resolution (global CEO chat), keyed by sorted candidates. */

--- a/packages/web/test/settings-database.test.tsx
+++ b/packages/web/test/settings-database.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { DatabaseSection } from '../src/components/database-section';
 import type { DatabaseInfo } from '../src/hooks/use-database-info';
@@ -25,24 +25,31 @@ test('general settings shows the embedded database card just before the Version 
 	expect(section.compareDocumentPosition(version) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
-// Isolated-component render with a seeded cache for the external variant — no
-// real external Postgres needed, and it proves the client renders exactly the
+// Isolated-component render with a seeded cache — no real external Postgres or
+// on-disk snapshots needed, and it proves the client renders exactly the
 // pre-redacted string it was given (no reveal affordance, no raw URL).
-function renderExternal(info: DatabaseInfo, opts: { superuser?: boolean } = {}) {
+function renderCard(
+	info: DatabaseInfo,
+	opts: { superuser?: boolean; superseded?: { count: number; bytes: number } } = {},
+) {
 	// staleTime: Infinity keeps the seeded cache authoritative — the file-level
 	// renderApp beforeEach reroutes fetch into the real in-process backend, and
-	// a mount refetch would overwrite the seeded external payload with the test
-	// server's embedded one.
+	// a mount refetch would overwrite the seeded payload with the test server's.
 	const qc = new QueryClient({
 		defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
 	});
 	qc.setQueryData(queryKeys.me(), { type: 'admin', is_superuser: opts.superuser ?? true });
 	qc.setQueryData(queryKeys.databaseInfo(), info);
+	if (opts.superseded) qc.setQueryData(queryKeys.supersededData(), opts.superseded);
 	return render(
 		<QueryClientProvider client={qc}>
 			<DatabaseSection />
 		</QueryClientProvider>,
 	);
+}
+
+function renderExternal(info: DatabaseInfo, opts: { superuser?: boolean } = {}) {
+	return renderCard(info, opts);
 }
 
 test('external variant renders the occluded connection string, never credentials', async () => {
@@ -69,4 +76,46 @@ test('the card does not render for non-superusers', () => {
 		{ superuser: false },
 	);
 	expect(queryByTestId('settings-database')).toBeNull();
+});
+
+// Embedded backend surfaces the pre-migration snapshots (pgdata.superseded.*)
+// with a control to reclaim them — sized in GB, gated on there being something
+// to prune.
+test('embedded card shows the prune control with the snapshot size', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ superseded: { count: 3, bytes: 1_932_735_283 } }, // ~1.8 GB
+	);
+	const size = await findByTestId('settings-database-superseded-size');
+	expect(size.textContent).toContain('3 snapshots');
+	expect(size.textContent).toContain('1.8 GB');
+	await findByTestId('settings-database-prune');
+});
+
+test('the prune button opens a confirm dialog warning that rollback is lost', async () => {
+	const { findByTestId, findByText } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ superseded: { count: 2, bytes: 1024 * 1024 } },
+	);
+	fireEvent.click(await findByTestId('settings-database-prune'));
+	// ConfirmDialog renders into a portal on document.body; the bound queries
+	// target baseElement (document.body), so they reach the portal content.
+	await findByText('Prune old database versions?');
+	await findByText(/able to roll back to an earlier version/);
+});
+
+test('no prune control when there are no snapshots to reclaim', () => {
+	const { queryByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ superseded: { count: 0, bytes: 0 } },
+	);
+	expect(queryByTestId('settings-database-superseded')).toBeNull();
+});
+
+test('no prune control for external Postgres', () => {
+	const { queryByTestId } = renderCard({
+		backend: 'external',
+		display: 'postgres://••••:••••@h/db',
+	});
+	expect(queryByTestId('settings-database-superseded')).toBeNull();
 });


### PR DESCRIPTION
## What & why

Every embedded-DB migration renames the old cluster aside to `pgdata.superseded.<timestamp>` so a failed upgrade can roll back. The swap auto-retains the newest 5, but on a long-lived server these copies accumulate into gigabytes with no way to reclaim them short of `rm`-ing directories by hand (a live instance was holding **1.8 GB across 5 snapshots**).

This adds a **superuser control in the Database card** (Settings → General → Storage) that shows the on-disk size of those snapshots and, behind a danger confirm dialog, deletes them all. The current `pgdata` and the migration swap logic are untouched. Embedded-only (external Postgres migrates in place and produces no snapshots) and superuser-only, matching the existing `/api/database-info` gate. Per the design decision, **Prune deletes every snapshot** — reclaims everything; no rollback to a prior DB version remains. The footer is hidden entirely when there is nothing to reclaim or the backend is external.

## Changes

**Backend**
- `db/superseded.ts` (new): shared `listSupersededDirs` / `measureSuperseded` / `pruneSuperseded(dataDir, keep)` helpers, extracted from the private routine in `migrate-swap.ts`, which now calls `pruneSuperseded(dataDir, 5)` — the auto-keep-5 behaviour is preserved.
- `routes/database-info.ts`: `buildDatabaseInfoRoutes(info, dataDir)` gains `GET /api/database-info/superseded` (live count + on-disk size) and `POST /api/database-info/prune-superseded` (delete all → `{ removed, freed_bytes }`). Both `requireSuperuser`; external backend reports zero / 409.
- `startup.ts`: passes `config.dataDir` into the factory.

**Frontend**
- `hooks/use-superseded-data.ts` (new): `useSupersededData` (query, embedded + superuser gated) and `usePruneSuperseded` (invalidate + refetch, never optimistic — mirrors the security-sensitive credential mutations).
- `components/database-section.tsx`: a footer with the snapshot count/size and a **Prune…** button + shared `ConfirmDialog`, rendered only when embedded with snapshots to reclaim.
- `components/asset-icon.tsx`: `formatBytes` extended with a GB branch (so `1.8 GB` renders instead of `1858.6 MB`).
- `lib/query-keys.ts`: `supersededData()` key under the `databaseInfo` prefix.

## Tests
- `packages/server/test/database-superseded.test.ts`: size measurement, prune-all + freed bytes, the superuser gate (403, and that a denied request deletes nothing), and the external-backend branch (zero / 409).
- `packages/web/test/settings-database.test.tsx`: footer + size render, the confirm dialog's rollback warning, and that the control is hidden with no snapshots / on external Postgres.

## Docs
- `.dev/architecture.md` (§ migrations): documents the two new superuser endpoints and that manual prune deletes all snapshots.
- `docs/concepts/your-data.md`: a "Reclaiming disk from old database versions" note for operators.

No CLI flag or MCP tool changed, so `cli.md`, the generated `mcp-api.md`, `SKILL.md`, and `llms.txt` are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QVVk97BwFdVscyxZtnvwV)_