### PR TITLE
feat: run-log compaction to reclaim database size

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1894,14 +1894,34 @@ renamed-aside originals are kept as `pgdata.superseded.<timestamp>` (the swap au
 newest 5 — `db/superseded.ts`). A superuser can reclaim them on demand: `GET
 /api/database-info/superseded` reports the on-disk size and `POST
 /api/database-info/prune-superseded` deletes **all** of them (no rollback retained; the live
-`pgdata` is untouched). Both are surfaced in the Database card on General settings and are
-embedded-only — external Postgres migrates in place and produces no snapshots.
+`pgdata` is untouched). Both are surfaced in the Database card on the Storage settings
+subpage and are embedded-only — external Postgres migrates in place and produces no snapshots.
 An **external Postgres** migrates **in place** instead: per-migration transactions under a
 session `pg_advisory_lock` (`applyPendingMigrationsExternal`), with the downgrade guard
 re-checked under the lock, so concurrent startups can't double-migrate and a failed
 migration leaves the committed prefix intact. A database carrying migrations the binary
 doesn't recognize makes the server exit and ask the operator to upgrade. Migration
 mechanics and the per-migration rules are in `AGENTS.md` › Database migrations.
+
+**Run-log compaction.** `heartbeat_runs.log_text` (one verbose per-run blob, stored
+out-of-line in TOAST) is the largest thing in a busy instance's DB, and the streaming
+flusher's repeated whole-log rewrites leave heavy dead-tuple bloat that only a `VACUUM
+(FULL)` returns to the OS. A superuser triggers compaction from the Database card on the
+Storage settings subpage: `POST /api/database-info/compact-run-logs {older_than_days}` writes
+a `log_compaction:active` marker in `system_meta` (also the "in progress" flag the panel's
+button disables on) and kicks the drain. The `log-compaction` cron
+(`services/log-compaction.ts`, guarded so a manual kick and the scheduled tick never overlap)
+drains the backlog a bounded batch at a time — trimming each old, finished, TOASTed run's log
+to its tail (a "compacted" notice + the run's `invocation_command` + the end-of-run
+summary/`[done]` line) and stamping `log_compacted_at` (migration `040`, partial index
+`idx_runs_compaction`). When the backlog drains it runs `VACUUM (FULL, ANALYZE)
+heartbeat_runs` on the **embedded** backend (reclaiming bloat across *all* runs, not just the
+trimmed ones — external Postgres is left to autovacuum), records the real bytes freed in
+`log_compaction:last`, and clears the marker. `GET /api/database-info/run-log-usage` reports
+live sizes (`pg_database_size`, `pg_total_relation_size` — cheap, no detoast) plus the
+reclaimable/backlog estimate and status for the panel, embedded-only figures degrading to
+null/0 elsewhere. Deploy-time knobs: `HEZO_LOG_COMPACTION_CRON`, `_BATCH`, `_MAX_PER_TICK`,
+`_PRESERVED_BYTES`. The trimmed detail is unrecoverable, so the UI confirms first.
 
 **Storage abstraction & transactions.** All app code takes the `Db` interface
 (`query`/`exec`/`transaction`/`acquireSessionLock`/`close`); the drivers live in

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -39,13 +39,13 @@ default, or in any **S3-compatible bucket** when you set `--asset-storage-url` /
 bucket configured, asset bytes live only with your storage provider — stored as plain
 objects (enable the provider's server-side encryption if you want them encrypted at
 rest) and always served through Hezo's signed URLs, so the bucket stays private. The
-active backend is shown under **Settings → General → Asset storage**.
+active backend is shown under **Settings → Storage → Asset storage**.
 
 Be clear-eyed about what changes: **your business content — tasks, comments, documents —
 is stored as ordinary database rows**, so with an external database that content lives
 with your database provider and travels the network. Hezo checks the server version at
 startup and shows the connection target (credentials occluded, never the full URL) under
-**Settings → General → Database**. Use TLS (`sslmode=verify-full`), prefer private
+**Settings → Storage → Database**. Use TLS (`sslmode=verify-full`), prefer private
 networking, and treat the provider's at-rest encryption and access controls as part of
 your security posture. Secrets are unaffected — see below.
 
@@ -85,7 +85,25 @@ without any manual migration work on your part.
 Each embedded upgrade leaves the previous database copy behind in the data directory as a
 rollback point, and Hezo keeps the few most recent ones automatically. On a long-running
 instance these can add up to gigabytes. When you're confident you won't need to roll back,
-open **Settings → General → Database** (superuser only): it shows how much disk the retained
+open **Settings → Storage → Database** (superuser only): it shows how much disk the retained
 copies are using next to a **Prune** button that deletes them all. Your current database is
 untouched — but once pruned, you can no longer roll back to an earlier version. This applies
 to the embedded database only; an external Postgres keeps no such copies.
+
+## Reclaiming disk from old agent run logs
+
+Every agent run keeps its full step-by-step log, and on a busy instance those logs become
+the largest thing in the database. When you no longer need the blow-by-blow detail of old
+runs, open **Settings → Storage → Database** (superuser only) and use **Compact old run
+logs**. Pick a window (for example, older than 30 days) and Hezo trims each of those runs'
+logs down to the part that still matters — the agent's end-of-run summary and outcome —
+while keeping the exact command that launched the run and clearly marking the log as
+compacted. Status, timing, token counts, and cost are untouched; runs newer than the window
+are left alone.
+
+The card also shows your current **database size** and how much run logs are using, so you
+can see the effect. Compaction runs in the background a batch at a time, so the button is
+disabled while a pass is in progress. On the embedded database the pass finishes by
+reclaiming the freed space (and accumulated storage overhead) so the on-disk size actually
+drops. Trimming is permanent — the detailed output of a compacted run can't be recovered —
+so Hezo confirms before it starts.

--- a/packages/server/migrations/040_run_log_compaction.sql
+++ b/packages/server/migrations/040_run_log_compaction.sql
@@ -1,0 +1,16 @@
+-- Agent run-log compaction. The dominant consumer of database size is
+-- `heartbeat_runs.log_text` — one verbose per-run blob (capped at ~10 MB each),
+-- kept forever. Compaction trims old runs' logs down to their meaningful tail
+-- (the agent's end-of-run summary + the trailing `[done] … tokens=… cost=…`
+-- line) and stamps this column so a trimmed run is never re-scanned.
+--
+-- `log_compacted_at` NULL = the full log is still intact; a timestamp = the log
+-- has been compacted (at that time). Mirrors the `compacted_at TIMESTAMPTZ`
+-- marker `008_chat_memory_compaction.sql` added to `ceo_messages`.
+--
+-- Purely additive: existing rows backfill to NULL (not yet compacted), so no
+-- current data changes. The partial index keeps the oldest-first "which runs
+-- still need compacting" scan cheap and shrinks as rows are compacted.
+ALTER TABLE heartbeat_runs ADD COLUMN log_compacted_at TIMESTAMPTZ;
+
+CREATE INDEX idx_runs_compaction ON heartbeat_runs (created_at) WHERE log_compacted_at IS NULL;

--- a/packages/server/src/routes/database-info.ts
+++ b/packages/server/src/routes/database-info.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOG_COMPACTION_RETENTION_DAYS } from '@hezo/shared';
 import { Hono } from 'hono';
 import { measureSuperseded, pruneSuperseded } from '../db/superseded';
 import type { StorageInfo } from '../lib/db-info';
@@ -5,6 +6,14 @@ import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireSuperuser } from '../middleware/auth';
+import {
+	clampRetentionDays,
+	getActiveCompaction,
+	getCompactionEstimate,
+	getDatabaseUsage,
+	getLastCompaction,
+	startCompaction,
+} from '../services/log-compaction';
 
 const log = logger.child('database-info');
 
@@ -56,6 +65,66 @@ export function buildDatabaseInfoRoutes(info: StorageInfo, dataDir: string): Hon
 			log.error(`Failed to prune superseded snapshots: ${e instanceof Error ? e.message : e}`);
 			return err(c, 'PRUNE_FAILED', 'Failed to prune old database snapshots.', 500);
 		}
+	});
+
+	// Live database-usage figures + run-log compaction status. `run_log_bytes` is
+	// the on-disk footprint of the run-logs table (main + TOAST + bloat);
+	// `database_bytes` is embedded-only. `reclaimable_bytes` / `compactable_run_count`
+	// reflect the requested window and are computed only when idle (they scan the
+	// table, so the polling path skips them). `compaction` is the active pass
+	// (also the "in progress" flag the DB panel disables its button on).
+	routes.get('/database-info/run-log-usage', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		const db = c.get('db');
+		const olderThanDays = clampRetentionDays(
+			Number(c.req.query('older_than_days') ?? DEFAULT_LOG_COMPACTION_RETENTION_DAYS),
+		);
+		const [usage, compaction, last] = await Promise.all([
+			getDatabaseUsage(db, info.backend),
+			getActiveCompaction(db),
+			getLastCompaction(db),
+		]);
+		// Skip the table-scanning estimate while a pass is running — the UI shows
+		// live progress then, not the reclaimable preview.
+		const estimate = compaction
+			? { runCount: 0, reclaimableBytes: 0 }
+			: await getCompactionEstimate(db, info.backend, olderThanDays);
+		return ok(c, {
+			backend: info.backend,
+			database_bytes: usage.databaseBytes,
+			run_log_bytes: usage.runLogDiskBytes,
+			run_count: usage.runCount,
+			reclaimable_bytes: estimate.reclaimableBytes,
+			compactable_run_count: estimate.runCount,
+			older_than_days: olderThanDays,
+			compaction,
+			last,
+		});
+	});
+
+	// Start a compaction pass over runs older than the chosen window: trims their
+	// verbose logs to the meaningful tail (keeping the launch command + a
+	// compacted marker) and, once the embedded backend is drained, VACUUMs to
+	// reclaim disk (including the dead-tuple bloat, across all runs). Runs in the
+	// background a batch at a time — this returns as soon as the pass is recorded.
+	// 409 if one is already running.
+	routes.post('/database-info/compact-run-logs', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		const db = c.get('db');
+		if (await getActiveCompaction(db)) {
+			return err(c, 'ALREADY_RUNNING', 'A log compaction is already in progress.', 409);
+		}
+		const body = (await c.req.json().catch(() => ({}))) as { older_than_days?: unknown };
+		const olderThanDays = clampRetentionDays(
+			Number(body.older_than_days ?? DEFAULT_LOG_COMPACTION_RETENTION_DAYS),
+		);
+		const state = await startCompaction(db, { olderThanDays, backend: info.backend });
+		// Start draining immediately rather than waiting for the next cron tick;
+		// guarded so it never overlaps the scheduled drain.
+		c.get('jobManager')?.kickLogCompaction();
+		return ok(c, state, 201);
 	});
 
 	return routes;

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -25,6 +25,7 @@ import type { Db } from '../db/database';
 import type { DomainEventBus } from '../events/bus';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
+import type { StorageBackend } from '../lib/db-info';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
 import { ref } from '../lib/log-ref';
 import { logger } from '../logger';
@@ -183,6 +184,11 @@ export interface JobManagerDeps {
 	connectivityStatus?: ContainerConnectivityStatus;
 	connectivityProbe?: () => Promise<ProbeResult>;
 	pricing?: PricingService;
+	/**
+	 * Storage backend, so the log-compaction drain knows whether it may VACUUM
+	 * FULL to reclaim disk (embedded only). Defaults to 'embedded' when omitted.
+	 */
+	storageBackend?: StorageBackend;
 	/** Anonymous daily usage telemetry. Omitted/disabled → the cron is not registered. */
 	telemetry?: { enabled: boolean; endpoint: string };
 	/**
@@ -237,6 +243,11 @@ const ORPHAN_DETECTION_CRON = process.env.HEZO_ORPHAN_DETECTION_CRON ?? '*/30 * 
 // literal for the `<> ALL(...)` / `= ANY(...)` enum-array params.
 const BUDGET_PAUSE_STATUSES_PG = `{${BUDGET_PAUSE_STATUSES.join(',')}}`;
 const INBOX_RETENTION_DAYS = Number(process.env.HEZO_INBOX_RETENTION_DAYS ?? 30);
+// Drain tick for agent run-log compaction. Cheap when idle (a single
+// `system_meta` read); only does work while a compaction pass is active, which
+// the operator starts from the DB panel. Frequent so a started pass makes
+// visible progress and resumes promptly after a restart.
+const LOG_COMPACTION_CRON = process.env.HEZO_LOG_COMPACTION_CRON ?? '*/10 * * * * *';
 // Lower bound on how often a heartbeat can fire (`HEARTBEAT_INTERVAL_FLOOR_MIN`,
 // from ./heartbeat-schedule) is shared with the agents API's computed
 // `next_heartbeat_at` so the UI countdown matches the cadence enforced here.
@@ -471,6 +482,11 @@ export class JobManager {
 			cron: INBOX_ARCHIVE_CRON,
 			log: cronLog,
 			onTick: () => this.guarded('inbox-archive', () => this.archiveInboxItems()),
+		});
+		this.cron.createJob('log-compaction', {
+			cron: LOG_COMPACTION_CRON,
+			log: cronLog,
+			onTick: () => this.guarded('log-compaction', () => this.compactRunLogs()),
 		});
 		this.cron.createJob('budget-resume', {
 			cron: BUDGET_RESUME_CRON,
@@ -2696,6 +2712,29 @@ export class JobManager {
 		if (count > 0) {
 			log.debug(`Archived ${count} inbox item(s)`);
 		}
+	}
+
+	/**
+	 * Kick the run-log compaction drain immediately, without waiting for the next
+	 * cron tick — used by the manual trigger on the DB panel. Guarded under the
+	 * same key as the cron so a manual kick and a scheduled tick never overlap;
+	 * whichever holds the guard drains the backlog the active marker describes.
+	 */
+	kickLogCompaction(): void {
+		void trackBackground(this.guarded('log-compaction', () => this.compactRunLogs()));
+	}
+
+	/**
+	 * One drain tick of run-log compaction. A no-op unless a compaction pass is
+	 * active (its marker set from the DB panel); otherwise it compacts a bounded
+	 * slice of the backlog and, once drained, reclaims space and clears the
+	 * marker. See {@link ./log-compaction}.
+	 */
+	private async compactRunLogs(): Promise<void> {
+		const { runLogCompactionTick } = await import('./log-compaction');
+		await runLogCompactionTick(this.deps.db, {
+			backend: this.deps.storageBackend ?? 'embedded',
+		});
 	}
 
 	/**

--- a/packages/server/src/services/log-compaction.ts
+++ b/packages/server/src/services/log-compaction.ts
@@ -1,0 +1,374 @@
+/**
+ * Agent run-log compaction. The biggest consumer of database size is
+ * `heartbeat_runs.log_text` — one verbose per-run blob kept forever, stored out
+ * of line in TOAST. Two things bloat it: the live text of old runs, and (much
+ * larger) the dead TOAST tuples the streaming log flusher leaves behind. Only a
+ * `VACUUM (FULL)` returns that dead space to the OS.
+ *
+ * Compaction addresses both: it trims the logs of old, finished runs down to the
+ * part that still matters (the agent's end-of-run summary and the trailing
+ * `[done] … tokens=… cost=…` line, both at the *end* of the blob), keeps the
+ * command that launched the run and a clear "compacted" notice, stamps
+ * `log_compacted_at`, and — on the embedded backend — runs a `VACUUM (FULL)` at
+ * the end of the pass so the on-disk size actually drops. The VACUUM reclaims
+ * dead tuples across *all* runs, not just the trimmed ones.
+ *
+ * The work is incremental: a manual trigger writes the `log_compaction:active`
+ * marker (with the chosen retention window), and the `log-compaction` cron job
+ * drains the backlog a batch at a time, then reclaims space and clears the
+ * marker. The marker doubles as the "compaction in progress" flag the DB panel
+ * disables its button on.
+ */
+
+import {
+	DEFAULT_LOG_COMPACTION_RETENTION_DAYS,
+	LOG_COMPACTION_PRESERVED_TAIL_BYTES,
+	LOG_COMPACTION_RETENTION_MAX_DAYS,
+	LOG_COMPACTION_RETENTION_MIN_DAYS,
+} from '@hezo/shared';
+import type { Db } from '../db/database';
+import type { StorageBackend } from '../lib/db-info';
+import { deleteSystemMeta, getSystemMeta, setSystemMeta } from '../lib/system-meta';
+import { logger } from '../logger';
+
+const log = logger.child('log-compaction');
+
+export const LOG_COMPACTION_ACTIVE_KEY = 'log_compaction:active';
+export const LOG_COMPACTION_LAST_KEY = 'log_compaction:last';
+
+/** Rows compacted per batch (one transaction). Deploy-time tunable. */
+const LOG_COMPACTION_BATCH = Number(process.env.HEZO_LOG_COMPACTION_BATCH ?? 50);
+/** Upper bound on rows a single cron tick processes before yielding to the next. */
+const LOG_COMPACTION_MAX_PER_TICK = Number(process.env.HEZO_LOG_COMPACTION_MAX_PER_TICK ?? 500);
+/** Trailing bytes of each old log kept (summary + outcome). Deploy-time tunable. */
+const PRESERVED_BYTES = Number(
+	process.env.HEZO_LOG_COMPACTION_PRESERVED_BYTES ?? LOG_COMPACTION_PRESERVED_TAIL_BYTES,
+);
+/**
+ * A log is worth compacting once its stored (compressed) size crosses Postgres's
+ * ~2KB TOAST threshold — i.e. once it lives out of line and contributes the
+ * write-amplification bloat. Filtering on `pg_column_size` (the stored size)
+ * rather than `length` avoids detoasting every row just to decide.
+ */
+const TOAST_THRESHOLD_BYTES = 2000;
+
+const TERMINAL_STATUS_SQL = "('succeeded','failed','cancelled','timed_out')";
+
+/**
+ * Clamp a requested retention window to the allowed range. Exported so the route
+ * validates with the same bounds the drain enforces (a stale/out-of-range value
+ * can never widen or invert the window).
+ */
+export function clampRetentionDays(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_LOG_COMPACTION_RETENTION_DAYS;
+	return Math.min(
+		LOG_COMPACTION_RETENTION_MAX_DAYS,
+		Math.max(LOG_COMPACTION_RETENTION_MIN_DAYS, Math.round(value)),
+	);
+}
+
+export interface CompactionState {
+	/** ISO timestamp the pass started. */
+	started_at: string;
+	older_than_days: number;
+	/** Runs that matched the window when the pass started (progress-bar denominator). */
+	total: number;
+	processed: number;
+	/** Logical bytes trimmed so far (disk is returned by the VACUUM at the end). */
+	bytes_reclaimed: number;
+}
+
+export interface LastCompaction {
+	finished_at: string;
+	older_than_days: number;
+	processed: number;
+	/** Actual on-disk bytes reclaimed (embedded, via VACUUM) or logical bytes trimmed. */
+	bytes_reclaimed: number;
+}
+
+const COMPACTED_NOTICE = (date: string, hadCommand: boolean): string =>
+	[
+		'════════════════════════════════════════════════════════════',
+		'  ⓘ THIS RUN LOG HAS BEEN COMPACTED',
+		`  The full step-by-step output was trimmed on ${date} to reduce`,
+		`  database size. Kept below:${hadCommand ? ' the command that launched this run,' : ''}`,
+		hadCommand
+			? "  and the final portion of the log (the run's summary and"
+			: "  the final portion of the log (the run's summary and",
+		'  outcome). The trimmed detail cannot be recovered.',
+		'════════════════════════════════════════════════════════════',
+	].join('\n');
+
+/**
+ * Build the compacted form of a run log: a clear "this log was compacted"
+ * notice, the full agent CLI command that launched the run, then the trailing
+ * slice of the original log (its summary + `[done]` line). Pure and
+ * unit-testable. Returns the input unchanged when it is already at/under the
+ * preserved size (nothing to trim), so it never grows a log.
+ */
+export function computeCompactedLog(
+	logText: string,
+	opts: { invocationCommand?: string | null; preservedBytes?: number; now?: Date } = {},
+): string {
+	const preserved = opts.preservedBytes ?? PRESERVED_BYTES;
+	if (logText.length <= preserved) return logText;
+
+	// Keep the trailing `preserved` chars, then advance past the first partial
+	// line so the excerpt starts cleanly on a line boundary.
+	let tail = logText.slice(logText.length - preserved);
+	const firstNewline = tail.indexOf('\n');
+	if (firstNewline >= 0 && firstNewline < tail.length - 1) {
+		tail = tail.slice(firstNewline + 1);
+	}
+
+	const date = (opts.now ?? new Date()).toISOString().slice(0, 10);
+	const command = opts.invocationCommand?.trim();
+	const blocks = [COMPACTED_NOTICE(date, Boolean(command))];
+	if (command) blocks.push(`$ ${command}`);
+	blocks.push(tail);
+	const compacted = blocks.join('\n\n');
+
+	// Defensive: never grow a log (short logs with a long command).
+	return compacted.length < logText.length ? compacted : logText;
+}
+
+/**
+ * Cheap database-usage figures for the DB panel — all metadata/counts, no
+ * detoast, so it stays fast even while a pass polls it every couple seconds.
+ * `databaseBytes` is embedded-only; `runLogDiskBytes` is the on-disk footprint
+ * of the run-logs table (main + TOAST + indexes + any bloat).
+ */
+export async function getDatabaseUsage(
+	db: Db,
+	backend: StorageBackend,
+): Promise<{ databaseBytes: number | null; runLogDiskBytes: number; runCount: number }> {
+	const counted = await db.query<{ run_count: string }>(
+		'SELECT COUNT(*)::bigint AS run_count FROM heartbeat_runs',
+	);
+	const runLogDiskBytes = await scalarBytes(
+		db,
+		`SELECT pg_total_relation_size('heartbeat_runs')::bigint AS b`,
+	);
+	let databaseBytes: number | null = null;
+	if (backend === 'embedded') {
+		databaseBytes = await scalarBytes(
+			db,
+			'SELECT pg_database_size(current_database())::bigint AS b',
+		);
+	}
+	return { databaseBytes, runLogDiskBytes, runCount: Number(counted.rows[0]?.run_count ?? 0) };
+}
+
+/** Run a single-column bigint size query, returning 0 if the function is unavailable. */
+async function scalarBytes(db: Db, sql: string): Promise<number> {
+	try {
+		const r = await db.query<{ b: string }>(sql);
+		return Number(r.rows[0]?.b ?? 0);
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * What a compaction pass over the given window would do: how many old runs get
+ * trimmed, and how much disk it would reclaim. On the embedded backend the
+ * reclaim is table bloat (dead TOAST tuples) the pass's VACUUM returns — far
+ * larger than the trimmed live text, and independent of the window. On external
+ * Postgres nothing is VACUUMed (autovacuum reuses the space), so it reports 0.
+ * The one full-table scan here runs only when idle (never on the polling path).
+ */
+export async function getCompactionEstimate(
+	db: Db,
+	backend: StorageBackend,
+	olderThanDays: number,
+): Promise<{ runCount: number; reclaimableBytes: number }> {
+	const counted = await db.query<{ c: string }>(
+		`SELECT COUNT(*)::bigint AS c FROM heartbeat_runs
+		 WHERE log_compacted_at IS NULL
+		   AND status IN ${TERMINAL_STATUS_SQL}
+		   AND pg_column_size(log_text) > $1
+		   AND created_at < now() - ($2 || ' days')::interval`,
+		[TOAST_THRESHOLD_BYTES, String(olderThanDays)],
+	);
+	const runCount = Number(counted.rows[0]?.c ?? 0);
+
+	let reclaimableBytes = 0;
+	if (backend === 'embedded') {
+		try {
+			const bloat = await db.query<{ bloat: string }>(
+				`SELECT GREATEST(0, pg_total_relation_size('heartbeat_runs')
+				               - COALESCE(SUM(pg_column_size(log_text)), 0))::bigint AS bloat
+				 FROM heartbeat_runs`,
+			);
+			reclaimableBytes = Number(bloat.rows[0]?.bloat ?? 0);
+		} catch {
+			reclaimableBytes = 0;
+		}
+	}
+	return { runCount, reclaimableBytes };
+}
+
+/**
+ * Compact one batch of the oldest eligible runs, in a single transaction.
+ * Returns how many rows were compacted and the logical bytes trimmed. A
+ * `processed` of 0 means the backlog for this window is drained.
+ */
+export async function compactRunLogsBatch(
+	db: Db,
+	opts: { olderThanDays: number; limit?: number },
+): Promise<{ processed: number; bytesReclaimed: number }> {
+	const limit = opts.limit ?? LOG_COMPACTION_BATCH;
+	const rows = await db.query<{ id: string; log_text: string; invocation_command: string | null }>(
+		`SELECT id, log_text, invocation_command
+		 FROM heartbeat_runs
+		 WHERE log_compacted_at IS NULL
+		   AND status IN ${TERMINAL_STATUS_SQL}
+		   AND pg_column_size(log_text) > $1
+		   AND created_at < now() - ($2 || ' days')::interval
+		 ORDER BY created_at ASC
+		 LIMIT $3`,
+		[TOAST_THRESHOLD_BYTES, String(opts.olderThanDays), limit],
+	);
+	if (rows.rows.length === 0) return { processed: 0, bytesReclaimed: 0 };
+
+	let bytesReclaimed = 0;
+	await db.transaction(async (tx) => {
+		for (const row of rows.rows) {
+			const compacted = computeCompactedLog(row.log_text, {
+				invocationCommand: row.invocation_command,
+			});
+			bytesReclaimed += Math.max(0, row.log_text.length - compacted.length);
+			await tx.query(
+				`UPDATE heartbeat_runs SET log_text = $1, log_compacted_at = now() WHERE id = $2`,
+				[compacted, row.id],
+			);
+		}
+	});
+	return { processed: rows.rows.length, bytesReclaimed };
+}
+
+export async function getActiveCompaction(db: Db): Promise<CompactionState | null> {
+	return readJson<CompactionState>(db, LOG_COMPACTION_ACTIVE_KEY);
+}
+
+export async function getLastCompaction(db: Db): Promise<LastCompaction | null> {
+	return readJson<LastCompaction>(db, LOG_COMPACTION_LAST_KEY);
+}
+
+async function readJson<T>(db: Db, key: string): Promise<T | null> {
+	const raw = await getSystemMeta(db, key);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Begin a compaction pass: record the window + backlog size in the active
+ * marker. The caller must have verified no pass is already active.
+ */
+export async function startCompaction(
+	db: Db,
+	opts: { olderThanDays: number; backend: StorageBackend },
+): Promise<CompactionState> {
+	const { runCount } = await getCompactionEstimate(db, opts.backend, opts.olderThanDays);
+	const state: CompactionState = {
+		started_at: new Date().toISOString(),
+		older_than_days: opts.olderThanDays,
+		total: runCount,
+		processed: 0,
+		bytes_reclaimed: 0,
+	};
+	await setSystemMeta(db, LOG_COMPACTION_ACTIVE_KEY, JSON.stringify(state));
+	return state;
+}
+
+async function finishCompaction(db: Db, state: CompactionState): Promise<void> {
+	const last: LastCompaction = {
+		finished_at: new Date().toISOString(),
+		older_than_days: state.older_than_days,
+		processed: state.processed,
+		bytes_reclaimed: state.bytes_reclaimed,
+	};
+	await setSystemMeta(db, LOG_COMPACTION_LAST_KEY, JSON.stringify(last));
+	await deleteSystemMeta(db, LOG_COMPACTION_ACTIVE_KEY);
+	log.info(
+		`Compaction complete: ${state.processed} run(s), ~${Math.round(state.bytes_reclaimed / 1024)} KB reclaimed`,
+	);
+}
+
+function runLogTableSize(db: Db): Promise<number> {
+	return scalarBytes(db, `SELECT pg_total_relation_size('heartbeat_runs')::bigint AS b`);
+}
+
+/**
+ * Reclaim the disk freed by trimming logs (and the dead-tuple bloat around it).
+ * On the embedded database a `VACUUM (FULL)` rewrites the table and returns
+ * space to the OS so the DB size actually drops; on external Postgres it is left
+ * to autovacuum (a VACUUM FULL there takes a heavy lock the operator did not ask
+ * for). Returns the on-disk bytes actually freed. Best-effort: a VACUUM failure
+ * is logged, not fatal — the logs are already trimmed.
+ */
+export async function reclaimRunLogSpace(db: Db, backend: StorageBackend): Promise<number> {
+	if (backend !== 'embedded') return 0;
+	const before = await runLogTableSize(db);
+	try {
+		await db.query('VACUUM (FULL, ANALYZE) heartbeat_runs');
+	} catch (fullErr) {
+		try {
+			await db.query('VACUUM (ANALYZE) heartbeat_runs');
+		} catch (plainErr) {
+			log.warn('VACUUM after compaction failed; space will be reused by autovacuum', {
+				fullError: fullErr instanceof Error ? fullErr.message : String(fullErr),
+				plainError: plainErr instanceof Error ? plainErr.message : String(plainErr),
+			});
+			return 0;
+		}
+	}
+	const after = await runLogTableSize(db);
+	return Math.max(0, before - after);
+}
+
+/**
+ * One cron tick of the drain loop. No-op unless a pass is active. Processes up
+ * to `LOG_COMPACTION_MAX_PER_TICK` rows this tick (updating the progress marker
+ * after each batch), then yields — the next tick continues where it left off.
+ * When a batch drains the backlog, reclaims space (recording the real on-disk
+ * bytes freed) and clears the marker.
+ */
+export async function runLogCompactionTick(
+	db: Db,
+	opts: { backend: StorageBackend; batchSize?: number; maxRunsPerTick?: number },
+): Promise<void> {
+	let state = await getActiveCompaction(db);
+	if (!state) return;
+
+	const batchSize = opts.batchSize ?? LOG_COMPACTION_BATCH;
+	const maxRunsPerTick = opts.maxRunsPerTick ?? LOG_COMPACTION_MAX_PER_TICK;
+	let processedThisTick = 0;
+
+	while (processedThisTick < maxRunsPerTick) {
+		const { processed, bytesReclaimed } = await compactRunLogsBatch(db, {
+			olderThanDays: state.older_than_days,
+			limit: batchSize,
+		});
+		if (processed === 0) {
+			const freed = await reclaimRunLogSpace(db, opts.backend);
+			// On embedded the VACUUM delta is the true disk reclaim (it captures the
+			// dead-tuple bloat, far larger than the trimmed live text); on external
+			// there is no VACUUM, so the logical trim total stands.
+			const finalReclaimed = opts.backend === 'embedded' ? freed : state.bytes_reclaimed;
+			await finishCompaction(db, { ...state, bytes_reclaimed: finalReclaimed });
+			return;
+		}
+		processedThisTick += processed;
+		state = {
+			...state,
+			processed: state.processed + processed,
+			bytes_reclaimed: state.bytes_reclaimed + bytesReclaimed,
+		};
+		await setSystemMeta(db, LOG_COMPACTION_ACTIVE_KEY, JSON.stringify(state));
+	}
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -346,6 +346,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		connectivityStatus,
 		connectivityProbe,
 		pricing,
+		storageBackend: storageInfo.backend,
 		telemetry: config.telemetry,
 		autoInstallUpdates: config.autoInstallUpdates,
 	});

--- a/packages/server/test/log-compaction.test.ts
+++ b/packages/server/test/log-compaction.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import { deleteSystemMeta, setSystemMeta } from '../src/lib/system-meta';
+import {
+	compactRunLogsBatch,
+	computeCompactedLog,
+	getActiveCompaction,
+	getCompactionEstimate,
+	getDatabaseUsage,
+	getLastCompaction,
+	LOG_COMPACTION_ACTIVE_KEY,
+	reclaimRunLogSpace,
+	runLogCompactionTick,
+	startCompaction,
+} from '../src/services/log-compaction';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+// A large, poorly-compressible log so its stored (pg_column_size) size clears
+// the ~2KB TOAST threshold the compaction filter uses. A run of repeated 'x'
+// would compress below it and never be selected.
+function bigLog(): string {
+	let s = '';
+	let x = 987654321;
+	while (s.length < 80 * 1024) {
+		x = (x * 1103515245 + 12345) & 0x7fffffff;
+		s += `${x.toString(36)} agent streaming output line with some varied entropy\n`;
+	}
+	return `${s}\nSUMMARY: did the thing.\n[done] succeeded turns=5 duration=1000ms tokens=100/200 cost=$0.01`;
+}
+
+describe('computeCompactedLog', () => {
+	it('leaves a short log unchanged', () => {
+		const log = 'short run\n[done] succeeded';
+		expect(computeCompactedLog(log, { preservedBytes: 1024 })).toBe(log);
+	});
+
+	it('trims a long log to its tail, keeping a compacted notice + the command', () => {
+		const log = `${'noise line\n'.repeat(5000)}FINAL SUMMARY\n[done] succeeded`;
+		const out = computeCompactedLog(log, {
+			preservedBytes: 200,
+			invocationCommand: 'claude -p --model opus',
+		});
+		expect(out.length).toBeLessThan(log.length);
+		expect(out).toContain('THIS RUN LOG HAS BEEN COMPACTED');
+		expect(out).toContain('$ claude -p --model opus');
+		// The meaningful tail (summary + done line) survives.
+		expect(out).toContain('FINAL SUMMARY');
+		expect(out).toContain('[done] succeeded');
+	});
+
+	it('never grows a log even with a long command', () => {
+		const log = `${'x'.repeat(300)}\n[done]`;
+		const out = computeCompactedLog(log, {
+			preservedBytes: 250,
+			invocationCommand: 'a'.repeat(500),
+		});
+		expect(out.length).toBeLessThanOrEqual(log.length);
+	});
+});
+
+describe('run-log compaction — service + routes', () => {
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let db: Db;
+	let teamId: string;
+	let memberId: string;
+	const runIds: Record<string, string> = {};
+
+	async function seedRun(
+		key: string,
+		opts: { ageDays: number; log: string; status?: string; command?: string; compacted?: boolean },
+	): Promise<void> {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, status, log_text, invocation_command, created_at, finished_at, log_compacted_at)
+			 VALUES ($1, $2, $3::heartbeat_run_status, $4, $5,
+			         now() - ($6 || ' days')::interval, now() - ($6 || ' days')::interval,
+			         CASE WHEN $7 THEN now() ELSE NULL END)
+			 RETURNING id`,
+			[
+				teamId,
+				memberId,
+				opts.status ?? 'succeeded',
+				opts.log,
+				opts.command ?? 'claude -p',
+				String(opts.ageDays),
+				opts.compacted ?? false,
+			],
+		);
+		runIds[key] = r.rows[0].id;
+	}
+
+	beforeAll(async () => {
+		ctx = await createTestApp();
+		db = ctx.db;
+		const team = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Compaction', 'compaction') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const member = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		memberId = member.rows[0].id;
+
+		await seedRun('oldBig', { ageDays: 60, log: bigLog() });
+		await seedRun('oldSmall', { ageDays: 60, log: 'tiny old log\n[done] succeeded' });
+		await seedRun('recentBig', { ageDays: 1, log: bigLog() });
+		await seedRun('oldRunning', { ageDays: 60, log: bigLog(), status: 'running' });
+		await seedRun('oldCompacted', { ageDays: 60, log: bigLog(), compacted: true });
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('reports database usage without scanning/detoasting failing', async () => {
+		const usage = await getDatabaseUsage(db, 'embedded');
+		expect(usage.runCount).toBeGreaterThanOrEqual(5);
+		expect(usage.runLogDiskBytes).toBeGreaterThan(0);
+		expect(usage.databaseBytes).toBeGreaterThan(0);
+	});
+
+	it('estimates only old, large, terminal, uncompacted runs as compactable', async () => {
+		const est = await getCompactionEstimate(db, 'embedded', 30);
+		// Only oldBig qualifies (oldSmall is below TOAST size, recentBig is inside
+		// the window, oldRunning is non-terminal, oldCompacted is already done).
+		expect(est.runCount).toBe(1);
+		expect(est.reclaimableBytes).toBeGreaterThanOrEqual(0);
+	});
+
+	it('external backend reports zero reclaimable (no VACUUM there)', async () => {
+		const est = await getCompactionEstimate(db, 'external', 30);
+		expect(est.reclaimableBytes).toBe(0);
+		expect(await reclaimRunLogSpace(db, 'external')).toBe(0);
+	});
+
+	it('compacts the old large run and leaves the others intact', async () => {
+		const before = await db.query<{ len: number }>(
+			`SELECT length(log_text) AS len FROM heartbeat_runs WHERE id = $1`,
+			[runIds.oldBig],
+		);
+		const { processed, bytesReclaimed } = await compactRunLogsBatch(db, { olderThanDays: 30 });
+		expect(processed).toBe(1);
+		expect(bytesReclaimed).toBeGreaterThan(0);
+
+		const oldBig = await db.query<{ log_text: string; log_compacted_at: string | null }>(
+			`SELECT log_text, log_compacted_at FROM heartbeat_runs WHERE id = $1`,
+			[runIds.oldBig],
+		);
+		expect(oldBig.rows[0].log_compacted_at).not.toBeNull();
+		expect(oldBig.rows[0].log_text).toContain('THIS RUN LOG HAS BEEN COMPACTED');
+		expect(oldBig.rows[0].log_text).toContain('$ claude -p');
+		expect(oldBig.rows[0].log_text.length).toBeLessThan(before.rows[0].len);
+
+		// The recent run's log is untouched.
+		const recent = await db.query<{ log_compacted_at: string | null }>(
+			`SELECT log_compacted_at FROM heartbeat_runs WHERE id = $1`,
+			[runIds.recentBig],
+		);
+		expect(recent.rows[0].log_compacted_at).toBeNull();
+
+		// Idempotent: nothing left older than the window.
+		const again = await compactRunLogsBatch(db, { olderThanDays: 30 });
+		expect(again.processed).toBe(0);
+	});
+
+	it('a full drain tick clears the active marker and records the last pass', async () => {
+		await startCompaction(db, { olderThanDays: 30, backend: 'embedded' });
+		expect(await getActiveCompaction(db)).not.toBeNull();
+
+		await runLogCompactionTick(db, { backend: 'embedded' });
+
+		expect(await getActiveCompaction(db)).toBeNull();
+		const last = await getLastCompaction(db);
+		expect(last).not.toBeNull();
+		expect(last?.older_than_days).toBe(30);
+	});
+
+	it('GET run-log-usage returns the usage shape for a superuser', async () => {
+		const res = await ctx.app.request('/api/database-info/run-log-usage?older_than_days=30', {
+			headers: authHeader(ctx.token),
+		});
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: Record<string, unknown> };
+		expect(data.backend).toBe('embedded');
+		expect(typeof data.run_log_bytes).toBe('number');
+		expect(typeof data.reclaimable_bytes).toBe('number');
+		expect(data.older_than_days).toBe(30);
+		expect(data.compaction).toBeNull();
+	});
+
+	it('POST compact-run-logs 409s when a pass is already active', async () => {
+		// Seed the active marker directly so the check is deterministic (a real
+		// kicked pass drains asynchronously and would race this assertion).
+		await setSystemMeta(
+			db,
+			LOG_COMPACTION_ACTIVE_KEY,
+			JSON.stringify({
+				started_at: new Date().toISOString(),
+				older_than_days: 30,
+				total: 1,
+				processed: 0,
+				bytes_reclaimed: 0,
+			}),
+		);
+		const res = await ctx.app.request('/api/database-info/compact-run-logs', {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ older_than_days: 30 }),
+		});
+		expect(res.status).toBe(409);
+		await deleteSystemMeta(db, LOG_COMPACTION_ACTIVE_KEY);
+	});
+
+	it('POST compact-run-logs starts a pass and clamps the window', async () => {
+		await seedRun('oldBig2', { ageDays: 90, log: bigLog() });
+		const res = await ctx.app.request('/api/database-info/compact-run-logs', {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ older_than_days: 100000 }), // clamps to the max
+		});
+		expect(res.status).toBe(201);
+		const { data } = (await res.json()) as { data: { older_than_days: number } };
+		expect(data.older_than_days).toBe(365);
+	});
+
+	it('run-log-usage requires a superuser', async () => {
+		const nonSuper = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Member', false) RETURNING id",
+		);
+		const { signAdminJwt } = await import('../src/middleware/auth');
+		const memberToken = await signAdminJwt(ctx.masterKeyManager, nonSuper.rows[0].id);
+		const res = await ctx.app.request('/api/database-info/run-log-usage', {
+			headers: authHeader(memberToken),
+		});
+		expect(res.status).toBe(403);
+	});
+});

--- a/packages/server/test/migrate-040-run-log-compaction.test.ts
+++ b/packages/server/test/migrate-040-run-log-compaction.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '040_run_log_compaction.sql';
+
+describe('040_run_log_compaction migration', () => {
+	let h: DataPreservationHarness;
+	let runId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema at 039
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		const memberId = member.rows[0].id;
+		const run = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, log_text, finished_at)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, $3, now()) RETURNING id`,
+			[teamId, memberId, 'verbose log line 1\nverbose log line 2\n[done] succeeded'],
+		);
+		runId = run.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds a nullable log_compacted_at column', async () => {
+		const cols = await h.db.query<{
+			column_name: string;
+			is_nullable: string;
+			data_type: string;
+		}>(
+			`SELECT column_name, is_nullable, data_type FROM information_schema.columns
+			 WHERE table_name = 'heartbeat_runs' AND column_name = 'log_compacted_at'`,
+		);
+		expect(cols.rows).toHaveLength(1);
+		expect(cols.rows[0].is_nullable).toBe('YES');
+		expect(cols.rows[0].data_type).toBe('timestamp with time zone');
+	});
+
+	it('adds the partial index used by the compaction scan', async () => {
+		const idx = await h.db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes
+			 WHERE tablename = 'heartbeat_runs' AND indexname = 'idx_runs_compaction'`,
+		);
+		expect(idx.rows).toHaveLength(1);
+	});
+
+	it('preserves pre-existing runs with their log intact and uncompacted', async () => {
+		const run = await h.db.query<{ log_text: string; log_compacted_at: string | null }>(
+			`SELECT log_text, log_compacted_at FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0].log_text).toBe('verbose log line 1\nverbose log line 2\n[done] succeeded');
+		expect(run.rows[0].log_compacted_at).toBeNull();
+	});
+
+	it('accepts a compaction timestamp on subsequent writes', async () => {
+		await h.db.query(
+			`UPDATE heartbeat_runs SET log_text = $1, log_compacted_at = now() WHERE id = $2`,
+			['[log compacted]\n[done] succeeded', runId],
+		);
+		const run = await h.db.query<{ log_text: string; log_compacted_at: string | null }>(
+			`SELECT log_text, log_compacted_at FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0].log_text).toBe('[log compacted]\n[done] succeeded');
+		expect(run.rows[0].log_compacted_at).not.toBeNull();
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -66,6 +66,23 @@ export const MAX_CHAT_HISTORY_SIZE_MAX = 256 * 1024;
 export const CHAT_WINDOW_RETAIN_MESSAGES = 6;
 
 /**
+ * Agent run-log compaction. The retention window (in days): runs older than this
+ * have their verbose `log_text` trimmed to the meaningful tail. Operator-chosen
+ * per compaction pass from the DB panel; clamped to [MIN, MAX].
+ */
+export const DEFAULT_LOG_COMPACTION_RETENTION_DAYS = 30;
+export const LOG_COMPACTION_RETENTION_MIN_DAYS = 1;
+export const LOG_COMPACTION_RETENTION_MAX_DAYS = 365;
+
+/**
+ * Bytes of each old run's log kept when it is compacted — the trailing slice
+ * that holds the agent's end-of-run summary and the `[done] … tokens=… cost=…`
+ * line. Everything before it is discarded. Internal (not operator-tunable via
+ * the UI); overridable at deploy time with `HEZO_LOG_COMPACTION_PRESERVED_BYTES`.
+ */
+export const LOG_COMPACTION_PRESERVED_TAIL_BYTES = 12 * 1024;
+
+/**
  * Default heartbeat interval for newly created agents and agent types, in
  * minutes (12 hours). Idle agents wake on this cadence to look for work; the
  * value is editable per agent and overridable per team-template role. The DB

--- a/packages/web/src/components/database-section.tsx
+++ b/packages/web/src/components/database-section.tsx
@@ -1,31 +1,45 @@
-import { Database, Server, Trash2 } from 'lucide-react';
+import { DEFAULT_LOG_COMPACTION_RETENTION_DAYS } from '@hezo/shared';
+import { Database, Loader2, Server, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { type DatabaseInfo, useDatabaseInfo } from '../hooks/use-database-info';
 import { useMe } from '../hooks/use-me';
+import {
+	type RunLogUsage,
+	useCompactRunLogs,
+	useRunLogUsage,
+} from '../hooks/use-run-log-compaction';
 import { usePruneSuperseded, useSupersededData } from '../hooks/use-superseded-data';
 import { toast } from '../hooks/use-toast';
 import { formatBytes } from './asset-icon';
+import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
+
+const RETENTION_OPTIONS = [7, 30, 90] as const;
 
 /**
  * Database storage card, rendered side-by-side with the asset-storage card
- * inside {@link StorageSection}. Superuser-only, matching the endpoint's gate.
- * The connection string arrives pre-redacted from the server — this component
- * never sees, stores, or reveals the raw URL.
+ * inside {@link StorageSection} (now on the dedicated Storage settings subpage).
+ * Superuser-only, matching the endpoints' gates. The connection string arrives
+ * pre-redacted from the server — this component never sees the raw URL.
  *
- * For the embedded backend it also surfaces the on-disk size of the retained
- * pre-migration snapshots (`pgdata.superseded.*`) with a control to prune them.
- * That footer is shown only when there is something to reclaim — hidden for
- * external Postgres (no snapshots) and when zero snapshots remain.
+ * Layout, top to bottom: the backend details, a live size readout, then the
+ * compaction control (all about the *current* database) — then a full-width
+ * divider, and below it the pre-migration snapshot prune (the *old* databases,
+ * shipped in #813). The size readout's `database_bytes` is embedded-only; the
+ * snapshot footer shows only when there is something to reclaim.
  */
 export function DatabaseSection() {
 	const { data: me } = useMe();
 	const isSuperuser = me?.is_superuser === true;
 	const { data: info } = useDatabaseInfo(isSuperuser);
 	const isEmbedded = info?.backend === 'embedded';
+
+	const [retentionDays, setRetentionDays] = useState<number>(DEFAULT_LOG_COMPACTION_RETENTION_DAYS);
+	const { data: usage } = useRunLogUsage(retentionDays, isSuperuser && info !== undefined);
+
 	const { data: superseded } = useSupersededData(isSuperuser && isEmbedded);
 	const prune = usePruneSuperseded();
-	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [pruneConfirmOpen, setPruneConfirmOpen] = useState(false);
 
 	if (!isSuperuser) return null;
 
@@ -34,60 +48,76 @@ export function DatabaseSection() {
 	return (
 		<div className="border border-border rounded-md p-3 bg-surface" data-testid="settings-database">
 			{info === undefined ? null : <DatabaseDetails info={info} />}
-			{hasSnapshots && (
-				<div
-					className="mt-3 pt-3 border-t border-border flex items-center justify-between gap-3"
-					data-testid="settings-database-superseded"
-				>
-					<div className="min-w-0">
-						<div className="text-[12px] font-medium">Previous versions</div>
-						<div
-							className="text-[12px] text-text-3 mt-0.5"
-							data-testid="settings-database-superseded-size"
-						>
-							{superseded.count} {superseded.count === 1 ? 'snapshot' : 'snapshots'} ·{' '}
-							{formatBytes(superseded.bytes)} on disk
-						</div>
-					</div>
-					<button
-						type="button"
-						onClick={() => setConfirmOpen(true)}
-						data-testid="settings-database-prune"
-						className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1.5 text-[12px] font-medium text-danger transition-colors hover:border-danger-soft hover:bg-danger-soft hover:text-danger-soft-fg"
-					>
-						<Trash2 className="h-3 w-3" />
-						Prune…
-					</button>
-				</div>
+
+			{usage && (
+				<>
+					<RunLogUsageStats usage={usage} />
+					<CompactionControl
+						usage={usage}
+						retentionDays={retentionDays}
+						onRetentionChange={setRetentionDays}
+					/>
+				</>
 			)}
+
 			{hasSnapshots && (
-				<ConfirmDialog
-					open={confirmOpen}
-					onOpenChange={setConfirmOpen}
-					title="Prune old database versions?"
-					variant="danger"
-					confirmLabel={`Prune ${formatBytes(superseded.bytes)}`}
-					description={
-						<>
-							Hezo keeps a copy of your previous database after each upgrade so it can roll back a
-							failed one. You have{' '}
-							<strong className="font-medium text-text-1">
-								{superseded.count} previous {superseded.count === 1 ? 'version' : 'versions'}
-							</strong>{' '}
-							using{' '}
-							<strong className="font-medium text-text-1">{formatBytes(superseded.bytes)}</strong>{' '}
-							of disk. This can’t be undone — your current database is untouched, but you won’t be
-							able to roll back to an earlier version.
-						</>
-					}
-					onConfirm={async () => {
-						try {
-							await prune.mutateAsync();
-						} catch (e) {
-							toast.error(e instanceof Error ? e.message : 'Failed to prune old database versions');
+				<>
+					{/* Full-width divider: the current database above, the old ones below. */}
+					<div className="-mx-3 my-3 border-t border-border-strong" aria-hidden="true" />
+					<div
+						className="flex items-center justify-between gap-3"
+						data-testid="settings-database-superseded"
+					>
+						<div className="min-w-0">
+							<div className="text-[12px] font-medium">Previous versions</div>
+							<div
+								className="text-[12px] text-text-3 mt-0.5"
+								data-testid="settings-database-superseded-size"
+							>
+								{superseded.count} {superseded.count === 1 ? 'snapshot' : 'snapshots'} ·{' '}
+								{formatBytes(superseded.bytes)} on disk
+							</div>
+						</div>
+						<button
+							type="button"
+							onClick={() => setPruneConfirmOpen(true)}
+							data-testid="settings-database-prune"
+							className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1.5 text-[12px] font-medium text-danger transition-colors hover:border-danger-soft hover:bg-danger-soft hover:text-danger-soft-fg"
+						>
+							<Trash2 className="h-3 w-3" />
+							Prune…
+						</button>
+					</div>
+					<ConfirmDialog
+						open={pruneConfirmOpen}
+						onOpenChange={setPruneConfirmOpen}
+						title="Prune old database versions?"
+						variant="danger"
+						confirmLabel={`Prune ${formatBytes(superseded.bytes)}`}
+						description={
+							<>
+								Hezo keeps a copy of your previous database after each upgrade so it can roll back a
+								failed one. You have{' '}
+								<strong className="font-medium text-text-1">
+									{superseded.count} previous {superseded.count === 1 ? 'version' : 'versions'}
+								</strong>{' '}
+								using{' '}
+								<strong className="font-medium text-text-1">{formatBytes(superseded.bytes)}</strong>{' '}
+								of disk. This can’t be undone — your current database is untouched, but you won’t be
+								able to roll back to an earlier version.
+							</>
 						}
-					}}
-				/>
+						onConfirm={async () => {
+							try {
+								await prune.mutateAsync();
+							} catch (e) {
+								toast.error(
+									e instanceof Error ? e.message : 'Failed to prune old database versions',
+								);
+							}
+						}}
+					/>
+				</>
 			)}
 		</div>
 	);
@@ -125,6 +155,190 @@ function DatabaseDetails({ info }: { info: DatabaseInfo }) {
 					</p>
 				)}
 			</div>
+		</div>
+	);
+}
+
+/** Live size readout: on-disk DB size (embedded) + total run-log size. */
+function RunLogUsageStats({ usage }: { usage: RunLogUsage }) {
+	return (
+		<div
+			className="mt-3 pt-3 border-t border-border grid grid-cols-2 gap-x-4 gap-y-2.5"
+			data-testid="settings-run-log-usage"
+		>
+			{usage.database_bytes != null && (
+				<div>
+					<div className="text-[11px] text-text-3">Database size</div>
+					<div className="text-[15px] font-medium tabular-nums" data-testid="settings-db-size">
+						{formatBytes(usage.database_bytes)}
+					</div>
+				</div>
+			)}
+			<div>
+				<div className="text-[11px] text-text-3">Run logs</div>
+				<div className="text-[15px] font-medium tabular-nums" data-testid="settings-run-log-size">
+					{formatBytes(usage.run_log_bytes)}{' '}
+					<span className="text-[11px] font-normal text-text-3">
+						· {usage.run_count.toLocaleString()} {usage.run_count === 1 ? 'run' : 'runs'}
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * The compaction control: pick a retention window, see what's reclaimable, and
+ * start a background pass. While a pass runs the button is disabled and a
+ * progress bar advances (driven by the polling usage query).
+ */
+function CompactionControl({
+	usage,
+	retentionDays,
+	onRetentionChange,
+}: {
+	usage: RunLogUsage;
+	retentionDays: number;
+	onRetentionChange: (days: number) => void;
+}) {
+	const compact = useCompactRunLogs();
+	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	const running = usage.compaction != null;
+	const nothingToTrim = usage.compactable_run_count === 0;
+	// The embedded backend can always reclaim dead-tuple bloat via VACUUM, even
+	// when nothing is old enough to trim; external only benefits from trimming.
+	const canReclaim = usage.backend === 'embedded';
+	const disabled = running || compact.isPending || (nothingToTrim && !canReclaim);
+
+	const percent = usage.compaction
+		? Math.min(
+				100,
+				Math.round((usage.compaction.processed / Math.max(1, usage.compaction.total)) * 100),
+			)
+		: 0;
+
+	return (
+		<div className="mt-3 pt-3 border-t border-border" data-testid="settings-compaction">
+			<h4 className="text-[12.5px] font-semibold">Compact old run logs</h4>
+			<p className="text-[12px] text-text-2 mt-1 leading-relaxed">
+				Trims the verbose output of old agent runs down to each run’s final summary. The command
+				that launched each run is kept, and every trimmed log is clearly marked as compacted. Runs
+				in the background, a batch at a time.
+			</p>
+
+			<div className="mt-2.5 flex flex-wrap items-center gap-2">
+				<label className="text-[12px] text-text-2" htmlFor="compaction-retention">
+					Older than
+				</label>
+				<select
+					id="compaction-retention"
+					data-testid="settings-compact-retention"
+					value={retentionDays}
+					disabled={running}
+					onChange={(e) => onRetentionChange(Number(e.target.value))}
+					className="rounded-md border border-border bg-surface-2 px-2 py-1 text-[12.5px] text-text-1 disabled:opacity-50"
+				>
+					{RETENTION_OPTIONS.map((d) => (
+						<option key={d} value={d}>
+							{d} days
+						</option>
+					))}
+				</select>
+				<Button
+					size="sm"
+					data-testid="settings-compact-button"
+					disabled={disabled}
+					onClick={() => setConfirmOpen(true)}
+				>
+					{running && <Loader2 className="w-3 h-3 animate-spin" />}
+					{running ? 'Compacting…' : 'Compact run logs'}
+				</Button>
+			</div>
+
+			{running && usage.compaction ? (
+				<div className="mt-3" data-testid="settings-compact-progress">
+					<div className="flex justify-between text-[11.5px] text-text-2 mb-1.5 tabular-nums">
+						<span>Compacting…</span>
+						<span>
+							{usage.compaction.processed.toLocaleString()} /{' '}
+							{usage.compaction.total.toLocaleString()} runs ·{' '}
+							{formatBytes(usage.compaction.bytes_reclaimed)} trimmed
+						</span>
+					</div>
+					<div className="h-1.5 rounded-full bg-surface-3 overflow-hidden">
+						<div
+							className="h-full rounded-full bg-accent transition-[width] duration-300"
+							style={{ width: `${percent}%` }}
+						/>
+					</div>
+				</div>
+			) : (
+				<p className="mt-2 text-[12px] text-text-2" data-testid="settings-compact-reclaimable">
+					{canReclaim ? (
+						<>
+							<span className="font-medium text-accent">
+								≈ {formatBytes(usage.reclaimable_bytes)}
+							</span>{' '}
+							reclaimable ·{' '}
+							{nothingToTrim ? (
+								<>reclaims storage bloat (no runs older than {retentionDays} days to trim)</>
+							) : (
+								<>
+									trims {usage.compactable_run_count.toLocaleString()}{' '}
+									{usage.compactable_run_count === 1 ? 'run' : 'runs'} older than {retentionDays}{' '}
+									days
+								</>
+							)}
+						</>
+					) : nothingToTrim ? (
+						<>Nothing older than {retentionDays} days to compact.</>
+					) : (
+						<>
+							Trims {usage.compactable_run_count.toLocaleString()}{' '}
+							{usage.compactable_run_count === 1 ? 'run' : 'runs'} older than {retentionDays} days.
+						</>
+					)}
+				</p>
+			)}
+
+			{!running && usage.last && (
+				<p className="mt-2 text-[12px] text-success-soft-fg" data-testid="settings-compact-last">
+					Last compaction: {usage.last.processed.toLocaleString()} runs ·{' '}
+					{formatBytes(usage.last.bytes_reclaimed)} reclaimed.
+				</p>
+			)}
+
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title={`Compact run logs older than ${retentionDays} days?`}
+				confirmLabel="Compact run logs"
+				description={
+					<>
+						This trims the full logs of agent runs older than{' '}
+						<strong className="font-medium text-text-1">{retentionDays} days</strong> down to their
+						final portion — the agent’s end-of-run summary and outcome. The full command that
+						launched each run is kept, every trimmed log is clearly marked as compacted, and status,
+						timing, tokens and cost are unchanged. Runs newer than the window are untouched. The
+						detailed step-by-step output is permanently discarded and can’t be recovered.
+						{usage.backend === 'embedded' && (
+							<>
+								{' '}
+								It then rewrites the run-logs table to return the freed space — and accumulated
+								storage bloat — to disk, which briefly locks that table.
+							</>
+						)}
+					</>
+				}
+				onConfirm={async () => {
+					try {
+						await compact.mutateAsync(retentionDays);
+					} catch (e) {
+						toast.error(e instanceof Error ? e.message : 'Failed to start log compaction');
+					}
+				}}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -26,6 +26,7 @@ const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/chat-channels', label: 'Chat channels' },
 	{ to: '/settings/credentials', label: 'Credentials' },
 	{ to: '/settings/api-keys', label: 'API keys' },
+	{ to: '/settings/storage', label: 'Storage' },
 	{ to: '/settings/archived-projects', label: 'Archived projects' },
 	{ to: '/settings/audit-log', label: 'Activity' },
 ];

--- a/packages/web/src/components/storage-section.tsx
+++ b/packages/web/src/components/storage-section.tsx
@@ -3,9 +3,9 @@ import { AssetStorageSection } from './asset-storage-section';
 import { DatabaseSection } from './database-section';
 
 /**
- * Storage section on General settings (rendered just before the Version
- * section). Superuser-only, matching the underlying endpoints' gates. Combines
- * the database and asset-storage cards into a single split view — stacked on
+ * Storage section, rendered on the dedicated Storage settings subpage.
+ * Superuser-only, matching the underlying endpoints' gates. Combines the
+ * database and asset-storage cards into a single split view — stacked on
  * mobile, side-by-side from `sm` up.
  */
 export function StorageSection() {
@@ -13,7 +13,7 @@ export function StorageSection() {
 	if (me?.is_superuser !== true) return null;
 
 	return (
-		<section className="mt-8" data-testid="settings-storage">
+		<section data-testid="settings-storage">
 			<div className="mb-4">
 				<h2 className="text-base font-medium">Storage</h2>
 				<p className="text-[13px] text-text-2 mt-1">

--- a/packages/web/src/hooks/use-run-log-compaction.ts
+++ b/packages/web/src/hooks/use-run-log-compaction.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+/** An in-progress compaction pass (also the "in progress" flag). */
+export interface RunLogCompactionState {
+	started_at: string;
+	older_than_days: number;
+	/** Runs that matched the window when the pass started (progress-bar denominator). */
+	total: number;
+	processed: number;
+	bytes_reclaimed: number;
+}
+
+/** The most recent completed compaction pass. */
+export interface LastRunLogCompaction {
+	finished_at: string;
+	older_than_days: number;
+	processed: number;
+	bytes_reclaimed: number;
+}
+
+export interface RunLogUsage {
+	backend: 'embedded' | 'external';
+	/** On-disk database size — embedded only; null for external Postgres. */
+	database_bytes: number | null;
+	/** On-disk footprint of the run-logs table (main + TOAST + bloat), in bytes. */
+	run_log_bytes: number;
+	run_count: number;
+	/** Disk a pass would reclaim (embedded: table bloat via VACUUM; external: 0). */
+	reclaimable_bytes: number;
+	/** Runs older than the window whose logs would be trimmed. */
+	compactable_run_count: number;
+	older_than_days: number;
+	compaction: RunLogCompactionState | null;
+	last: LastRunLogCompaction | null;
+}
+
+/** Poll cadence (ms) while a compaction pass is draining. */
+const POLL_INTERVAL_MS = 2000;
+
+/** Refetch every couple seconds while a pass is active, then stop. */
+export function runLogUsagePollInterval(data: RunLogUsage | undefined): number | false {
+	return data?.compaction != null ? POLL_INTERVAL_MS : false;
+}
+
+/**
+ * Live database-usage figures and run-log compaction status for the given
+ * retention window. Superuser-only — pass `enabled: false` otherwise so the
+ * fetch is skipped (other users would 403). Polls itself while a pass runs so
+ * the progress + disabled state advance without a manual reload.
+ */
+export function useRunLogUsage(olderThanDays: number, enabled: boolean) {
+	return useQuery({
+		queryKey: queryKeys.runLogUsage(olderThanDays),
+		queryFn: () =>
+			api.get<RunLogUsage>(`/api/database-info/run-log-usage?older_than_days=${olderThanDays}`),
+		enabled,
+		refetchInterval: (query) => runLogUsagePollInterval(query.state.data),
+	});
+}
+
+/**
+ * Start a compaction pass over runs older than `olderThanDays`. The server kicks
+ * the background drain and returns the active state; invalidating the usage
+ * query (and the database-info prefix, so the size readout refreshes) starts the
+ * poll that reflects progress. 409s if a pass is already running.
+ */
+export function useCompactRunLogs() {
+	return useMutation({
+		mutationFn: (olderThanDays: number) =>
+			api.post<RunLogCompactionState>('/api/database-info/compact-run-logs', {
+				older_than_days: olderThanDays,
+			}),
+		onSuccess: () => {
+			// The databaseInfo prefix covers run-log-usage (all windows) + superseded.
+			queryClient.invalidateQueries({ queryKey: queryKeys.databaseInfo() });
+		},
+	});
+}

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -38,6 +38,11 @@ export const queryKeys = {
 	 * cascades here too.
 	 */
 	supersededData: () => ['instance', 'database', 'superseded'],
+	/**
+	 * Live DB-usage figures + run-log compaction status for the chosen retention
+	 * window. Under the `databaseInfo` prefix so invalidating it cascades here.
+	 */
+	runLogUsage: (olderThanDays: number) => ['instance', 'database', 'run-log-usage', olderThanDays],
 	/** Asset storage backend metadata (server-side redacted) for the General settings page. */
 	assetStorageInfo: () => ['instance', 'asset-storage'],
 	/** Instance-wide mention resolution (global CEO chat), keyed by sorted candidates. */

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
 import { Route as HomeIndexRouteImport } from './routes/home/index'
 import { Route as SettingsUsersRouteImport } from './routes/settings/users'
+import { Route as SettingsStorageRouteImport } from './routes/settings/storage'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
@@ -84,6 +85,11 @@ const HomeIndexRoute = HomeIndexRouteImport.update({
 const SettingsUsersRoute = SettingsUsersRouteImport.update({
   id: '/users',
   path: '/users',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsStorageRoute = SettingsStorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
 const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
@@ -325,6 +331,7 @@ export interface FileRoutesByFullPath {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/storage': typeof SettingsStorageRoute
   '/settings/users': typeof SettingsUsersRoute
   '/home/': typeof HomeIndexRoute
   '/marketplace/': typeof MarketplaceIndexRoute
@@ -371,6 +378,7 @@ export interface FileRoutesByTo {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/storage': typeof SettingsStorageRoute
   '/settings/users': typeof SettingsUsersRoute
   '/home': typeof HomeIndexRoute
   '/marketplace': typeof MarketplaceIndexRoute
@@ -419,6 +427,7 @@ export interface FileRoutesById {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/storage': typeof SettingsStorageRoute
   '/settings/users': typeof SettingsUsersRoute
   '/home/': typeof HomeIndexRoute
   '/marketplace/': typeof MarketplaceIndexRoute
@@ -469,6 +478,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/storage'
     | '/settings/users'
     | '/home/'
     | '/marketplace/'
@@ -515,6 +525,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/storage'
     | '/settings/users'
     | '/home'
     | '/marketplace'
@@ -562,6 +573,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/storage'
     | '/settings/users'
     | '/home/'
     | '/marketplace/'
@@ -649,6 +661,13 @@ declare module '@tanstack/react-router' {
       path: '/users'
       fullPath: '/settings/users'
       preLoaderRoute: typeof SettingsUsersRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/storage': {
+      id: '/settings/storage'
+      path: '/storage'
+      fullPath: '/settings/storage'
+      preLoaderRoute: typeof SettingsStorageRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/settings/skills': {
@@ -945,6 +964,7 @@ interface SettingsRouteRouteChildren {
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
+  SettingsStorageRoute: typeof SettingsStorageRoute
   SettingsUsersRoute: typeof SettingsUsersRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -960,6 +980,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,
+  SettingsStorageRoute: SettingsStorageRoute,
   SettingsUsersRoute: SettingsUsersRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { InstanceSettingsSection } from '../../components/instance-settings-section';
-import { StorageSection } from '../../components/storage-section';
 import { VersionDisplay } from '../../components/version-display';
 
 /** The default Settings page (visiting /settings with no subpage) — general instance settings. */
@@ -8,7 +7,6 @@ function GeneralSettingsPage() {
 	return (
 		<div className="max-w-[900px]">
 			<InstanceSettingsSection />
-			<StorageSection />
 			<VersionDisplay />
 		</div>
 	);

--- a/packages/web/src/routes/settings/storage.tsx
+++ b/packages/web/src/routes/settings/storage.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { StorageSection } from '../../components/storage-section';
+import { useMe } from '../../hooks/use-me';
+
+/**
+ * Storage settings subpage: where this instance keeps its database and uploaded
+ * files, plus database maintenance (run-log compaction, old-version pruning).
+ * Superuser-only, matching the underlying endpoints' gates.
+ */
+function StorageSettingsPage() {
+	const { data: me } = useMe();
+	if (me && !me.is_superuser) {
+		return (
+			<div className="max-w-[900px]">
+				<p className="text-[13px] text-text-2">
+					Storage settings are managed by the Admin. You don't have access to this page.
+				</p>
+			</div>
+		);
+	}
+	return (
+		<div className="max-w-[900px]">
+			<StorageSection />
+		</div>
+	);
+}
+
+export const Route = createFileRoute('/settings/storage')({
+	component: StorageSettingsPage,
+});

--- a/packages/web/test/settings-asset-storage.test.tsx
+++ b/packages/web/test/settings-asset-storage.test.tsx
@@ -7,10 +7,10 @@ import { queryKeys } from '../src/lib/query-keys';
 import { renderApp } from './helpers/render';
 
 // Full-route render against the real in-process backend: the local variant is
-// what a test server actually runs, and placement (after the Database card,
-// before the Version section) is part of the requirement.
-test('general settings shows the local asset-storage card between Database and Version', async () => {
-	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+// what a test server actually runs, and placement (after the Database card) on
+// the dedicated Storage subpage is part of the requirement.
+test('storage subpage shows the local asset-storage card after Database', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/settings/storage' });
 
 	const backend = await findByTestId('settings-asset-storage-backend');
 	expect(backend.textContent).toBe('Local filesystem');
@@ -19,9 +19,7 @@ test('general settings shows the local asset-storage card between Database and V
 
 	const database = await findByTestId('settings-database');
 	const section = await findByTestId('settings-asset-storage');
-	const version = await findByTestId('settings-version');
 	expect(database.compareDocumentPosition(section) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-	expect(section.compareDocumentPosition(version) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
 // Isolated-component render with a seeded cache for the s3 variant — no real

--- a/packages/web/test/settings-database.test.tsx
+++ b/packages/web/test/settings-database.test.tsx
@@ -1,16 +1,17 @@
+import { DEFAULT_LOG_COMPACTION_RETENTION_DAYS } from '@hezo/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { DatabaseSection } from '../src/components/database-section';
 import type { DatabaseInfo } from '../src/hooks/use-database-info';
+import type { RunLogUsage } from '../src/hooks/use-run-log-compaction';
 import { queryKeys } from '../src/lib/query-keys';
 import { renderApp } from './helpers/render';
 
 // Full-route render against the real in-process backend: the embedded variant
-// is what a test server actually runs, and placement (before the Version
-// section) is part of the requirement.
-test('general settings shows the embedded database card just before the Version section', async () => {
-	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+// is what a test server actually runs, on the dedicated Storage subpage.
+test('storage subpage shows the embedded database card', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/settings/storage' });
 
 	// findByTestId auto-waits — anchor on the data-driven rows so the query has
 	// resolved before asserting content.
@@ -18,19 +19,33 @@ test('general settings shows the embedded database card just before the Version 
 	expect(backend.textContent).toBe('Embedded (PGlite)');
 	const display = await findByTestId('settings-database-display');
 	expect(display.textContent).toContain('pgdata');
-
-	const section = await findByTestId('settings-database');
-	const version = await findByTestId('settings-version');
-	// The Database section renders BEFORE the Version section.
-	expect(section.compareDocumentPosition(version) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
+
+/** A zero-usage payload — no run logs, nothing compactable, no pass running. */
+function emptyUsage(backend: 'embedded' | 'external'): RunLogUsage {
+	return {
+		backend,
+		database_bytes: backend === 'embedded' ? 4096 : null,
+		run_log_bytes: 0,
+		run_count: 0,
+		reclaimable_bytes: 0,
+		compactable_run_count: 0,
+		older_than_days: DEFAULT_LOG_COMPACTION_RETENTION_DAYS,
+		compaction: null,
+		last: null,
+	};
+}
 
 // Isolated-component render with a seeded cache — no real external Postgres or
 // on-disk snapshots needed, and it proves the client renders exactly the
 // pre-redacted string it was given (no reveal affordance, no raw URL).
 function renderCard(
 	info: DatabaseInfo,
-	opts: { superuser?: boolean; superseded?: { count: number; bytes: number } } = {},
+	opts: {
+		superuser?: boolean;
+		superseded?: { count: number; bytes: number };
+		usage?: RunLogUsage;
+	} = {},
 ) {
 	// staleTime: Infinity keeps the seeded cache authoritative — the file-level
 	// renderApp beforeEach reroutes fetch into the real in-process backend, and
@@ -41,6 +56,11 @@ function renderCard(
 	qc.setQueryData(queryKeys.me(), { type: 'admin', is_superuser: opts.superuser ?? true });
 	qc.setQueryData(queryKeys.databaseInfo(), info);
 	if (opts.superseded) qc.setQueryData(queryKeys.supersededData(), opts.superseded);
+	// Seed the usage query so the mounted component doesn't fetch it live.
+	qc.setQueryData(
+		queryKeys.runLogUsage(DEFAULT_LOG_COMPACTION_RETENTION_DAYS),
+		opts.usage ?? emptyUsage(info.backend),
+	);
 	return render(
 		<QueryClientProvider client={qc}>
 			<DatabaseSection />
@@ -118,4 +138,95 @@ test('no prune control for external Postgres', () => {
 		display: 'postgres://••••:••••@h/db',
 	});
 	expect(queryByTestId('settings-database-superseded')).toBeNull();
+});
+
+// ── Run-log compaction ──────────────────────────────────────────────────────
+
+function usageWith(overrides: Partial<RunLogUsage>): RunLogUsage {
+	return { ...emptyUsage('embedded'), ...overrides };
+}
+
+test('embedded card shows the database size + run-log readout', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{
+			usage: usageWith({
+				database_bytes: 2_500_000_000,
+				run_log_bytes: 1_100_000_000,
+				run_count: 1333,
+			}),
+		},
+	);
+	const dbSize = await findByTestId('settings-db-size');
+	expect(dbSize.textContent).toContain('2.3 GB');
+	const logSize = await findByTestId('settings-run-log-size');
+	expect(logSize.textContent).toContain('1.0 GB');
+	expect(logSize.textContent).toContain('1,333');
+});
+
+test('reclaimable estimate + trim count show for the chosen window', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ usage: usageWith({ reclaimable_bytes: 1_073_741_824, compactable_run_count: 900 }) },
+	);
+	const line = await findByTestId('settings-compact-reclaimable');
+	expect(line.textContent).toContain('1.0 GB');
+	expect(line.textContent).toContain('trims 900 runs');
+});
+
+test('embedded can still reclaim bloat when nothing is old enough to trim', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ usage: usageWith({ reclaimable_bytes: 800_000_000, compactable_run_count: 0 }) },
+	);
+	// The button stays enabled (VACUUM reclaims bloat regardless of run age)...
+	const button = (await findByTestId('settings-compact-button')) as HTMLButtonElement;
+	expect(button.disabled).toBe(false);
+	// ...and the copy says so.
+	const line = await findByTestId('settings-compact-reclaimable');
+	expect(line.textContent).toContain('reclaims storage bloat');
+});
+
+test('external Postgres with nothing to trim disables the button', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'external', display: 'postgres://••••:••••@h/db' },
+		{ usage: usageWith({ backend: 'external', database_bytes: null, compactable_run_count: 0 }) },
+	);
+	const button = (await findByTestId('settings-compact-button')) as HTMLButtonElement;
+	expect(button.disabled).toBe(true);
+});
+
+test('the compact button opens a confirm dialog explaining what is kept', async () => {
+	const { findByTestId, findByText } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{ usage: usageWith({ reclaimable_bytes: 500_000_000, compactable_run_count: 120 }) },
+	);
+	fireEvent.click(await findByTestId('settings-compact-button'));
+	await findByText('Compact run logs older than 30 days?');
+	// Phrases unique to the dialog (the help paragraph is worded differently), so
+	// findByText resolves to a single element.
+	await findByText(/full command that launched each run is kept/);
+	await findByText(/clearly marked as compacted, and status/);
+	await findByText(/permanently discarded and can.t be recovered/);
+});
+
+test('while a pass is running the button is disabled and progress shows', async () => {
+	const { findByTestId } = renderCard(
+		{ backend: 'embedded', display: '/root/.hezo/pgdata' },
+		{
+			usage: usageWith({
+				compaction: {
+					started_at: new Date().toISOString(),
+					older_than_days: 30,
+					total: 2740,
+					processed: 1200,
+					bytes_reclaimed: 640_000_000,
+				},
+			}),
+		},
+	);
+	const button = (await findByTestId('settings-compact-button')) as HTMLButtonElement;
+	expect(button.disabled).toBe(true);
+	const progress = await findByTestId('settings-compact-progress');
+	expect(progress.textContent).toContain('1,200 / 2,740 runs');
 });

--- a/packages/web/test/settings-storage.test.tsx
+++ b/packages/web/test/settings-storage.test.tsx
@@ -3,10 +3,9 @@ import { renderApp } from './helpers/render';
 
 // Full-route render against the real in-process backend: the embedded/local
 // variants are what a test server actually runs. Asserts the two cards share a
-// single "Storage" split view, each carries a storage-type icon, and the whole
-// section sits just before the Version section.
-test('general settings shows database + asset storage as one split view before Version', async () => {
-	const { findByTestId, findByRole } = await renderApp({ initialPath: '/settings' });
+// single "Storage" split view on the dedicated Storage subpage.
+test('storage subpage shows database + asset storage as one split view', async () => {
+	const { findByTestId, findByRole } = await renderApp({ initialPath: '/settings/storage' });
 
 	// findByTestId auto-waits — anchor on the data-driven rows so both queries
 	// have resolved before asserting layout.
@@ -15,20 +14,17 @@ test('general settings shows database + asset storage as one split view before V
 	const assetBackend = await findByTestId('settings-asset-storage-backend');
 	expect(assetBackend.textContent).toBe('Local filesystem');
 
-	// One shared "Storage" heading now fronts both cards.
+	// One shared "Storage" heading fronts both cards.
 	await findByRole('heading', { name: 'Storage' });
 
 	const section = await findByTestId('settings-storage');
 	const database = await findByTestId('settings-database');
 	const asset = await findByTestId('settings-asset-storage');
-	const version = await findByTestId('settings-version');
 
-	// Both cards live inside the single Storage section...
+	// Both cards live inside the single Storage section, database before asset.
 	expect(section.contains(database)).toBe(true);
 	expect(section.contains(asset)).toBe(true);
-	// ...database before asset storage, and the section before Version.
 	expect(database.compareDocumentPosition(asset) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-	expect(section.compareDocumentPosition(version) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
 	// Each card renders an icon standing in for its storage type.
 	expect(database.querySelector('svg')).not.toBeNull();


### PR DESCRIPTION
## What & why

Agent run logs (`heartbeat_runs.log_text`) are the largest thing in a busy instance's database. Because each is a large blob stored out-of-line in TOAST, and the streaming log flusher rewrites the *whole* log on every flush, old runs also leave heavy dead-tuple bloat that only a `VACUUM (FULL)` returns to disk (observed: ~1.1 GB relation for ~25 MB of live data). There was no way to reclaim any of it.

This adds **run-log compaction**: a superuser control that trims the logs of old, finished runs down to the part that still matters and reclaims the freed disk — on a new dedicated **Settings → Storage** subpage, with a live database-size readout so the effect is visible.

> Note: this addresses the **symptom** (reclaim + trim). The **root cause** (the O(n²) whole-log rewrites) is being fixed separately by moving to append-only log storage; this feature works regardless of how logs are stored going forward.

## What it does

- **Trims** each old, finished, TOASTed run's log to: a clear "this log has been compacted" notice, the **full command that launched the run** (`invocation_command`, re-prepended since the log head is trimmed away), and the trailing slice (the agent's end-of-run summary + `[done] … tokens=… cost=…` line). Status, timing, tokens, and cost are untouched; runs newer than the chosen window are left alone.
- **Marks** each trimmed run via `heartbeat_runs.log_compacted_at` (migration `040` + partial index `idx_runs_compaction`), so it's never re-scanned.
- **Runs in the background**, a bounded batch at a time, via a guarded `log-compaction` cron (a manual kick and the scheduled tick never overlap). The `log_compaction:active` `system_meta` marker doubles as the "in progress" flag the panel's button disables on.
- **Reclaims disk**: when the backlog drains, runs `VACUUM (FULL, ANALYZE) heartbeat_runs` on the **embedded** backend — reclaiming dead-tuple bloat across *all* runs, not just the trimmed ones — and records the real bytes freed. External Postgres is left to autovacuum (no heavy lock the operator didn't ask for). Because the bloat dominates, embedded can reclaim even when nothing is old enough to trim.
- Irreversible, so the UI **confirms first**.

## Changes

**Server**
- `migrations/040_run_log_compaction.sql` (+ data-preservation test): `log_compacted_at` marker + partial index.
- `services/log-compaction.ts`: `computeCompactedLog` (pure), batch/estimate/usage queries (cheap metadata — `pg_database_size`/`pg_total_relation_size`, no detoast on the polling path), the guarded drain tick, and `VACUUM` reclaim.
- `routes/database-info.ts`: `GET /database-info/run-log-usage` (live sizes + status) and `POST /database-info/compact-run-logs` (start a pass) — both `requireSuperuser`, 409 if one is already running.
- `job-manager.ts` / `startup.ts`: registers the `log-compaction` cron + `kickLogCompaction`, threads the storage backend through.
- `@hezo/shared`: retention + preserved-tail constants.

**Web**
- `use-run-log-compaction.ts`: usage query (polls while a pass runs) + start mutation.
- `database-section.tsx`: size readout + compaction control + confirm dialog, above a full-width divider and #813's snapshot prune (which moved below).
- **Storage moved to its own `/settings/storage` subpage** (new route + sidebar item), off the General settings page.

**Docs**
- `docs/concepts/your-data.md`: new compaction section; fixed the Settings-location references to the new Storage subpage.
- `.dev/architecture.md`: new *Run-log compaction* paragraph.

## Testing

- Server: `test/log-compaction.test.ts` (pure trim logic; batch selects only old/finished/TOASTed/uncompacted runs and leaves the rest; idempotent; drain clears the marker + records the last pass; route shape, superuser gate, 409) and `test/migrate-040-*.test.ts`.
- Web: `settings-database.test.tsx` (size readout, reclaimable estimate, embedded-reclaims-bloat-with-nothing-to-trim, external-disabled, confirm dialog copy, in-progress disabled + progress) and updated `settings-storage`/`settings-asset-storage` for the subpage.
- `bun run typecheck` and `bun run check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QqL6KAfMrjJfD2YA8HJMx

---
_Generated by [Claude Code](https://claude.ai/code/session_018QqL6KAfMrjJfD2YA8HJMx)_