### PR TITLE
feat(web): offer document download on the preview panel and preview tab

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -389,7 +389,11 @@ task-sidebar panel, Documents tab view mode) via a rehype plugin
 (selection pill, hover-line ghost, margin icons, editor) is extracted into
 `ReviewSurface` (`packages/web/src/components/document-review/review-surface.tsx`), which
 the asset viewer reuses for text assets (markdown through the same rehype plugin, plain
-text through `PlainTextWithHighlights`). Each project-doc revision carries a
+text through `PlainTextWithHighlights`). Those same three surfaces each carry
+`DocumentDownloadMenu` (`packages/web/src/components/document-download-menu.tsx`) — a
+client-side save of the already-loaded content as Markdown (verbatim) or plain text
+(`markdownToPlainText`), no server round-trip; the two preview surfaces render it in the
+compact `variant="icon"` form that matches their icon-only header clusters. Each project-doc revision carries a
 **changelog** (`change_summary`): the web PUT forwards `change_summary` and the MCP
 `write_project_doc` tool takes an optional `changelog`, both stored on the revision recorded for
 the *prior* content; `restoreRevision` writes `Restored content from revision N`. The single-doc

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -82,7 +82,9 @@ the list. A **dropdown** next to the open document's title opens a name search f
 inside the reader, so you can jump straight to another document without going back to the
 list; it's hidden while you're editing. The reader's toolbar also has a **Download** button
 that saves the open document to your device — as **Markdown** (`.md`, the original source)
-or as **plain text** (`.txt`, with the Markdown formatting stripped).
+or as **plain text** (`.txt`, with the Markdown formatting stripped). Download is available
+on every surface you can read a document from, so a document you opened from a task thread
+saves from right there.
 
 Agents don't carry every document's full text on every run. Instead each run includes a
 **manifest** — a table of contents listing each document's filename, its one-line
@@ -142,10 +144,12 @@ confirms with a link straight to the new task comment. The same review loop also
 files in the assets library — see [Reviewing assets](/docs/concepts/assets).
 
 Wherever you read a document — the Documents page, the task-sidebar preview, or its own tab —
-its header carries **Edit** and **History** buttons. On the two preview views these take you
-to the document on the Documents page, ready to edit or with its version history open, so you
-can move from a quick look straight into changing the document or seeing how it changed.
-(Edit is hidden while a document is archived, since archived documents are read-only.)
+its header carries **Edit**, **History**, and **Download** buttons. On the two preview views
+Edit and History take you to the document on the Documents page, ready to edit or with its
+version history open, so you can move from a quick look straight into changing the document or
+seeing how it changed. Download saves the copy from where you are, with no detour through the
+Documents page. (Edit is hidden while a document is archived, since archived documents are
+read-only.)
 
 On a larger screen you can also **hide the document list** — the panel button just left of
 the document's title collapses it, giving the document the full width of the page; the same

--- a/packages/web/src/components/document-download-menu.tsx
+++ b/packages/web/src/components/document-download-menu.tsx
@@ -8,9 +8,22 @@ import * as Popover from '@radix-ui/react-popover';
 import { ChevronDown, Download, FileText, Type } from 'lucide-react';
 import { useState } from 'react';
 import { downloadTextFile } from '../lib/download-file';
+import { Tooltip } from './ui/tooltip';
 
-const TRIGGER_CLASS =
-	'inline-flex h-[26px] items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent bg-transparent px-2.5 text-[12.5px] font-medium text-text-2 transition-colors cursor-pointer outline-none hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent';
+/**
+ * `'toolbar'` is the labelled control on the Documents page, which has room for
+ * the word "Download". `'icon'` is the compact form for the two preview surfaces
+ * (task-sidebar panel, standalone preview route), whose headers are icon-only
+ * clusters — it matches their shared icon-button styling and names itself
+ * through a tooltip instead.
+ */
+export type DocumentDownloadVariant = 'toolbar' | 'icon';
+
+const TRIGGER_CLASS: Record<DocumentDownloadVariant, string> = {
+	toolbar:
+		'inline-flex h-[26px] items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent bg-transparent px-2.5 text-[12.5px] font-medium text-text-2 transition-colors cursor-pointer outline-none hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent',
+	icon: 'shrink-0 rounded-md p-1 text-text-3 transition-colors cursor-pointer outline-none hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring',
+};
 
 interface DownloadOption {
 	format: DocDownloadFormat;
@@ -38,12 +51,22 @@ const OPTIONS: DownloadOption[] = [
 ];
 
 /**
- * View-mode toolbar control that downloads the open document. Documents are
- * stored as Markdown, so Markdown is the lossless native download and plain text
- * is a stripped rendering. Both are produced client-side from the already-loaded
- * content — no server round-trip (see {@link downloadTextFile}).
+ * View-mode control that downloads the open document, shared by every read-only
+ * doc surface (Documents page, task-sidebar preview panel, standalone preview
+ * route). Documents are stored as Markdown, so Markdown is the lossless native
+ * download and plain text is a stripped rendering. Both are produced client-side
+ * from the already-loaded content — no server round-trip (see
+ * {@link downloadTextFile}).
  */
-export function DocumentDownloadMenu({ filename, content }: { filename: string; content: string }) {
+export function DocumentDownloadMenu({
+	filename,
+	content,
+	variant = 'toolbar',
+}: {
+	filename: string;
+	content: string;
+	variant?: DocumentDownloadVariant;
+}) {
 	const [open, setOpen] = useState(false);
 
 	function handleDownload(format: DocDownloadFormat) {
@@ -53,22 +76,35 @@ export function DocumentDownloadMenu({ filename, content }: { filename: string; 
 		setOpen(false);
 	}
 
+	const trigger = (
+		<Popover.Trigger
+			className={TRIGGER_CLASS[variant]}
+			aria-label="Download document"
+			data-testid="doc-download"
+		>
+			{variant === 'icon' ? (
+				<Download className="h-4 w-4" />
+			) : (
+				<>
+					<Download className="w-3.5 h-3.5" />
+					<span className="hidden sm:inline">Download</span>
+					<ChevronDown className="w-3 h-3 opacity-70" />
+				</>
+			)}
+		</Popover.Trigger>
+	);
+
 	return (
 		<Popover.Root open={open} onOpenChange={setOpen}>
-			<Popover.Trigger
-				className={TRIGGER_CLASS}
-				aria-label="Download document"
-				data-testid="doc-download"
-			>
-				<Download className="w-3.5 h-3.5" />
-				<span className="hidden sm:inline">Download</span>
-				<ChevronDown className="w-3 h-3 opacity-70" />
-			</Popover.Trigger>
+			{variant === 'icon' ? <Tooltip content="Download document">{trigger}</Tooltip> : trigger}
 			<Popover.Portal>
+				{/* z-[70] clears the task-detail preview panel, which is a full-screen
+				    z-[60] overlay below lg — at z-50 the portalled menu painted behind
+				    it and was invisible on mobile. Dialogs (z-[80]/[90]) still win. */}
 				<Popover.Content
 					align="end"
 					sideOffset={6}
-					className="z-50 w-56 rounded-md border border-border bg-surface p-1 shadow-md"
+					className="z-[70] w-56 rounded-md border border-border bg-surface p-1 shadow-md"
 				>
 					<p className="px-2 pt-1 pb-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-text-3">
 						Download as

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { ExternalLink, History, Pencil, X } from 'lucide-react';
 import { type ProjectDoc, useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
+import { DocumentDownloadMenu } from '../document-download-menu';
 import type { ReviewTaskContext } from '../document-review/action-review-dialog';
 import { DocumentBody } from '../document-review/document-body';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
@@ -91,6 +92,15 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 						<History className="h-4 w-4" />
 					</Link>
 				</Tooltip>
+				{/* Same client-side download the Documents toolbar offers, so a doc read
+				    from the task thread doesn't have to be reopened elsewhere to save it. */}
+				{typeof docQuery.data?.content === 'string' && (
+					<DocumentDownloadMenu
+						filename={item.filename}
+						content={docQuery.data.content}
+						variant="icon"
+					/>
+				)}
 				<Tooltip content="Open in new tab">
 					<a
 						href={openUrl}

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { History, Pencil } from 'lucide-react';
 import { useState } from 'react';
+import { DocumentDownloadMenu } from '../../../components/document-download-menu';
 import { DocumentBody } from '../../../components/document-review/document-body';
 import { ReviewToolbarActions } from '../../../components/document-review/review-toolbar-actions';
 import { ScrollToBottomButton } from '../../../components/scroll-to-bottom-button';
@@ -79,6 +80,10 @@ function DocPreviewPage() {
 								<History className="h-4 w-4" />
 							</Link>
 						</Tooltip>
+						{/* Same client-side download the Documents toolbar offers — this
+						    standalone tab is where a doc gets read in full, so it's where
+						    saving a copy is most likely to be wanted. */}
+						<DocumentDownloadMenu filename={filename} content={doc.content} variant="icon" />
 					</div>
 				</div>
 			</div>

--- a/packages/web/test/document-download.test.tsx
+++ b/packages/web/test/document-download.test.tsx
@@ -1,6 +1,12 @@
 import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
-import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+import {
+	type SeededWorkspace,
+	seedComment,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
 
 async function seedDoc(
 	apiBase: (path: string, init: RequestInit) => Promise<Response>,
@@ -18,14 +24,12 @@ async function seedDoc(
 	if (!res.ok) throw new Error(`seed failed: ${res.status}`);
 }
 
-test('downloads the open document as Markdown (lossless) and as stripped plain text', async () => {
-	let ws!: SeededWorkspace;
-	let projectSlug = '';
-	const filename = `guide-${Math.random().toString(36).slice(2, 8)}.md`;
-	const source = '# Guide\n\nRead **this** carefully before you [continue](https://example.com).';
-
-	// Capture what the client-side download would produce: the Blob handed to
-	// URL.createObjectURL and the anchor's `download` filename on click.
+/**
+ * Capture what the client-side download would produce: the Blob handed to
+ * URL.createObjectURL and the anchor's `download` filename on click. The
+ * download never leaves the page, so this is the only observable outcome.
+ */
+function captureDownloads(): { blobs: Blob[]; names: string[]; restore: () => void } {
 	const blobs: Blob[] = [];
 	const names: string[] = [];
 	const origCreate = URL.createObjectURL;
@@ -40,6 +44,24 @@ test('downloads the open document as Markdown (lossless) and as stripped plain t
 	) {
 		names.push(this.download);
 	});
+	return {
+		blobs,
+		names,
+		restore: () => {
+			clickSpy.mockRestore();
+			URL.createObjectURL = origCreate;
+			URL.revokeObjectURL = origRevoke;
+		},
+	};
+}
+
+test('downloads the open document as Markdown (lossless) and as stripped plain text', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `guide-${Math.random().toString(36).slice(2, 8)}.md`;
+	const source = '# Guide\n\nRead **this** carefully before you [continue](https://example.com).';
+
+	const { blobs, names, restore } = captureDownloads();
 
 	try {
 		const { findByTestId, user, router } = await renderApp({
@@ -80,8 +102,95 @@ test('downloads the open document as Markdown (lossless) and as stripped plain t
 		expect(blobs[1].type).toContain('text/plain');
 		expect(await blobs[1].text()).toBe('Guide\n\nRead this carefully before you continue.');
 	} finally {
-		clickSpy.mockRestore();
-		URL.createObjectURL = origCreate;
-		URL.revokeObjectURL = origRevoke;
+		restore();
+	}
+});
+
+// The task-sidebar preview panel is a full read surface for a document, so it
+// carries the same download control as the Documents toolbar — reading a doc
+// from the task thread shouldn't force a detour through another page to save it.
+test('downloads the document from the task-sidebar preview panel', async () => {
+	let ctx!: { projectSlug: string; taskId: string };
+	const source = '# Mockups\n\nThe **hero** section needs a [rework](https://example.com).';
+
+	const { blobs, names, restore } = captureDownloads();
+
+	try {
+		const { findByTestId, user, router } = await renderApp({
+			initialPath: '/',
+			seed: async ({ apiBase, token }) => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Panel Download Demo' });
+				await seedDoc(apiBase, token, project.slug, 'ui-mockups.md', source);
+				const task = await seedTask(ws, project, { title: 'Review the mockup' });
+				await seedComment(ws, task, 'Please review ui-mockups.md before the demo.');
+				ctx = { projectSlug: project.slug, taskId: task.id };
+			},
+		});
+
+		await router.navigate({
+			to: '/projects/$projectId/tasks/$taskId',
+			params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
+		});
+
+		// The panel opens from the doc mention in the comment.
+		const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+		await user.click(mention);
+		await findByTestId('preview-panel');
+
+		// The control renders only once the panel's doc query has resolved.
+		const trigger = await findByTestId('doc-download', undefined, { timeout: 15_000 });
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-markdown'));
+		expect(names).toEqual(['ui-mockups.md']);
+		expect(await blobs[0].text()).toBe(source);
+
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-text'));
+		expect(names).toEqual(['ui-mockups.md', 'ui-mockups.txt']);
+		expect(blobs[1].type).toContain('text/plain');
+		expect(await blobs[1].text()).toBe('Mockups\n\nThe hero section needs a rework.');
+	} finally {
+		restore();
+	}
+});
+
+// The standalone preview route (the doc's "open in new tab") is the other read
+// surface, and the one most likely to be where a doc is read in full.
+test('downloads the document from the standalone preview tab', async () => {
+	let ctx!: { projectSlug: string };
+	const source = '# Notes\n\nA line with **emphasis**.';
+
+	const { blobs, names, restore } = captureDownloads();
+
+	try {
+		const { findByTestId, findByText, user, router } = await renderApp({
+			initialPath: '/',
+			seed: async ({ apiBase, token }) => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Tab Download Demo' });
+				await seedDoc(apiBase, token, project.slug, 'notes.md', source);
+				ctx = { projectSlug: project.slug };
+			},
+		});
+
+		await router.navigate({
+			to: '/preview/$projectId/$filename',
+			params: { projectId: ctx.projectSlug, filename: 'notes.md' },
+		});
+		await findByText('Notes');
+
+		const trigger = await findByTestId('doc-download', undefined, { timeout: 15_000 });
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-markdown'));
+		expect(names).toEqual(['notes.md']);
+		expect(await blobs[0].text()).toBe(source);
+
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-text'));
+		expect(names).toEqual(['notes.md', 'notes.txt']);
+		expect(await blobs[1].text()).toBe('Notes\n\nA line with emphasis.');
+	} finally {
+		restore();
 	}
 });

--- a/test/browser/task-doc-preview-download.spec.ts
+++ b/test/browser/task-doc-preview-download.spec.ts
@@ -1,0 +1,87 @@
+// Viewport-conditional stacking assertion (testing decision tree, points 1 & 2):
+// below lg the task-detail preview panel is a full-screen `fixed inset-0 z-[60]`
+// overlay, and the download menu is a Radix popover portalled onto document.body.
+// Whether the menu paints *above* that overlay is a real-compositing question —
+// happy-dom neither resolves the media query that makes the panel full-screen nor
+// hit-tests painted layers, so a component test sees an "attached and visible"
+// menu either way (it was, in fact, invisible under the panel at z-50). The
+// download behaviour itself — which formats, what bytes, what filename — is
+// covered by packages/web/test/document-download.test.tsx on all three surfaces.
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+const DOC = 'download-me.md';
+const DOC_CONTENT = ['# Download me', '', 'Body text for the download menu spec.'].join('\n');
+
+test('the preview panel download menu paints above the full-screen mobile panel', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { token } = sharedWorkspace;
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	// Mobile viewport: the panel becomes the fixed inset-0 z-[60] overlay.
+	await page.setViewportSize({ width: 390, height: 844 });
+
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Doc Preview Download'),
+		description: 'Preview panel download menu test.',
+	});
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const docRes = await page.request.put(`/api/projects/${project.slug}/docs/${DOC}`, {
+		headers,
+		data: { content: DOC_CONTENT },
+	});
+	expect(docRes.ok()).toBe(true);
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Read the doc', assignee_id: assigneeId },
+	});
+	expect(taskRes.ok()).toBe(true);
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	const commentRes = await page.request.post(
+		`/api/projects/${project.slug}/tasks/${task.id}/comments`,
+		{ headers, data: { content_type: 'text', content: { text: `Please read ${DOC} today.` } } },
+	);
+	expect(commentRes.ok()).toBe(true);
+
+	await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+	await waitForPageLoad(page);
+
+	await page.getByTestId('doc-mention-link').first().click();
+	await expect(page.getByTestId('preview-panel')).toBeVisible();
+
+	// The whole header cluster still fits the 390px row — the trigger is inside
+	// the viewport, not pushed off the right edge by the other icon actions.
+	const trigger = page.getByTestId('doc-download');
+	await expect(trigger).toBeVisible();
+	const triggerBox = await trigger.boundingBox();
+	expect(triggerBox).not.toBeNull();
+	expect(triggerBox?.x).toBeGreaterThanOrEqual(0);
+	expect((triggerBox?.x ?? 0) + (triggerBox?.width ?? 0)).toBeLessThanOrEqual(390);
+
+	await trigger.click();
+	const option = page.getByTestId('doc-download-markdown');
+	await expect(option).toBeVisible();
+
+	// The real check: hit-test the option's centre. `toBeVisible()` passes on an
+	// element that is fully painted over, so ask the browser what is actually on
+	// top there — it must be the option (or something inside it).
+	const box = await option.boundingBox();
+	expect(box).not.toBeNull();
+	const onTop = await page.evaluate(
+		({ x, y }) => {
+			const el = document.elementFromPoint(x, y);
+			return !!el?.closest('[data-testid="doc-download-markdown"]');
+		},
+		{ x: (box?.x ?? 0) + (box?.width ?? 0) / 2, y: (box?.y ?? 0) + (box?.height ?? 0) / 2 },
+	);
+	expect(onTop).toBe(true);
+});


### PR DESCRIPTION
The **Download** control only existed on the Documents page toolbar, so a document read from a task's side panel or from its own tab had to be reopened on the Documents page just to save a copy. Both preview surfaces already load the full content, so the client-side download works there unchanged.

## Changes

- `DocumentDownloadMenu` gains a `variant`: `toolbar` (the existing labelled control) and `icon` - the compact form that matches the icon-only header clusters on the two preview surfaces, named through a tooltip instead of a label.
- Wired into the task-sidebar preview panel and the standalone `/preview/:project/:filename` tab, in the same toolbar position it holds on the Documents page (after History).
- The popover content moves from `z-50` to `z-[70]`. Below `lg` the task-detail preview panel is a full-screen `z-[60]` overlay, so the portalled menu painted *behind* it and was invisible on mobile. Dialogs (`z-[80]`/`z-[90]`) still win.

## Tests

- `packages/web/test/document-download.test.tsx` - the existing Documents-page case plus one per new surface, asserting the produced bytes and filename for both formats (Markdown verbatim, plain text stripped).
- `test/browser/task-doc-preview-download.spec.ts` - the mobile stacking, which no component test can see: `toBeVisible()` passes on a fully painted-over element, so it hit-tests the option's centre with `elementFromPoint`. Verified it fails at the old `z-50` and passes at `z-[70]`.
- Full web component tier green (1248 passed; one unrelated `header-new-task` load flake that passes on re-run).

## Docs

- `docs/concepts/documents-and-memory.md` - Download is available on every surface you can read a document from, not just the Documents toolbar.
- `.dev/architecture.md` - `DocumentDownloadMenu` and its icon variant noted alongside the three doc view surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBAiHqVh5bF3qybcrADpKS)_