### PR TITLE
feat(restore): show progress while restoring large databases and asset bundles

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2023,7 +2023,17 @@ artifact internal callers still use), `--no-database` an assets-only bundle, and
 `--strict-assets` fails restore on any blob with no verifying row. Restore auto-detects the
 input: a directory is a bundle, a file with a logical header is a `.backup.gz`, otherwise a
 legacy physical pgdata tarball (`db/backup.ts` `dumpDataDir`/`restoreDataDir`, embedded
-only). External startup migrations write a bare logical `.backup.gz` into `<dataDir>/backups/`
+only). Restoring a large instance is minutes of work inside two loops (row inserts, blob
+copies), so both engines emit `ProgressState` updates through an optional `onProgress`
+callback and `runRestore` renders them (`lib/progress.ts`): a phase line per step
+(read/decompress/wipe/schema/prepare/constraints) and a live counter with percentage and
+ETA for the countable ones (rows parsed, rows loaded per table, blobs copied). Rendering
+adapts to the stream — one line rewritten in place (`\r` + erase-to-EOL) on a TTY, throttled
+appended lines into a pipe or log file — and the engines themselves stay terminal-agnostic.
+The CLI decompresses a single-file `.backup.gz` **once** (`decompressLogicalBackup` +
+`parseLogicalBackupHeader`, then handing the text to `restoreLogicalBackup`, which accepts
+`Buffer | string`) rather than gunzipping a multi-GB backup for the header and again for the
+load. External startup migrations write a bare logical `.backup.gz` into `<dataDir>/backups/`
 automatically before applying (last 5 kept; a failed backup aborts the migration); the
 embedded path keeps its stronger copy-swap instead. The `hezo backup`/`hezo restore`
 subcommands resolve the data dir with the same precedence as the server (`HEZO_DATA_DIR` >

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -103,6 +103,22 @@ restored database forward to the binary's current schema.
 Legacy physical snapshots (`.tar.gz` files from older Hezo versions) still restore with
 the same command, into the embedded database only.
 
+### Watching a large restore
+
+A big instance takes minutes to restore, so `hezo restore` reports what it is doing at every
+step - reading and decompressing the backup, recreating the schema, then a live counter for
+the two long parts:
+
+```
+Loading rows · 42% · 1,204,000/2,860,113 rows · task_comments · 1m 12s · ~1m 40s left
+Restoring asset files · 88% · 8,412/9,530 files · 3.1 GB · 4m 06s · ~32s left
+```
+
+In a terminal that single line is rewritten in place. When the output goes to a pipe or a
+log file (systemd, Docker), the same updates are appended as ordinary lines every few
+seconds instead, so a restore you started over SSH or under a service manager still shows
+its progress in the log.
+
 ## Moving between local and hosted storage
 
 The same two commands are the migration path for the database **and** assets, in either

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -111,7 +111,12 @@ The target database must be empty unless `--wipe` is passed. Restored asset blob
 verified by checksum against the database rows; `--strict-assets` fails if any blob has
 no matching row. `--no-assets` / `--no-database` restore only one half of a bundle.
 Backups taken by a newer Hezo are refused — upgrade first. Like `hezo backup`, restore
-reads `--data-dir` from `HEZO_DATA_DIR` when the flag is omitted. See
+reads `--data-dir` from `HEZO_DATA_DIR` when the flag is omitted.
+
+Restore prints its progress as it goes - a line per step, plus a live counter with a
+percentage and an estimated time remaining while it loads rows and copies asset files. In a
+terminal the counter is rewritten in place; piped to a log file it is appended every few
+seconds. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Reset

--- a/packages/server/src/assets/blob-backup.ts
+++ b/packages/server/src/assets/blob-backup.ts
@@ -27,6 +27,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Db } from '../db/database';
+import type { ProgressCallback } from '../lib/progress';
 import { logger } from '../logger';
 import { AssetNotFoundError, type AssetStore } from './store';
 
@@ -187,6 +188,15 @@ export async function dumpAssetBlobs(
 	return { count, bytes, missing };
 }
 
+export interface RestoreAssetBlobsOptions {
+	strict?: boolean;
+	/**
+	 * Per-file counter updates for a terminal progress line - a bundle can hold
+	 * tens of thousands of blobs, and copying them is otherwise silent.
+	 */
+	onProgress?: ProgressCallback;
+}
+
 /**
  * Write every blob in the bundle's `assets/` tree into `store`. Each write
  * recomputes the sha256, which is asserted against the target `assets` row when
@@ -199,9 +209,11 @@ export async function restoreAssetBlobs(
 	db: Db,
 	store: AssetStore,
 	bundleDir: string,
-	options: { strict?: boolean } = {},
+	options: RestoreAssetBlobsOptions = {},
 ): Promise<AssetRestoreSummary> {
+	const progress: ProgressCallback = options.onProgress ?? (() => {});
 	const assetsRoot = join(bundleDir, BUNDLE_ASSETS_DIR);
+	progress({ phase: 'assets-scan', label: 'Scanning the bundle for asset files' });
 	const blobs = await enumerateBundleBlobs(assetsRoot);
 	const rowsById = new Map<string, AssetRow>();
 	for (const row of await enumerateAssetRows(db)) rowsById.set(row.id, row);
@@ -210,6 +222,17 @@ export async function restoreAssetBlobs(
 	let bytes = 0;
 	let verified = 0;
 	let unverified = 0;
+
+	const reportCopied = () =>
+		progress({
+			phase: 'assets',
+			label: 'Restoring asset files',
+			done: count,
+			total: blobs.length,
+			unit: 'files',
+			bytes,
+		});
+	reportCopied();
 
 	await forEachConcurrent(blobs, ASSET_COPY_CONCURRENCY, async ({ projectId, assetId }) => {
 		const buf = await readFile(join(assetsRoot, projectId, assetId));
@@ -236,6 +259,7 @@ export async function restoreAssetBlobs(
 		}
 		count += 1;
 		bytes += buf.byteLength;
+		reportCopied();
 	});
 
 	return { count, bytes, verified, unverified };

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -8,6 +8,7 @@ import {
 	validateMnemonic,
 } from '@hezo/shared';
 import { Command } from 'commander';
+import { createStreamProgressReporter, formatBytes } from './lib/progress';
 import { DEFAULT_TELEMETRY_ENDPOINT } from './services/telemetry';
 import { HEZO_VERSION } from './version';
 
@@ -423,6 +424,11 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
  * Asset blobs are verified by sha256 against the target rows when present.
  * Returns `true` when it handled the invocation so the caller skips normal
  * server startup.
+ *
+ * Every phase reports progress (`lib/progress.ts`) — a live row/file counter
+ * with a percentage and ETA, rewritten in place on a TTY and appended as
+ * throttled lines when the output is a pipe or a log file — so a restore of a
+ * large instance is never a silent multi-minute wait.
  */
 export async function runRestore(argv: string[] = process.argv): Promise<boolean> {
 	if (argv[2] !== 'restore') return false;
@@ -466,6 +472,10 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	const { openDatabase } = await import('./db/open.js');
 	const blob = await import('./assets/blob-backup.js');
 
+	// Restoring a large instance is minutes of work with nothing to look at:
+	// report each phase (and a live row/file counter) on the way through.
+	const progress = createStreamProgressReporter();
+
 	// Backup bundle (a directory): restore the database and/or assets it holds.
 	if (await blob.isBundleDir(backupPath)) {
 		const withAssets = opts.assets !== false;
@@ -477,7 +487,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 		const restoreDb = withDatabase && manifest.database !== null;
 		const restoreAssets = withAssets && manifest.assets !== null;
 
-		const { readFile } = await import('node:fs/promises');
+		const { readFile, stat } = await import('node:fs/promises');
 		const { openAssetStorage } = await import('./assets/open.js');
 
 		const opened = await openDatabase({ dataDir, databaseUrl });
@@ -490,10 +500,18 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 					throw new Error('No migrations found — cannot reproduce the backup schema.');
 				}
 				const { restoreLogicalBackup } = await import('./db/logical-backup.js');
-				const dbBytes = await readFile(join(backupPath, blob.BUNDLE_DB_NAME));
+				const dbPath = join(backupPath, blob.BUNDLE_DB_NAME);
+				progress.report({
+					phase: 'read',
+					label: 'Reading the database backup',
+					detail: formatBytes((await stat(dbPath)).size),
+				});
+				const dbBytes = await readFile(dbPath);
 				const summary = await restoreLogicalBackup(opened.db, dbBytes, migrations, {
 					wipe: opts.wipe === true,
+					onProgress: progress.report,
 				});
+				progress.finish();
 				console.log(
 					`Restored database (Hezo ${manifest.hezoVersion}, taken ${manifest.createdAt}) into the ` +
 						`${opened.storage.backend} backend: ${summary.rows} rows across ${summary.tables} tables.`,
@@ -502,7 +520,9 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 			if (restoreAssets && openedStore) {
 				const summary = await blob.restoreAssetBlobs(opened.db, openedStore.store, backupPath, {
 					strict: opts.strictAssets === true,
+					onProgress: progress.report,
 				});
+				progress.finish();
 				const unverifiedNote = summary.unverified
 					? ` (${summary.unverified} without a matching database row)`
 					: '';
@@ -514,6 +534,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 				console.log('This bundle has nothing to restore for the given options.');
 			}
 		} finally {
+			progress.finish();
 			await closeQuietly(openedStore?.store);
 			await closeQuietly(opened.db);
 		}
@@ -521,15 +542,27 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	}
 
 	// Single-file backups (unchanged): logical .backup.gz, or a legacy pgdata tarball.
-	const { readFile } = await import('node:fs/promises');
+	const { readFile, stat } = await import('node:fs/promises');
+	progress.report({
+		phase: 'read',
+		label: 'Reading the backup',
+		detail: formatBytes((await stat(backupPath)).size),
+	});
 	const bytes = await readFile(backupPath);
 
-	const { readLogicalBackupHeader, restoreLogicalBackup } = await import('./db/logical-backup.js');
-	const header = readLogicalBackupHeader(bytes);
+	const { decompressLogicalBackup, parseLogicalBackupHeader, restoreLogicalBackup } = await import(
+		'./db/logical-backup.js'
+	);
+	// Decompress once here and hand the text to the restore: on a multi-GB
+	// backup a second gunzip inside it would be minutes of duplicated work.
+	progress.report({ phase: 'decompress', label: 'Decompressing the backup' });
+	const text = decompressLogicalBackup(bytes);
+	const header = text === null ? null : parseLogicalBackupHeader(text);
 
-	if (!header) {
+	if (!header || text === null) {
 		// Legacy physical pgdata tarball — embedded only.
 		if (databaseUrl) {
+			progress.finish();
 			console.error(
 				'This file is a legacy pgdata snapshot, which only restores into the embedded ' +
 					'database. To move data into an external Postgres, take a portable backup with ' +
@@ -538,7 +571,11 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 			process.exit(1);
 		}
 		const { restoreDataDir } = await import('./db/backup.js');
-		await restoreDataDir(dataDir, backupPath);
+		try {
+			await restoreDataDir(dataDir, backupPath, { onProgress: progress.report });
+		} finally {
+			progress.finish();
+		}
 		return true;
 	}
 
@@ -547,14 +584,17 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 
 	const opened = await openDatabase({ dataDir, databaseUrl });
 	try {
-		const summary = await restoreLogicalBackup(opened.db, bytes, migrations, {
+		const summary = await restoreLogicalBackup(opened.db, text, migrations, {
 			wipe: opts.wipe === true,
+			onProgress: progress.report,
 		});
+		progress.finish();
 		console.log(
 			`Restored logical backup (Hezo ${header.hezoVersion}, taken ${header.createdAt}) ` +
 				`into the ${opened.storage.backend} database: ${summary.rows} rows across ${summary.tables} tables.`,
 		);
 	} finally {
+		progress.finish();
 		await closeQuietly(opened.db);
 	}
 	return true;

--- a/packages/server/src/db/backup.ts
+++ b/packages/server/src/db/backup.ts
@@ -1,5 +1,6 @@
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { formatBytes, type ProgressCallback } from '../lib/progress';
 import { logger } from '../logger';
 import type { PgliteDb } from './drivers/pglite';
 
@@ -70,12 +71,18 @@ async function pruneBackups(backupsDir: string): Promise<void> {
  * data directory first. After this the operator runs the matching (older) Hezo
  * binary. Used by the `hezo restore` CLI subcommand for manual downgrade.
  */
-export async function restoreDataDir(dataDir: string, backupFile: string): Promise<void> {
+export async function restoreDataDir(
+	dataDir: string,
+	backupFile: string,
+	options: { onProgress?: ProgressCallback } = {},
+): Promise<void> {
+	const progress: ProgressCallback = options.onProgress ?? (() => {});
 	const { PGlite } = await import('@electric-sql/pglite');
 	const { NodeFS } = await import('@electric-sql/pglite/nodefs');
 	const { loadPgliteAssets } = await import('./pglite-assets');
 
 	const pgDataPath = join(dataDir, 'pgdata');
+	progress({ phase: 'read', label: 'Reading the snapshot' });
 	const bytes = await readFile(backupFile);
 	const blob = new File([bytes as BlobPart], 'dump.tar.gz', { type: 'application/gzip' });
 
@@ -83,6 +90,13 @@ export async function restoreDataDir(dataDir: string, backupFile: string): Promi
 	// in dev they resolve from node_modules.
 	const assets = await loadPgliteAssets();
 
+	// The whole snapshot is unpacked inside one PGlite open call, so this phase
+	// can only be announced (with its size) - there is no interior to count.
+	progress({
+		phase: 'legacy-load',
+		label: 'Loading the pgdata snapshot',
+		detail: formatBytes(bytes.byteLength),
+	});
 	await rm(pgDataPath, { recursive: true, force: true });
 	const db = assets
 		? new PGlite({

--- a/packages/server/src/db/logical-backup.ts
+++ b/packages/server/src/db/logical-backup.ts
@@ -1,4 +1,5 @@
 import { gunzipSync, gzipSync } from 'node:zlib';
+import { formatBytes, type ProgressCallback } from '../lib/progress';
 import type { Db, Queryable } from './database';
 import { checksumOfMigration, type Migration, runMigrations } from './migrate';
 import { BackupNewerThanAppError, RestorePreconditionError } from './migrate-errors';
@@ -27,6 +28,13 @@ import { BASE_SCHEMA } from './schema';
 const FORMAT_VERSION = 1;
 const DUMP_PAGE_SIZE = 5_000;
 const INSERT_BATCH_SIZE = 500;
+
+/**
+ * Rows between progress reports while parsing the dump. Parsing is a tight loop
+ * over millions of lines, so it reports on a row interval rather than per row;
+ * the reporter throttles rendering on top of that.
+ */
+const PARSE_PROGRESS_ROWS = 20_000;
 
 /**
  * Ceiling on the data volume a single dump query may return / a single restore
@@ -258,14 +266,23 @@ export async function dumpLogicalBackup(
 	return gzipSync(`${lines.join('\n')}\n`);
 }
 
-/** Parse just the header from a logical backup buffer; null if not this format. */
-export function readLogicalBackupHeader(bytes: Buffer): LogicalBackupHeader | null {
-	let text: string;
+/**
+ * Decompress a logical backup to its JSONL text; null when the bytes aren't
+ * gzip at all (a legacy physical pgdata tarball, or a wrong file entirely).
+ * Exposed separately from the header parse so a caller restoring a multi-GB
+ * backup decompresses it once and hands the text to `restoreLogicalBackup`
+ * rather than paying for a second pass.
+ */
+export function decompressLogicalBackup(bytes: Buffer): string | null {
 	try {
-		text = gunzipSync(bytes).toString('utf8');
+		return gunzipSync(bytes).toString('utf8');
 	} catch {
 		return null;
 	}
+}
+
+/** Parse just the header line of a decompressed backup; null if not this format. */
+export function parseLogicalBackupHeader(text: string): LogicalBackupHeader | null {
 	const firstLine = text.slice(0, text.indexOf('\n'));
 	try {
 		const header = JSON.parse(firstLine) as LogicalBackupHeader;
@@ -277,8 +294,24 @@ export function readLogicalBackupHeader(bytes: Buffer): LogicalBackupHeader | nu
 	}
 }
 
+/** Parse just the header from a logical backup buffer; null if not this format. */
+export function readLogicalBackupHeader(bytes: Buffer): LogicalBackupHeader | null {
+	const text = decompressLogicalBackup(bytes);
+	return text === null ? null : parseLogicalBackupHeader(text);
+}
+
+export interface RestoreLogicalBackupOptions {
+	wipe?: boolean;
+	/**
+	 * Phase/counter updates for a terminal progress line. A restore of a large
+	 * instance is minutes of silence otherwise (see `lib/progress.ts`).
+	 */
+	onProgress?: ProgressCallback;
+}
+
 /**
- * Restore a logical backup into `db`. The target must be empty (no tables in
+ * Restore a logical backup into `db`, from either the gzipped bytes or the
+ * already-decompressed JSONL text. The target must be empty (no tables in
  * `public`) unless `wipe` is set, which drops and recreates the schema first.
  * Schema is reproduced by replaying the binary's own migrations up to exactly
  * the set the backup recorded (a backup carrying unknown migrations refuses —
@@ -289,11 +322,24 @@ export function readLogicalBackupHeader(bytes: Buffer): LogicalBackupHeader | nu
  */
 export async function restoreLogicalBackup(
 	db: Db,
-	bytes: Buffer,
+	backup: Buffer | string,
 	binaryMigrations: Record<string, Migration>,
-	options: { wipe?: boolean } = {},
+	options: RestoreLogicalBackupOptions = {},
 ): Promise<RestoreSummary> {
-	const text = gunzipSync(bytes).toString('utf8');
+	const progress: ProgressCallback = options.onProgress ?? (() => {});
+	let text: string;
+	if (typeof backup === 'string') {
+		text = backup;
+	} else {
+		// gunzip is one blocking call with no observable interior, so this phase
+		// is announced rather than counted.
+		progress({
+			phase: 'decompress',
+			label: 'Decompressing the database backup',
+			detail: formatBytes(backup.byteLength),
+		});
+		text = gunzipSync(backup).toString('utf8');
+	}
 	const newline = text.indexOf('\n');
 	const header = JSON.parse(text.slice(0, newline)) as LogicalBackupHeader;
 	if (header.formatVersion !== FORMAT_VERSION) {
@@ -330,10 +376,17 @@ export async function restoreLogicalBackup(
 					`Pass --wipe to drop the existing schema and restore over it, or point at an empty database.`,
 			);
 		}
+		progress({ phase: 'wipe', label: 'Dropping the existing schema' });
 		await db.exec('DROP SCHEMA public CASCADE; CREATE SCHEMA public;');
 	}
 
-	// Reproduce the schema at exactly the backup's migration set.
+	// Reproduce the schema at exactly the backup's migration set. Announced (not
+	// counted) because `runMigrations` logs a line per migration itself.
+	progress({
+		phase: 'schema',
+		label: 'Recreating the schema',
+		detail: `${header.migrations.length} migrations`,
+	});
 	await db.exec(BASE_SCHEMA);
 	const subset: Record<string, Migration> = {};
 	for (const m of header.migrations) subset[m.filename] = binaryMigrations[m.filename];
@@ -346,16 +399,35 @@ export async function restoreLogicalBackup(
 	// each row's encoded size so inserts can be batched by bytes as well as
 	// row count.
 	const rowsByTable = new Map<string, Array<{ row: Record<string, unknown>; bytes: number }>>();
-	for (const line of text.slice(newline + 1).split('\n')) {
+	const body = text.slice(newline + 1);
+	// The row total isn't known until the whole body is read, so completion is
+	// reported as the fraction of the body consumed.
+	const reportParsed = (parsed: number, consumed: number) =>
+		progress({
+			phase: 'parse',
+			label: 'Reading rows from the backup',
+			done: parsed,
+			unit: 'rows',
+			ratio: body.length > 0 ? consumed / body.length : 1,
+		});
+	let parsedRows = 0;
+	let consumedChars = 0;
+	reportParsed(0, 0);
+	for (const line of body.split('\n')) {
+		consumedChars += line.length + 1;
 		if (!line) continue;
 		const { t, r } = JSON.parse(line) as { t: string; r: Record<string, unknown> };
 		const list = rowsByTable.get(t) ?? [];
 		list.push({ row: r, bytes: line.length });
 		rowsByTable.set(t, list);
+		parsedRows += 1;
+		if (parsedRows % PARSE_PROGRESS_ROWS === 0) reportParsed(parsedRows, consumedChars);
 	}
+	reportParsed(parsedRows, body.length);
 
 	let totalRows = 0;
 	await db.transaction(async (tx) => {
+		progress({ phase: 'prepare', label: 'Preparing the target schema' });
 		// Drop every FK so insert order (and self-references) never matter;
 		// re-created verbatim below. DDL is transactional — a failed restore
 		// leaves no half-loaded state.
@@ -376,6 +448,17 @@ export async function restoreLogicalBackup(
 			if (table.name === '_migrations') continue;
 			await tx.exec(`TRUNCATE ${quoteIdent(table.name)}`);
 		}
+
+		const reportLoaded = (table: string) =>
+			progress({
+				phase: 'load',
+				label: 'Loading rows',
+				done: totalRows,
+				total: parsedRows,
+				unit: 'rows',
+				detail: table,
+			});
+		reportLoaded('');
 
 		for (const [tableName, rows] of rowsByTable) {
 			const meta = tableMeta.get(tableName);
@@ -412,9 +495,11 @@ export async function restoreLogicalBackup(
 					params,
 				);
 				totalRows += batch.length;
+				reportLoaded(tableName);
 			}
 		}
 
+		progress({ phase: 'constraints', label: 'Restoring foreign keys and sequences' });
 		for (const fk of fks.rows) {
 			await tx.exec(`ALTER TABLE ${fk.tbl} ADD CONSTRAINT ${quoteIdent(fk.name)} ${fk.def}`);
 		}

--- a/packages/server/src/lib/progress.ts
+++ b/packages/server/src/lib/progress.ts
@@ -1,0 +1,256 @@
+/**
+ * Terminal progress reporting for the long-running CLI subcommands.
+ *
+ * A restore of a real instance spends most of its wall time inside two silent
+ * loops - inserting millions of rows and copying thousands of asset blobs -
+ * during which the operator cannot tell a slow restore from a hung one. The
+ * engines (`db/logical-backup.ts`, `assets/blob-backup.ts`) stay free of
+ * terminal concerns: they emit `ProgressState` values through an optional
+ * callback, and the CLI owns rendering.
+ *
+ * Rendering adapts to the output stream. On a TTY a single line is rewritten in
+ * place, so a minutes-long phase occupies one row. When output is a pipe or a
+ * log file (systemd, Docker, CI) the same information is appended as ordinary
+ * lines, throttled so a long restore adds a handful of lines rather than
+ * thousands.
+ *
+ * Two shapes of phase:
+ *
+ * - **Announcement** (no `done`/`bytes`/`ratio`) - a step whose duration can't
+ *   be measured from outside, e.g. a blocking `gunzip`. Printed as a terminated
+ *   line, so anything the step itself logs (migration lines during the schema
+ *   replay) starts on a clean row.
+ * - **Counter** - a step with a running count. Rewritten in place until the
+ *   phase changes; the final state of each phase is always flushed.
+ */
+
+export interface ProgressState {
+	/** Stable phase id; a change ends the previous phase's line. */
+	phase: string;
+	/** Human-readable phase label, e.g. "Loading rows". */
+	label: string;
+	/** Units completed so far. */
+	done?: number;
+	/** Total units, when known up front. */
+	total?: number;
+	/** Unit noun for `done`/`total`, e.g. "rows" or "files". */
+	unit?: string;
+	/** Bytes processed so far, shown alongside the unit counts. */
+	bytes?: number;
+	/** Extra context - the table or file currently being processed. */
+	detail?: string;
+	/**
+	 * Explicit 0..1 completion for a phase whose progress isn't expressed by
+	 * `done`/`total` (e.g. rows parsed out of a known input length).
+	 */
+	ratio?: number;
+}
+
+export type ProgressCallback = (state: ProgressState) => void;
+
+export interface ProgressReporter {
+	report: ProgressCallback;
+	/** Flush and end the active line. Safe to call repeatedly. */
+	finish: () => void;
+	/** Print a standalone line without losing the current phase's last state. */
+	note: (line: string) => void;
+}
+
+export interface ProgressWriteStream {
+	write(chunk: string): unknown;
+	isTTY?: boolean;
+	columns?: number;
+}
+
+export interface ProgressReporterOptions {
+	write: (chunk: string) => void;
+	isTty?: boolean;
+	columns?: number;
+	/** Minimum ms between re-renders within one phase. */
+	throttleMs?: number;
+	now?: () => number;
+}
+
+/** Re-render at most ~8x/second on a TTY - smooth without burning the terminal. */
+const TTY_THROTTLE_MS = 120;
+/** One appended line every few seconds keeps a piped log readable. */
+const PIPE_THROTTLE_MS = 5_000;
+/** An ETA computed off the first moment of a phase is noise. */
+const ETA_MIN_ELAPSED_MS = 3_000;
+const DEFAULT_COLUMNS = 80;
+/** ANSI erase-to-end-of-line, so a shorter re-render leaves no stale tail. */
+const CLEAR_TO_EOL = '\u001b[K';
+
+const COUNT_FORMAT = new Intl.NumberFormat('en-US');
+
+export function formatCount(n: number): string {
+	if (!Number.isFinite(n)) return '0';
+	return COUNT_FORMAT.format(Math.round(n));
+}
+
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+export function formatBytes(n: number): string {
+	if (!Number.isFinite(n) || n <= 0) return '0 B';
+	let value = n;
+	let unit = 0;
+	while (value >= 1024 && unit < BYTE_UNITS.length - 1) {
+		value /= 1024;
+		unit += 1;
+	}
+	const digits = unit === 0 ? 0 : value < 10 ? 1 : 0;
+	return `${value.toFixed(digits)} ${BYTE_UNITS[unit]}`;
+}
+
+export function formatDuration(ms: number): string {
+	if (!Number.isFinite(ms) || ms <= 0) return '0s';
+	const totalSeconds = Math.round(ms / 1000);
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+	const minutes = Math.floor(totalSeconds / 60);
+	if (minutes < 60) return `${minutes}m ${String(totalSeconds % 60).padStart(2, '0')}s`;
+	const hours = Math.floor(minutes / 60);
+	return `${hours}h ${String(minutes % 60).padStart(2, '0')}m`;
+}
+
+/** Completion of a state as 0..1, or undefined when it can't be known. */
+export function progressRatio(state: ProgressState): number | undefined {
+	if (state.ratio !== undefined && Number.isFinite(state.ratio)) {
+		return Math.min(1, Math.max(0, state.ratio));
+	}
+	if (state.total !== undefined && state.total > 0 && state.done !== undefined) {
+		return Math.min(1, Math.max(0, state.done / state.total));
+	}
+	return undefined;
+}
+
+/** Linear extrapolation from the phase's own elapsed time; undefined when unusable. */
+function estimateRemainingMs(ratio: number | undefined, elapsedMs: number): number | undefined {
+	if (ratio === undefined || ratio <= 0 || ratio >= 1) return undefined;
+	if (elapsedMs < ETA_MIN_ELAPSED_MS) return undefined;
+	return (elapsedMs * (1 - ratio)) / ratio;
+}
+
+/** Trim to `columns` so an over-wide line can still be rewritten in place. */
+export function truncateLine(line: string, columns: number): string {
+	if (columns <= 1 || line.length <= columns) return line;
+	return `${line.slice(0, Math.max(1, columns - 1))}…`;
+}
+
+export function formatProgressLine(state: ProgressState, elapsedMs: number): string {
+	const parts: string[] = [state.label];
+	const ratio = progressRatio(state);
+	if (ratio !== undefined) parts.push(`${Math.floor(ratio * 100)}%`);
+	if (state.done !== undefined) {
+		const unit = state.unit ? ` ${state.unit}` : '';
+		parts.push(
+			state.total !== undefined
+				? `${formatCount(state.done)}/${formatCount(state.total)}${unit}`
+				: `${formatCount(state.done)}${unit}`,
+		);
+	}
+	if (state.bytes !== undefined) parts.push(formatBytes(state.bytes));
+	if (state.detail) parts.push(state.detail);
+	if (elapsedMs >= 1_000) parts.push(formatDuration(elapsedMs));
+	const remaining = estimateRemainingMs(ratio, elapsedMs);
+	if (remaining !== undefined) parts.push(`~${formatDuration(remaining)} left`);
+	return parts.join(' · ');
+}
+
+/** True when the state carries a running measure (vs a one-shot announcement). */
+function isCounterState(state: ProgressState): boolean {
+	return state.done !== undefined || state.bytes !== undefined || state.ratio !== undefined;
+}
+
+export function createProgressReporter(options: ProgressReporterOptions): ProgressReporter {
+	const isTty = options.isTty === true;
+	const now = options.now ?? (() => Date.now());
+	const throttleMs = options.throttleMs ?? (isTty ? TTY_THROTTLE_MS : PIPE_THROTTLE_MS);
+	const columns = Math.max(20, options.columns || DEFAULT_COLUMNS);
+
+	let phase: string | null = null;
+	let phaseStartedAt = 0;
+	/** Latest state not yet rendered (throttled away) - flushed before the phase ends. */
+	let pending: ProgressState | null = null;
+	let lastRenderAt = 0;
+	/** A TTY line is on screen without its terminating newline. */
+	let lineOpen = false;
+
+	const render = (state: ProgressState): void => {
+		const line = truncateLine(formatProgressLine(state, now() - phaseStartedAt), columns - 1);
+		if (isTty) {
+			// \r returns to column 0, CLEAR_TO_EOL wipes the tail of a longer previous line.
+			options.write(`\r${line}${CLEAR_TO_EOL}`);
+			lineOpen = true;
+		} else {
+			options.write(`${line}\n`);
+		}
+		lastRenderAt = now();
+		pending = null;
+	};
+
+	const endPhase = (): void => {
+		if (pending) render(pending);
+		if (lineOpen) {
+			options.write('\n');
+			lineOpen = false;
+		}
+		phase = null;
+	};
+
+	return {
+		report(state: ProgressState): void {
+			if (state.phase !== phase) {
+				endPhase();
+				phase = state.phase;
+				phaseStartedAt = now();
+				lastRenderAt = 0;
+				render(state);
+			} else {
+				const ratio = progressRatio(state);
+				const complete = ratio !== undefined && ratio >= 1;
+				if (!complete && now() - lastRenderAt < throttleMs) {
+					pending = state;
+					return;
+				}
+				render(state);
+			}
+			// An announcement never stays open: whatever the step logs next starts
+			// on its own row.
+			if (!isCounterState(state) && lineOpen) {
+				options.write('\n');
+				lineOpen = false;
+			}
+		},
+		finish(): void {
+			endPhase();
+		},
+		note(line: string): void {
+			endPhase();
+			options.write(`${line}\n`);
+		},
+	};
+}
+
+/** A reporter that renders nothing - for tests and non-interactive callers. */
+export function createNullProgressReporter(): ProgressReporter {
+	return { report: () => {}, finish: () => {}, note: () => {} };
+}
+
+/**
+ * Reporter bound to a process stream (stdout by default). Silent under vitest
+ * (`NODE_ENV=test`), where raw stream writes would fight the test reporter -
+ * the rendering itself is covered by unit tests against an injected stream.
+ */
+export function createStreamProgressReporter(
+	stream: ProgressWriteStream = process.stdout,
+	env: NodeJS.ProcessEnv = process.env,
+): ProgressReporter {
+	if (env.NODE_ENV === 'test') return createNullProgressReporter();
+	return createProgressReporter({
+		write: (chunk) => {
+			stream.write(chunk);
+		},
+		isTty: stream.isTTY === true,
+		columns: stream.columns,
+	});
+}

--- a/packages/server/test/restore-progress.test.ts
+++ b/packages/server/test/restore-progress.test.ts
@@ -1,0 +1,450 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { restoreAssetBlobs } from '../src/assets/blob-backup';
+import { LocalAssetStore } from '../src/assets/drivers/local';
+import { createMemoryDb } from '../src/db/client';
+import type { Db } from '../src/db/database';
+import {
+	decompressLogicalBackup,
+	dumpLogicalBackup,
+	parseLogicalBackupHeader,
+	readLogicalBackupHeader,
+	restoreLogicalBackup,
+} from '../src/db/logical-backup';
+import { runMigrations } from '../src/db/migrate';
+import { openDatabase } from '../src/db/open';
+import { BASE_SCHEMA } from '../src/db/schema';
+import {
+	createProgressReporter,
+	createStreamProgressReporter,
+	formatBytes,
+	formatCount,
+	formatDuration,
+	formatProgressLine,
+	type ProgressState,
+	progressRatio,
+	truncateLine,
+} from '../src/lib/progress';
+import { safeClose } from './helpers';
+import { createTestApp } from './helpers/app';
+import { allMigrations } from './helpers/migrate';
+
+// `hezo restore` on a real instance spends minutes inside two loops (row
+// inserts, asset-blob copies) that used to print nothing at all, so an operator
+// could not tell a slow restore from a hung one. These cover both halves: the
+// renderer that turns progress states into terminal output, and the restore
+// engines that emit those states.
+
+/** The ANSI erase-to-end-of-line the in-place renderer appends. */
+const CLEAR_TO_EOL = '\u001b[K';
+
+const tempDirs: string[] = [];
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'hezo-restore-progress-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A stream stand-in that records every chunk the reporter writes. */
+function fakeStream(opts: { isTTY?: boolean; columns?: number } = {}) {
+	const chunks: string[] = [];
+	return {
+		write: (chunk: string) => {
+			chunks.push(chunk);
+			return true;
+		},
+		isTTY: opts.isTTY,
+		columns: opts.columns,
+		text: () => chunks.join(''),
+		/** Rendered lines, with the in-place control codes stripped. */
+		lines: () =>
+			chunks
+				.join('')
+				.split(CLEAR_TO_EOL)
+				.join('')
+				.split(/[\r\n]/)
+				.filter((l) => l.length > 0),
+	};
+}
+
+/** A clock the reporter reads, so throttling and ETAs are deterministic. */
+function fakeClock(start = 0) {
+	let t = start;
+	return {
+		now: () => t,
+		advance: (ms: number) => {
+			t += ms;
+		},
+	};
+}
+
+describe('progress formatting', () => {
+	it('formats counts, bytes and durations for an operator', () => {
+		expect(formatCount(0)).toBe('0');
+		expect(formatCount(1_204_000)).toBe('1,204,000');
+
+		expect(formatBytes(0)).toBe('0 B');
+		expect(formatBytes(-5)).toBe('0 B');
+		expect(formatBytes(900)).toBe('900 B');
+		expect(formatBytes(1536)).toBe('1.5 KB');
+		expect(formatBytes(20 * 1024 * 1024)).toBe('20 MB');
+		expect(formatBytes(3.5 * 1024 ** 3)).toBe('3.5 GB');
+
+		expect(formatDuration(0)).toBe('0s');
+		expect(formatDuration(12_400)).toBe('12s');
+		expect(formatDuration(72_000)).toBe('1m 12s');
+		expect(formatDuration(3_930_000)).toBe('1h 05m');
+	});
+
+	it('derives completion from counters or an explicit ratio, clamped to 0..1', () => {
+		expect(progressRatio({ phase: 'p', label: 'l' })).toBeUndefined();
+		// No total to divide by → unknown, not 0%.
+		expect(progressRatio({ phase: 'p', label: 'l', done: 5 })).toBeUndefined();
+		expect(progressRatio({ phase: 'p', label: 'l', done: 5, total: 20 })).toBe(0.25);
+		expect(progressRatio({ phase: 'p', label: 'l', done: 30, total: 20 })).toBe(1);
+		expect(progressRatio({ phase: 'p', label: 'l', ratio: 0.5, done: 1, total: 20 })).toBe(0.5);
+		expect(progressRatio({ phase: 'p', label: 'l', total: 0, done: 0 })).toBeUndefined();
+	});
+
+	it('renders percent, counts, detail, elapsed and an ETA', () => {
+		const state: ProgressState = {
+			phase: 'load',
+			label: 'Loading rows',
+			done: 250_000,
+			total: 1_000_000,
+			unit: 'rows',
+			detail: 'task_comments',
+		};
+		expect(formatProgressLine(state, 60_000)).toBe(
+			'Loading rows · 25% · 250,000/1,000,000 rows · task_comments · 1m 00s · ~3m 00s left',
+		);
+
+		// Under a second in: no elapsed, and no ETA extrapolated from noise.
+		expect(formatProgressLine(state, 200)).toBe(
+			'Loading rows · 25% · 250,000/1,000,000 rows · task_comments',
+		);
+		// Complete → nothing left to estimate.
+		expect(formatProgressLine({ ...state, done: 1_000_000 }, 60_000)).toBe(
+			'Loading rows · 100% · 1,000,000/1,000,000 rows · task_comments · 1m 00s',
+		);
+		// Byte counters ride alongside the unit counts.
+		expect(
+			formatProgressLine(
+				{
+					phase: 'assets',
+					label: 'Restoring asset files',
+					done: 3,
+					total: 10,
+					unit: 'files',
+					bytes: 2048,
+				},
+				0,
+			),
+		).toBe('Restoring asset files · 30% · 3/10 files · 2.0 KB');
+		// An announcement is just its label plus context.
+		expect(
+			formatProgressLine({ phase: 'read', label: 'Reading the backup', detail: '1.5 KB' }, 0),
+		).toBe('Reading the backup · 1.5 KB');
+	});
+
+	it('truncates a line that would wrap past the terminal width', () => {
+		expect(truncateLine('short', 40)).toBe('short');
+		expect(truncateLine('0123456789', 5)).toBe('0123…');
+		expect(truncateLine('0123456789', 0)).toBe('0123456789');
+	});
+});
+
+describe('progress reporter', () => {
+	it('rewrites one line in place on a TTY and closes it when the phase ends', () => {
+		const stream = fakeStream({ isTTY: true, columns: 200 });
+		const clock = fakeClock();
+		const reporter = createProgressReporter({
+			write: stream.write,
+			isTty: true,
+			columns: 200,
+			throttleMs: 100,
+			now: clock.now,
+		});
+
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 0, total: 10, unit: 'rows' });
+		clock.advance(150);
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 5, total: 10, unit: 'rows' });
+		clock.advance(150);
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 10, total: 10, unit: 'rows' });
+		reporter.finish();
+
+		// Every update rewrote the same row: carriage returns, one closing newline.
+		const text = stream.text();
+		expect(text.split('\r').length - 1).toBe(3);
+		expect(text.split('\n').length - 1).toBe(1);
+		expect(text).toContain(CLEAR_TO_EOL);
+		expect(stream.lines()).toEqual([
+			'Loading rows · 0% · 0/10 rows',
+			'Loading rows · 50% · 5/10 rows',
+			'Loading rows · 100% · 10/10 rows',
+		]);
+	});
+
+	it('throttles mid-phase updates but always flushes the phase’s final state', () => {
+		const stream = fakeStream({ isTTY: true, columns: 200 });
+		const clock = fakeClock();
+		const reporter = createProgressReporter({
+			write: stream.write,
+			isTty: true,
+			columns: 200,
+			throttleMs: 1_000,
+			now: clock.now,
+		});
+
+		reporter.report({ phase: 'parse', label: 'Reading rows', done: 0, unit: 'rows', ratio: 0 });
+		// Three updates inside the throttle window collapse to nothing rendered…
+		for (const done of [10, 20, 30]) {
+			clock.advance(10);
+			reporter.report({
+				phase: 'parse',
+				label: 'Reading rows',
+				done,
+				unit: 'rows',
+				ratio: done / 100,
+			});
+		}
+		expect(stream.lines()).toEqual(['Reading rows · 0% · 0 rows']);
+
+		// …but the last one is flushed when the phase ends, so the counter never
+		// stalls at a stale value.
+		reporter.finish();
+		expect(stream.lines()).toEqual(['Reading rows · 0% · 0 rows', 'Reading rows · 30% · 30 rows']);
+	});
+
+	it('appends throttled whole lines when the output is a pipe, not a TTY', () => {
+		const stream = fakeStream();
+		const clock = fakeClock();
+		const reporter = createProgressReporter({
+			write: stream.write,
+			isTty: false,
+			throttleMs: 5_000,
+			now: clock.now,
+		});
+
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 0, total: 100, unit: 'rows' });
+		clock.advance(1_000);
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 20, total: 100, unit: 'rows' });
+		clock.advance(6_000);
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 60, total: 100, unit: 'rows' });
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 100, total: 100, unit: 'rows' });
+		reporter.finish();
+
+		// No carriage returns into a log file; the 1s-later update was throttled
+		// away, the 6s-later one and the completion were kept.
+		expect(stream.text()).not.toContain('\r');
+		expect(stream.text()).not.toContain(CLEAR_TO_EOL);
+		expect(stream.lines()).toEqual([
+			'Loading rows · 0% · 0/100 rows',
+			'Loading rows · 60% · 60/100 rows · 7s · ~5s left',
+			'Loading rows · 100% · 100/100 rows · 7s',
+		]);
+	});
+
+	it('closes an announcement line so the step’s own logging starts clean', () => {
+		const stream = fakeStream({ isTTY: true, columns: 200 });
+		const reporter = createProgressReporter({ write: stream.write, isTty: true, columns: 200 });
+
+		reporter.report({ phase: 'schema', label: 'Recreating the schema', detail: '41 migrations' });
+		expect(stream.text()).toBe(`\rRecreating the schema · 41 migrations${CLEAR_TO_EOL}\n`);
+
+		// note() and finish() stay safe on an already-closed line.
+		reporter.note('Restored database: 12 rows.');
+		reporter.finish();
+		expect(stream.lines()).toEqual([
+			'Recreating the schema · 41 migrations',
+			'Restored database: 12 rows.',
+		]);
+	});
+
+	it('keeps a note on its own row while a counter line is open', () => {
+		const stream = fakeStream({ isTTY: true, columns: 200 });
+		const reporter = createProgressReporter({ write: stream.write, isTty: true, columns: 200 });
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 1, total: 2, unit: 'rows' });
+		reporter.note('done');
+		expect(stream.text()).toBe(`\rLoading rows · 50% · 1/2 rows${CLEAR_TO_EOL}\ndone\n`);
+	});
+
+	it('is silent under NODE_ENV=test and renders against a real stream otherwise', () => {
+		const quiet = fakeStream({ isTTY: true, columns: 200 });
+		const silent = createStreamProgressReporter(quiet, { NODE_ENV: 'test' });
+		silent.report({ phase: 'load', label: 'Loading rows', done: 1, total: 2 });
+		silent.note('nothing');
+		silent.finish();
+		expect(quiet.text()).toBe('');
+
+		const live = fakeStream({ isTTY: true, columns: 200 });
+		const reporter = createStreamProgressReporter(live, { NODE_ENV: 'production' });
+		reporter.report({ phase: 'load', label: 'Loading rows', done: 1, total: 2, unit: 'rows' });
+		reporter.finish();
+		expect(live.lines()).toEqual(['Loading rows · 50% · 1/2 rows']);
+	});
+});
+
+describe('database restore progress emission', () => {
+	const migrations = allMigrations();
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let bytes: Buffer;
+
+	beforeAll(async () => {
+		ctx = await createTestApp();
+		bytes = await dumpLogicalBackup(ctx.db, { hezoVersion: 'test', migrations });
+	}, 120_000);
+
+	afterAll(async () => {
+		await safeClose(ctx.db);
+	});
+
+	it('reports every phase, with a row counter that reaches the total', async () => {
+		const restored = await createMemoryDb();
+		const states: ProgressState[] = [];
+		try {
+			const summary = await restoreLogicalBackup(restored, bytes, migrations, {
+				onProgress: (s) => states.push({ ...s }),
+			});
+
+			// The phases an operator watching a long restore should see, in order.
+			expect([...new Set(states.map((s) => s.phase))]).toEqual([
+				'decompress',
+				'schema',
+				'parse',
+				'prepare',
+				'load',
+				'constraints',
+			]);
+
+			// The parse counter climbs and finishes at 100%.
+			const parse = states.filter((s) => s.phase === 'parse');
+			expect(parse[0]).toMatchObject({ done: 0, unit: 'rows' });
+			expect(progressRatio(parse[parse.length - 1])).toBe(1);
+
+			// The load counter is monotonic and lands exactly on the restored rows.
+			const load = states.filter((s) => s.phase === 'load');
+			expect(load.length).toBeGreaterThan(1);
+			const done = load.map((s) => s.done ?? -1);
+			expect(done).toEqual([...done].sort((a, b) => a - b));
+			expect(done[0]).toBe(0);
+			expect(done[done.length - 1]).toBe(summary.rows);
+			expect(load[load.length - 1].total).toBe(summary.rows);
+			// The table being loaded is named, so a stall is attributable.
+			expect(load.some((s) => (s.detail ?? '').length > 0)).toBe(true);
+		} finally {
+			await safeClose(restored as { close: () => Promise<void> });
+		}
+	}, 120_000);
+
+	it('reports the wipe phase only when restoring over an existing schema', async () => {
+		const target = await createMemoryDb();
+		try {
+			const first: ProgressState[] = [];
+			await restoreLogicalBackup(target, bytes, migrations, {
+				onProgress: (s) => first.push({ ...s }),
+			});
+			expect(first.some((s) => s.phase === 'wipe')).toBe(false);
+
+			const second: ProgressState[] = [];
+			await restoreLogicalBackup(target, bytes, migrations, {
+				wipe: true,
+				onProgress: (s) => second.push({ ...s }),
+			});
+			expect(second.some((s) => s.phase === 'wipe')).toBe(true);
+		} finally {
+			await safeClose(target as { close: () => Promise<void> });
+		}
+	}, 120_000);
+
+	it('accepts pre-decompressed text so a large backup is only gunzipped once', async () => {
+		const text = decompressLogicalBackup(bytes);
+		expect(text).not.toBeNull();
+		// The split header parse matches the buffer-level reader it composes into.
+		expect(parseLogicalBackupHeader(text as string)).toEqual(readLogicalBackupHeader(bytes));
+		// Not gzip at all (a legacy pgdata tarball, or a wrong file) → null, which
+		// is how the CLI still detects the legacy-snapshot path.
+		expect(decompressLogicalBackup(Buffer.from('not gzip'))).toBeNull();
+
+		const restored = await createMemoryDb();
+		const states: ProgressState[] = [];
+		try {
+			const summary = await restoreLogicalBackup(restored, text as string, migrations, {
+				onProgress: (s) => states.push({ ...s }),
+			});
+			expect(summary.rows).toBeGreaterThan(0);
+			// Text in → nothing to decompress, so no decompress phase is claimed.
+			expect(states.some((s) => s.phase === 'decompress')).toBe(false);
+			const teams = await restored.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM teams`);
+			expect(teams.rows[0].c).toBeGreaterThan(0);
+		} finally {
+			await safeClose(restored as { close: () => Promise<void> });
+		}
+	}, 120_000);
+});
+
+describe('asset restore progress emission', () => {
+	it('counts asset blobs as they are copied out of a bundle', async () => {
+		const dataDir = makeTempDir();
+		const opened = await openDatabase({ dataDir });
+		const db: Db = opened.db;
+		try {
+			await db.exec(BASE_SCHEMA);
+			await runMigrations(db, allMigrations());
+
+			const team = await db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ('Progress', 'progress') RETURNING id`,
+			);
+			const project = await db.query<{ id: string }>(
+				`INSERT INTO projects (team_id, name, slug, task_prefix)
+				 VALUES ($1, 'Assets', 'assets', 'AS') RETURNING id`,
+				[team.rows[0].id],
+			);
+			const projectId = project.rows[0].id;
+
+			// A bundle carrying several blobs, laid out the way `hezo backup` writes
+			// them (`<bundle>/assets/<projectId>/<assetId>`).
+			const bundleDir = makeTempDir();
+			const source = new LocalAssetStore(bundleDir);
+			let expectedBytes = 0;
+			for (let i = 0; i < 5; i++) {
+				const content = Buffer.from(`asset payload ${i}`.repeat(i + 1));
+				expectedBytes += content.byteLength;
+				const asset = await db.query<{ id: string }>(
+					`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+					 VALUES ($1, $2, 'text/plain', $3, $4, $5) RETURNING id`,
+					[
+						team.rows[0].id,
+						projectId,
+						content.byteLength,
+						createHash('sha256').update(content).digest('hex'),
+						`asset-${i}.txt`,
+					],
+				);
+				await source.write(projectId, asset.rows[0].id, new Blob([content]));
+			}
+
+			const states: ProgressState[] = [];
+			const summary = await restoreAssetBlobs(db, new LocalAssetStore(makeTempDir()), bundleDir, {
+				onProgress: (s) => states.push({ ...s }),
+			});
+			expect(summary.count).toBe(5);
+
+			expect([...new Set(states.map((s) => s.phase))]).toEqual(['assets-scan', 'assets']);
+			const copied = states.filter((s) => s.phase === 'assets');
+			expect(copied[0]).toMatchObject({ done: 0, total: 5, unit: 'files', bytes: 0 });
+			const last = copied[copied.length - 1];
+			expect(last).toMatchObject({ done: 5, total: 5, bytes: expectedBytes });
+			expect(progressRatio(last)).toBe(1);
+		} finally {
+			await safeClose(db as { close: () => Promise<void> });
+		}
+	}, 120_000);
+});


### PR DESCRIPTION
## Problem

`hezo restore` printed the migration replay lines and then went silent until the final summary. On a real instance the two long parts - inserting millions of rows and copying thousands of asset blobs - produce no output at all, so an operator watching a multi-minute restore cannot tell a slow one from a hung one.

```
2026-07-26T07:52:35.361Z [info] <migrate> Applied migration: 041_run_log_chunks.sql
   ... nothing, for minutes ...
```

## What changed

Both restore engines now emit `ProgressState` updates through an optional `onProgress` callback, and `runRestore` renders them. The engines stay terminal-agnostic; rendering lives in the new `packages/server/src/lib/progress.ts`.

- **A line per phase**: reading the backup (with its size), decompressing, dropping the existing schema (`--wipe`), recreating the schema, preparing the target, restoring foreign keys and sequences.
- **A live counter for the long parts**: rows parsed, rows loaded (naming the table currently loading, so a stall is attributable), and asset blobs copied with a running byte total - each with a percentage, elapsed time and an ETA.
- **Rendering adapts to the stream**: a single line rewritten in place (`\r` + erase-to-EOL) on a TTY; throttled appended lines when the output is a pipe or a log file, so a restore run under systemd/Docker still shows progress in the log without thousands of lines.

Piped output from a real restore:

```
Reading the database backup · 1.5 MB
Decompressing the database backup · 1.5 MB
Recreating the schema · 44 migrations
Reading rows from the backup · 100% · 40,770 rows
Preparing the target schema
Loading rows · 27% · 11,269/40,770 rows · tasks · 5s · ~14s left
Loading rows · 69% · 28,269/40,770 rows · tasks · 16s · ~7s left
Loading rows · 100% · 40,770/40,770 rows · teams · 24s
Restoring foreign keys and sequences
Restored database (Hezo 0.33.0, taken …) into the embedded backend: 40770 rows across 5 tables.
Scanning the bundle for asset files
Restoring asset files · 100% · 300/300 files · 564 KB
Restored 300 asset blob(s) into the local storage.
```

### Also: stop gunzipping a single-file backup twice

The CLI read the header with `readLogicalBackupHeader(bytes)` (which gunzipped the whole file) and then `restoreLogicalBackup` gunzipped it again. On a multi-GB backup that second pass is minutes of duplicated work. `decompressLogicalBackup` + `parseLogicalBackupHeader` split the old function (which is now their composition, unchanged for existing callers), and `restoreLogicalBackup` accepts `Buffer | string` so the CLI hands it the text it already has. Legacy-snapshot detection is unchanged - a non-gzip file still decompresses to `null` and falls through to the pgdata path.

## Tests

New `packages/server/test/restore-progress.test.ts` (14 tests):

- **Formatting/renderer** against an injected stream and clock: counts/bytes/durations, percentage from counters or an explicit ratio, ETA suppressed under 3s and at 100%, line truncation to terminal width, in-place rewriting on a TTY (one closing newline per phase), throttled appended lines on a pipe, the phase's final state always flushed even when throttled, announcements closing their line so the step's own logging starts clean.
- **Emission** from the real engines: the phase sequence a restore produces, a monotonic row counter landing exactly on `summary.rows`, `wipe` reported only when restoring over an existing schema, no `decompress` phase when handed text, and the asset counter reaching `total` with the expected byte total.

Progress is silent under `NODE_ENV=test` (raw stream writes would fight the vitest reporter), which is covered explicitly.

`bun run test --package server --pattern backup` and `--pattern progress` pass; `check` and `typecheck` are clean.

## Docs

- `docs/reference/cli.md` and `docs/deployment/backup-and-recovery.md` - what a large restore now prints, and the TTY vs log-file difference.
- `.dev/architecture.md` § Backup/restore - the progress callback/reporter split and the single-decompress path.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gs9fnZGrrHuBBf187pF7A)_