### PR TITLE
Rebrand tagline; rename marketplace teams to Social Media Marketing and Investment Portfolio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,7 @@ To add a channel:
 These rules apply to **user-facing prose** — the `docs/` tree and anything a Hezo operator reads — because the audience is users, not engineers. They do **not** force renames of code identifiers, DB columns, route paths, or internal comments.
 
 - **Say "task", never "ticket".** The work item on the board is a **task** everywhere in `docs/`. "Ticket" is banned from user-facing prose — use "task" (plural "tasks"). The generated `docs/reference/mcp-api.md` is the one exception: it is built from the MCP tool registry and must not be hand-edited; when you author a tool's description or `TOOL_DOC_META` that will surface there, prefer "task" too so the generated page stays consistent.
+- **Use hyphens, not em dashes, in new or updated prose.** When you write or rewrite user-facing text (docs/, READMEs, UI strings, marketing copy), put a plain " - " where an em dash would go. Existing prose isn't mass-rewritten for this; apply it to the lines you touch.
 - **Say "global", never "instance-wide".** Describe HQ, the CEO, the Coach, skills, and MCP connections as **global** (e.g. "the global HQ project"). Users don't know what "instance-wide" means — don't use it in `docs/`.
 
 ### Web frontend mutations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <strong>Your own AI workforce. Built to ship.</strong>
+  <strong>Your own team of AI agents</strong>
 </p>
 
 <p align="center">

--- a/agents/influencer/team.json
+++ b/agents/influencer/team.json
@@ -1,10 +1,14 @@
 {
 	"schema_version": 1,
 	"slug": "influencer",
-	"name": "Influencer Marketing",
+	"name": "Social Media Marketing",
 	"description": "Grow your social reach — a team that learns your brand, plans a content calendar, drafts and verifies content, and publishes with your approval",
-	"summary": "The Influencer Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
+	"summary": "The Social Media Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
 	"changelog": [
+		{
+			"version": 4,
+			"notes": "Renamed the team to Social Media Marketing."
+		},
 		{
 			"version": 3,
 			"notes": "Clarified goal suggestions: outcomes and dated milestones from the admin's answers; recurring chores are filed as standing tasks, not goals."

--- a/agents/investment/team.json
+++ b/agents/investment/team.json
@@ -1,10 +1,14 @@
 {
 	"schema_version": 1,
 	"slug": "investment",
-	"name": "Investment",
+	"name": "Investment Portfolio",
 	"description": "Research-grade stock research and tracking — analysts, verifiers, and a monitor that keeps a living document on every stock you care about up to date",
-	"summary": "The Investment template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
+	"summary": "The Investment Portfolio template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
 	"changelog": [
+		{
+			"version": 4,
+			"notes": "Renamed the team to Investment Portfolio."
+		},
 		{
 			"version": 3,
 			"notes": "Goal suggestions are formulated from the admin's stated objectives — outcomes and milestones only; recurring work (daily monitoring, periodic reviews) runs as standing tasks, never goals."

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -57,9 +57,9 @@ point — you change the team's structure freely from there; see
 [Team structure](/docs/concepts/team-structure) for the bigger picture.
 
 Hezo ships with the minimal **Blank** template plus a set of ready-made teams in the
-[team marketplace](/docs/concepts/marketplace) — an **App Team** that builds software, an
-**Influencer Marketing** team that grows a creator's reach, and an **Investment** team that
-researches and tracks stocks. Each agent's behaviour comes from a **system
+[team marketplace](/docs/concepts/marketplace) — an **App Team** that builds software, a
+**Social Media Marketing** team that grows a creator's reach, and an **Investment
+Portfolio** team that researches and tracks stocks. Each agent's behaviour comes from a **system
 prompt** that you can read (and, once hired, customise — see
 [Hiring & customizing agents](/docs/concepts/hiring-and-agents)). The links below point
 at the source prompt for each role.
@@ -103,7 +103,7 @@ assuming, and can suggest project goals for you to approve.
 - [Researcher](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/researcher.md) —
   competitive analysis, technical research, and feasibility studies.
 
-### Influencer Marketing team
+### Social Media Marketing team
 
 A content team that grows a creator's social reach. Its Captain onboards you first —
 asking which accounts to work on (connect them on the project's Connections page), your
@@ -126,7 +126,7 @@ that off in the team's preferences).
 - [Distribution Manager](https://github.com/hezo-ai/hezo/blob/main/agents/influencer/distribution-manager.md) —
   publishes approved content, cross-posts, and runs the engagement/analytics loop.
 
-### Investment team
+### Investment Portfolio team
 
 A research team that tracks stocks and produces research-grade analysis (**not financial
 advice**). Its Captain onboards you first — which stocks and categories to watch, your

--- a/docs/concepts/team-structure.md
+++ b/docs/concepts/team-structure.md
@@ -41,14 +41,14 @@ Change any of these and you've changed the team's structure.
 
 Every project starts from a **team** — the minimal **Blank** team (just a Captain) or one
 of the ready-made teams in the [marketplace](/docs/concepts/marketplace): a full
-software-development **App Team**, an **Influencer Marketing** team, or an **Investment**
-team. You can also save and add your own. For the built-in rosters and a link to every
+software-development **App Team**, a **Social Media Marketing** team, or an **Investment
+Portfolio** team. You can also save and add your own. For the built-in rosters and a link to every
 role's prompt, see [Team templates](/docs/concepts/projects-and-teams#team-templates).
 
 A starting team is just a convenient starting point — it's not a cage. The Blank team is
 designed to be grown into whatever the work needs; the App Team is a fully-staffed
-structure for building software, and the Influencer Marketing and Investment teams are
-staffed for content and stock research respectively. Pick whichever is closest and adjust
+structure for building software, and the Social Media Marketing and Investment Portfolio
+teams are staffed for content and stock research respectively. Pick whichever is closest and adjust
 from there.
 
 ## Changing a team's structure while it runs

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -3,21 +3,21 @@
 	"teams": [
 		{
 			"slug": "influencer",
-			"name": "Influencer Marketing",
+			"name": "Social Media Marketing",
 			"description": "Grow your social reach — a team that learns your brand, plans a content calendar, drafts and verifies content, and publishes with your approval",
-			"summary": "The Influencer Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
-			"version": 3,
+			"summary": "The Social Media Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
+			"version": 4,
 			"roster_count": 7,
-			"latest_notes": "Clarified goal suggestions: outcomes and dated milestones from the admin's answers; recurring chores are filed as standing tasks, not goals."
+			"latest_notes": "Renamed the team to Social Media Marketing."
 		},
 		{
 			"slug": "investment",
-			"name": "Investment",
+			"name": "Investment Portfolio",
 			"description": "Research-grade stock research and tracking — analysts, verifiers, and a monitor that keeps a living document on every stock you care about up to date",
-			"summary": "The Investment template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
-			"version": 3,
+			"summary": "The Investment Portfolio template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
+			"version": 4,
 			"roster_count": 6,
-			"latest_notes": "Goal suggestions are formulated from the admin's stated objectives — outcomes and milestones only; recurring work (daily monitoring, periodic reviews) runs as standing tasks, never goals."
+			"latest_notes": "Renamed the team to Investment Portfolio."
 		},
 		{
 			"slug": "software-development",

--- a/marketplace/teams/influencer.json
+++ b/marketplace/teams/influencer.json
@@ -1,12 +1,16 @@
 {
 	"schema_version": 1,
 	"slug": "influencer",
-	"name": "Influencer Marketing",
+	"name": "Social Media Marketing",
 	"description": "Grow your social reach — a team that learns your brand, plans a content calendar, drafts and verifies content, and publishes with your approval",
-	"summary": "The Influencer Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
-	"version": 3,
-	"content_hash": "f184f79897a6486cb80457b5c74eb77d09440fd4a749c52d367360e4c8df39ac",
+	"summary": "The Social Media Marketing template provisions a content team that grows a creator's reach. A Captain runs onboarding — learning the creator's accounts, persona, brand, and goals — and suggests goals for the admin to approve. The Brand Strategist owns voice, pillars, and the content calendar; the Trend Researcher feeds ideas; the Content Writer and Media Producer produce; the Content Editor verifies every piece; and the Distribution Manager publishes, but only after the admin approves the content.",
+	"version": 4,
+	"content_hash": "a2c2a59d450abdb74a007f2e947ffe896c33a4d808080b380f090335cd3b043c",
 	"changelog": [
+		{
+			"version": 4,
+			"notes": "Renamed the team to Social Media Marketing."
+		},
 		{
 			"version": 3,
 			"notes": "Clarified goal suggestions: outcomes and dated milestones from the admin's answers; recurring chores are filed as standing tasks, not goals."

--- a/marketplace/teams/investment.json
+++ b/marketplace/teams/investment.json
@@ -1,12 +1,16 @@
 {
 	"schema_version": 1,
 	"slug": "investment",
-	"name": "Investment",
+	"name": "Investment Portfolio",
 	"description": "Research-grade stock research and tracking — analysts, verifiers, and a monitor that keeps a living document on every stock you care about up to date",
-	"summary": "The Investment template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
-	"version": 3,
-	"content_hash": "8b49711c42f1f70c853b02b9922d33d1d0036704c608832201882d2d2b417509",
+	"summary": "The Investment Portfolio template provisions a research team that tracks stocks and produces research-grade analysis (never financial advice). A Captain runs onboarding — the stocks and categories to watch, the investor's objective, risk appetite, and horizon — and suggests goals for the admin to approve. The Market Researcher screens and sources ideas; the Equity Analyst runs deep-dives and maintains a living per-stock document; the Catalyst Monitor sweeps filings and news daily and notifies the admin; the Risk Verifier challenges and verifies every thesis; and the Report Writer produces periodic portfolio reviews.",
+	"version": 4,
+	"content_hash": "cc7808791d66a2ca34c623a276b03a8e66a78a4c42e04dae71e77fa2bfb3497d",
 	"changelog": [
+		{
+			"version": 4,
+			"notes": "Renamed the team to Investment Portfolio."
+		},
 		{
 			"version": 3,
 			"notes": "Goal suggestions are formulated from the admin's stated objectives — outcomes and milestones only; recurring work (daily monitoring, periodic reviews) runs as standing tasks, never goals."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "Your own AI workforce. Built to ship.",
+	"description": "Your own team of AI agents",
 	"private": true,
 	"license": "GPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,19 +11,19 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
 		/>
-		<title>Hezo — Your own team of AI agents</title>
+		<title>Hezo - Your own team of AI agents</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo — Your own team of AI agents" />
+		<meta property="og:title" content="Hezo - Your own team of AI agents" />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo — Your own team of AI agents" />
+		<meta name="twitter:title" content="Hezo - Your own team of AI agents" />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,19 +11,19 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
 		/>
-		<title>Hezo — Your own AI workforce. Built to ship.</title>
+		<title>Hezo — Your own team of AI agents</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo — Your own AI workforce. Built to ship." />
+		<meta property="og:title" content="Hezo — Your own team of AI agents" />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo — Your own AI workforce. Built to ship." />
+		<meta name="twitter:title" content="Hezo — Your own team of AI agents" />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
## What this does

Two small, coordinated changes backing the hezo.ai website refresh (see the companion website PR):

### Tagline
The brand line becomes **"Your own team of AI agents"** on the three surfaces that carry it:
- root `package.json` description
- `README.md` header strong line
- `packages/web/index.html` title / `og:title` / `twitter:title`

The longer meta descriptions, CLI/`llms.txt`/`SKILL.md` blurbs, and CHANGELOG history are intentionally unchanged. `assets/hezo-og-card.png` may still show the old line baked into the artwork — design follow-up.

### Marketplace team renames (display names only)
- **Influencer Marketing → Social Media Marketing**
- **Investment → Investment Portfolio**

Slugs and directories stay `influencer/` and `investment/` for catalog identity, so existing provisioned teams and marketplace references keep working; a version-4 bump with changelog notes lets running instances pick the rename up as a normal team update. Regenerated `marketplace/teams/*.json` + `index.json` are committed, and the two docs pages naming the teams (`docs/concepts/projects-and-teams.md`, `docs/concepts/team-structure.md`) are updated.

## Verification
- `bun run --cwd packages/server build:marketplace` + `build:docs` regenerated cleanly.
- `packages/server/test/marketplace-build.test.ts` and `test/docs-bundle.test.ts` pass.
- Pre-commit biome + typecheck + build green on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xhuh2UA6tFKcQqEp4i2C8k

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhuh2UA6tFKcQqEp4i2C8k)_