### PR TITLE
fix(web): deliver the container-provisioning-complete signal in situ

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1804,6 +1804,31 @@ shell watches). Clients react by refetching the per-caller-authorized project in
 left project rail updates live — for the dialog, the CEO's `create_project`, and other
 sessions alike — without a row on the shared room leaking a project a user can't see.
 
+**Row-change → project-slug resolution** (`resolveProjectSlugForChange` in
+`hooks/use-websocket.ts`) picks a resolver per table, and getting it wrong silently drops
+the event (an unresolved row invalidates nothing):
+
+- **`projects`** resolves by the row's **own `id`** — the row *is* the project, and no
+  `projects` row carries a `project_id`. It must not use the generic resolver: that falls
+  through to `team_id`, which maps a team-wide row to the team's *non-internal* project and
+  so can never resolve **HQ**. Several call sites also broadcast a partial row (`{ id,
+  container_status }` from the startup container restart and the self-heal re-attach in
+  `job-manager`, plus the progress-summary and designated-repo writes) carrying neither
+  `project_id` nor `team_id`; keying on `id` covers those too.
+- **`tasks` / `task_comments` / `heartbeat_runs` / `agent_wakeup_requests`** resolve by
+  `project_id` **only** — never the `team_id` fallback, which would misattribute one
+  project's high-frequency activity to another and storm its caches.
+- **Everything else** resolves `project_id` first, then falls back to `team_id`.
+
+**Container-state convergence.** The container status banner
+(`components/container-status-banner.tsx`), the CEO chat's HQ gate, and the create-project
+gate all derive from one `useContainerHealth(project)` reading `container_status` off the
+project index, and provisioning ends with a single `projects` UPDATE broadcast. WebSocket
+events have no replay, so the index also **polls every 10s while any container sits in a
+transient state** (`creating` / `stopping` — deliberately not the `null` of a torn-down
+project, which would poll forever). That bounds the damage of a missed transition to a few
+seconds of stale banner instead of "stuck until the operator reloads the page."
+
 **Lazy comments feed.** A task's comment thread can be long, so the feed
 (`components/task-detail/comments-section.tsx`, virtualized with react-virtuoso) loads in
 two payloads off the one `GET …/tasks/:taskId/comments` route. On mount it fetches a

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -72,9 +72,27 @@ export interface Repo {
 export type ProjectWithTeam = Project & { teamSlug: string; teamName: string };
 
 /**
+ * Container states that always resolve on their own, so a UI parked on one is
+ * waiting for a transition it must not miss. Deliberately excludes the `null`
+ * status: a torn-down project sits at `null` indefinitely and would poll forever.
+ */
+const TRANSIENT_CONTAINER_STATUSES = new Set(['creating', 'stopping']);
+
+/** How often to re-check the index while a container is mid-transition. */
+const TRANSIENT_CONTAINER_POLL_MS = 10_000;
+
+/**
  * The instance-wide project index: every project the caller can see across all
  * their teams, including the per-team internal projects. The single source the
  * rail, the project→team resolution, and realtime invalidation all read from.
+ *
+ * The container status banner and the CEO chat's HQ gate both read their health
+ * from here, and provisioning ends with a single `projects` row-change broadcast.
+ * That event has no replay — a socket that hasn't joined the team room yet (the
+ * rooms are derived from this very query, so there is a window between its
+ * response and the join) drops it, and the UI then shows "provisioning" until a
+ * full reload. Poll while any container is in a transient state so the UI
+ * converges on its own; the interval switches off once everything has settled.
  */
 export function useProjectsIndex() {
 	return useQuery({
@@ -82,6 +100,12 @@ export function useProjectsIndex() {
 		queryFn: () => api.get<Project[]>('/api/projects'),
 		staleTime: 0,
 		refetchOnMount: 'always',
+		refetchInterval: (query) =>
+			(query.state.data ?? []).some(
+				(p) => p.container_status && TRANSIENT_CONTAINER_STATUSES.has(p.container_status),
+			)
+				? TRANSIENT_CONTAINER_POLL_MS
+				: false,
 	});
 }
 

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -181,6 +181,30 @@ export function resolveProjectSlugByIdOnly(
 }
 
 /**
+ * Resolve a `projects`-table row change. The row *is* the project, so its own
+ * `id` is the project id — `project_id` never appears on it.
+ *
+ * This must not go through `resolveProjectSlugForRow`: a projects row carries no
+ * `project_id`, so that path falls through to the `team_id` lookup, which filters
+ * out `is_internal` projects and therefore can *never* resolve HQ. That silently
+ * dropped every HQ projects UPDATE — including the `container_status` →
+ * `running` transition that ends provisioning — so the banner and the CEO chat
+ * kept rendering the provisioning state until a full page reload refetched the
+ * index. Several broadcasts (the startup container restart and the self-heal
+ * re-attach in `job-manager`, the progress-summary write, the designated-repo
+ * update) also emit a *partial* row carrying neither `project_id` nor `team_id`,
+ * which was unresolvable for ordinary projects too. Every projects broadcast
+ * carries `id`, so keying on it covers all of them.
+ */
+export function resolveProjectSlugForProjectRow(
+	index: Project[],
+	row: Record<string, unknown>,
+): string | undefined {
+	const projectUuid = row.id as string | undefined;
+	return projectUuid ? index.find((p) => p.id === projectUuid)?.slug : undefined;
+}
+
+/**
  * Tables whose row-change broadcasts must resolve to their own project by
  * `project_id` only (never the team fallback). These fire often during agent
  * activity, so a misattributed invalidation storms an unrelated project's
@@ -192,6 +216,22 @@ const PROJECT_STRICT_TABLES = new Set([
 	'heartbeat_runs',
 	'agent_wakeup_requests',
 ]);
+
+/**
+ * The single entry point mapping a row_change to the project slug its caches are
+ * keyed by. Picks the resolver the table needs: its own `id` for `projects`, the
+ * strict `project_id`-only lookup for the high-frequency project-scoped tables,
+ * and the `project_id`-then-`team_id` lookup for everything else.
+ */
+export function resolveProjectSlugForChange(
+	index: Project[],
+	table: string,
+	row: Record<string, unknown>,
+): string | undefined {
+	if (table === 'projects') return resolveProjectSlugForProjectRow(index, row);
+	if (PROJECT_STRICT_TABLES.has(table)) return resolveProjectSlugByIdOnly(index, row);
+	return resolveProjectSlugForRow(index, row);
+}
 
 interface TeamRoom {
 	id: string;
@@ -250,17 +290,15 @@ export function useShellWebSockets(teams: TeamRoom[] | undefined): void {
 			const { table, row } = msg as WsRowChangeMessage;
 
 			// Resolve the project slug the change maps to from the cached index.
+			// High-frequency, project-scoped tables resolve by their own `project_id`
+			// only — never the `team_id` fallback. That fallback maps a row to the
+			// team's first non-internal project, so a run/wakeup in *any* project on
+			// the team would invalidate *every* team project's task list, producing a
+			// refetch storm (and breaking infinite-scroll pagination, which never
+			// settles while it's being re-fetched). A `projects` row resolves by its
+			// own `id`. Skip when the row carries no resolvable project.
 			const index = queryClient.getQueryData<Project[]>(queryKeys.projects.all()) ?? [];
-			// High-frequency, project-scoped tables must resolve by their own
-			// `project_id` only — never the `team_id` fallback. That fallback maps a
-			// row to the team's first non-internal project, so a run/wakeup in *any*
-			// project on the team would invalidate *every* team project's task list,
-			// producing a refetch storm (and breaking infinite-scroll pagination,
-			// which never settles while it's being re-fetched). Skip when the row
-			// carries no resolvable project.
-			const cid = PROJECT_STRICT_TABLES.has(table)
-				? resolveProjectSlugByIdOnly(index, row)
-				: resolveProjectSlugForRow(index, row);
+			const cid = resolveProjectSlugForChange(index, table, row);
 
 			if (cid) {
 				invalidateQueriesForRowChange(queryClient, cid, table, row);

--- a/packages/web/test/hq-provisioning-signal.test.tsx
+++ b/packages/web/test/hq-provisioning-signal.test.tsx
@@ -1,0 +1,76 @@
+// Regression: the "provisioning is complete" signal has to land in situ.
+//
+// The container status banner and the CEO chat's HQ gate both read their health
+// from the project index, and provisioning ends with a single `projects` row
+// change broadcast over the WebSocket. Resolving that row to a project slug used
+// to fall through to the `team_id` lookup, which filters out `is_internal`
+// projects — so the HQ transition resolved to nothing and was dropped, leaving
+// the chat stuck on "Starting the HQ container…" until a full page reload.
+//
+// Component tier: the harness stubs the WebSocket transport, so the spec drives
+// the subscriber's own resolve-then-invalidate path directly against the real
+// components and the real backend. The resolver's table branching is unit-tested
+// in resolve-project-slug-for-row.test.ts.
+
+import { queryClient } from '@hezo/web/lib/query-client';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import type { Project } from '../src/hooks/use-projects';
+import {
+	invalidateQueriesForRowChange,
+	resolveProjectSlugForChange,
+} from '../src/hooks/use-websocket';
+import { queryKeys } from '../src/lib/query-keys';
+import { renderApp } from './helpers/render';
+
+test('the CEO chat unblocks in situ when HQ finishes provisioning', async () => {
+	let hq!: { id: string; team_id: string };
+	let db!: Parameters<NonNullable<Parameters<typeof renderApp>[0]['seed']>>[0]['db'];
+
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			db = ctx.db;
+			const r = await ctx.db.query<{ id: string; team_id: string }>(
+				`UPDATE projects SET container_status = 'creating'
+				 WHERE is_internal = true
+				 RETURNING id, team_id`,
+			);
+			hq = r.rows[0];
+		},
+	});
+
+	const panel = async () => await findByTestId('chat-panel');
+	(await findByTestId('chat-launcher')).click();
+
+	// Provisioning: the notice replaces the composer.
+	const notice = await waitFor(async () => {
+		const el = (await panel()).querySelector('[data-testid="hq-container-notice"]');
+		if (!el) throw new Error('notice not yet rendered');
+		return el as HTMLElement;
+	});
+	expect(notice.textContent ?? '').toContain('Starting the HQ container');
+	expect((await panel()).querySelector('[data-testid="chat-input"]')).toBeNull();
+
+	// The container comes up server-side and broadcasts a `projects` UPDATE. The
+	// row is the shape broadcastProjectUpdate emits: its own `id` and `team_id`,
+	// never a `project_id`.
+	await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [hq.id]);
+	const row = { id: hq.id, team_id: hq.team_id, container_status: 'running' };
+
+	// The crux: HQ is the is_internal project, so the `team_id` fallback resolves
+	// nothing for it. Keying on the row's own id is what makes the signal land.
+	const index = queryClient.getQueryData<Project[]>(queryKeys.projects.all()) ?? [];
+	const slug = resolveProjectSlugForChange(index, 'projects', row);
+	expect(slug).toBe('hq');
+
+	invalidateQueriesForRowChange(queryClient, slug as string, 'projects', row);
+
+	// The gate clears and the composer comes back — no navigation, no reload.
+	await waitFor(async () => {
+		if ((await panel()).querySelector('[data-testid="hq-container-notice"]')) {
+			throw new Error('still gated on the container');
+		}
+	});
+	expect((await panel()).querySelector('[data-testid="chat-input"]')).toBeTruthy();
+});

--- a/packages/web/test/query-keys-websocket.test.ts
+++ b/packages/web/test/query-keys-websocket.test.ts
@@ -97,6 +97,19 @@ describe('invalidateQueriesForRowChange uses the queryKeys factory', () => {
 		expect(keys).toContainEqual(queryKeys.projects.budgetStatus(SLUG));
 	});
 
+	test('projects row change refetches the index the container UI reads from', () => {
+		// The container status banner and the CEO chat's HQ gate both derive their
+		// health from the project index, so a container_status transition has to
+		// invalidate it (exactly) plus the container page's detail query.
+		const { client, keys } = recordingClient();
+		invalidateQueriesForRowChange(client, SLUG, 'projects', {
+			id: 'p1',
+			container_status: 'running',
+		});
+		expect(keys).toContainEqual(queryKeys.projects.all());
+		expect(keys).toContainEqual(queryKeys.projects.detail(SLUG));
+	});
+
 	test('unknown table is a no-op', () => {
 		const { client, keys } = recordingClient();
 		invalidateQueriesForRowChange(client, SLUG, 'nonexistent', {});

--- a/packages/web/test/resolve-project-slug-for-row.test.ts
+++ b/packages/web/test/resolve-project-slug-for-row.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import type { Project } from '../src/hooks/use-projects';
-import { resolveProjectSlugByIdOnly, resolveProjectSlugForRow } from '../src/hooks/use-websocket';
+import {
+	resolveProjectSlugByIdOnly,
+	resolveProjectSlugForChange,
+	resolveProjectSlugForProjectRow,
+	resolveProjectSlugForRow,
+} from '../src/hooks/use-websocket';
 
 // resolveProjectSlugForRow only reads id/slug/team_id/is_internal; cast minimal
 // fixtures rather than spelling out every Project field.
@@ -68,5 +73,71 @@ describe('resolveProjectSlugByIdOnly', () => {
 		expect(resolveProjectSlugByIdOnly(index, { project_id: 'ops-proj', team_id: 'hq-team' })).toBe(
 			'operations',
 		);
+	});
+});
+
+describe('resolveProjectSlugForProjectRow', () => {
+	test('resolves HQ from the row id — the team fallback never can', () => {
+		// The bug this exists for: a `projects` row carries no project_id, so the
+		// generic resolver fell through to team_id, which excludes is_internal
+		// projects. Every HQ projects UPDATE — including container_status →
+		// running, the end of provisioning — was silently dropped, leaving the
+		// banner and the CEO chat stuck until a full page reload.
+		expect(resolveProjectSlugForRow(index, { id: 'hq-proj', team_id: 'hq-team' })).toBeUndefined();
+		expect(resolveProjectSlugForProjectRow(index, { id: 'hq-proj', team_id: 'hq-team' })).toBe(
+			'hq',
+		);
+	});
+
+	test('resolves an ordinary project from the row id', () => {
+		expect(resolveProjectSlugForProjectRow(index, { id: 'ops-proj', team_id: 'ops-team' })).toBe(
+			'operations',
+		);
+	});
+
+	test('resolves a partial row carrying neither project_id nor team_id', () => {
+		// The shape the startup container restart and the self-heal re-attach in
+		// job-manager broadcast, plus the progress-summary and designated-repo
+		// writes. These were unresolvable for ordinary projects too, not just HQ.
+		expect(
+			resolveProjectSlugForProjectRow(index, {
+				id: 'ops-proj',
+				container_status: 'running',
+				container_error: null,
+			}),
+		).toBe('operations');
+	});
+
+	test('returns undefined for an unknown project id', () => {
+		expect(resolveProjectSlugForProjectRow(index, { id: 'gone' })).toBeUndefined();
+		expect(resolveProjectSlugForProjectRow(index, {})).toBeUndefined();
+	});
+});
+
+describe('resolveProjectSlugForChange', () => {
+	test('routes a projects row to the id-based resolver', () => {
+		expect(resolveProjectSlugForChange(index, 'projects', { id: 'hq-proj' })).toBe('hq');
+	});
+
+	test('routes a strict table to the project_id-only resolver', () => {
+		expect(resolveProjectSlugForChange(index, 'heartbeat_runs', { project_id: 'ops-proj' })).toBe(
+			'operations',
+		);
+		expect(
+			resolveProjectSlugForChange(index, 'heartbeat_runs', { team_id: 'ops-team' }),
+		).toBeUndefined();
+	});
+
+	test('routes every other table to the project_id-then-team_id resolver', () => {
+		expect(resolveProjectSlugForChange(index, 'secrets', { team_id: 'ops-team' })).toBe(
+			'operations',
+		);
+		expect(resolveProjectSlugForChange(index, 'secrets', { project_id: 'hq-proj' })).toBe('hq');
+	});
+
+	test('a non-projects table is never resolved by its own row id', () => {
+		// `id` is the row's own primary key on every other table — resolving by it
+		// would map an unrelated row onto whichever project shares that uuid.
+		expect(resolveProjectSlugForChange(index, 'secrets', { id: 'ops-proj' })).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## The bug

Start the dev server, let it provision the HQ container: the container page reads **Running**, but the provisioning banner stays pinned at the top and the CEO chatbox stays on "waiting for container". A full page reload fixes it.

## Root cause

`useShellWebSockets` maps every `row_change` to a project slug before invalidating caches. A `projects` row went through the generic resolver, which prefers `row.project_id` and falls back to `row.team_id`. A `projects` row carries **neither** - its own `id` *is* the project id - so it always took the `team_id` fallback:

```ts
const teamUserProject = index.find((p) => p.team_id === teamUuid && !p.is_internal);
```

…which filters out `is_internal` projects. **HQ is the internal project**, so every HQ `projects` UPDATE resolved to `undefined` and invalidated nothing.

The transition that ends provisioning (`container_status` → `running`, broadcast by `broadcastProjectUpdate` from `provisionContainer`) is one of those. The status banner and the CEO chat's HQ gate both derive from `useContainerHealth(project)` reading the **project index**, so they stayed frozen. The container page looked correct only because it reads the **per-project detail** query, freshly fetched on navigation - which is exactly the "page says running, banner says provisioning" split that was reported.

A second, wider class of the same defect: several call sites broadcast a **partial** `projects` row carrying neither `project_id` nor `team_id`, so they were unresolvable for **ordinary projects too**, not just HQ:

- `job-manager.ts` startup container restart - `{ id, container_status, container_error }`
- `job-manager.ts` self-heal re-attach - `{ id, container_id, container_status }`
- `services/projects.ts` progress-summary write
- `repo-provisioning.ts` designated-repo update

The first two are precisely the boot-time paths that run when the dev server starts.

## The fix

`resolveProjectSlugForChange(index, table, row)` is now the single entry point and picks the resolver per table:

| Table | Resolves by |
|---|---|
| `projects` | the row's own **`id`** (new) |
| `tasks` / `task_comments` / `heartbeat_runs` / `agent_wakeup_requests` | `project_id` only |
| everything else | `project_id`, then `team_id` |

Every `projects` broadcast carries `id`, so this covers the full-row and partial-row shapes alike, HQ included. No server change needed.

**Safety net.** Row-change events have no replay, and the team rooms are derived from the project index itself - so there is a window between that query's response and the room join where a transition is dropped for good. The index now polls every 10s while any container sits in a **transient** state (`creating` / `stopping`; deliberately *not* the `null` of a torn-down project, which would poll forever). A missed transition costs a few seconds of stale banner instead of being stuck until reload. The interval switches off once everything settles, so it is inert in the steady state.

## Testing

- `packages/web/test/hq-provisioning-signal.test.tsx` (new, component tier) - seeds HQ at `creating`, opens the CEO chat, asserts the gate blocks the composer, flips the container to `running` and drives the subscriber's own resolve-then-invalidate path, then asserts the notice clears and the composer returns with no navigation or remount. **Verified red before the fix** (`expected undefined to be 'hq'`), green after.
- `resolve-project-slug-for-row.test.ts` - 11 new cases pinning the per-table routing, including that the generic resolver still cannot resolve HQ from a `projects` row (the trap), the partial-row shapes, and that a non-`projects` table is never resolved by its own row `id`.
- `query-keys-websocket.test.ts` - a `projects` row change invalidates the index (exactly) plus the container page's detail query.
- Full web component tier: 1246/1247 passing. The one failure (`task-detail.test.tsx` mention navigation) is an environmental flake under the oversubscribed 809s local run - it passes in isolation, and the change is provably inert there: the component harness stubs the WebSocket transport entirely (no row-change events are delivered), and a probe confirms seeded projects settle at `running`/`null`, never a transient status, so the poll never arms.
- `bun run typecheck` and `biome check` clean.

## Docs

`.dev/architecture.md` § web frontend data flow gains the row-change → project-slug resolution rules (with the HQ trap called out) and a container-state convergence note covering the poll. No `docs/` page documents the banner or CEO-gate behaviour, and this restores already-expected behaviour rather than changing it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Pu9HFT3rXzeNhGayagDiT)_