### PR TITLE
Extend the headline with "Built to ship."

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <strong>Your own team of AI agents</strong>
+  <strong>Your own team of AI agents. Built to ship.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "Your own team of AI agents",
+	"description": "Your own team of AI agents. Built to ship.",
 	"private": true,
 	"license": "GPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,19 +11,19 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
 		/>
-		<title>Hezo - Your own team of AI agents</title>
+		<title>Hezo - Your own team of AI agents. Built to ship.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo - Your own team of AI agents" />
+		<meta property="og:title" content="Hezo - Your own team of AI agents. Built to ship." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo - Your own team of AI agents" />
+		<meta name="twitter:title" content="Hezo - Your own team of AI agents. Built to ship." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
The headline becomes **"Your own team of AI agents. Built to ship."** everywhere it appears in this repo, matching the change to the marketing site.

## Changes

- `README.md` - the tagline line under the logo.
- `package.json` - the root `description`.
- `packages/web/index.html` - `<title>`, `og:title`, and `twitter:title` (all three were `Hezo - Your own team of AI agents`).

## Verification

Grepped the repo for the old headline: no remaining occurrences. `docs/` and `.dev/` never carried it, so nothing there needed updating. The web app's meta `description` and the manifest description are separate copy and are untouched.

No CLI flag, route, MCP tool, or architecture surface is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJjFDyftYJ3Vh6pwYXwjCp)_