### PR TITLE
fix(backup): page logical dump/restore by bytes to survive large-log tables

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1964,7 +1964,14 @@ blobs — as a **backup bundle** directory: `database.backup.gz` (the portable l
 database backup) + `assets/<projectId>/<assetId>` blob files + a `manifest.json` written
 **last** as the completion marker. The database half is the **portable logical backup**
 (`src/db/logical-backup.ts`): gzipped JSONL carrying the applied-migration set plus every
-row (bytea → base64, generated tsvector columns excluded and recomputed on load).
+row (bytea → base64, generated tsvector columns excluded and recomputed on load). Dump
+queries and restore inserts are batched by **bytes** as well as rows
+(`dumpPageRows`/`planInsertBatches`): each table's page size derives from its measured
+uncompressed row sizes, keeping every protocol message far below the embedded engine's
+~16MB per-response ceiling — which a large-log table (`heartbeat_runs.log_text`) would
+otherwise breach in a single flat-size page and hard-crash the WASM instance. The
+subcommands' teardown closes are best-effort (`closeQuietly` in `cli.ts`), so closing an
+already-crashed engine can never mask the original dump/restore error.
 Restore replays the binary's own migrations up to exactly the recorded set, then loads
 data in one transaction with FK constraints dropped/re-added around the inserts (insert
 order and self-references never matter) and serial sequences resumed; migration-seeded

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -257,6 +257,23 @@ async function assertNoLiveEmbeddedServer(
  * directory). An external database + S3 storage can be backed up any time — the
  * source is only ever read.
  */
+
+/**
+ * Best-effort teardown for backup/restore cleanup paths. A close failure must
+ * never mask the operation's real error: when a query crashes the embedded
+ * engine's WASM instance, closing that dead instance throws the same runtime
+ * error, and a throwing `finally` would replace the diagnosable original.
+ */
+async function closeQuietly(closeable: { close(): Promise<unknown> } | null | undefined) {
+	if (!closeable) return;
+	try {
+		await closeable.close();
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`Warning: could not close the database cleanly (${msg}); continuing.`);
+	}
+}
+
 export async function runBackup(argv: string[] = process.argv): Promise<boolean> {
 	if (argv[2] !== 'backup') return false;
 
@@ -338,7 +355,7 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 			await writeFile(output, bytes);
 			console.log(`Wrote logical backup of ${opened.storage.backend} database → ${output}`);
 		} finally {
-			await opened.db.close();
+			await closeQuietly(opened.db);
 		}
 		return true;
 	}
@@ -385,8 +402,8 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 				`(${dbNote}${assets.count} asset blob(s) from ${openedStore.info.backend} storage)${missingNote}`,
 		);
 	} finally {
-		await openedStore.store.close();
-		await opened.db.close();
+		await closeQuietly(openedStore.store);
+		await closeQuietly(opened.db);
 	}
 	return true;
 }
@@ -497,8 +514,8 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 				console.log('This bundle has nothing to restore for the given options.');
 			}
 		} finally {
-			if (openedStore) await openedStore.store.close();
-			await opened.db.close();
+			await closeQuietly(openedStore?.store);
+			await closeQuietly(opened.db);
 		}
 		return true;
 	}
@@ -538,7 +555,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 				`into the ${opened.storage.backend} database: ${summary.rows} rows across ${summary.tables} tables.`,
 		);
 	} finally {
-		await opened.db.close();
+		await closeQuietly(opened.db);
 	}
 	return true;
 }

--- a/packages/server/src/db/logical-backup.ts
+++ b/packages/server/src/db/logical-backup.ts
@@ -28,6 +28,60 @@ const FORMAT_VERSION = 1;
 const DUMP_PAGE_SIZE = 5_000;
 const INSERT_BATCH_SIZE = 500;
 
+/**
+ * Ceiling on the data volume a single dump query may return / a single restore
+ * INSERT may carry. Embedded PGlite hard-crashes its WASM instance
+ * ("RuntimeError: Out of bounds memory access") when one protocol message
+ * exceeds roughly 16MB, so both directions size their batches by bytes as well
+ * as rows, with generous headroom under that ceiling. Large-log tables (a
+ * single agent run's log can be megabytes) are what make row-count-only
+ * batching unsafe.
+ */
+const BATCH_TARGET_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Rows per page for one table's dump queries: as many rows as fit the byte
+ * target given the table's average row size, at least 1 and at most the flat
+ * row cap. A table whose largest single row alone exceeds the target is read
+ * one row at a time — the best a row-granular reader can do.
+ */
+export function dumpPageRows(stats: {
+	rowCount: number;
+	totalBytes: number;
+	maxRowBytes: number;
+}): number {
+	if (stats.rowCount === 0) return DUMP_PAGE_SIZE;
+	if (stats.maxRowBytes > BATCH_TARGET_BYTES) return 1;
+	const avgRowBytes = Math.max(1, Math.ceil(stats.totalBytes / stats.rowCount));
+	return Math.min(DUMP_PAGE_SIZE, Math.max(1, Math.floor(BATCH_TARGET_BYTES / avgRowBytes)));
+}
+
+/**
+ * Split `sizes.length` rows into contiguous insert batches, closing a batch
+ * when it reaches the row cap or the cumulative byte target. Every batch holds
+ * at least one row, so a single oversized row still travels (alone).
+ */
+export function planInsertBatches(
+	sizes: number[],
+	maxRows = INSERT_BATCH_SIZE,
+	targetBytes = BATCH_TARGET_BYTES,
+): Array<{ start: number; end: number }> {
+	const batches: Array<{ start: number; end: number }> = [];
+	let start = 0;
+	let bytes = 0;
+	for (let i = 0; i < sizes.length; i++) {
+		const rowsInBatch = i - start;
+		if (rowsInBatch > 0 && (rowsInBatch >= maxRows || bytes + sizes[i] > targetBytes)) {
+			batches.push({ start, end: i });
+			start = i;
+			bytes = 0;
+		}
+		bytes += sizes[i];
+	}
+	if (start < sizes.length) batches.push({ start, end: sizes.length });
+	return batches;
+}
+
 interface ColumnMeta {
 	name: string;
 	udt: string;
@@ -152,25 +206,52 @@ export async function dumpLogicalBackup(
 		const orderBy =
 			table.pk.length > 0 ? `ORDER BY ${table.pk.map((c) => quoteIdent(c)).join(', ')}` : '';
 
-		let offset = 0;
-		for (;;) {
-			// Keyset pagination would be nicer, but OFFSET paging with a stable
-			// PK order is correct and Hezo-scale tables are modest. Tables with
-			// no PK are read in one page.
-			const page = await db.query<Record<string, unknown>>(
-				orderBy
-					? `SELECT ${colList} FROM ${quoteIdent(table.name)} ${orderBy} LIMIT ${DUMP_PAGE_SIZE} OFFSET ${offset}`
-					: `SELECT ${colList} FROM ${quoteIdent(table.name)}`,
+		try {
+			// Page size is derived from the table's *uncompressed* row sizes
+			// (rendering the whole row to text detoasts it), so one page's
+			// response stays well under the embedded engine's per-message
+			// ceiling regardless of how large individual rows are. Only the
+			// aggregates travel back here, so this probe itself is safe on any
+			// table.
+			const stats = await db.query<{
+				row_count: number;
+				total_bytes: string;
+				max_row_bytes: number;
+			}>(
+				`SELECT COUNT(*)::int AS row_count,
+				        COALESCE(SUM(octet_length(__hezo_row::text)), 0)::text AS total_bytes,
+				        COALESCE(MAX(octet_length(__hezo_row::text)), 0)::int AS max_row_bytes
+				 FROM ${quoteIdent(table.name)} AS __hezo_row`,
 			);
-			for (const row of page.rows) {
-				const encoded: Record<string, unknown> = {};
-				for (const col of cols) {
-					encoded[col.name] = encodeValue(row[col.name], col.udt);
+			const pageRows = dumpPageRows({
+				rowCount: stats.rows[0].row_count,
+				totalBytes: Number(stats.rows[0].total_bytes),
+				maxRowBytes: stats.rows[0].max_row_bytes,
+			});
+
+			let offset = 0;
+			for (;;) {
+				// Keyset pagination would be nicer, but OFFSET paging with a
+				// stable PK order is correct at backup scale. Tables with no PK
+				// are read in one page.
+				const page = await db.query<Record<string, unknown>>(
+					orderBy
+						? `SELECT ${colList} FROM ${quoteIdent(table.name)} ${orderBy} LIMIT ${pageRows} OFFSET ${offset}`
+						: `SELECT ${colList} FROM ${quoteIdent(table.name)}`,
+				);
+				for (const row of page.rows) {
+					const encoded: Record<string, unknown> = {};
+					for (const col of cols) {
+						encoded[col.name] = encodeValue(row[col.name], col.udt);
+					}
+					lines.push(JSON.stringify({ t: table.name, r: encoded }));
 				}
-				lines.push(JSON.stringify({ t: table.name, r: encoded }));
+				if (!orderBy || page.rows.length < pageRows) break;
+				offset += pageRows;
 			}
-			if (!orderBy || page.rows.length < DUMP_PAGE_SIZE) break;
-			offset += DUMP_PAGE_SIZE;
+		} catch (err) {
+			const causeMsg = err instanceof Error ? err.message : String(err);
+			throw new Error(`Dumping table "${table.name}" failed: ${causeMsg}`, { cause: err });
 		}
 	}
 
@@ -261,13 +342,15 @@ export async function restoreLogicalBackup(
 	const tables = await introspectTables(db);
 	const tableMeta = new Map(tables.map((t) => [t.name, t]));
 
-	// Group data lines by table (the file is written table-by-table).
-	const rowsByTable = new Map<string, Record<string, unknown>[]>();
+	// Group data lines by table (the file is written table-by-table), keeping
+	// each row's encoded size so inserts can be batched by bytes as well as
+	// row count.
+	const rowsByTable = new Map<string, Array<{ row: Record<string, unknown>; bytes: number }>>();
 	for (const line of text.slice(newline + 1).split('\n')) {
 		if (!line) continue;
 		const { t, r } = JSON.parse(line) as { t: string; r: Record<string, unknown> };
 		const list = rowsByTable.get(t) ?? [];
-		list.push(r);
+		list.push({ row: r, bytes: line.length });
 		rowsByTable.set(t, list);
 	}
 
@@ -313,10 +396,10 @@ export async function restoreLogicalBackup(
 			});
 			const colList = colMeta.map((c) => quoteIdent(c.name)).join(', ');
 
-			for (let i = 0; i < rows.length; i += INSERT_BATCH_SIZE) {
-				const batch = rows.slice(i, i + INSERT_BATCH_SIZE);
+			for (const { start, end } of planInsertBatches(rows.map((r) => r.bytes))) {
+				const batch = rows.slice(start, end);
 				const params: unknown[] = [];
-				const tuples = batch.map((row) => {
+				const tuples = batch.map(({ row }) => {
 					const placeholders = colMeta.map((col) => {
 						params.push(decodeValue(row[col.name], col.udt));
 						const cast = col.udt === 'jsonb' || col.udt === 'json' ? `::${col.udt}` : '';

--- a/packages/server/test/database-logical-backup.test.ts
+++ b/packages/server/test/database-logical-backup.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { MasterKeyManager } from '../src/crypto/master-key';
 import { createMemoryDb } from '../src/db/client';
-import type { Db } from '../src/db/database';
+import type { Db, Queryable } from '../src/db/database';
 import { PostgresDb } from '../src/db/drivers/postgres';
 import {
 	dumpLogicalBackup,
+	dumpPageRows,
+	planInsertBatches,
 	readLogicalBackupHeader,
 	restoreLogicalBackup,
 } from '../src/db/logical-backup';
@@ -48,6 +50,70 @@ async function seedRichData(db: Db): Promise<{ teamId: string; taskId: string }>
 		[projectId, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff])],
 	);
 	return { teamId, taskId: parent.rows[0].id };
+}
+
+describe('byte-aware batch sizing', () => {
+	it('sizes dump pages from average row size, clamped to [1, flat cap]', () => {
+		// Empty table: nothing to size, keep the flat cap.
+		expect(dumpPageRows({ rowCount: 0, totalBytes: 0, maxRowBytes: 0 })).toBe(5000);
+		// Tiny rows: the flat row cap keeps a single response bounded.
+		expect(dumpPageRows({ rowCount: 100_000, totalBytes: 1_000_000, maxRowBytes: 50 })).toBe(5000);
+		// ~300KB average rows fit ~13 to a 4MB page.
+		expect(dumpPageRows({ rowCount: 30, totalBytes: 9_000_000, maxRowBytes: 310_000 })).toBe(
+			Math.floor((4 * 1024 * 1024) / 300_000),
+		);
+		// Average at/above the byte target: one row at a time.
+		expect(dumpPageRows({ rowCount: 2, totalBytes: 8_000_000, maxRowBytes: 4_000_000 })).toBe(1);
+		// A single outlier row past the target forces row-at-a-time even when
+		// the average looks harmless.
+		expect(dumpPageRows({ rowCount: 1000, totalBytes: 10_000_000, maxRowBytes: 9_000_000 })).toBe(
+			1,
+		);
+	});
+
+	it('splits insert batches on row cap and cumulative byte target', () => {
+		expect(planInsertBatches([])).toEqual([]);
+		// Row cap.
+		expect(planInsertBatches([1, 1, 1, 1, 1], 2, 1000)).toEqual([
+			{ start: 0, end: 2 },
+			{ start: 2, end: 4 },
+			{ start: 4, end: 5 },
+		]);
+		// Byte target: a row that would push past it starts the next batch.
+		expect(planInsertBatches([3, 3, 3], 500, 4)).toEqual([
+			{ start: 0, end: 1 },
+			{ start: 1, end: 2 },
+			{ start: 2, end: 3 },
+		]);
+		expect(planInsertBatches([1, 1, 1, 1, 1], 500, 4)).toEqual([
+			{ start: 0, end: 4 },
+			{ start: 4, end: 5 },
+		]);
+		// A single oversized row still gets its own batch.
+		expect(planInsertBatches([100], 500, 4)).toEqual([{ start: 0, end: 1 }]);
+	});
+});
+
+/** Wrap a Db so every SQL statement (incl. inside transactions) is recorded. */
+function recordingDb(inner: Db): { db: Db; queries: string[] } {
+	const queries: string[] = [];
+	const wrapQueryable = <Q extends Queryable>(q: Q): Q =>
+		new Proxy(q, {
+			get(target, prop, receiver) {
+				if (prop === 'query' || prop === 'exec') {
+					return (sql: string, params?: unknown[]) => {
+						queries.push(sql);
+						return prop === 'query' ? target.query(sql, params) : target.exec(sql);
+					};
+				}
+				if (prop === 'transaction') {
+					return (cb: (tx: Queryable) => Promise<unknown>) =>
+						(target as unknown as Db).transaction((tx) => cb(wrapQueryable(tx)));
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+	return { db: wrapQueryable(inner), queries };
 }
 
 describe('logical backup round-trip (PGlite leg)', () => {
@@ -112,6 +178,59 @@ describe('logical backup round-trip (PGlite leg)', () => {
 				// The vault travels: the same unlock key unlocks the restored DB.
 				const mkm = new MasterKeyManager();
 				expect(await mkm.initialize(restored, ctx.unlockKeyHex)).toBe('unlocked');
+			} finally {
+				await restored.close();
+			}
+		} finally {
+			await safeClose(ctx.db);
+		}
+	});
+
+	it('pages a large-log table by bytes on dump and byte-caps restore inserts', async () => {
+		const ctx = await createTestApp();
+		const migrations = allMigrations();
+		try {
+			// ~9MB of log_text across 30 runs — far past one 4MB page, so a flat
+			// row-count page would return it all in one response (the shape that
+			// crashes embedded PGlite's WASM on real instances).
+			const member = await ctx.db.query<{ id: string; team_id: string }>(
+				`SELECT id, team_id FROM members LIMIT 1`,
+			);
+			await ctx.db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, status, log_text)
+				 SELECT $1, $2, 'succeeded', repeat('x', 300000) || n::text
+				 FROM generate_series(1, 30) n`,
+				[member.rows[0].team_id, member.rows[0].id],
+			);
+
+			const source = recordingDb(ctx.db);
+			const bytes = await dumpLogicalBackup(source.db, { hezoVersion: 'test', migrations });
+			const pageSelects = source.queries.filter(
+				(q) => q.includes('FROM "heartbeat_runs"') && q.includes('LIMIT'),
+			);
+			expect(pageSelects.length).toBeGreaterThanOrEqual(3);
+			// Every page carries the byte-derived row limit, not the flat cap.
+			for (const q of pageSelects) expect(q).not.toContain('LIMIT 5000');
+
+			const restored = await createMemoryDb();
+			try {
+				const target = recordingDb(restored);
+				await restoreLogicalBackup(target.db, bytes, migrations);
+				const inserts = target.queries.filter((q) => q.startsWith('INSERT INTO "heartbeat_runs"'));
+				expect(inserts.length).toBeGreaterThanOrEqual(3);
+
+				// The paged dump + batched restore is lossless.
+				const [a, b] = await Promise.all([
+					ctx.db.query<{ n: number; len: string }>(
+						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(log_text)), 0)::text AS len
+						 FROM heartbeat_runs`,
+					),
+					restored.query<{ n: number; len: string }>(
+						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(log_text)), 0)::text AS len
+						 FROM heartbeat_runs`,
+					),
+				]);
+				expect(b.rows[0]).toEqual(a.rows[0]);
 			} finally {
 				await restored.close();
 			}

--- a/packages/server/test/git-worktree-prune.test.ts
+++ b/packages/server/test/git-worktree-prune.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -16,7 +16,9 @@ import { HostGitExecutor } from '../src/services/git-executor';
 // (host path == container path), mirroring git-worktree-state.test.ts. These back
 // the admin "Prune worktrees" action that sweeps closed/orphaned tasks' worktrees.
 
-const root = mkdtempSync(join(tmpdir(), 'git-wt-prune-'));
+// realpath so prefix comparisons against git-reported worktree paths hold on
+// macOS, where the tmpdir sits behind a symlink git resolves.
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'git-wt-prune-')));
 const exec = new HostGitExecutor();
 const repoLoc = (p: string): RepoLoc => ({ hostPath: p, containerPath: p });
 const wtLoc = (p: string): WorktreeLoc => ({ hostPath: p, containerPath: p });


### PR DESCRIPTION
## Problem

`hezo backup` on a real instance crashed with:

```
uncaughtException RuntimeError: Out of bounds memory access (evaluating 'getWasmTableEntry(e)(t)')
    at execProtocolRaw → execProtocol → close → runBackup
```

Root cause (verified empirically against a copy of the affected instance's 1.3GB pgdata): **embedded PGlite hard-crashes its WASM instance when a single protocol message exceeds ~16MB** (a lone `repeat('x', 16MB)` value returns fine; 20MB crashes — related: electric-sql/pglite#339). The logical dump paged a flat 5,000 rows per query, so `heartbeat_runs` (1,333 rows carrying ~51MB of `log_text`) came back in one response and killed the engine mid-dump. The `finally` block's `close()` on the dead engine then threw the same `RuntimeError`, **masking the real error** — which is why the reported stack pointed at `close`.

## Fix

- **Byte-aware dump paging** — a cheap per-table stats probe (`COUNT`/`SUM`/`MAX` over `octet_length(row::text)`, aggregates only, so the probe itself is safe on any table) feeds `dumpPageRows`, which sizes each table's pages to ~4MB of uncompressed row data (clamped to `[1, 5000]` rows; a single oversized row travels alone).
- **Byte-capped restore batches** — `planInsertBatches` closes an INSERT batch at 500 rows *or* ~4MB cumulative encoded size, so a restored backup can't recreate the same crash on the way back in.
- **Per-table error context** — a dump failure now names the table it died on.
- **Best-effort teardown** — the backup/restore subcommands close their databases via `closeQuietly`, so a close failure can never again mask the operation's original error.
- **Test-env fix** — `git-worktree-prune.test.ts` failed on macOS because the symlinked tmpdir (`/var` → `/private/var`) never prefix-matched git's resolved worktree paths; the temp root is now `realpathSync`'d.

## Validation

- Ran the fixed dump/restore against a copy of the crashing instance's actual 1.3GB pgdata: dump completes in **~1.4s → 20.3MB backup**; restore is lossless (18,190 rows across 45 tables; `log_text` totals byte-identical at 53,145,638).
- New unit tests for `dumpPageRows` / `planInsertBatches`, plus an integration test proving a ~9MB-log table dumps in ≥3 byte-sized pages and restores in ≥3 byte-capped batches, losslessly.
- Full server suite green (441 files), `bun run check` + `typecheck` clean.

## Notes

- The affected table was 1,094MB on disk for ~25MB of live data — TOAST bloat from the log flusher rewriting the full `log_text` on every flush. Not addressed here; a backup+restore cycle compacts it, but stopping the bloat at the source is a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YEzU8nUghB3GsNMKesLkU