### PR TITLE
feat: append-only run-log chunk storage to eliminate TOAST write-amplification

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -833,9 +833,16 @@ stay on fetch. Before that exec it
 the cached `container_status`: a container pruned externally or lost to a Docker restart is
 reconciled (status flipped, `container_id` nulled, project update broadcast) and the run
 fails fast with a clear message rather than tripping over a raw 404 mid-exec. It captures
-interleaved stdout/stderr into `log_text` (recorded in full, `[stderr]`-prefixed, with a
-10 MB runaway-output backstop) and
-broadcasts the same stream live over the `project-runs:<projectId>` WebSocket room.
+interleaved stdout/stderr (recorded in full, `[stderr]`-prefixed, with a 10 MB
+runaway-output backstop) into **append-only log chunks**: the debounced flusher
+(`services/log-stream-broker.ts`) persists only the text appended since the last successful
+flush as an INSERT into `heartbeat_run_log_chunks` (`db/run-log-chunks.ts`), serialized
+per stream so overlapping flushes can never duplicate a delta, with the running token/cost
+snapshot updated on `heartbeat_runs` in the same transaction. Readers concatenate the
+chunks (`string_agg` ordered by `seq`) back into the API's `log_text` field. INSERT-only
+writes replaced the old whole-blob `UPDATE heartbeat_runs.log_text` pattern, whose per-flush
+dead TOAST copies were the dominant source of database bloat. The same stream broadcasts
+live over the `project-runs:<projectId>` WebSocket room from the in-memory buffer.
 
 **System prompt composition.** The agent's stored template (its `agent_system_prompt`
 document, loaded from its **home** team) is resolved per run by
@@ -873,8 +880,9 @@ the project Custom Prompt (MCP or REST) — files a team-coherence review via
 knows what changed and why the review was triggered — regardless of who made the change (agent or
 admin).
 
-**Run logs to MCP.** A run's `log_text` is readable through the read-only `list_task_runs` (per-task
-run metadata) and `get_run_log` (one run's log tail, capped by `excerpt_chars`) MCP tools, team-scoped
+**Run logs to MCP.** A run's log (concatenated from its chunks, still a `log_text` string on the
+wire) is readable through the read-only `list_task_runs` (per-task run metadata) and `get_run_log`
+(one run's log tail, capped by `excerpt_chars`) MCP tools, team-scoped
 like any other resource. The Coach's post-task review prompt (`buildCoachReviewPrompt`) injects a
 compact **Agent Runs** summary alongside the comment history and directs the Coach to pull a specific
 run's log when the comments don't explain a struggle.
@@ -1903,25 +1911,31 @@ migration leaves the committed prefix intact. A database carrying migrations the
 doesn't recognize makes the server exit and ask the operator to upgrade. Migration
 mechanics and the per-migration rules are in `AGENTS.md` › Database migrations.
 
-**Run-log compaction.** `heartbeat_runs.log_text` (one verbose per-run blob, stored
-out-of-line in TOAST) is the largest thing in a busy instance's DB, and the streaming
-flusher's repeated whole-log rewrites leave heavy dead-tuple bloat that only a `VACUUM
-(FULL)` returns to the OS. A superuser triggers compaction from the Database card on the
-Storage settings subpage: `POST /api/database-info/compact-run-logs {older_than_days}` writes
-a `log_compaction:active` marker in `system_meta` (also the "in progress" flag the panel's
-button disables on) and kicks the drain. The `log-compaction` cron
-(`services/log-compaction.ts`, guarded so a manual kick and the scheduled tick never overlap)
-drains the backlog a bounded batch at a time — trimming each old, finished, TOASTed run's log
-to its tail (a "compacted" notice + the run's `invocation_command` + the end-of-run
-summary/`[done]` line) and stamping `log_compacted_at` (migration `040`, partial index
-`idx_runs_compaction`). When the backlog drains it runs `VACUUM (FULL, ANALYZE)
-heartbeat_runs` on the **embedded** backend (reclaiming bloat across *all* runs, not just the
-trimmed ones — external Postgres is left to autovacuum), records the real bytes freed in
-`log_compaction:last`, and clears the marker. `GET /api/database-info/run-log-usage` reports
-live sizes (`pg_database_size`, `pg_total_relation_size` — cheap, no detoast) plus the
+**Run-log compaction.** Run logs (the append-only `heartbeat_run_log_chunks` table, kept
+forever) are the largest thing in a busy instance's DB; compaction is the retention trim
+that keeps old runs' logs down to what still matters. A superuser triggers it from the
+Database card on the Storage settings subpage: `POST /api/database-info/compact-run-logs
+{older_than_days}` writes a `log_compaction:active` marker in `system_meta` (also the "in
+progress" flag the panel's button disables on) and kicks the drain. The `log-compaction`
+cron (`services/log-compaction.ts`, guarded so a manual kick and the scheduled tick never
+overlap) drains the backlog a bounded batch at a time — replacing each old, finished,
+large-enough run's chunks with a single compacted chunk (a "compacted" notice + the run's
+`invocation_command` + the end-of-run summary/`[done]` line) and stamping
+`log_compacted_at` (migration `040`, partial index `idx_runs_compaction`; eligibility
+filters on the summed `pg_column_size` of the run's chunks). When the backlog drains it
+runs `VACUUM (FULL, ANALYZE)` over both run tables on the **embedded** backend — the chunk
+table (compaction's DELETEs) and `heartbeat_runs` (the flusher's per-flush usage UPDATEs;
+PGlite has no autovacuum daemon — external Postgres is left to autovacuum) — records the
+real bytes freed in `log_compaction:last`, and clears the marker.
+`GET /api/database-info/run-log-usage` reports live sizes (`pg_database_size`,
+`pg_total_relation_size` over both tables — cheap, no detoast) plus the
 reclaimable/backlog estimate and status for the panel, embedded-only figures degrading to
 null/0 elsewhere. Deploy-time knobs: `HEZO_LOG_COMPACTION_CRON`, `_BATCH`, `_MAX_PER_TICK`,
 `_PRESERVED_BYTES`. The trimmed detail is unrecoverable, so the UI confirms first.
+Migration `041` (which moved logs from the old `heartbeat_runs.log_text` blob into chunks
+and dropped the column) leaves the legacy dead-TOAST graveyard behind — a one-time,
+marker-gated `VACUUM (FULL, ANALYZE) heartbeat_runs` at startup
+(`runLegacyRunLogVacuumOnce`, embedded only) reclaims it on the first post-upgrade boot.
 
 **Storage abstraction & transactions.** All app code takes the `Db` interface
 (`query`/`exec`/`transaction`/`acquireSessionLock`/`close`); the drivers live in
@@ -1988,7 +2002,8 @@ row (bytea → base64, generated tsvector columns excluded and recomputed on loa
 queries and restore inserts are batched by **bytes** as well as rows
 (`dumpPageRows`/`planInsertBatches`): each table's page size derives from its measured
 uncompressed row sizes, keeping every protocol message far below the embedded engine's
-~16MB per-response ceiling — which a large-log table (`heartbeat_runs.log_text`) would
+~16MB per-response ceiling — which a large-log table (`heartbeat_run_log_chunks`, whose
+legacy-migrated rows can each carry a whole multi-MB run log) would
 otherwise breach in a single flat-size page and hard-crash the WASM instance. The
 subcommands' teardown closes are best-effort (`closeQuietly` in `cli.ts`), so closing an
 already-crashed engine can never mask the original dump/restore error.

--- a/packages/server/migrations/041_run_log_chunks.sql
+++ b/packages/server/migrations/041_run_log_chunks.sql
@@ -1,0 +1,26 @@
+-- Append-only run-log chunk storage. The streaming log flusher used to rewrite
+-- the ENTIRE accumulated `heartbeat_runs.log_text` blob every debounce tick;
+-- under MVCC each rewrite left a full dead TOAST copy behind, so a
+-- linearly-growing log wrote O(n²) bytes and bloated the database (~98% dead
+-- space measured on busy instances). Logs now live in this child table as
+-- ordered chunks: the flusher INSERTs only the text appended since the last
+-- flush, and readers concatenate with `string_agg(content ORDER BY seq)`.
+-- INSERT-only means no UPDATE-driven TOAST orphaning at all — O(n) bytes
+-- written per run.
+--
+-- Data-preserving: every existing run's log is carried over as a single seq-0
+-- chunk before the old column is dropped. The drop itself is metadata-only;
+-- the legacy dead TOAST space is reclaimed by a one-time startup VACUUM (see
+-- runLegacyRunLogVacuumOnce in src/db/run-log-chunks.ts).
+CREATE TABLE heartbeat_run_log_chunks (
+    run_id     UUID NOT NULL REFERENCES heartbeat_runs(id) ON DELETE CASCADE,
+    seq        INTEGER NOT NULL,
+    content    TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (run_id, seq)
+);
+
+INSERT INTO heartbeat_run_log_chunks (run_id, seq, content)
+SELECT id, 0, log_text FROM heartbeat_runs WHERE log_text <> '';
+
+ALTER TABLE heartbeat_runs DROP COLUMN log_text;

--- a/packages/server/src/db/run-log-chunks.ts
+++ b/packages/server/src/db/run-log-chunks.ts
@@ -1,0 +1,153 @@
+/**
+ * Append-only run-log chunk storage (`heartbeat_run_log_chunks`). A run's log
+ * is a sequence of ordered text chunks: the streaming flusher INSERTs only the
+ * delta appended since the last successful flush, and readers concatenate with
+ * `string_agg(content ORDER BY seq)`. INSERT-only writes leave no dead TOAST
+ * copies behind, unlike the old whole-blob `UPDATE heartbeat_runs.log_text`
+ * pattern that wrote O(n²) bytes over a run's lifetime.
+ *
+ * Every SQL surface that used to read `hr.log_text` now embeds the fragments
+ * built here, keeping the wire shape (a `log_text` string) unchanged.
+ */
+
+import type { StorageBackend } from '../lib/db-info';
+import { getSystemMeta, setSystemMeta } from '../lib/system-meta';
+import { logger } from '../logger';
+import type { Db, Queryable } from './database';
+
+const log = logger.child('run-log-chunks');
+
+/**
+ * Upper bound on a single chunk row's content. A normal debounced flush is a
+ * few KB; this only bites on pathological bursts, keeping any one row far
+ * below the ~16MB single-protocol-message limit embedded PGlite can crash on
+ * (see db/logical-backup.ts) and letting the byte-paged backup batch rows
+ * sanely.
+ */
+export const MAX_RUN_LOG_CHUNK_CHARS = 1_000_000;
+
+/**
+ * SQL fragment: the run's full log text, concatenated from its chunks. The
+ * COALESCE mirrors the old column's `NOT NULL DEFAULT ''` — a run with no
+ * chunks reads as the empty string, never NULL.
+ */
+export function runLogTextSql(runIdExpr = 'hr.id'): string {
+	return `(SELECT COALESCE(string_agg(c.content, '' ORDER BY c.seq), '')
+		FROM heartbeat_run_log_chunks c WHERE c.run_id = ${runIdExpr})`;
+}
+
+/**
+ * SQL fragment: the run's total log length in characters. `::int` keeps the
+ * JSON serialization a number — a bare int8 SUM comes back as a string.
+ */
+export function runLogLengthSql(runIdExpr = 'hr.id'): string {
+	return `COALESCE((SELECT SUM(length(c.content))::int
+		FROM heartbeat_run_log_chunks c WHERE c.run_id = ${runIdExpr}), 0)`;
+}
+
+/**
+ * SQL fragment: the run's stored (compressed, on-disk) log size in bytes,
+ * summed over its chunks. The compaction pass filters on this — cheap, no
+ * detoast of the content itself.
+ */
+export function runLogStoredBytesSql(runIdExpr = 'hr.id'): string {
+	return `COALESCE((SELECT SUM(pg_column_size(c.content))::bigint
+		FROM heartbeat_run_log_chunks c WHERE c.run_id = ${runIdExpr}), 0)`;
+}
+
+/** Read one run's full log text (concatenated chunks). */
+export async function readRunLogText(q: Queryable, runId: string): Promise<string> {
+	const r = await q.query<{ log_text: string }>(
+		`SELECT COALESCE(string_agg(content, '' ORDER BY seq), '') AS log_text
+		 FROM heartbeat_run_log_chunks WHERE run_id = $1`,
+		[runId],
+	);
+	return r.rows[0]?.log_text ?? '';
+}
+
+/**
+ * Append `text` to a run's log as one or more chunk rows (split at
+ * `MAX_RUN_LOG_CHUNK_CHARS`). Sequence numbers continue from the stored
+ * maximum, so appends survive process restarts without any in-memory counter.
+ * The single-writer-per-run guarantee (the log broker serializes flushes per
+ * stream) makes MAX+1 race-free. Callers that must commit the append together
+ * with other writes pass their transaction handle.
+ */
+export async function appendRunLogChunks(q: Queryable, runId: string, text: string): Promise<void> {
+	if (text.length === 0) return;
+	const next = await q.query<{ next_seq: number }>(
+		'SELECT COALESCE(MAX(seq), -1) + 1 AS next_seq FROM heartbeat_run_log_chunks WHERE run_id = $1',
+		[runId],
+	);
+	let seq = Number(next.rows[0]?.next_seq ?? 0);
+	for (let offset = 0; offset < text.length; offset += MAX_RUN_LOG_CHUNK_CHARS) {
+		await q.query(
+			'INSERT INTO heartbeat_run_log_chunks (run_id, seq, content) VALUES ($1, $2, $3)',
+			[runId, seq, text.slice(offset, offset + MAX_RUN_LOG_CHUNK_CHARS)],
+		);
+		seq += 1;
+	}
+}
+
+/**
+ * Replace a run's entire log with a single seq-0 chunk (compaction). Only ever
+ * called for terminal runs, so no live flusher can collide with the sequence
+ * reset. Run inside the caller's transaction so the delete+insert is atomic.
+ */
+export async function replaceRunLog(tx: Queryable, runId: string, content: string): Promise<void> {
+	await tx.query('DELETE FROM heartbeat_run_log_chunks WHERE run_id = $1', [runId]);
+	await tx.query('INSERT INTO heartbeat_run_log_chunks (run_id, seq, content) VALUES ($1, 0, $2)', [
+		runId,
+		content,
+	]);
+}
+
+export const LEGACY_RUN_LOG_VACUUM_KEY = 'run_log_chunks:legacy_vacuum_done';
+
+/**
+ * One-time reclaim of the disk space the pre-chunk write pattern left behind.
+ * Migration 041 drops `heartbeat_runs.log_text`, but a column drop is
+ * metadata-only — the dead TOAST graveyard (routinely ~98% of the table's
+ * on-disk size) stays until a VACUUM FULL rewrites the table. Runs once per
+ * instance, marker-gated: on the embedded backend it VACUUMs `heartbeat_runs`
+ * (with a plain-VACUUM fallback, same posture as reclaimRunLogSpace); on
+ * external Postgres it only sets the marker — a VACUUM FULL takes an exclusive
+ * lock the operator did not ask for, and autovacuum reuses the space. The
+ * marker is set only after success so a failed attempt retries next boot.
+ */
+export async function runLegacyRunLogVacuumOnce(db: Db, backend: StorageBackend): Promise<void> {
+	const done = await getSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY);
+	if (done !== null) return;
+	if (backend === 'embedded') {
+		const before = await relationBytes(db);
+		try {
+			await db.query('VACUUM (FULL, ANALYZE) heartbeat_runs');
+		} catch (fullErr) {
+			try {
+				await db.query('VACUUM (ANALYZE) heartbeat_runs');
+			} catch (plainErr) {
+				log.warn('One-time legacy run-log VACUUM failed; will retry next startup', {
+					fullError: fullErr instanceof Error ? fullErr.message : String(fullErr),
+					plainError: plainErr instanceof Error ? plainErr.message : String(plainErr),
+				});
+				return;
+			}
+		}
+		const after = await relationBytes(db);
+		log.info(
+			`One-time reclaim of legacy run-log space: freed ~${Math.max(0, Math.round((before - after) / 1024))} KB`,
+		);
+	}
+	await setSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY, new Date().toISOString());
+}
+
+async function relationBytes(db: Db): Promise<number> {
+	try {
+		const r = await db.query<{ b: string }>(
+			`SELECT pg_total_relation_size('heartbeat_runs')::bigint AS b`,
+		);
+		return Number(r.rows[0]?.b ?? 0);
+	} catch {
+		return 0;
+	}
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -50,6 +50,7 @@ import { LocalAssetStore } from '../assets/drivers/local';
 import type { AssetStore } from '../assets/store';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { Db } from '../db/database';
+import { runLogLengthSql, runLogTextSql } from '../db/run-log-chunks';
 import type { DomainEventBus } from '../events/bus';
 import { assertNoActiveRun } from '../lib/active-run';
 import { isHqInstanceAgent, isVirtualHqMemberInTeam } from '../lib/agent-roles';
@@ -2455,7 +2456,7 @@ export function registerTools(
 			const { teamId, taskId } = scope;
 			const r = await db.query<Record<string, unknown>>(
 				`SELECT hr.id, hr.status, hr.exit_code, hr.started_at, hr.finished_at,
-				        hr.invocation_command, length(hr.log_text) AS log_length,
+				        hr.invocation_command, ${runLogLengthSql('hr.id')} AS log_length,
 				        ma.title AS agent_title, ma.slug AS agent_slug
 				 FROM heartbeat_runs hr
 				 LEFT JOIN member_agents ma ON ma.id = hr.member_id
@@ -2497,7 +2498,8 @@ export function registerTools(
 				task_id: string | null;
 				log_text: string;
 			}>(
-				`SELECT id, status, exit_code, task_id, log_text
+				`SELECT id, status, exit_code, task_id,
+				        ${runLogTextSql('heartbeat_runs.id')} AS log_text
 				 FROM heartbeat_runs WHERE id = $1 AND team_id = $2`,
 				[runId, scope.teamId],
 			);

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -29,6 +29,7 @@ import {
 import { type Context, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import type { Db } from '../db/database';
+import { runLogTextSql } from '../db/run-log-chunks';
 import { trackBackground } from '../lib/background';
 import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast';
 import { budgetWindowsError } from '../lib/budget-validation';
@@ -144,7 +145,7 @@ async function withAgentIconUrl(
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id, hr.kind,
 	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
 	hr.input_tokens, hr.output_tokens, hr.cost_cents, hr.usage_partial,
-	hr.invocation_command, hr.log_text, hr.working_dir,
+	hr.invocation_command, ${runLogTextSql('hr.id')} AS log_text, hr.working_dir,
 	hr.process_pid, hr.retry_of_run_id, hr.process_loss_retry_count,
 	i.identifier AS task_identifier, i.title AS task_title,
 	i.project_id AS project_id, p.slug AS project_slug, p.name AS project_name,

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -1,6 +1,7 @@
 import { AuthType, TaskStatus, TERMINAL_TASK_STATUSES, WakeupSource, wsRoom } from '@hezo/shared';
 import { type Context, Hono } from 'hono';
 import type { Db } from '../db/database';
+import { runLogTextSql } from '../db/run-log-chunks';
 import { assertNoActiveRun } from '../lib/active-run';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
@@ -426,7 +427,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId/latest-run', async (c) => {
 
 	const result = await db.query(
 		`SELECT hr.id, hr.member_id, hr.status, hr.started_at, hr.finished_at,
-		        hr.exit_code, hr.log_text, hr.invocation_command, hr.working_dir,
+		        hr.exit_code, ${runLogTextSql('hr.id')} AS log_text, hr.invocation_command, hr.working_dir,
 		        i.project_id AS project_id,
 		        ma.title AS agent_title, ma.slug AS agent_slug
 		 FROM heartbeat_runs hr

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -32,6 +32,7 @@ import {
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { Db } from '../db/database';
+import { appendRunLogChunks, runLogLengthSql } from '../db/run-log-chunks';
 import type { DomainEventBus } from '../events/bus';
 import { signAgentAssetUrl } from '../lib/asset-urls';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
@@ -924,8 +925,8 @@ export async function runAgent(
 	const streamId = `run:${heartbeatRunId}`;
 
 	// Latest running token usage, refreshed from the parser on every exec chunk.
-	// Flushed to the row alongside log_text (below) so that whatever the run has
-	// burned so far survives a crash — reconcileOnStartup never overwrites these
+	// Persisted on every log flush (below) so that whatever the run has burned
+	// so far survives a crash — reconcileOnStartup never overwrites these
 	// columns, so the last snapshot is what a restart-failed run reports.
 	let currentUsage: AgentRunUsage | null = null;
 
@@ -949,32 +950,34 @@ export async function runAgent(
 			text,
 			replace: true,
 		}),
-		onFlush: async (text) => {
-			// Persist the running usage with the log so a crash mid-run still leaves a
-			// non-zero token/cost snapshot, flagged partial until a clean completion.
-			if (currentUsage) {
-				await deps.db.query(
-					`UPDATE heartbeat_runs
-					 SET log_text = $1,
-					     input_tokens = COALESCE($2, input_tokens),
-					     output_tokens = COALESCE($3, output_tokens),
-					     cost_cents = COALESCE($4, cost_cents),
-					     usage_partial = true
-					 WHERE id = $5`,
-					[
-						text,
-						currentUsage.inputTokens,
-						currentUsage.outputTokens,
-						currentUsage.costCents,
-						heartbeatRunId,
-					],
-				);
-			} else {
-				await deps.db.query('UPDATE heartbeat_runs SET log_text = $1 WHERE id = $2', [
-					text,
-					heartbeatRunId,
-				]);
-			}
+		onFlush: async (delta) => {
+			// Append only the new log text as a chunk row (never rewrite the whole
+			// log — the old full-blob UPDATE pattern left a dead TOAST copy per
+			// flush). The running usage persists alongside so a crash mid-run still
+			// leaves a non-zero token/cost snapshot, flagged partial until a clean
+			// completion. One transaction: the broker re-sends the same delta after
+			// a failed flush, so chunk + usage must land all-or-nothing to stay
+			// exactly-once.
+			if (delta.length === 0 && !currentUsage) return;
+			await deps.db.transaction(async (tx) => {
+				if (delta.length > 0) await appendRunLogChunks(tx, heartbeatRunId, delta);
+				if (currentUsage) {
+					await tx.query(
+						`UPDATE heartbeat_runs
+						 SET input_tokens = COALESCE($1, input_tokens),
+						     output_tokens = COALESCE($2, output_tokens),
+						     cost_cents = COALESCE($3, cost_cents),
+						     usage_partial = true
+						 WHERE id = $4`,
+						[
+							currentUsage.inputTokens,
+							currentUsage.outputTokens,
+							currentUsage.costCents,
+							heartbeatRunId,
+						],
+					);
+				}
+			});
 		},
 	});
 
@@ -2505,7 +2508,7 @@ async function loadRunSummaries(db: Db, taskId: string, teamId: string): Promise
 		agent_slug: string | null;
 	}>(
 		`SELECT hr.id, hr.status, hr.exit_code, hr.started_at,
-		        length(hr.log_text) AS log_length,
+		        ${runLogLengthSql('hr.id')} AS log_length,
 		        ma.title AS agent_title, ma.slug AS agent_slug
 		 FROM heartbeat_runs hr
 		 LEFT JOIN member_agents ma ON ma.id = hr.member_id

--- a/packages/server/src/services/log-buffer.ts
+++ b/packages/server/src/services/log-buffer.ts
@@ -4,6 +4,13 @@
  * `[stderr] ` prefix so the persisted log preserves stream provenance when later
  * replayed as plain text — the prefix sits at the start of its own line so the
  * reader can strip it back off cleanly.
+ *
+ * INVARIANT: `toString()` is prefix-stable — every earlier `toString()` result
+ * is a strict prefix of every later one. Parts are append-only, and the
+ * truncation marker is appended exactly once at the cap, after which `append()`
+ * is a no-op. The log broker's delta flushing (log-stream-broker.ts) slices new
+ * text off by a persisted character offset and silently corrupts persisted logs
+ * if this ever breaks.
  */
 export class CappedLogBuffer {
 	private bytes = 0;

--- a/packages/server/src/services/log-compaction.ts
+++ b/packages/server/src/services/log-compaction.ts
@@ -1,17 +1,16 @@
 /**
- * Agent run-log compaction. The biggest consumer of database size is
- * `heartbeat_runs.log_text` — one verbose per-run blob kept forever, stored out
- * of line in TOAST. Two things bloat it: the live text of old runs, and (much
- * larger) the dead TOAST tuples the streaming log flusher leaves behind. Only a
- * `VACUUM (FULL)` returns that dead space to the OS.
- *
- * Compaction addresses both: it trims the logs of old, finished runs down to the
- * part that still matters (the agent's end-of-run summary and the trailing
- * `[done] … tokens=… cost=…` line, both at the *end* of the blob), keeps the
+ * Agent run-log compaction — retention trimming of old runs' logs. Run logs
+ * live in the append-only `heartbeat_run_log_chunks` table (one INSERT per
+ * flush, concatenated on read — see src/db/run-log-chunks.ts), kept forever.
+ * Compaction trims the logs of old, finished runs down to the part that still
+ * matters (the agent's end-of-run summary and the trailing
+ * `[done] … tokens=… cost=…` line, both at the *end* of the log), keeps the
  * command that launched the run and a clear "compacted" notice, stamps
- * `log_compacted_at`, and — on the embedded backend — runs a `VACUUM (FULL)` at
- * the end of the pass so the on-disk size actually drops. The VACUUM reclaims
- * dead tuples across *all* runs, not just the trimmed ones.
+ * `log_compacted_at`, and — on the embedded backend — runs a `VACUUM (FULL)`
+ * at the end of the pass so the on-disk size actually drops (compaction's
+ * chunk DELETEs, and the flusher's small per-flush usage UPDATEs on
+ * `heartbeat_runs`, leave dead tuples PGlite has no autovacuum daemon to
+ * reuse).
  *
  * The work is incremental: a manual trigger writes the `log_compaction:active`
  * marker (with the chosen retention window), and the `log-compaction` cron job
@@ -27,6 +26,7 @@ import {
 	LOG_COMPACTION_RETENTION_MIN_DAYS,
 } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { replaceRunLog, runLogStoredBytesSql, runLogTextSql } from '../db/run-log-chunks';
 import type { StorageBackend } from '../lib/db-info';
 import { deleteSystemMeta, getSystemMeta, setSystemMeta } from '../lib/system-meta';
 import { logger } from '../logger';
@@ -46,9 +46,10 @@ const PRESERVED_BYTES = Number(
 );
 /**
  * A log is worth compacting once its stored (compressed) size crosses Postgres's
- * ~2KB TOAST threshold — i.e. once it lives out of line and contributes the
- * write-amplification bloat. Filtering on `pg_column_size` (the stored size)
- * rather than `length` avoids detoasting every row just to decide.
+ * ~2KB TOAST threshold — below that the whole log fits in line and trimming it
+ * saves nothing worth a rewrite. Filtering on summed `pg_column_size` (the
+ * stored size) rather than `length` avoids detoasting every chunk just to
+ * decide.
  */
 const TOAST_THRESHOLD_BYTES = 2000;
 
@@ -136,7 +137,8 @@ export function computeCompactedLog(
  * Cheap database-usage figures for the DB panel — all metadata/counts, no
  * detoast, so it stays fast even while a pass polls it every couple seconds.
  * `databaseBytes` is embedded-only; `runLogDiskBytes` is the on-disk footprint
- * of the run-logs table (main + TOAST + indexes + any bloat).
+ * of the run tables — `heartbeat_runs` plus the log-chunk table (main + TOAST
+ * + indexes + any bloat).
  */
 export async function getDatabaseUsage(
 	db: Db,
@@ -147,7 +149,8 @@ export async function getDatabaseUsage(
 	);
 	const runLogDiskBytes = await scalarBytes(
 		db,
-		`SELECT pg_total_relation_size('heartbeat_runs')::bigint AS b`,
+		`SELECT (pg_total_relation_size('heartbeat_runs')
+		       + pg_total_relation_size('heartbeat_run_log_chunks'))::bigint AS b`,
 	);
 	let databaseBytes: number | null = null;
 	if (backend === 'embedded') {
@@ -172,10 +175,11 @@ async function scalarBytes(db: Db, sql: string): Promise<number> {
 /**
  * What a compaction pass over the given window would do: how many old runs get
  * trimmed, and how much disk it would reclaim. On the embedded backend the
- * reclaim is table bloat (dead TOAST tuples) the pass's VACUUM returns — far
- * larger than the trimmed live text, and independent of the window. On external
- * Postgres nothing is VACUUMed (autovacuum reuses the space), so it reports 0.
- * The one full-table scan here runs only when idle (never on the polling path).
+ * reclaim is the chunk table's bloat (dead tuples from earlier compaction
+ * DELETEs and any storage overhead) the pass's VACUUM returns, independent of
+ * the window. On external Postgres nothing is VACUUMed (autovacuum reuses the
+ * space), so it reports 0. The one full-table scan here runs only when idle
+ * (never on the polling path).
  */
 export async function getCompactionEstimate(
 	db: Db,
@@ -183,11 +187,11 @@ export async function getCompactionEstimate(
 	olderThanDays: number,
 ): Promise<{ runCount: number; reclaimableBytes: number }> {
 	const counted = await db.query<{ c: string }>(
-		`SELECT COUNT(*)::bigint AS c FROM heartbeat_runs
-		 WHERE log_compacted_at IS NULL
-		   AND status IN ${TERMINAL_STATUS_SQL}
-		   AND pg_column_size(log_text) > $1
-		   AND created_at < now() - ($2 || ' days')::interval`,
+		`SELECT COUNT(*)::bigint AS c FROM heartbeat_runs hr
+		 WHERE hr.log_compacted_at IS NULL
+		   AND hr.status IN ${TERMINAL_STATUS_SQL}
+		   AND ${runLogStoredBytesSql('hr.id')} > $1
+		   AND hr.created_at < now() - ($2 || ' days')::interval`,
 		[TOAST_THRESHOLD_BYTES, String(olderThanDays)],
 	);
 	const runCount = Number(counted.rows[0]?.c ?? 0);
@@ -196,9 +200,9 @@ export async function getCompactionEstimate(
 	if (backend === 'embedded') {
 		try {
 			const bloat = await db.query<{ bloat: string }>(
-				`SELECT GREATEST(0, pg_total_relation_size('heartbeat_runs')
-				               - COALESCE(SUM(pg_column_size(log_text)), 0))::bigint AS bloat
-				 FROM heartbeat_runs`,
+				`SELECT GREATEST(0, pg_total_relation_size('heartbeat_run_log_chunks')
+				               - COALESCE(SUM(pg_column_size(content)), 0))::bigint AS bloat
+				 FROM heartbeat_run_log_chunks`,
 			);
 			reclaimableBytes = Number(bloat.rows[0]?.bloat ?? 0);
 		} catch {
@@ -219,13 +223,13 @@ export async function compactRunLogsBatch(
 ): Promise<{ processed: number; bytesReclaimed: number }> {
 	const limit = opts.limit ?? LOG_COMPACTION_BATCH;
 	const rows = await db.query<{ id: string; log_text: string; invocation_command: string | null }>(
-		`SELECT id, log_text, invocation_command
-		 FROM heartbeat_runs
-		 WHERE log_compacted_at IS NULL
-		   AND status IN ${TERMINAL_STATUS_SQL}
-		   AND pg_column_size(log_text) > $1
-		   AND created_at < now() - ($2 || ' days')::interval
-		 ORDER BY created_at ASC
+		`SELECT hr.id, ${runLogTextSql('hr.id')} AS log_text, hr.invocation_command
+		 FROM heartbeat_runs hr
+		 WHERE hr.log_compacted_at IS NULL
+		   AND hr.status IN ${TERMINAL_STATUS_SQL}
+		   AND ${runLogStoredBytesSql('hr.id')} > $1
+		   AND hr.created_at < now() - ($2 || ' days')::interval
+		 ORDER BY hr.created_at ASC
 		 LIMIT $3`,
 		[TOAST_THRESHOLD_BYTES, String(opts.olderThanDays), limit],
 	);
@@ -238,10 +242,8 @@ export async function compactRunLogsBatch(
 				invocationCommand: row.invocation_command,
 			});
 			bytesReclaimed += Math.max(0, row.log_text.length - compacted.length);
-			await tx.query(
-				`UPDATE heartbeat_runs SET log_text = $1, log_compacted_at = now() WHERE id = $2`,
-				[compacted, row.id],
-			);
+			await replaceRunLog(tx, row.id, compacted);
+			await tx.query(`UPDATE heartbeat_runs SET log_compacted_at = now() WHERE id = $1`, [row.id]);
 		}
 	});
 	return { processed: rows.rows.length, bytesReclaimed };
@@ -300,31 +302,38 @@ async function finishCompaction(db: Db, state: CompactionState): Promise<void> {
 }
 
 function runLogTableSize(db: Db): Promise<number> {
-	return scalarBytes(db, `SELECT pg_total_relation_size('heartbeat_runs')::bigint AS b`);
+	return scalarBytes(
+		db,
+		`SELECT (pg_total_relation_size('heartbeat_runs')
+		       + pg_total_relation_size('heartbeat_run_log_chunks'))::bigint AS b`,
+	);
 }
 
 /**
  * Reclaim the disk freed by trimming logs (and the dead-tuple bloat around it).
- * On the embedded database a `VACUUM (FULL)` rewrites the table and returns
+ * On the embedded database a `VACUUM (FULL)` rewrites the tables and returns
  * space to the OS so the DB size actually drops; on external Postgres it is left
  * to autovacuum (a VACUUM FULL there takes a heavy lock the operator did not ask
- * for). Returns the on-disk bytes actually freed. Best-effort: a VACUUM failure
- * is logged, not fatal — the logs are already trimmed.
+ * for). Both run-log tables are vacuumed: the chunk table (compaction's chunk
+ * DELETEs) and `heartbeat_runs` itself (the flusher's per-flush usage UPDATEs).
+ * Returns the on-disk bytes actually freed. Best-effort: a VACUUM failure is
+ * logged, not fatal — the logs are already trimmed.
  */
 export async function reclaimRunLogSpace(db: Db, backend: StorageBackend): Promise<number> {
 	if (backend !== 'embedded') return 0;
 	const before = await runLogTableSize(db);
-	try {
-		await db.query('VACUUM (FULL, ANALYZE) heartbeat_runs');
-	} catch (fullErr) {
+	for (const table of ['heartbeat_run_log_chunks', 'heartbeat_runs']) {
 		try {
-			await db.query('VACUUM (ANALYZE) heartbeat_runs');
-		} catch (plainErr) {
-			log.warn('VACUUM after compaction failed; space will be reused by autovacuum', {
-				fullError: fullErr instanceof Error ? fullErr.message : String(fullErr),
-				plainError: plainErr instanceof Error ? plainErr.message : String(plainErr),
-			});
-			return 0;
+			await db.query(`VACUUM (FULL, ANALYZE) ${table}`);
+		} catch (fullErr) {
+			try {
+				await db.query(`VACUUM (ANALYZE) ${table}`);
+			} catch (plainErr) {
+				log.warn(`VACUUM of ${table} after compaction failed; space stays unreclaimed`, {
+					fullError: fullErr instanceof Error ? fullErr.message : String(fullErr),
+					plainError: plainErr instanceof Error ? plainErr.message : String(plainErr),
+				});
+			}
 		}
 	}
 	const after = await runLogTableSize(db);

--- a/packages/server/src/services/log-stream-broker.ts
+++ b/packages/server/src/services/log-stream-broker.ts
@@ -1,6 +1,9 @@
+import { logger } from '../logger';
 import { CappedLogBuffer } from './log-buffer';
 import { splitLogLines } from './log-format';
 import type { WebSocketManager, WsEvent } from './ws';
+
+const log = logger.child('log-stream');
 
 export type LogStream = 'stdout' | 'stderr';
 
@@ -14,7 +17,17 @@ export interface LogStreamConfig {
 	room: string;
 	buildMessage: (line: LogLine) => WsEvent;
 	buildSnapshot: (text: string) => WsEvent;
-	onFlush?: (text: string) => Promise<void>;
+	/**
+	 * Persistence callback. Receives only the text appended since the last
+	 * SUCCESSFUL flush (the delta), so implementations append it — they must
+	 * never treat it as the whole log. A throw re-marks the stream dirty and the
+	 * same delta is re-sent on the next flush, so the callback must persist the
+	 * delta atomically (all-or-nothing) to stay exactly-once. An empty-string
+	 * delta is still delivered when the buffer is dirty-but-capped — callbacks
+	 * that piggyback other state (usage snapshots) on the flush cadence rely on
+	 * the call happening.
+	 */
+	onFlush?: (delta: string) => Promise<void>;
 	capBytes?: number;
 	debounceMs?: number;
 }
@@ -25,6 +38,10 @@ interface LogStreamEntry {
 	dirty: boolean;
 	flushTimer: ReturnType<typeof setTimeout> | null;
 	ended: boolean;
+	/** Chars of `buffer.toString()` already persisted by a successful onFlush. */
+	persistedChars: number;
+	/** Tail of the serialized flush chain — every flush awaits its predecessor. */
+	flushing: Promise<void> | null;
 }
 
 // Backstop against a runaway run flooding memory/DB — not a content truncation.
@@ -55,6 +72,8 @@ export class LogStreamBroker {
 			dirty: false,
 			flushTimer: null,
 			ended: false,
+			persistedChars: 0,
+			flushing: null,
 		};
 		this.streams.set(config.streamId, entry);
 
@@ -102,6 +121,13 @@ export class LogStreamBroker {
 		}
 	}
 
+	/**
+	 * Final-flush and tear down a stream. Drains any in-flight flush, then
+	 * persists the remaining unflushed tail. Unlike a mid-run flush there is no
+	 * retry after this — a persistence failure here is logged and the tail is
+	 * dropped (the run is finishing regardless; failing finalization over a log
+	 * tail would be worse).
+	 */
 	async end(streamId: string): Promise<void> {
 		const entry = this.streams.get(streamId);
 		if (!entry) return;
@@ -110,9 +136,11 @@ export class LogStreamBroker {
 			clearTimeout(entry.flushTimer);
 			entry.flushTimer = null;
 		}
-		if (entry.dirty && entry.config.onFlush) {
-			entry.dirty = false;
-			await entry.config.onFlush(entry.buffer.toString());
+		await this.flushDelta(entry);
+		if (entry.dirty) {
+			log.warn(
+				`Final log flush failed for stream ${streamId}; trailing log text was not persisted`,
+			);
 		}
 		this.streams.delete(streamId);
 		this.removeFromRoomIndex(entry.config.room, streamId);
@@ -138,15 +166,40 @@ export class LogStreamBroker {
 	}
 
 	private async performFlush(entry: LogStreamEntry): Promise<void> {
-		if (!entry.dirty || !entry.config.onFlush || entry.ended) return;
-		entry.dirty = false;
-		const text = entry.buffer.toString();
-		try {
-			await entry.config.onFlush(text);
-		} catch {
-			entry.dirty = true;
-		}
+		if (entry.ended) return;
+		await this.flushDelta(entry);
 		if (entry.dirty && !entry.ended) this.scheduleFlush(entry);
+	}
+
+	/**
+	 * The single serialized persistence path: every call chains on the previous
+	 * flush's promise, so two flushes can never overlap — an overlap would
+	 * compute its delta from a not-yet-advanced offset and persist the same text
+	 * twice. `persistedChars` advances only after `onFlush` succeeds; on failure
+	 * the stream is re-marked dirty and the identical delta goes out on the next
+	 * attempt. Delta extraction by offset is sound because
+	 * `CappedLogBuffer.toString()` is prefix-stable (append-only; the truncation
+	 * marker is appended once at the cap, after which nothing changes).
+	 */
+	private flushDelta(entry: LogStreamEntry): Promise<void> {
+		const prev = entry.flushing ?? Promise.resolve();
+		const next = prev.then(async () => {
+			if (!entry.dirty || !entry.config.onFlush) return;
+			entry.dirty = false;
+			const text = entry.buffer.toString();
+			const delta = text.slice(entry.persistedChars);
+			try {
+				await entry.config.onFlush(delta);
+				entry.persistedChars = text.length;
+			} catch {
+				entry.dirty = true;
+			}
+		});
+		const guarded = next.finally(() => {
+			if (entry.flushing === guarded) entry.flushing = null;
+		});
+		entry.flushing = guarded;
+		return guarded;
 	}
 
 	private removeFromRoomIndex(room: string, streamId: string): void {

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -7,6 +7,7 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { runLogTextSql } from '../db/run-log-chunks';
 import { broadcastRowChange } from '../lib/broadcast';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
@@ -102,7 +103,11 @@ export async function detectOrphans(
 			const failedRun = await db.query<{
 				exit_code: number | null;
 				log_text: string | null;
-			}>('SELECT exit_code, log_text FROM heartbeat_runs WHERE id = $1', [run.id]);
+			}>(
+				`SELECT exit_code, ${runLogTextSql('heartbeat_runs.id')} AS log_text
+				 FROM heartbeat_runs WHERE id = $1`,
+				[run.id],
+			);
 			const fr = failedRun.rows[0];
 
 			await createWakeup(db, run.member_id, run.team_id, WakeupSource.Timer, {

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -186,6 +186,20 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	setStartupPhase('seed');
 	await runSeed(db);
 
+	// One-time reclaim of the disk space the pre-chunk run-log write pattern
+	// left behind (migration 041 drops `heartbeat_runs.log_text`, but the column
+	// drop is metadata-only — the dead TOAST graveyard stays until a VACUUM FULL
+	// rewrites the table). Marker-gated, embedded-only, and synchronous on
+	// purpose: PGlite is single-connection, so running it in the background
+	// would stall the first requests anyway. Can take a while on a multi-GB
+	// table — once, on the first post-upgrade boot.
+	try {
+		const { runLegacyRunLogVacuumOnce } = await import('./db/run-log-chunks.js');
+		await runLegacyRunLogVacuumOnce(db, storageInfo.backend);
+	} catch (err) {
+		log.error('One-time legacy run-log reclaim failed (will retry next startup):', err);
+	}
+
 	// Asset blob storage: local filesystem by default, S3-compatible object
 	// storage when configured. Like databaseUrl, the raw assetStorageUrl stops
 	// here — only the pre-redacted info travels further.

--- a/packages/server/test/agent-runner-handoff-delivery.test.ts
+++ b/packages/server/test/agent-runner-handoff-delivery.test.ts
@@ -3,6 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { runLogTextSql } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import { type RunnerDeps, runAgent } from '../src/services/agent-runner';
 import type { DockerClient } from '../src/services/docker';
@@ -249,7 +250,7 @@ describe('runAgent handoff-delivery guardrail', () => {
 		// The no-op run became a success because the guardrail produced a comment.
 		expect(result.success).toBe(true);
 		const run = await db.query<{ status: string; produced_output: boolean; log_text: string }>(
-			'SELECT status, produced_output, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, produced_output, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[runId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
@@ -414,7 +415,7 @@ describe('runAgent handoff-delivery guardrail', () => {
 		// Instead, the stranded handoff is surfaced as a warning in the run log,
 		// naming the teammate and the active-mention fix.
 		const run = await db.query<{ log_text: string }>(
-			'SELECT log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].log_text).toContain('wakes no one');
@@ -471,7 +472,7 @@ describe('runAgent handoff-delivery guardrail', () => {
 		expect(comments.rows[0].parent_comment_id).toBe(adminReply);
 
 		const run = await db.query<{ produced_output: boolean; log_text: string }>(
-			'SELECT produced_output, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT produced_output, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].produced_output).toBe(true);
@@ -643,7 +644,7 @@ describe('runAgent handoff-delivery guardrail', () => {
 		const comments = await textComments(result.heartbeatRunId);
 		expect(comments.rows.length).toBe(0);
 		const run = await db.query<{ log_text: string }>(
-			'SELECT log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].log_text).not.toContain('wakes no one');

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -19,6 +19,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { decrypt } from '../src/crypto/encryption';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { runLogTextSql } from '../src/db/run-log-chunks';
 import { DomainEventBus } from '../src/events/bus';
 import type { Env } from '../src/lib/types';
 import {
@@ -439,7 +440,7 @@ describe('runAgent lifecycle — full success bookkeeping', () => {
 		expect(result.success).toBe(false);
 		expect(result.stderr).toContain('not running');
 		const run = await db.query<{ status: string; log_text: string | null }>(
-			'SELECT status, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);

--- a/packages/server/test/agent-runner-worktree-cov.test.ts
+++ b/packages/server/test/agent-runner-worktree-cov.test.ts
@@ -11,6 +11,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { runLogTextSql } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import { type RunnerDeps, runAgent } from '../src/services/agent-runner';
 import type { DockerClient } from '../src/services/docker';
@@ -224,7 +225,7 @@ async function markProducedOutput() {
 
 async function runLog(runId: string): Promise<string> {
 	const r = await db.query<{ log_text: string | null; working_dir: string | null }>(
-		'SELECT log_text, working_dir FROM heartbeat_runs WHERE id = $1',
+		`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text, working_dir FROM heartbeat_runs WHERE id = $1`,
 		[runId],
 	);
 	return r.rows[0].log_text ?? '';

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -11,6 +11,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { runLogTextSql } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import {
 	acquireCredentialLock,
@@ -257,7 +258,7 @@ describe('runAgent', () => {
 		expect(result.heartbeatRunId).toBeDefined();
 
 		const run = await db.query<{ status: string; log_text: string; error: string | null }>(
-			'SELECT status, log_text, error FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text, error FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
@@ -315,7 +316,7 @@ describe('runAgent', () => {
 		expect(result.stderr).toContain('not running');
 
 		const run = await db.query<{ status: string; log_text: string }>(
-			'SELECT status, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
@@ -359,7 +360,7 @@ describe('runAgent', () => {
 		expect(result.heartbeatRunId).toBeDefined();
 
 		const run = await db.query<{ status: string; log_text: string }>(
-			'SELECT status, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
@@ -430,7 +431,7 @@ describe('runAgent', () => {
 		expect(result.success).toBe(false);
 
 		const run = await db.query<{ status: string; error: string | null; log_text: string }>(
-			'SELECT status, error, log_text FROM heartbeat_runs WHERE id = $1',
+			`SELECT status, error, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
@@ -1736,7 +1737,7 @@ describe('runAgent', () => {
 			expect(runLogBroadcasts.some((b) => b.event.stream === 'stderr')).toBe(true);
 
 			const row = await db.query<{ log_text: string }>(
-				'SELECT log_text FROM heartbeat_runs WHERE id = $1',
+				`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 				[result.heartbeatRunId],
 			);
 			expect(row.rows[0].log_text).toContain('hello world');
@@ -2078,7 +2079,7 @@ describe('runAgent', () => {
 				output_tokens: number;
 				cost_cents: number;
 			}>(
-				'SELECT log_text, input_tokens::int AS input_tokens, output_tokens::int AS output_tokens, cost_cents FROM heartbeat_runs WHERE id = $1',
+				`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text, input_tokens::int AS input_tokens, output_tokens::int AS output_tokens, cost_cents FROM heartbeat_runs WHERE id = $1`,
 				[result.heartbeatRunId],
 			);
 			const log = row.rows[0].log_text;

--- a/packages/server/test/agents-coverage.test.ts
+++ b/packages/server/test/agents-coverage.test.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import { signAgentJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
@@ -418,11 +419,12 @@ describe('heartbeat-runs not-found / terminate branches', () => {
 	it('single heartbeat-run returns a real run', async () => {
 		const captain = await findAgent('captain');
 		const inserted = await db.query<{ id: string }>(
-			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code, log_text)
-			 VALUES ($1, $2, 'succeeded', now() - interval '2 minutes', now(), 0, 'done')
+			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code)
+			 VALUES ($1, $2, 'succeeded', now() - interval '2 minutes', now(), 0)
 			 RETURNING id`,
 			[captain.id, teamId],
 		);
+		await appendRunLogChunks(db, inserted.rows[0].id, 'done');
 		const res = await app.request(
 			`/api/projects/${projectSlug}/agents/${captain.id}/heartbeat-runs/${inserted.rows[0].id}`,
 			{ headers: authHeader(token) },

--- a/packages/server/test/agents-routes-more-coverage.test.ts
+++ b/packages/server/test/agents-routes-more-coverage.test.ts
@@ -5,6 +5,7 @@ import {
 	REQUIRED_SYSTEM_PROMPT_VARS,
 } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import { signAdminJwt, signAgentJwt } from '../src/middleware/auth';
 import { authHeader, createAgentRun, createTestTeam, projectSlugFor } from './helpers/app';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
@@ -898,12 +899,15 @@ describe('heartbeat runs', () => {
 
 	it('lists runs newest-first with trigger/task metadata', async () => {
 		const agent = await createAgent('Runner Agent');
-		await ctx.db.query(
-			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code, log_text)
-			 VALUES ($1, $2, 'succeeded', now() - interval '10 minutes', now() - interval '9 minutes', 0, 'older'),
-			        ($1, $2, 'failed', now() - interval '2 minutes', now() - interval '1 minute', 1, 'newer')`,
+		const seeded = await ctx.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code)
+			 VALUES ($1, $2, 'succeeded', now() - interval '10 minutes', now() - interval '9 minutes', 0),
+			        ($1, $2, 'failed', now() - interval '2 minutes', now() - interval '1 minute', 1)
+			 RETURNING id`,
 			[agent.id, teamId],
 		);
+		await appendRunLogChunks(ctx.db, seeded.rows[0].id, 'older');
+		await appendRunLogChunks(ctx.db, seeded.rows[1].id, 'newer');
 		const res = await ctx.app.request(
 			`/api/projects/${projectSlug}/agents/${agent.id}/heartbeat-runs`,
 			{ headers: authHeader(ctx.token) },

--- a/packages/server/test/agents.test.ts
+++ b/packages/server/test/agents.test.ts
@@ -2,6 +2,7 @@ import { DEFAULT_TEAM_ID, HQ_PROJECT_SLUG } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
@@ -472,11 +473,12 @@ describe('heartbeat runs', () => {
 		const agents = (await listRes.json()).data;
 		const agent = agents[0];
 
-		await db.query(
-			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code, log_text)
-			 VALUES ($1, $2, 'succeeded', now() - interval '5 minutes', now(), 0, 'All done')`,
+		const inserted = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, exit_code)
+			 VALUES ($1, $2, 'succeeded', now() - interval '5 minutes', now(), 0) RETURNING id`,
 			[agent.id, teamId],
 		);
+		await appendRunLogChunks(db, inserted.rows[0].id, 'All done');
 
 		const res = await app.request(
 			`/api/projects/${projectSlug}/agents/${agent.id}/heartbeat-runs`,

--- a/packages/server/test/database-logical-backup.test.ts
+++ b/packages/server/test/database-logical-backup.test.ts
@@ -190,23 +190,27 @@ describe('logical backup round-trip (PGlite leg)', () => {
 		const ctx = await createTestApp();
 		const migrations = allMigrations();
 		try {
-			// ~9MB of log_text across 30 runs — far past one 4MB page, so a flat
+			// ~9MB of log chunks across 30 runs — far past one 4MB page, so a flat
 			// row-count page would return it all in one response (the shape that
 			// crashes embedded PGlite's WASM on real instances).
 			const member = await ctx.db.query<{ id: string; team_id: string }>(
 				`SELECT id, team_id FROM members LIMIT 1`,
 			);
 			await ctx.db.query(
-				`INSERT INTO heartbeat_runs (team_id, member_id, status, log_text)
-				 SELECT $1, $2, 'succeeded', repeat('x', 300000) || n::text
-				 FROM generate_series(1, 30) n`,
+				`WITH new_runs AS (
+				   INSERT INTO heartbeat_runs (team_id, member_id, status)
+				   SELECT $1, $2, 'succeeded' FROM generate_series(1, 30) n
+				   RETURNING id
+				 )
+				 INSERT INTO heartbeat_run_log_chunks (run_id, seq, content)
+				 SELECT id, 0, repeat('x', 300000) || id::text FROM new_runs`,
 				[member.rows[0].team_id, member.rows[0].id],
 			);
 
 			const source = recordingDb(ctx.db);
 			const bytes = await dumpLogicalBackup(source.db, { hezoVersion: 'test', migrations });
 			const pageSelects = source.queries.filter(
-				(q) => q.includes('FROM "heartbeat_runs"') && q.includes('LIMIT'),
+				(q) => q.includes('FROM "heartbeat_run_log_chunks"') && q.includes('LIMIT'),
 			);
 			expect(pageSelects.length).toBeGreaterThanOrEqual(3);
 			// Every page carries the byte-derived row limit, not the flat cap.
@@ -216,18 +220,20 @@ describe('logical backup round-trip (PGlite leg)', () => {
 			try {
 				const target = recordingDb(restored);
 				await restoreLogicalBackup(target.db, bytes, migrations);
-				const inserts = target.queries.filter((q) => q.startsWith('INSERT INTO "heartbeat_runs"'));
+				const inserts = target.queries.filter((q) =>
+					q.startsWith('INSERT INTO "heartbeat_run_log_chunks"'),
+				);
 				expect(inserts.length).toBeGreaterThanOrEqual(3);
 
 				// The paged dump + batched restore is lossless.
 				const [a, b] = await Promise.all([
 					ctx.db.query<{ n: number; len: string }>(
-						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(log_text)), 0)::text AS len
-						 FROM heartbeat_runs`,
+						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(content)), 0)::text AS len
+						 FROM heartbeat_run_log_chunks`,
 					),
 					restored.query<{ n: number; len: string }>(
-						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(log_text)), 0)::text AS len
-						 FROM heartbeat_runs`,
+						`SELECT COUNT(*)::int AS n, COALESCE(SUM(length(content)), 0)::text AS len
+						 FROM heartbeat_run_log_chunks`,
 					),
 				]);
 				expect(b.rows[0]).toEqual(a.rows[0]);

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -2,6 +2,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import {
 	type AgentInfo,
@@ -105,13 +106,13 @@ describe('heartbeat-runs API', () => {
 			 SET status = 'succeeded'::heartbeat_run_status,
 			     finished_at = now(),
 			     exit_code = 0,
-			     log_text = 'test output',
 			     invocation_command = '$ claude --mcp-config {...} -p task',
 			     working_dir = '/worktrees/RT-1/main',
 			     started_at = now()
 			 WHERE id = $1`,
 			[runId],
 		);
+		await appendRunLogChunks(db, runId, 'test output');
 
 		const res = await app.request(`/api/projects/${projectSlug}/agents/${agentId}/heartbeat-runs`, {
 			headers: authHeader(token),

--- a/packages/server/test/log-compaction.test.ts
+++ b/packages/server/test/log-compaction.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks, readRunLogText } from '../src/db/run-log-chunks';
 import { deleteSystemMeta, setSystemMeta } from '../src/lib/system-meta';
 import {
 	compactRunLogsBatch,
@@ -72,22 +73,22 @@ describe('run-log compaction — service + routes', () => {
 	): Promise<void> {
 		const r = await db.query<{ id: string }>(
 			`INSERT INTO heartbeat_runs
-			   (team_id, member_id, status, log_text, invocation_command, created_at, finished_at, log_compacted_at)
-			 VALUES ($1, $2, $3::heartbeat_run_status, $4, $5,
-			         now() - ($6 || ' days')::interval, now() - ($6 || ' days')::interval,
-			         CASE WHEN $7 THEN now() ELSE NULL END)
+			   (team_id, member_id, status, invocation_command, created_at, finished_at, log_compacted_at)
+			 VALUES ($1, $2, $3::heartbeat_run_status, $4,
+			         now() - ($5 || ' days')::interval, now() - ($5 || ' days')::interval,
+			         CASE WHEN $6 THEN now() ELSE NULL END)
 			 RETURNING id`,
 			[
 				teamId,
 				memberId,
 				opts.status ?? 'succeeded',
-				opts.log,
 				opts.command ?? 'claude -p',
 				String(opts.ageDays),
 				opts.compacted ?? false,
 			],
 		);
 		runIds[key] = r.rows[0].id;
+		await appendRunLogChunks(db, r.rows[0].id, opts.log);
 	}
 
 	beforeAll(async () => {
@@ -137,22 +138,28 @@ describe('run-log compaction — service + routes', () => {
 	});
 
 	it('compacts the old large run and leaves the others intact', async () => {
-		const before = await db.query<{ len: number }>(
-			`SELECT length(log_text) AS len FROM heartbeat_runs WHERE id = $1`,
-			[runIds.oldBig],
-		);
+		const beforeLen = (await readRunLogText(db, runIds.oldBig)).length;
 		const { processed, bytesReclaimed } = await compactRunLogsBatch(db, { olderThanDays: 30 });
 		expect(processed).toBe(1);
 		expect(bytesReclaimed).toBeGreaterThan(0);
 
-		const oldBig = await db.query<{ log_text: string; log_compacted_at: string | null }>(
-			`SELECT log_text, log_compacted_at FROM heartbeat_runs WHERE id = $1`,
+		const oldBig = await db.query<{ log_compacted_at: string | null }>(
+			`SELECT log_compacted_at FROM heartbeat_runs WHERE id = $1`,
 			[runIds.oldBig],
 		);
+		const compactedText = await readRunLogText(db, runIds.oldBig);
 		expect(oldBig.rows[0].log_compacted_at).not.toBeNull();
-		expect(oldBig.rows[0].log_text).toContain('THIS RUN LOG HAS BEEN COMPACTED');
-		expect(oldBig.rows[0].log_text).toContain('$ claude -p');
-		expect(oldBig.rows[0].log_text.length).toBeLessThan(before.rows[0].len);
+		expect(compactedText).toContain('THIS RUN LOG HAS BEEN COMPACTED');
+		expect(compactedText).toContain('$ claude -p');
+		expect(compactedText.length).toBeLessThan(beforeLen);
+
+		// The run's chunks were replaced by a single compacted chunk.
+		const chunks = await db.query<{ seq: number }>(
+			'SELECT seq FROM heartbeat_run_log_chunks WHERE run_id = $1',
+			[runIds.oldBig],
+		);
+		expect(chunks.rows).toHaveLength(1);
+		expect(chunks.rows[0].seq).toBe(0);
 
 		// The recent run's log is untouched.
 		const recent = await db.query<{ log_compacted_at: string | null }>(

--- a/packages/server/test/log-stream-broker.test.ts
+++ b/packages/server/test/log-stream-broker.test.ts
@@ -1,5 +1,6 @@
 import { WsMessageType } from '@hezo/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CappedLogBuffer } from '../src/services/log-buffer';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { WebSocketManager } from '../src/services/ws';
 
@@ -201,5 +202,137 @@ describe('LogStreamBroker', () => {
 		const replayed: unknown[] = [];
 		broker.replay('project-runs:p1', (p) => replayed.push(p));
 		expect(replayed).toHaveLength(0);
+	});
+
+	describe('delta flushing', () => {
+		it('each flush receives only the text appended since the last successful flush', async () => {
+			vi.useFakeTimers();
+			const flushes: string[] = [];
+			broker.begin(makeRunConfig('r1', 'p1', async (delta) => void flushes.push(delta)));
+
+			broker.emit('run:r1', 'stdout', 'first\n');
+			await vi.advanceTimersByTimeAsync(500);
+			broker.emit('run:r1', 'stdout', 'second\n');
+			await vi.advanceTimersByTimeAsync(500);
+
+			expect(flushes).toEqual(['first\n', 'second\n']);
+		});
+
+		it('re-sends the identical delta after a failed flush, exactly once after success', async () => {
+			vi.useFakeTimers();
+			const flushes: string[] = [];
+			let fail = true;
+			broker.begin(
+				makeRunConfig('r1', 'p1', async (delta) => {
+					flushes.push(delta);
+					if (fail) throw new Error('db down');
+				}),
+			);
+
+			broker.emit('run:r1', 'stdout', 'tail\n');
+			await vi.advanceTimersByTimeAsync(500);
+			expect(flushes).toEqual(['tail\n']);
+
+			// The failure re-marked the stream dirty; the retry re-sends the same
+			// delta (the offset never advanced), and success settles it for good.
+			fail = false;
+			await vi.advanceTimersByTimeAsync(500);
+			expect(flushes).toEqual(['tail\n', 'tail\n']);
+
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(flushes).toHaveLength(2);
+		});
+
+		it('end() after a successful periodic flush sends only the remainder', async () => {
+			vi.useFakeTimers();
+			const flushes: string[] = [];
+			broker.begin(makeRunConfig('r1', 'p1', async (delta) => void flushes.push(delta)));
+
+			broker.emit('run:r1', 'stdout', 'persisted\n');
+			await vi.advanceTimersByTimeAsync(500);
+			broker.emit('run:r1', 'stdout', 'remainder\n');
+			await broker.end('run:r1');
+
+			expect(flushes).toEqual(['persisted\n', 'remainder\n']);
+		});
+
+		it('serializes overlapping flushes so a slow flush never duplicates content', async () => {
+			vi.useFakeTimers();
+			const flushes: string[] = [];
+			let release: (() => void) | null = null;
+			broker.begin(
+				makeRunConfig('r1', 'p1', async (delta) => {
+					flushes.push(delta);
+					await new Promise<void>((resolve) => {
+						release = resolve;
+					});
+				}),
+			);
+
+			broker.emit('run:r1', 'stdout', 'one\n');
+			await vi.advanceTimersByTimeAsync(500); // first flush starts, blocks in onFlush
+
+			broker.emit('run:r1', 'stdout', 'two\n');
+			await vi.advanceTimersByTimeAsync(500); // second flush chains behind the first
+			expect(flushes).toEqual(['one\n']);
+
+			const releaseFirst = release as unknown as () => void;
+			release = null;
+			releaseFirst(); // unblock the first flush; the chained one now runs
+			await vi.advanceTimersByTimeAsync(0);
+			expect(flushes).toEqual(['one\n', 'two\n']);
+
+			(release as unknown as () => void)();
+			await broker.end('run:r1');
+			// Nothing new appended after 'two' — end() has no remainder to send.
+			expect(flushes).toEqual(['one\n', 'two\n']);
+		});
+
+		it('a capped stream still invokes onFlush with an empty delta', async () => {
+			vi.useFakeTimers();
+			const flushes: string[] = [];
+			broker.begin({
+				...makeRunConfig('r1', 'p1', async (delta) => void flushes.push(delta)),
+				capBytes: 10,
+			});
+
+			broker.emit('run:r1', 'stdout', '1234567890\n');
+			await vi.advanceTimersByTimeAsync(500);
+			expect(flushes).toHaveLength(1);
+			expect(flushes[0]).toContain('truncated');
+
+			// Emits after the cap append nothing, but the flush cadence must keep
+			// firing — the run's usage snapshot rides the same callback.
+			broker.emit('run:r1', 'stdout', 'dropped\n');
+			await vi.advanceTimersByTimeAsync(500);
+			expect(flushes).toHaveLength(2);
+			expect(flushes[1]).toBe('');
+		});
+	});
+});
+
+describe('CappedLogBuffer prefix stability', () => {
+	// The broker's delta flushing slices new text off by a persisted character
+	// offset, which is only sound if every earlier toString() result is a strict
+	// prefix of every later one — including across the truncation transition.
+	it('every toString() result is a prefix of every later one, through truncation', () => {
+		const buffer = new CappedLogBuffer(20);
+		const snapshots: string[] = [buffer.toString()];
+
+		buffer.append('stdout', 'one');
+		snapshots.push(buffer.toString());
+		buffer.append('stderr', 'two');
+		snapshots.push(buffer.toString());
+		buffer.append('stdout', 'x'.repeat(50)); // crosses the cap → truncation marker
+		snapshots.push(buffer.toString());
+		buffer.append('stdout', 'after-cap-noop');
+		snapshots.push(buffer.toString());
+
+		expect(buffer.isTruncated).toBe(true);
+		for (let i = 1; i < snapshots.length; i++) {
+			expect(snapshots[i].startsWith(snapshots[i - 1])).toBe(true);
+		}
+		// After the cap the text is frozen entirely.
+		expect(snapshots[snapshots.length - 1]).toBe(snapshots[snapshots.length - 2]);
 	});
 });

--- a/packages/server/test/migrate-041-run-log-chunks.test.ts
+++ b/packages/server/test/migrate-041-run-log-chunks.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '041_run_log_chunks.sql';
+
+describe('041_run_log_chunks migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let memberId: string;
+	let loggedRunId: string;
+	let emptyRunId: string;
+	let compactedRunId: string;
+
+	const LOGGED_TEXT = 'verbose log line 1\nverbose log line 2\n[done] succeeded';
+	const COMPACTED_TEXT = '[log compacted]\n[done] succeeded';
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema at 040
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		memberId = member.rows[0].id;
+
+		const logged = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, log_text, finished_at)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, $3, now()) RETURNING id`,
+			[teamId, memberId, LOGGED_TEXT],
+		);
+		loggedRunId = logged.rows[0].id;
+
+		const empty = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status)
+			 VALUES ($1, $2, 'queued'::heartbeat_run_status) RETURNING id`,
+			[teamId, memberId],
+		);
+		emptyRunId = empty.rows[0].id;
+
+		const compacted = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, log_text, finished_at, log_compacted_at)
+			 VALUES ($1, $2, 'failed'::heartbeat_run_status, $3, now(), now()) RETURNING id`,
+			[teamId, memberId, COMPACTED_TEXT],
+		);
+		compactedRunId = compacted.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the chunk table with the composite primary key', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'heartbeat_run_log_chunks' ORDER BY column_name`,
+		);
+		expect(cols.rows.map((r) => r.column_name)).toEqual(['content', 'created_at', 'run_id', 'seq']);
+	});
+
+	it('carries every non-empty legacy log over as a single seq-0 chunk', async () => {
+		const chunk = await h.db.query<{ seq: number; content: string }>(
+			`SELECT seq, content FROM heartbeat_run_log_chunks WHERE run_id = $1`,
+			[loggedRunId],
+		);
+		expect(chunk.rows).toHaveLength(1);
+		expect(chunk.rows[0].seq).toBe(0);
+		expect(chunk.rows[0].content).toBe(LOGGED_TEXT);
+
+		const compactedChunk = await h.db.query<{ content: string }>(
+			`SELECT content FROM heartbeat_run_log_chunks WHERE run_id = $1`,
+			[compactedRunId],
+		);
+		expect(compactedChunk.rows).toHaveLength(1);
+		expect(compactedChunk.rows[0].content).toBe(COMPACTED_TEXT);
+	});
+
+	it('creates no chunk row for a run with an empty legacy log', async () => {
+		const none = await h.db.query(`SELECT 1 FROM heartbeat_run_log_chunks WHERE run_id = $1`, [
+			emptyRunId,
+		]);
+		expect(none.rows).toHaveLength(0);
+	});
+
+	it('drops the log_text column from heartbeat_runs', async () => {
+		const cols = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM information_schema.columns
+			 WHERE table_name = 'heartbeat_runs' AND column_name = 'log_text'`,
+		);
+		expect(cols.rows[0].c).toBe(0);
+	});
+
+	it('preserves the run rows themselves (status, compaction stamp intact)', async () => {
+		const rows = await h.db.query<{ id: string; status: string; log_compacted_at: string | null }>(
+			`SELECT id, status, log_compacted_at FROM heartbeat_runs WHERE team_id = $1 ORDER BY created_at`,
+			[teamId],
+		);
+		expect(rows.rows).toHaveLength(3);
+		expect(rows.rows.map((r) => r.id)).toEqual([loggedRunId, emptyRunId, compactedRunId]);
+		expect(rows.rows[0].log_compacted_at).toBeNull();
+		expect(rows.rows[2].log_compacted_at).not.toBeNull();
+	});
+
+	it('reads a run log back by concatenating chunks in seq order', async () => {
+		await h.db.query(
+			`INSERT INTO heartbeat_run_log_chunks (run_id, seq, content) VALUES ($1, 1, $2)`,
+			[loggedRunId, '\nlater delta'],
+		);
+		const text = await h.db.query<{ log_text: string }>(
+			`SELECT COALESCE(string_agg(content, '' ORDER BY seq), '') AS log_text
+			 FROM heartbeat_run_log_chunks WHERE run_id = $1`,
+			[loggedRunId],
+		);
+		expect(text.rows[0].log_text).toBe(`${LOGGED_TEXT}\nlater delta`);
+	});
+
+	it('cascades chunk deletion when the run row is deleted', async () => {
+		await h.db.query(`DELETE FROM heartbeat_runs WHERE id = $1`, [compactedRunId]);
+		const gone = await h.db.query(`SELECT 1 FROM heartbeat_run_log_chunks WHERE run_id = $1`, [
+			compactedRunId,
+		]);
+		expect(gone.rows).toHaveLength(0);
+	});
+});

--- a/packages/server/test/project-preferences-and-runs.test.ts
+++ b/packages/server/test/project-preferences-and-runs.test.ts
@@ -3,6 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
 import { buildCoachReviewPrompt, type TaskInfo } from '../src/services/agent-runner';
 import { safeClose } from './helpers';
@@ -68,11 +69,12 @@ async function seedRun(opts: {
 }): Promise<string> {
 	const r = await db.query<{ id: string }>(
 		`INSERT INTO heartbeat_runs
-		   (team_id, member_id, task_id, status, exit_code, invocation_command, log_text, started_at, finished_at)
-		 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, 0, 'run agent', $4, now(), now())
+		   (team_id, member_id, task_id, status, exit_code, invocation_command, started_at, finished_at)
+		 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, 0, 'run agent', now(), now())
 		 RETURNING id`,
-		[opts.team, opts.member, opts.task, opts.log],
+		[opts.team, opts.member, opts.task],
 	);
+	await appendRunLogChunks(db, r.rows[0].id, opts.log);
 	return r.rows[0].id;
 }
 

--- a/packages/server/test/run-log-chunks.test.ts
+++ b/packages/server/test/run-log-chunks.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import {
+	appendRunLogChunks,
+	LEGACY_RUN_LOG_VACUUM_KEY,
+	MAX_RUN_LOG_CHUNK_CHARS,
+	readRunLogText,
+	replaceRunLog,
+	runLegacyRunLogVacuumOnce,
+	runLogLengthSql,
+	runLogStoredBytesSql,
+	runLogTextSql,
+} from '../src/db/run-log-chunks';
+import { deleteSystemMeta, getSystemMeta } from '../src/lib/system-meta';
+import { safeClose } from './helpers';
+import { createTestDbWithMigrations } from './helpers/db';
+
+let db: Db;
+let teamId: string;
+let memberId: string;
+
+async function seedRun(): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs (team_id, member_id, status)
+		 VALUES ($1, $2, 'succeeded'::heartbeat_run_status) RETURNING id`,
+		[teamId, memberId],
+	);
+	return r.rows[0].id;
+}
+
+beforeAll(async () => {
+	db = await createTestDbWithMigrations();
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ('Chunks', 'chunks-test') RETURNING id`,
+	);
+	teamId = team.rows[0].id;
+	const member = await db.query<{ id: string }>(
+		`INSERT INTO members (team_id, member_type, display_name)
+		 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+		[teamId],
+	);
+	memberId = member.rows[0].id;
+});
+
+afterAll(() => safeClose(db));
+
+describe('appendRunLogChunks / readRunLogText', () => {
+	it('appends deltas as sequential chunks and reads them back concatenated', async () => {
+		const runId = await seedRun();
+		await appendRunLogChunks(db, runId, 'first delta\n');
+		await appendRunLogChunks(db, runId, 'second delta\n');
+		await appendRunLogChunks(db, runId, ''); // empty append is a no-op
+
+		expect(await readRunLogText(db, runId)).toBe('first delta\nsecond delta\n');
+		const seqs = await db.query<{ seq: number }>(
+			'SELECT seq FROM heartbeat_run_log_chunks WHERE run_id = $1 ORDER BY seq',
+			[runId],
+		);
+		expect(seqs.rows.map((r) => r.seq)).toEqual([0, 1]);
+	});
+
+	it('splits an oversized delta at the chunk-size boundary', async () => {
+		const runId = await seedRun();
+		const oversized = 'a'.repeat(MAX_RUN_LOG_CHUNK_CHARS + 5);
+		await appendRunLogChunks(db, runId, oversized);
+
+		const chunks = await db.query<{ seq: number; len: number }>(
+			`SELECT seq, length(content) AS len FROM heartbeat_run_log_chunks
+			 WHERE run_id = $1 ORDER BY seq`,
+			[runId],
+		);
+		expect(chunks.rows.map((r) => r.len)).toEqual([MAX_RUN_LOG_CHUNK_CHARS, 5]);
+		expect(await readRunLogText(db, runId)).toBe(oversized);
+	});
+
+	it('reads an empty string for a run with no chunks', async () => {
+		const runId = await seedRun();
+		expect(await readRunLogText(db, runId)).toBe('');
+	});
+});
+
+describe('SQL fragments', () => {
+	it('runLogTextSql and runLogLengthSql compose into run queries', async () => {
+		const runId = await seedRun();
+		await appendRunLogChunks(db, runId, 'hello ');
+		await appendRunLogChunks(db, runId, 'world');
+
+		const r = await db.query<{ log_text: string; log_length: number; stored: string }>(
+			`SELECT ${runLogTextSql('hr.id')} AS log_text,
+			        ${runLogLengthSql('hr.id')} AS log_length,
+			        ${runLogStoredBytesSql('hr.id')} AS stored
+			 FROM heartbeat_runs hr WHERE hr.id = $1`,
+			[runId],
+		);
+		expect(r.rows[0].log_text).toBe('hello world');
+		expect(r.rows[0].log_length).toBe(11);
+		expect(Number(r.rows[0].stored)).toBeGreaterThan(0);
+	});
+
+	it('reads empty text and zero length for a chunkless run', async () => {
+		const runId = await seedRun();
+		const r = await db.query<{ log_text: string; log_length: number }>(
+			`SELECT ${runLogTextSql('hr.id')} AS log_text, ${runLogLengthSql('hr.id')} AS log_length
+			 FROM heartbeat_runs hr WHERE hr.id = $1`,
+			[runId],
+		);
+		expect(r.rows[0].log_text).toBe('');
+		expect(r.rows[0].log_length).toBe(0);
+	});
+});
+
+describe('replaceRunLog', () => {
+	it('replaces all chunks with a single seq-0 chunk', async () => {
+		const runId = await seedRun();
+		await appendRunLogChunks(db, runId, 'one\n');
+		await appendRunLogChunks(db, runId, 'two\n');
+		await db.transaction((tx) => replaceRunLog(tx, runId, '[compacted]\n'));
+
+		const chunks = await db.query<{ seq: number; content: string }>(
+			'SELECT seq, content FROM heartbeat_run_log_chunks WHERE run_id = $1 ORDER BY seq',
+			[runId],
+		);
+		expect(chunks.rows).toHaveLength(1);
+		expect(chunks.rows[0].seq).toBe(0);
+		expect(chunks.rows[0].content).toBe('[compacted]\n');
+	});
+
+	it('appends continue after a replace (seq resumes past 0)', async () => {
+		const runId = await seedRun();
+		await appendRunLogChunks(db, runId, 'log\n');
+		await db.transaction((tx) => replaceRunLog(tx, runId, 'compacted\n'));
+		await appendRunLogChunks(db, runId, 'more\n');
+		expect(await readRunLogText(db, runId)).toBe('compacted\nmore\n');
+	});
+});
+
+describe('runLegacyRunLogVacuumOnce', () => {
+	it('embedded: vacuums once, sets the marker, and never re-runs', async () => {
+		await deleteSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY);
+		let vacuums = 0;
+		const origQuery = db.query.bind(db);
+		// biome-ignore lint/suspicious/noExplicitAny: test-only spy
+		(db as any).query = (sql: string, params?: unknown[]) => {
+			if (sql.startsWith('VACUUM')) vacuums += 1;
+			return origQuery(sql, params);
+		};
+		try {
+			await runLegacyRunLogVacuumOnce(db, 'embedded');
+			expect(vacuums).toBe(1);
+			expect(await getSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY)).not.toBeNull();
+
+			await runLegacyRunLogVacuumOnce(db, 'embedded');
+			expect(vacuums).toBe(1); // marker short-circuits
+		} finally {
+			// biome-ignore lint/suspicious/noExplicitAny: test-only spy
+			(db as any).query = origQuery;
+		}
+	});
+
+	it('external: sets the marker without vacuuming', async () => {
+		await deleteSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY);
+		let vacuums = 0;
+		const origQuery = db.query.bind(db);
+		// biome-ignore lint/suspicious/noExplicitAny: test-only spy
+		(db as any).query = (sql: string, params?: unknown[]) => {
+			if (sql.startsWith('VACUUM')) vacuums += 1;
+			return origQuery(sql, params);
+		};
+		try {
+			await runLegacyRunLogVacuumOnce(db, 'external');
+			expect(vacuums).toBe(0);
+			expect(await getSystemMeta(db, LEGACY_RUN_LOG_VACUUM_KEY)).not.toBeNull();
+		} finally {
+			// biome-ignore lint/suspicious/noExplicitAny: test-only spy
+			(db as any).query = origQuery;
+		}
+	});
+});

--- a/packages/web/test/formatted-log-view.test.tsx
+++ b/packages/web/test/formatted-log-view.test.tsx
@@ -24,10 +24,14 @@ test('run log defaults to the formatted view and toggles to raw via the icon but
 			const ws = await seedWorkspace();
 			const agent = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
 			const run = await ctx.db.query<{ id: string }>(
-				`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, log_text, input_tokens, output_tokens, cost_cents)
-				 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, now(), now(), $3, 100, 200, 1)
+				`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, input_tokens, output_tokens, cost_cents)
+				 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, now(), now(), 100, 200, 1)
 				 RETURNING id`,
-				[agent.id, ws.team.id, LOG_TEXT],
+				[agent.id, ws.team.id],
+			);
+			await ctx.db.query(
+				`INSERT INTO heartbeat_run_log_chunks (run_id, seq, content) VALUES ($1, 0, $2)`,
+				[run.rows[0].id, LOG_TEXT],
 			);
 			seeded.projectSlug = ws.internalSlug;
 			seeded.agentSlug = agent.slug;

--- a/packages/web/test/run-log-comment-ref.test.tsx
+++ b/packages/web/test/run-log-comment-ref.test.tsx
@@ -27,10 +27,14 @@ test('agent-run formatted view links a comment public_id in the prose to the run
 			// A run scoped to the task: its detail response carries task_identifier /
 			// task_title / project_slug, which the page passes as the comment-ref task.
 			const run = await ctx.db.query<{ id: string }>(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, log_text, input_tokens, output_tokens, cost_cents)
-				 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, now(), now(), $4, 10, 20, 1)
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, input_tokens, output_tokens, cost_cents)
+				 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, now(), now(), 10, 20, 1)
 				 RETURNING id`,
-				[captain.id, ws.team.id, task.id, LOG_TEXT],
+				[captain.id, ws.team.id, task.id],
+			);
+			await ctx.db.query(
+				`INSERT INTO heartbeat_run_log_chunks (run_id, seq, content) VALUES ($1, 0, $2)`,
+				[run.rows[0].id, LOG_TEXT],
 			);
 			seeded.projectSlug = project.slug;
 			seeded.agentSlug = captain.slug;


### PR DESCRIPTION
## Problem

Agent run logs were persisted by rewriting the **entire** accumulated log into `heartbeat_runs.log_text` on every 500 ms flush while a run streams. Under Postgres MVCC each rewrite writes a fresh full TOAST copy and orphans the previous one, so a linearly-growing log writes **O(n²) bytes** over its lifetime — measured in production as ~1,094 MB on disk for ~25 MB of live log data (~98% dead space). The compaction subsystem (migration 040) treated the symptom, not the write pattern.

All run kinds (heartbeat, triggered, goal/progress-update, mention, timer, …) already share the single `heartbeat_runs` table, so this converts that one log store to **append-only chunk storage**.

## What changed

- **Migration `041_run_log_chunks.sql`** — new `heartbeat_run_log_chunks (run_id, seq, content, created_at)` child table (PK `(run_id, seq)`, `ON DELETE CASCADE`); every legacy log backfilled as a single seq-0 chunk; `heartbeat_runs.log_text` dropped. Ships a data-preservation test (`migrate-041-run-log-chunks.test.ts`).
- **Delta flushing** (`log-stream-broker.ts`) — the flusher now persists only the text appended since the last *successful* flush, funneled through a per-stream serialized flush chain so overlapping flushes can never duplicate a delta. The offset advances only on success (a failed flush re-sends the identical delta); `end()` drains in-flight work and sends only the remainder; capped streams keep firing empty-delta flushes because the usage snapshot rides the same callback. Correctness rests on `CappedLogBuffer.toString()` being prefix-stable, now documented and pinned by a test.
- **Atomic flush** (`agent-runner.ts`) — chunk INSERT + running token/cost UPDATE commit in one transaction, so broker retries stay exactly-once.
- **Concatenate-on-read** — shared SQL fragments (`db/run-log-chunks.ts`) rebuild `log_text` via `string_agg(... ORDER BY seq)` at every read site: run list/detail/terminate routes, `latest-run`, `get_run_log` / `list_task_runs` MCP tools, the orphan detector's log tail, and Coach run summaries. **The wire shape is unchanged — zero frontend changes.** Live logs still stream over WebSocket from the in-memory buffer.
- **Compaction retargeted** (`log-compaction.ts`) — now pure retention trimming: eligibility filters on summed chunk `pg_column_size`, compaction replaces a run's chunks with one compacted chunk, and the end-of-pass `VACUUM (FULL, ANALYZE)` covers both run tables (chunk DELETEs + the flusher's usage-UPDATE dead tuples; PGlite has no autovacuum). Usage/estimate figures span both relations. Routes and DB-panel UI are unchanged.
- **One-time legacy reclaim** (`startup.ts`) — dropping `log_text` is metadata-only, so a marker-gated `VACUUM (FULL, ANALYZE) heartbeat_runs` runs once at startup on the embedded backend to return the legacy dead-TOAST graveyard to the OS (external Postgres: marker only, no unrequested exclusive lock).

## Why chunks (vs. file-and-persist-at-end)

Chunks keep the crash-safety property of the old flusher (log + usage persisted every 500 ms, so a killed run still shows its progress) while making every flush an INSERT of just the new bytes — O(n) total writes, no dead TOAST copies at all. Small chunk rows also page better through the byte-batched logical backup than one multi-MB TOAST value.

## Tests

- New: migration 041 data-preservation test; `run-log-chunks` unit tests (split boundaries, seq continuity, replace semantics, one-shot vacuum marker); broker delta tests (delta-only flush, failed-flush retry stays exactly-once, `end()` remainder, overlap serialization, capped-stream empty deltas, buffer prefix-stability).
- Updated: all server/web fixtures that seeded or read `log_text` now go through chunks; the logical-backup large-log fixture seeds 9 MB of chunks and asserts byte-paged dump/restore of the chunk table.
- Full server suite (5,714 tests + Bun-native tier), lint, and typecheck green. Web run-log specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCNthwss2pbfKpcB1326Uu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCNthwss2pbfKpcB1326Uu)_