### PR TITLE
feat(web): drag to re-order projects in the project rail

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -108,6 +108,23 @@ default (`?filter=active|archived|all`, mirroring the docs/assets soft-delete), 
 archived project drops out of the left rail while keeping its tasks/history. Unarchiving
 (`POST /projects/:id/unarchive`) clears the stamp and restores rail visibility.
 
+**Rail order.** `projects.display_order` (INTEGER NOT NULL) is the operator's own ordering
+of the project rail, ascending — 1 is the topmost avatar. Every project listing sorts
+`display_order ASC, created_at DESC`; the tiebreak preserves the newest-first behaviour the
+rail had before the column existed (migration 042 backfilled positions in exactly that
+order, so upgrading is a visual no-op). `project-create.ts` inserts at
+`MIN(display_order) - 1` so a new project still lands on top without renumbering anything;
+values drift negative and self-heal, because a reorder renumbers the whole visible list
+back to 1..N. Reordering is `PUT /project-display-order` with the full ordered id list —
+a *collection*-level route (it spans projects across many teams, so it takes
+`requireSuperuser` rather than `requireProjectAccessMiddleware`, and lives outside the
+`/projects/…` tree because Hono's `/projects/:projectId/*` pattern also matches
+`/projects/<word>`). It renumbers in one `unnest … WITH ORDINALITY` statement, rejects
+archived/internal/unknown ids with a 400, and signals `broadcastProjectsChanged` on the
+global `projects:global` room (no row data — the index is authorized per caller) so every
+open shell re-orders live. The MCP `list_projects` tool is deliberately unaffected and
+keeps its alphabetical `ORDER BY p.name`.
+
 **Repos.** `repos` stores a GitHub `owner/repo` identifier; the segment after the owner
 is the display label, worktree directory name, and `@mention` handle. The **first** repo
 linked to a project becomes its immutable `designated_repo_id` (`ON DELETE RESTRICT` +

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -23,6 +23,25 @@ appears as the project's thumbnail in the rail. Pick any common image (PNG, JPEG
 GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use **Replace image**
 to swap it or **Remove** to go back to the initials.
 
+## Reordering the project rail
+
+The rail lists your projects newest first. Once you have more than a few, the one you
+work in every day drifts down the list - so you can drag the avatars into whatever order
+you like:
+
+- **On a computer**, press an avatar and drag it up or down the rail.
+- **On a phone or tablet**, press and hold an avatar for a moment until it lifts, then
+  drag. A quick swipe still scrolls the rail as usual.
+- **From the keyboard**, focus an avatar and press **Alt+Up** or **Alt+Down** to move it
+  one place at a time.
+
+The order is saved as soon as you drop, and it applies everywhere projects are listed -
+the rail, the home dashboard, and the project pickers. New projects still arrive at the
+top. HQ stays pinned at the bottom of the rail and is not part of the ordering.
+
+Reordering is an admin (superuser) action, because the order is shared across everyone
+using this Hezo install.
+
 ## Agent and admin avatars
 
 Agents and the admin user work the same way. Open an agent's **Settings** and upload an

--- a/packages/server/migrations/042_project_display_order.sql
+++ b/packages/server/migrations/042_project_display_order.sql
@@ -1,0 +1,31 @@
+-- User-controlled ordering for the project rail: the operator drags a project
+-- avatar up or down and the rail remembers where it was put. Before this, rail
+-- order was derived (`created_at DESC`), so the project you work in every day
+-- drifted down as newer projects were created.
+--
+-- Ascending, lowest first — `display_order` 1 is the topmost avatar. The sort key
+-- everywhere is `display_order ASC, created_at DESC`; the tiebreak keeps the old
+-- behaviour for rows that tie (concurrent creates, an unarchived project rejoining
+-- the rail). Plain integers with a full renumber per reorder rather than sparse or
+-- float positions: the list is tens of rows at most and the renumber is one
+-- statement, so the column stays trivially readable.
+--
+-- Newly created projects are inserted at `MIN(display_order) - 1` so they keep
+-- landing on top, as they do today. Values therefore drift negative over time —
+-- that is by design and harmless, and it self-heals because every reorder
+-- renumbers the whole visible list back to 1..N.
+--
+-- The backfill assigns positions in the order the rail renders them today, so
+-- upgrading an existing instance is a visual no-op. `id` breaks ties on identical
+-- timestamps to keep the backfill deterministic.
+ALTER TABLE projects ADD COLUMN display_order INTEGER NOT NULL DEFAULT 0;
+
+WITH ranked AS (
+    SELECT id, row_number() OVER (ORDER BY created_at DESC, id) AS rn FROM projects
+)
+UPDATE projects p SET display_order = ranked.rn FROM ranked WHERE p.id = ranked.id;
+
+-- Mirrors `idx_projects_active` (026) — the partial index behind the active-only
+-- rail listing, now keyed by the column that listing actually orders on.
+CREATE INDEX idx_projects_display_order ON projects(display_order, created_at DESC)
+    WHERE archived_at IS NULL;

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -13,7 +13,11 @@ import { type Context, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import type { Db } from '../db/database';
 import { trackBackground } from '../lib/background';
-import { broadcastChange, broadcastProjectUpdate } from '../lib/broadcast';
+import {
+	broadcastChange,
+	broadcastProjectsChanged,
+	broadcastProjectUpdate,
+} from '../lib/broadcast';
 import { budgetWindowsError } from '../lib/budget-validation';
 import { readImageDimensions } from '../lib/image-dimensions';
 import { ref } from '../lib/log-ref';
@@ -39,6 +43,8 @@ import { enqueueAddMarketplaceTeamTask } from '../services/marketplace-add-team'
 import { createProjectWithTeam } from '../services/project-create';
 import { createProjectIntake, getOpenProjectIntakeForHome } from '../services/project-intake';
 import { getProjectProgress } from '../services/projects';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function buildContainerDeps(c: Context<Env>): ContainerDeps {
 	return {
@@ -139,17 +145,23 @@ projectsRoutes.get('/projects', async (c) => {
      FROM projects p
      JOIN teams t ON t.id = p.team_id`;
 
+	// The operator's own rail order (PUT /project-display-order), lowest first.
+	// `created_at DESC` breaks ties so rows sharing a position — concurrent creates,
+	// a project just unarchived back into the rail — keep the newest-first
+	// behaviour the rail had before it became reorderable.
+	const orderBy = 'ORDER BY p.display_order ASC, p.created_at DESC';
+
 	let query: string;
 	if (!isAdmin || isSuperuser) {
 		const where = archivedCond ? ` WHERE ${archivedCond}` : '';
-		query = `${base}${where} ORDER BY p.created_at DESC`;
+		query = `${base}${where} ${orderBy}`;
 	} else {
 		const and = archivedCond ? ` AND ${archivedCond}` : '';
 		query = `${base}
      JOIN members m2 ON m2.team_id = p.team_id
      JOIN member_users mu ON mu.id = m2.id
      WHERE mu.user_id = $${params.length + 1}${and}
-     ORDER BY p.created_at DESC`;
+     ${orderBy}`;
 		params.push(auth.userId);
 	}
 
@@ -158,6 +170,71 @@ projectsRoutes.get('/projects', async (c) => {
 		result.rows.map((r) => withIconUrl(c, r as Record<string, unknown>)),
 	);
 	return ok(c, rows);
+});
+
+// Persist the operator's project-rail order: the full ordered list of visible
+// project ids, topmost first, renumbered to 1..N in one atomic statement.
+//
+// A collection-level route, not `PATCH /projects/:projectId` — a reorder spans
+// many projects across many teams, so it carries its own gate rather than
+// `requireProjectAccessMiddleware`. It sits at `/project-display-order`, outside
+// the `/projects/…` tree, for the same reason `/project-intakes` does: Hono's
+// `/projects/:projectId/*` middleware pattern also matches `/projects/<word>`
+// (the wildcard matches the empty rest), so a collection-level route nested under
+// `/projects/` would be resolved as a project slug and 404 before reaching here.
+//
+// `display_order` is global to the instance, so reordering is superuser-only,
+// matching the rail's other superuser-gated affordances (create, archive,
+// unarchive).
+projectsRoutes.put('/project-display-order', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const db = c.get('db');
+	const body = await c.req.json<{ project_ids?: unknown }>();
+	const ids = body.project_ids;
+
+	if (!Array.isArray(ids) || ids.length === 0) {
+		return err(c, 'INVALID_REQUEST', 'project_ids must be a non-empty array', 400);
+	}
+	if (!ids.every((id): id is string => typeof id === 'string' && UUID_RE.test(id))) {
+		return err(c, 'INVALID_REQUEST', 'project_ids must contain only project UUIDs', 400);
+	}
+	if (new Set(ids).size !== ids.length) {
+		return err(c, 'INVALID_REQUEST', 'project_ids must not contain duplicates', 400);
+	}
+
+	// Only projects the rail actually sorts may be reordered: HQ is rendered
+	// outside the sortable list and archived projects are not in it at all.
+	const eligible = await db.query<{ id: string }>(
+		`SELECT id FROM projects
+		 WHERE id = ANY($1::uuid[]) AND archived_at IS NULL AND is_internal = false`,
+		[ids],
+	);
+	if (eligible.rows.length !== ids.length) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'project_ids must all reference active, non-internal projects',
+			400,
+		);
+	}
+
+	// One statement, so a partial ordering is never visible. Projects absent from
+	// the payload keep their value — including one created mid-drag, which sits
+	// below the minimum and correctly stays on top.
+	const updated = await db.query<{ id: string; display_order: number }>(
+		`UPDATE projects p SET display_order = v.pos
+		 FROM (SELECT * FROM unnest($1::uuid[]) WITH ORDINALITY AS t(id, pos)) v
+		 WHERE p.id = v.id
+		 RETURNING p.id, p.display_order`,
+		[ids],
+	);
+
+	// The change spans teams, and the index is authorized per caller, so signal the
+	// global project-index room (no row data) rather than per-team row changes.
+	broadcastProjectsChanged(c.get('wsManager'));
+	return ok(c, updated.rows);
 });
 
 // Projects-primary creation: a project owns its own team (1:1). "Create a

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -111,9 +111,14 @@ export async function createProject(
 		);
 		const deferCaptainPlanningWake = Number(countResult.rows[0]?.count ?? 0) === 0;
 
+		// `display_order` ascends with the rail (1 = topmost), so one below the
+		// current minimum puts a new project on top — the newest-first placement the
+		// rail had before it became reorderable. Values drift negative over time;
+		// that is harmless and self-heals, since every reorder renumbers the whole
+		// visible list back to 1..N.
 		const projectResult = await db.query(
-			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image)
-			 VALUES ($1, $2, $3, $4, $5, $6)
+			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image, display_order)
+			 VALUES ($1, $2, $3, $4, $5, $6, (SELECT COALESCE(MIN(display_order), 1) - 1 FROM projects))
 			 RETURNING *`,
 			[
 				input.teamId,

--- a/packages/server/test/migrate-042-project-display-order.test.ts
+++ b/packages/server/test/migrate-042-project-display-order.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '042_project_display_order.sql';
+
+describe('042_project_display_order migration', () => {
+	let h: DataPreservationHarness;
+	// Seeded oldest → newest, so the rail's newest-first order is c, b, a.
+	let oldestId: string;
+	let middleId: string;
+	let newestId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema before 042
+
+		const seedProject = async (
+			teamSlug: string,
+			name: string,
+			slug: string,
+			prefix: string,
+			createdAt: string,
+		): Promise<string> => {
+			const team = await h.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ($1, $2) RETURNING id`,
+				[name, teamSlug],
+			);
+			const project = await h.db.query<{ id: string }>(
+				`INSERT INTO projects (team_id, name, slug, task_prefix, created_at)
+				 VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+				[team.rows[0].id, name, slug, prefix, createdAt],
+			);
+			return project.rows[0].id;
+		};
+
+		oldestId = await seedProject('acme', 'Acme', 'acme', 'AC', '2024-01-01T00:00:00Z');
+		middleId = await seedProject('beta', 'Beta', 'beta', 'BT', '2024-02-01T00:00:00Z');
+		newestId = await seedProject('gamma', 'Gamma', 'gamma', 'GA', '2024-03-01T00:00:00Z');
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds a NOT NULL integer display_order column to projects', async () => {
+		const cols = await h.db.query<{ column_name: string; is_nullable: string; data_type: string }>(
+			`SELECT column_name, is_nullable, data_type FROM information_schema.columns
+			 WHERE table_name = 'projects' AND column_name = 'display_order'`,
+		);
+		expect(cols.rows.length).toBe(1);
+		expect(cols.rows[0].is_nullable).toBe('NO');
+		expect(cols.rows[0].data_type).toBe('integer');
+	});
+
+	it('preserves pre-existing projects', async () => {
+		const kept = await h.db.query<{ id: string; name: string }>(
+			`SELECT id, name FROM projects WHERE id = ANY($1::uuid[]) ORDER BY name`,
+			[[oldestId, middleId, newestId]],
+		);
+		expect(kept.rows.map((r) => r.name)).toEqual(['Acme', 'Beta', 'Gamma']);
+	});
+
+	it('backfills positions in the rail order those projects rendered in before (newest first)', async () => {
+		const ordered = await h.db.query<{ id: string; display_order: number }>(
+			`SELECT id, display_order FROM projects ORDER BY display_order ASC`,
+		);
+		expect(ordered.rows.map((r) => r.id)).toEqual([newestId, middleId, oldestId]);
+		// Dense from 1 — the reorder route renumbers back into this shape.
+		expect(ordered.rows.map((r) => r.display_order)).toEqual([1, 2, 3]);
+	});
+
+	it('adds the partial index the active-rail listing orders on', async () => {
+		const idx = await h.db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes
+			 WHERE tablename = 'projects' AND indexname = 'idx_projects_display_order'`,
+		);
+		expect(idx.rows).toHaveLength(1);
+	});
+
+	it('accepts a renumbering reorder, including the negative values new projects get', async () => {
+		await h.db.query(`UPDATE projects SET display_order = 1 WHERE id = $1`, [oldestId]);
+		await h.db.query(`UPDATE projects SET display_order = 2 WHERE id = $1`, [newestId]);
+		await h.db.query(`UPDATE projects SET display_order = 3 WHERE id = $1`, [middleId]);
+		await h.db.query(`UPDATE projects SET display_order = -1 WHERE id = $1`, [middleId]);
+
+		const ordered = await h.db.query<{ id: string }>(
+			`SELECT id FROM projects ORDER BY display_order ASC, created_at DESC`,
+		);
+		expect(ordered.rows.map((r) => r.id)).toEqual([middleId, oldestId, newestId]);
+	});
+});

--- a/packages/server/test/project-display-order.test.ts
+++ b/packages/server/test/project-display-order.test.ts
@@ -1,0 +1,176 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+interface IndexProject {
+	id: string;
+	slug: string;
+	name: string;
+	display_order: number;
+	is_internal?: boolean;
+}
+
+describe('project display order', () => {
+	let app: Hono<Env>;
+	let db: Db;
+	let token: string;
+	let boardUserToken: string;
+	let alphaId: string;
+	let betaId: string;
+	let gammaId: string;
+	let hqId: string;
+
+	/** The rail's own list: visible (non-internal) projects, in index order. */
+	const railOrder = async (authToken = token): Promise<string[]> => {
+		const res = await app.request('/api/projects', { headers: authHeader(authToken) });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { data: IndexProject[] };
+		return body.data.filter((p) => !p.is_internal).map((p) => p.id);
+	};
+
+	const reorder = async (ids: string[], authToken = token) =>
+		app.request('/api/project-display-order', {
+			method: 'PUT',
+			headers: { ...authHeader(authToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_ids: ids }),
+		});
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		token = ctx.token;
+
+		// Three projects, created oldest → newest. A project owns exactly one team,
+		// so each needs its own team.
+		const create = async (name: string, prefix: string): Promise<string> => {
+			const teamRes = await createTestTeam(db, { name: `${name} Co` });
+			const teamId = (await teamRes.json()).data.id;
+			const projRes = await createTestProject(db, teamId, {
+				name,
+				description: `The ${name} project.`,
+				task_prefix: prefix,
+			});
+			return (await projRes.json()).data.id;
+		};
+		alphaId = await create('Alpha', 'AL');
+		betaId = await create('Beta', 'BE');
+		gammaId = await create('Gamma', 'GA');
+
+		const hq = await db.query<{ id: string }>(
+			'SELECT id FROM projects WHERE is_internal = true LIMIT 1',
+		);
+		hqId = hq.rows[0].id;
+
+		const boardUser = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Board User', false) RETURNING id",
+		);
+		boardUserToken = await signAdminJwt(ctx.masterKeyManager, boardUser.rows[0].id);
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('lists newly created projects on top, preserving the old newest-first rail', async () => {
+		expect(await railOrder()).toEqual([gammaId, betaId, alphaId]);
+	});
+
+	it('persists a reorder and serves the index in the new order', async () => {
+		const res = await reorder([alphaId, gammaId, betaId]);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { data: Array<{ id: string; display_order: number }> };
+		expect(new Map(body.data.map((r) => [r.id, r.display_order]))).toEqual(
+			new Map([
+				[alphaId, 1],
+				[gammaId, 2],
+				[betaId, 3],
+			]),
+		);
+
+		expect(await railOrder()).toEqual([alphaId, gammaId, betaId]);
+	});
+
+	it('puts a project created after a reorder back on top', async () => {
+		const teamRes = await createTestTeam(db, { name: 'Delta Co' });
+		const teamId = (await teamRes.json()).data.id;
+		const projRes = await createTestProject(db, teamId, {
+			name: 'Delta',
+			description: 'The Delta project.',
+			task_prefix: 'DE',
+		});
+		const deltaId = (await projRes.json()).data.id;
+
+		expect(await railOrder()).toEqual([deltaId, alphaId, gammaId, betaId]);
+
+		// Renumbering the visible list folds it back into a dense 1..N.
+		const res = await reorder([alphaId, betaId, gammaId, deltaId]);
+		expect(res.status).toBe(200);
+		expect(await railOrder()).toEqual([alphaId, betaId, gammaId, deltaId]);
+	});
+
+	describe('authorization', () => {
+		it('rejects a non-superuser board user', async () => {
+			const res = await reorder([betaId, alphaId, gammaId], boardUserToken);
+			expect(res.status).toBe(403);
+			// And the order is untouched.
+			expect((await railOrder()).slice(0, 2)).toEqual([alphaId, betaId]);
+		});
+
+		it('rejects an unauthenticated caller', async () => {
+			const res = await app.request('/api/project-display-order', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ project_ids: [alphaId] }),
+			});
+			expect(res.status).toBe(401);
+		});
+	});
+
+	describe('validation', () => {
+		const cases: Array<[string, () => unknown]> = [
+			['an empty array', () => []],
+			['a non-array', () => 'alpha'],
+			['a non-UUID entry', () => ['not-a-uuid']],
+			['duplicate ids', () => [alphaId, alphaId]],
+			['an unknown project id', () => ['00000000-0000-4000-8000-000000000000']],
+			['the internal HQ project', () => [hqId]],
+		];
+
+		for (const [label, ids] of cases) {
+			it(`rejects ${label} with a 400`, async () => {
+				const before = await railOrder();
+				const res = await app.request('/api/project-display-order', {
+					method: 'PUT',
+					headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+					body: JSON.stringify({ project_ids: ids() }),
+				});
+				expect(res.status).toBe(400);
+				// All-or-nothing: a rejected payload changes no ordering at all.
+				expect(await railOrder()).toEqual(before);
+			});
+		}
+
+		it('rejects an archived project id, leaving every position unchanged', async () => {
+			await db.query('UPDATE projects SET archived_at = now() WHERE id = $1', [gammaId]);
+			try {
+				const before = await railOrder();
+				const res = await reorder([betaId, gammaId, alphaId]);
+				expect(res.status).toBe(400);
+				expect(await railOrder()).toEqual(before);
+			} finally {
+				await db.query('UPDATE projects SET archived_at = NULL WHERE id = $1', [gammaId]);
+			}
+		});
+	});
+
+	it('leaves the HQ project out of the reorderable list but still in the index', async () => {
+		const res = await app.request('/api/projects', { headers: authHeader(token) });
+		const body = (await res.json()) as { data: IndexProject[] };
+		expect(body.data.some((p) => p.id === hqId && p.is_internal)).toBe(true);
+	});
+});

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -4,7 +4,13 @@ import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useInboxUnreadCount, useInboxUnreadCountsBySlug } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
-import { useAllVisibleProjects, useHqProject } from '../hooks/use-projects';
+import {
+	type ProjectWithTeam,
+	useAllVisibleProjects,
+	useHqProject,
+	useReorderProjects,
+} from '../hooks/use-projects';
+import { moveItem, useSortableRail } from '../hooks/use-sortable-rail';
 import { CreateProjectWithTeamDialog } from './create-project-with-team-dialog';
 import { Avatar, avatarColorFromString, getInitials } from './ui/avatar';
 import { CountOverlayBadge } from './ui/count-overlay-badge';
@@ -27,6 +33,12 @@ import { Tooltip } from './ui/tooltip';
  * `showHome` pins a Home button above the avatar list (separated by a border).
  * It's used in the mobile side drawer, where the header logo opens the drawer
  * instead of linking home, so the drawer needs its own way back to the dashboard.
+ *
+ * The avatars are drag-reorderable (see `use-sortable-rail`): press and drag with
+ * a mouse, press-and-hold then drag on touch, or `Alt+ArrowUp`/`Alt+ArrowDown`
+ * from the keyboard. The order is global to the instance, so — like the create
+ * button below and archiving — it is offered to superusers only. Neither the
+ * create button nor the pinned HQ entry takes part.
  */
 export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 	const { data: me } = useMe();
@@ -34,6 +46,14 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 	const hq = useHqProject();
 	const active = useActiveProject();
 	const inboxCounts = useInboxUnreadCountsBySlug();
+	const reorder = useReorderProjects();
+	const canReorder = !!me?.is_superuser && projects.length > 1;
+	const { containerRef, getItemProps, announcement } = useSortableRail<ProjectWithTeam>({
+		items: projects,
+		enabled: canReorder,
+		labelFor: (p) => p.name,
+		onReorder: (from, to) => reorder.mutate(moveItem(projects, from, to).map((p) => p.id)),
+	});
 	// HQ is excluded from the visible-project map (it's internal), so fetch its
 	// outstanding count separately to badge the pinned HQ entry.
 	const { data: hqInbox } = useInboxUnreadCount(hq?.slug ?? '', !!hq);
@@ -68,33 +88,48 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 				  overhang plus the active ring.
 				*/}
 				<div
+					ref={containerRef}
 					className="flex-1 min-h-0 w-full overflow-y-auto flex flex-col items-center gap-2 pt-2.5 pb-1"
 					data-testid="project-rail-scroll"
 				>
-					{projects.map((p) => {
+					{projects.map((p, index) => {
 						const isActive = active?.slug === p.slug && active?.teamSlug === p.teamSlug;
+						/*
+						  The drag handlers live on this wrapper rather than the Link:
+						  Radix's `Tooltip.Trigger asChild` already owns the Link's pointer
+						  handlers, and pointerdown bubbles up here anyway. The wrapper is
+						  also what the hook measures and transforms, so the lifted avatar
+						  and its displaced neighbours all move *inside* the scroll
+						  container — `overflow-y-auto` never has an escaping element to
+						  clip. `items-center` keeps it shrink-to-fit, so it adds no layout.
+						*/
 						return (
-							<Tooltip key={p.id} content={p.name} side="right">
-								<Link
-									to="/projects/$projectId"
-									params={{ projectId: p.slug }}
-									aria-label={p.name}
-									data-testid={`project-rail-avatar-${p.slug}`}
-									className={`relative inline-flex rounded-full transition-shadow ${
-										isActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
-									}`}
-								>
-									<Avatar
-										initials={getInitials(p.name)}
-										color={avatarColorFromString(p.name)}
-										imageUrl={p.icon_url}
-									/>
-									<CountOverlayBadge
-										count={inboxCounts[p.slug] ?? 0}
-										testId={`project-rail-inbox-badge-${p.slug}`}
-									/>
-								</Link>
-							</Tooltip>
+							<div key={p.id} data-sortable-index={index} {...getItemProps(index)}>
+								<Tooltip content={p.name} side="right">
+									<Link
+										to="/projects/$projectId"
+										params={{ projectId: p.slug }}
+										aria-label={p.name}
+										// Chromium natively drags anchors; that gesture would hijack
+										// the reorder drag and cancel the pointer stream.
+										draggable={false}
+										data-testid={`project-rail-avatar-${p.slug}`}
+										className={`relative inline-flex rounded-full transition-shadow ${
+											isActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
+										}`}
+									>
+										<Avatar
+											initials={getInitials(p.name)}
+											color={avatarColorFromString(p.name)}
+											imageUrl={p.icon_url}
+										/>
+										<CountOverlayBadge
+											count={inboxCounts[p.slug] ?? 0}
+											testId={`project-rail-inbox-badge-${p.slug}`}
+										/>
+									</Link>
+								</Tooltip>
+							</div>
 						);
 					})}
 					{me?.is_superuser && (
@@ -142,6 +177,15 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 						</Tooltip>
 					</div>
 				)}
+				{/* Announces keyboard reorders, which have no other audible result. */}
+				<div
+					className="sr-only"
+					role="status"
+					aria-live="polite"
+					data-testid="project-rail-reorder-status"
+				>
+					{announcement}
+				</div>
 			</nav>
 			<CreateProjectWithTeamDialog open={createOpen} onOpenChange={setCreateOpen} />
 		</>

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { type ApiError, api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
-import { useSimpleOptimisticUpdate } from './use-optimistic-mutation';
+import { useOptimisticMutation, useSimpleOptimisticUpdate } from './use-optimistic-mutation';
 import { useRouteProjectId } from './use-route-project-id';
 
 export interface Project {
@@ -41,6 +41,12 @@ export interface Project {
 	today_spend_cents: number;
 	/** Most recent task update, falling back to the project's creation time. */
 	last_activity_at: string;
+	/**
+	 * The operator's rail position, lowest first (1 = topmost). Set by dragging in
+	 * the project rail; new projects land below the current minimum so they still
+	 * appear on top. Always compared with `created_at DESC` as the tiebreak.
+	 */
+	display_order: number;
 	created_at: string;
 	/** When the project was archived (soft-deleted), or null/absent when active.
 	 * Archived projects are excluded from the default index that backs the rail. */
@@ -109,13 +115,25 @@ export function useProjectsIndex() {
 	});
 }
 
+/**
+ * The order every project list in the app renders in: the operator's own rail
+ * order (set by dragging in the project rail), newest-first within a tie. The
+ * server's index is already sorted this way; re-sorting here keeps the order
+ * correct through an optimistic reorder, which rewrites `display_order` in the
+ * cache before the server has confirmed.
+ */
+export function compareProjectOrder(a: Project, b: Project): number {
+	if (a.display_order !== b.display_order) return a.display_order - b.display_order;
+	return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+}
+
 /** User-facing projects across all teams (excludes internal projects). */
 export function useAllVisibleProjects() {
 	const { data, isLoading } = useProjectsIndex();
 	const projects: ProjectWithTeam[] = (data ?? [])
 		.filter((p) => !p.is_internal)
 		.map((p) => ({ ...p, teamSlug: p.team_slug, teamName: p.team_name }))
-		.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+		.sort(compareProjectOrder);
 	return { projects, isLoading };
 }
 
@@ -227,6 +245,37 @@ export function useUpdateProject(projectId: string) {
 			errorMessage: 'Failed to update project',
 		},
 	);
+}
+
+/**
+ * Persist the project rail's order. Takes the full ordered list of visible
+ * project ids, topmost first — the same payload shape the server renumbers to
+ * 1..N in one statement.
+ *
+ * Optimistic: the rail must settle under the finger the instant a drag is
+ * dropped, so the cached index is rewritten with the new positions and rolled
+ * back (with a toast) if the server refuses. Positions are written as 1..N to
+ * match exactly what the server will store, so the confirming refetch is a no-op
+ * rather than a visible re-shuffle. Projects outside the payload (HQ, archived)
+ * keep their cached position, as they do server-side.
+ */
+export function useReorderProjects() {
+	return useOptimisticMutation<string[], Array<{ id: string; display_order: number }>, Project[]>({
+		mutationFn: (projectIds) =>
+			api.put<Array<{ id: string; display_order: number }>>('/api/project-display-order', {
+				project_ids: projectIds,
+			}),
+		queryKey: queryKeys.projects.all(),
+		applyOptimistic: (current, projectIds) => {
+			if (!current) return current;
+			const positions = new Map(projectIds.map((id, i) => [id, i + 1]));
+			return current.map((p) => {
+				const position = positions.get(p.id);
+				return position === undefined ? p : { ...p, display_order: position };
+			});
+		},
+		errorMessage: 'Failed to reorder projects',
+	});
 }
 
 export function useDeleteProject() {

--- a/packages/web/src/hooks/use-sortable-rail.ts
+++ b/packages/web/src/hooks/use-sortable-rail.ts
@@ -1,0 +1,411 @@
+import {
+	type CSSProperties,
+	type DragEvent as ReactDragEvent,
+	type KeyboardEvent as ReactKeyboardEvent,
+	type MouseEvent as ReactMouseEvent,
+	type PointerEvent as ReactPointerEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
+import { moveItem, shiftForIndex, targetIndexForOffset } from '../lib/list-reorder';
+
+/**
+ * Below this pointer travel (px) a mouse press is a click and nothing moves;
+ * beyond it the gesture becomes a drag and the resulting click is swallowed.
+ * Same threshold and rationale as `use-draggable-fab.ts`.
+ */
+const DRAG_THRESHOLD_PX = 8;
+
+/**
+ * A touch must rest this long before it lifts an avatar. The rail scrolls
+ * vertically, so a bare touch-drag would fight the scroll — press-and-hold is the
+ * standard disambiguation. Any travel beyond {@link TOUCH_SLOP_PX} before the
+ * timer fires means the user meant to scroll, and we bow out entirely.
+ */
+const LONG_PRESS_MS = 250;
+const TOUCH_SLOP_PX = 8;
+
+/** Fallback pitch (avatar height + `gap-2`) before anything has been measured. */
+const FALLBACK_PITCH_PX = 44;
+
+/** How close to a scroll edge the pointer must get before the rail auto-scrolls. */
+const EDGE_SCROLL_ZONE_PX = 40;
+/** Auto-scroll speed at the very edge, in px per animation frame. */
+const EDGE_SCROLL_MAX_PX_PER_FRAME = 8;
+
+interface DragGesture {
+	pointerId: number;
+	fromIndex: number;
+	startY: number;
+	/** Scroll offset when the gesture began, so auto-scroll folds into the delta. */
+	startScrollTop: number;
+	/** True once the gesture has been promoted from a press to a real drag. */
+	lifted: boolean;
+	pitch: number;
+	pointerType: string;
+	/** Latest pointer position, read by the auto-scroll frame loop. */
+	clientY: number;
+	/** The item wrapper the press started on; captures the pointer once lifted. */
+	element: HTMLElement;
+}
+
+export interface SortableItemProps {
+	style: CSSProperties;
+	draggable: false;
+	onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+	onClickCapture: (e: ReactMouseEvent<HTMLElement>) => void;
+	onKeyDown: (e: ReactKeyboardEvent<HTMLElement>) => void;
+	onDragStart: (e: ReactDragEvent<HTMLElement>) => void;
+	onContextMenu: (e: ReactMouseEvent<HTMLElement>) => void;
+	'data-dragging'?: string;
+}
+
+export interface SortableRail {
+	/** Attach to the scroll container so the hook can measure and auto-scroll it. */
+	containerRef: RefObject<HTMLDivElement | null>;
+	/** Props for the wrapper around item `index`. */
+	getItemProps: (index: number) => SortableItemProps;
+	/** Index currently being dragged, or null. */
+	draggingIndex: number | null;
+	/** Text for the visually-hidden live region after a keyboard move. */
+	announcement: string;
+}
+
+export interface UseSortableRailOptions<T> {
+	items: T[];
+	/** Off entirely when false — no handlers, no styles, markup stays inert. */
+	enabled: boolean;
+	/** Commit a move. Called once per completed drag or keyboard step. */
+	onReorder: (from: number, to: number) => void;
+	/** Label for the live-region announcement, e.g. the project name. */
+	labelFor: (item: T) => string;
+}
+
+/**
+ * Drag-to-reorder for the vertical project rail, hand-rolled on Pointer Events
+ * in the shape of `use-draggable-fab.ts` (the repo carries no DnD library).
+ *
+ * Everything moves via `translateY` *inside* the scroll container: the dragged
+ * item follows the pointer, the items it passes slide one pitch out of the way.
+ * Nothing is portalled out, so the rail's `overflow-y-auto` never has a lifted
+ * element to clip.
+ *
+ * Activation differs by input, because the rail itself scrolls:
+ * - mouse: press, then travel past {@link DRAG_THRESHOLD_PX};
+ * - touch: press and hold for {@link LONG_PRESS_MS} without moving. A touch that
+ *   travels first is a scroll and is left entirely to the browser.
+ *
+ * The document listeners are attached synchronously from `pointerdown` rather
+ * than from a state-driven effect: a fast pointer can emit its whole move
+ * sequence inside the frame React would take to re-render, and the gesture would
+ * be missed entirely. Native HTML5 dragging is suppressed too — rail items are
+ * anchors, and Chromium's own link-drag would otherwise `pointercancel` us.
+ *
+ * Keyboard path: `Alt+ArrowUp` / `Alt+ArrowDown` on a focused item moves it one
+ * slot. Alt-modified so it never shadows browser scrolling or a screen reader's
+ * own arrow navigation.
+ */
+export function useSortableRail<T>({
+	items,
+	enabled,
+	onReorder,
+	labelFor,
+}: UseSortableRailOptions<T>): SortableRail {
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const gestureRef = useRef<DragGesture | null>(null);
+	const suppressClickRef = useRef(false);
+	const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const detachRef = useRef<(() => void) | null>(null);
+	const rafRef = useRef<number | null>(null);
+
+	const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+	const [dragDelta, setDragDelta] = useState(0);
+	const [targetIndex, setTargetIndex] = useState<number | null>(null);
+	const [announcement, setAnnouncement] = useState('');
+
+	// Read from inside the document listeners, which outlive a given render.
+	const itemsRef = useRef(items);
+	itemsRef.current = items;
+	const onReorderRef = useRef(onReorder);
+	onReorderRef.current = onReorder;
+	const labelForRef = useRef(labelFor);
+	labelForRef.current = labelFor;
+
+	const clearLongPress = useCallback(() => {
+		if (longPressTimerRef.current === null) return;
+		clearTimeout(longPressTimerRef.current);
+		longPressTimerRef.current = null;
+	}, []);
+
+	const stopAutoScroll = useCallback(() => {
+		if (rafRef.current === null) return;
+		cancelAnimationFrame(rafRef.current);
+		rafRef.current = null;
+	}, []);
+
+	const endGesture = useCallback(() => {
+		gestureRef.current = null;
+		clearLongPress();
+		stopAutoScroll();
+		detachRef.current?.();
+		detachRef.current = null;
+		setDraggingIndex(null);
+		setTargetIndex(null);
+		setDragDelta(0);
+	}, [clearLongPress, stopAutoScroll]);
+
+	// Tear the gesture down if the component unmounts mid-drag.
+	useEffect(() => endGesture, [endGesture]);
+
+	/**
+	 * Measure the distance between two consecutive item origins from the live DOM,
+	 * so the maths tracks whatever the rail's gap and avatar size actually are.
+	 */
+	const measurePitch = useCallback((): number => {
+		const container = containerRef.current;
+		if (!container) return FALLBACK_PITCH_PX;
+		const children = container.querySelectorAll('[data-sortable-index]');
+		if (children.length < 2) return FALLBACK_PITCH_PX;
+		const pitch = children[1].getBoundingClientRect().top - children[0].getBoundingClientRect().top;
+		// happy-dom reports zeros for every rect; fall back rather than divide by 0.
+		return pitch > 0 ? pitch : FALLBACK_PITCH_PX;
+	}, []);
+
+	const applyMove = useCallback((from: number, to: number) => {
+		if (from === to) return;
+		const list = itemsRef.current;
+		const item = list[from];
+		if (item === undefined) return;
+		onReorderRef.current(from, to);
+		setAnnouncement(`${labelForRef.current(item)} moved to position ${to + 1} of ${list.length}`);
+	}, []);
+
+	/** Recompute the dragged item's offset and the slot it currently occupies. */
+	const syncToPointer = useCallback(() => {
+		const g = gestureRef.current;
+		if (!g) return;
+		const container = containerRef.current;
+		const scrolled = container ? container.scrollTop - g.startScrollTop : 0;
+		const delta = g.clientY - g.startY + scrolled;
+		setDragDelta(delta);
+		setTargetIndex(targetIndexForOffset(g.fromIndex, delta, g.pitch, itemsRef.current.length));
+	}, []);
+
+	/**
+	 * Scroll the rail when the pointer nears an edge of an overflowing list, so a
+	 * project can be dragged past the visible window.
+	 */
+	const startAutoScroll = useCallback(() => {
+		if (rafRef.current !== null) return;
+		const step = () => {
+			const g = gestureRef.current;
+			const container = containerRef.current;
+			if (!g || !container) {
+				rafRef.current = null;
+				return;
+			}
+			const rect = container.getBoundingClientRect();
+			const maxScroll = container.scrollHeight - container.clientHeight;
+			const y = g.clientY;
+			let dy = 0;
+			if (y < rect.top + EDGE_SCROLL_ZONE_PX && container.scrollTop > 0) {
+				const depth = (rect.top + EDGE_SCROLL_ZONE_PX - y) / EDGE_SCROLL_ZONE_PX;
+				dy = -Math.min(1, depth) * EDGE_SCROLL_MAX_PX_PER_FRAME;
+			} else if (y > rect.bottom - EDGE_SCROLL_ZONE_PX && container.scrollTop < maxScroll) {
+				const depth = (y - (rect.bottom - EDGE_SCROLL_ZONE_PX)) / EDGE_SCROLL_ZONE_PX;
+				dy = Math.min(1, depth) * EDGE_SCROLL_MAX_PX_PER_FRAME;
+			}
+			if (dy !== 0) {
+				container.scrollTop += dy;
+				syncToPointer();
+			}
+			rafRef.current = requestAnimationFrame(step);
+		};
+		rafRef.current = requestAnimationFrame(step);
+	}, [syncToPointer]);
+
+	/** Promote a press to a real drag. */
+	const lift = useCallback(() => {
+		const g = gestureRef.current;
+		if (!g || g.lifted) return;
+		g.lifted = true;
+		clearLongPress();
+		// Capture only once the gesture is genuinely a drag. Capturing on
+		// `pointerdown` instead would retarget the *click* that ends an ordinary
+		// press from the inner `<a>` to this wrapper, so tapping a project would
+		// stop navigating — the capture boundary, not the click-suppression, is
+		// what swallows it. By the time we lift, suppressing the click is exactly
+		// what we want anyway.
+		try {
+			g.element.setPointerCapture(g.pointerId);
+		} catch {
+			// happy-dom lacks pointer capture; document listeners still work.
+		}
+		setDraggingIndex(g.fromIndex);
+		setTargetIndex(g.fromIndex);
+		syncToPointer();
+		startAutoScroll();
+	}, [clearLongPress, syncToPointer, startAutoScroll]);
+
+	const onPointerDown = useCallback(
+		(index: number, e: ReactPointerEvent<HTMLElement>) => {
+			if (!enabled || !e.isPrimary || (e.pointerType === 'mouse' && e.button !== 0)) return;
+			// A second press while one is in flight would leave orphaned listeners.
+			endGesture();
+			// A drop that produced no synthesized click (released over dead space, or
+			// the item unmounted) would otherwise leave the flag armed and swallow
+			// this press's click instead. A new press always ends the old window.
+			suppressClickRef.current = false;
+
+			gestureRef.current = {
+				pointerId: e.pointerId,
+				fromIndex: index,
+				startY: e.clientY,
+				startScrollTop: containerRef.current?.scrollTop ?? 0,
+				lifted: false,
+				pitch: measurePitch(),
+				pointerType: e.pointerType,
+				clientY: e.clientY,
+				element: e.currentTarget,
+			};
+
+			const onMove = (ev: PointerEvent) => {
+				const g = gestureRef.current;
+				if (!g || ev.pointerId !== g.pointerId) return;
+				g.clientY = ev.clientY;
+				if (g.lifted) {
+					syncToPointer();
+					return;
+				}
+				const travel = Math.abs(ev.clientY - g.startY);
+				if (g.pointerType === 'touch') {
+					// Moving before the hold completes means "scroll", not "reorder".
+					if (travel > TOUCH_SLOP_PX) endGesture();
+					return;
+				}
+				if (travel >= DRAG_THRESHOLD_PX) lift();
+			};
+			const onUp = (ev: PointerEvent) => {
+				const g = gestureRef.current;
+				if (!g || ev.pointerId !== g.pointerId) return;
+				if (!g.lifted) {
+					// Released before promotion — a plain click or tap; let it through.
+					endGesture();
+					return;
+				}
+				const container = containerRef.current;
+				const scrolled = container ? container.scrollTop - g.startScrollTop : 0;
+				const from = g.fromIndex;
+				const to = targetIndexForOffset(
+					from,
+					ev.clientY - g.startY + scrolled,
+					g.pitch,
+					itemsRef.current.length,
+				);
+				endGesture();
+				// Swallow the click the browser is about to synthesize, or the rail
+				// would navigate to the project that was just dropped.
+				suppressClickRef.current = true;
+				applyMove(from, to);
+			};
+			const onCancel = (ev: PointerEvent) => {
+				const g = gestureRef.current;
+				if (g && ev.pointerId !== g.pointerId) return;
+				endGesture();
+			};
+			// Non-passive: once an avatar is lifted the browser must not also scroll.
+			const onTouchMove = (ev: TouchEvent) => {
+				if (gestureRef.current?.lifted) ev.preventDefault();
+			};
+
+			document.addEventListener('pointermove', onMove);
+			document.addEventListener('pointerup', onUp);
+			document.addEventListener('pointercancel', onCancel);
+			document.addEventListener('touchmove', onTouchMove, { passive: false });
+			detachRef.current = () => {
+				document.removeEventListener('pointermove', onMove);
+				document.removeEventListener('pointerup', onUp);
+				document.removeEventListener('pointercancel', onCancel);
+				document.removeEventListener('touchmove', onTouchMove);
+			};
+
+			if (e.pointerType !== 'touch') return;
+			longPressTimerRef.current = setTimeout(() => {
+				longPressTimerRef.current = null;
+				lift();
+			}, LONG_PRESS_MS);
+		},
+		[enabled, measurePitch, endGesture, lift, syncToPointer, applyMove],
+	);
+
+	const onClickCapture = useCallback((e: ReactMouseEvent<HTMLElement>) => {
+		if (!suppressClickRef.current) return;
+		suppressClickRef.current = false;
+		e.preventDefault();
+		e.stopPropagation();
+	}, []);
+
+	const onKeyDown = useCallback(
+		(index: number, e: ReactKeyboardEvent<HTMLElement>) => {
+			if (!enabled || !e.altKey) return;
+			if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+			const to = index + (e.key === 'ArrowDown' ? 1 : -1);
+			if (to < 0 || to >= itemsRef.current.length) return;
+			e.preventDefault();
+			applyMove(index, to);
+		},
+		[enabled, applyMove],
+	);
+
+	const getItemProps = useCallback(
+		(index: number): SortableItemProps => {
+			const dragging = draggingIndex === index;
+			const to = targetIndex ?? draggingIndex;
+			const pitch = gestureRef.current?.pitch ?? FALLBACK_PITCH_PX;
+			const shift =
+				draggingIndex === null || to === null ? 0 : shiftForIndex(index, draggingIndex, to, pitch);
+			const offset = dragging ? dragDelta : shift;
+
+			const style: CSSProperties = {
+				// Base state stays scrollable; only a lifted item takes the pointer
+				// stream away from the browser's own scrolling.
+				touchAction: dragging ? 'none' : 'manipulation',
+				transform: offset === 0 ? undefined : `translateY(${offset}px)`,
+				// The dragged item must track the pointer exactly; its displaced
+				// neighbours animate into place.
+				transition: dragging || draggingIndex === null ? undefined : 'transform 150ms ease',
+				zIndex: dragging ? 10 : undefined,
+				position: dragging ? 'relative' : undefined,
+				...(dragging ? { scale: '1.08', filter: 'drop-shadow(0 4px 8px rgb(0 0 0 / 0.35))' } : {}),
+				...(enabled
+					? { userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none' }
+					: {}),
+			};
+
+			return {
+				style,
+				// Rail items are anchors. Chromium's native link-drag would hijack the
+				// gesture and `pointercancel` it, so it is suppressed outright.
+				draggable: false,
+				onDragStart: (e) => e.preventDefault(),
+				onPointerDown: (e) => onPointerDown(index, e),
+				onClickCapture,
+				onKeyDown: (e) => onKeyDown(index, e),
+				// iOS pops a callout on long-press; the gesture owns that press.
+				onContextMenu: (e) => {
+					if (draggingIndex !== null) e.preventDefault();
+				},
+				...(dragging ? { 'data-dragging': 'true' } : {}),
+			};
+		},
+		[draggingIndex, targetIndex, dragDelta, enabled, onPointerDown, onClickCapture, onKeyDown],
+	);
+
+	return { containerRef, getItemProps, draggingIndex, announcement };
+}
+
+/** Re-exported so callers can build the optimistic list without a second import. */
+export { moveItem };

--- a/packages/web/src/lib/list-reorder.ts
+++ b/packages/web/src/lib/list-reorder.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure geometry and array math behind drag-to-reorder in a vertical list (the
+ * project rail). Kept out of the hook so it can be unit-tested without a DOM —
+ * happy-dom has no layout engine, so anything measured lives in Playwright while
+ * the arithmetic is asserted here. Same split as `fab-position.ts` under
+ * `use-draggable-fab.ts`.
+ *
+ * "Pitch" throughout is the distance between two consecutive item origins: the
+ * item's height plus the flex `gap` between them.
+ */
+
+/** Immutably move `items[from]` to index `to`. Out-of-range indices are a no-op. */
+export function moveItem<T>(items: T[], from: number, to: number): T[] {
+	if (from === to) return items;
+	if (from < 0 || from >= items.length || to < 0 || to >= items.length) return items;
+	const next = items.slice();
+	const [moved] = next.splice(from, 1);
+	next.splice(to, 0, moved);
+	return next;
+}
+
+/** Clamp `value` into `[min, max]`. */
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Which slot a dragged item currently occupies, given how far it has travelled.
+ * Rounding at the half-pitch means the gap opens once the item is more than
+ * halfway over its neighbour, which is what "it feels like it snapped" means.
+ */
+export function targetIndexForOffset(
+	fromIndex: number,
+	deltaY: number,
+	pitch: number,
+	count: number,
+): number {
+	if (count <= 0) return 0;
+	if (pitch <= 0) return clamp(fromIndex, 0, count - 1);
+	return clamp(fromIndex + Math.round(deltaY / pitch), 0, count - 1);
+}
+
+/**
+ * The `translateY` a *non-dragged* item needs so the gap opens in the right
+ * place: everything between the drag's origin and its current slot slides one
+ * pitch toward the origin. The dragged item itself follows the pointer and is
+ * excluded (returns 0).
+ */
+export function shiftForIndex(
+	index: number,
+	fromIndex: number,
+	toIndex: number,
+	pitch: number,
+): number {
+	if (index === fromIndex || fromIndex === toIndex) return 0;
+	// Dragging down: the items it passed move up into the vacated slot.
+	if (toIndex > fromIndex) return index > fromIndex && index <= toIndex ? -pitch : 0;
+	// Dragging up: the items it passed move down.
+	return index >= toIndex && index < fromIndex ? pitch : 0;
+}

--- a/packages/web/test/list-reorder.test.ts
+++ b/packages/web/test/list-reorder.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+import { moveItem, shiftForIndex, targetIndexForOffset } from '../src/lib/list-reorder';
+
+const ITEMS = ['a', 'b', 'c', 'd'];
+
+describe('moveItem', () => {
+	test('moves an item down, shifting the ones it passes up', () => {
+		expect(moveItem(ITEMS, 0, 2)).toEqual(['b', 'c', 'a', 'd']);
+	});
+
+	test('moves an item up, shifting the ones it passes down', () => {
+		expect(moveItem(ITEMS, 3, 1)).toEqual(['a', 'd', 'b', 'c']);
+	});
+
+	test('moving to the same index returns the original array untouched', () => {
+		expect(moveItem(ITEMS, 2, 2)).toBe(ITEMS);
+	});
+
+	test('does not mutate the input', () => {
+		const original = [...ITEMS];
+		moveItem(ITEMS, 0, 3);
+		expect(ITEMS).toEqual(original);
+	});
+
+	test('handles the ends', () => {
+		expect(moveItem(ITEMS, 3, 0)).toEqual(['d', 'a', 'b', 'c']);
+		expect(moveItem(ITEMS, 0, 3)).toEqual(['b', 'c', 'd', 'a']);
+	});
+
+	test('out-of-range indices are a no-op', () => {
+		expect(moveItem(ITEMS, -1, 2)).toBe(ITEMS);
+		expect(moveItem(ITEMS, 1, 9)).toBe(ITEMS);
+		expect(moveItem([], 0, 0)).toEqual([]);
+	});
+});
+
+describe('targetIndexForOffset', () => {
+	const PITCH = 44;
+
+	test('stays put below half a pitch of travel', () => {
+		expect(targetIndexForOffset(1, 0, PITCH, 4)).toBe(1);
+		expect(targetIndexForOffset(1, 21, PITCH, 4)).toBe(1);
+		expect(targetIndexForOffset(1, -21, PITCH, 4)).toBe(1);
+	});
+
+	test('advances one slot once past half a pitch', () => {
+		expect(targetIndexForOffset(1, 23, PITCH, 4)).toBe(2);
+		expect(targetIndexForOffset(1, -23, PITCH, 4)).toBe(0);
+	});
+
+	test('advances multiple slots on longer travel', () => {
+		expect(targetIndexForOffset(0, PITCH * 2, PITCH, 4)).toBe(2);
+		expect(targetIndexForOffset(3, -PITCH * 3, PITCH, 4)).toBe(0);
+	});
+
+	test('clamps at both ends of the list', () => {
+		expect(targetIndexForOffset(3, PITCH * 10, PITCH, 4)).toBe(3);
+		expect(targetIndexForOffset(0, -PITCH * 10, PITCH, 4)).toBe(0);
+	});
+
+	test('degenerate pitch or count cannot produce an out-of-range index', () => {
+		expect(targetIndexForOffset(2, 500, 0, 4)).toBe(2);
+		expect(targetIndexForOffset(9, 500, PITCH, 4)).toBe(3);
+		expect(targetIndexForOffset(0, 500, PITCH, 0)).toBe(0);
+	});
+});
+
+describe('shiftForIndex', () => {
+	const PITCH = 44;
+
+	test('the dragged item itself never gets a shift', () => {
+		expect(shiftForIndex(1, 1, 3, PITCH)).toBe(0);
+	});
+
+	test('dragging down moves the passed items up by one pitch', () => {
+		// 0 -> 2: items 1 and 2 slide up, item 3 is untouched.
+		expect(shiftForIndex(1, 0, 2, PITCH)).toBe(-PITCH);
+		expect(shiftForIndex(2, 0, 2, PITCH)).toBe(-PITCH);
+		expect(shiftForIndex(3, 0, 2, PITCH)).toBe(0);
+	});
+
+	test('dragging up moves the passed items down by one pitch', () => {
+		// 3 -> 1: items 1 and 2 slide down, item 0 is untouched.
+		expect(shiftForIndex(1, 3, 1, PITCH)).toBe(PITCH);
+		expect(shiftForIndex(2, 3, 1, PITCH)).toBe(PITCH);
+		expect(shiftForIndex(0, 3, 1, PITCH)).toBe(0);
+	});
+
+	test('no shift at all when the drag has not changed slots', () => {
+		for (let i = 0; i < 4; i++) expect(shiftForIndex(i, 2, 2, PITCH)).toBe(0);
+	});
+
+	test('the shifts describe exactly the ordering moveItem produces', () => {
+		// Every non-dragged item that moves must end up in a different slot, and
+		// the count of shifted items must match the distance travelled.
+		const from = 0;
+		const to = 2;
+		const shifted = ITEMS.filter((_, i) => shiftForIndex(i, from, to, PITCH) !== 0);
+		expect(shifted).toEqual(['b', 'c']);
+		expect(moveItem(ITEMS, from, to)).toEqual(['b', 'c', 'a', 'd']);
+	});
+});

--- a/packages/web/test/project-rail-reorder.test.tsx
+++ b/packages/web/test/project-rail-reorder.test.tsx
@@ -1,0 +1,176 @@
+import { api } from '@hezo/web/lib/api';
+import { waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+/**
+ * Behavioural coverage for drag-to-reorder in the project rail. happy-dom has no
+ * layout engine and no pointer capture, so the pointer-drag geometry lives in
+ * `test/browser/project-rail-reorder*.spec.ts`; what is asserted here is the
+ * ordering contract, the keyboard path, the superuser gate, and rollback.
+ */
+
+interface RailProject {
+	slug: string;
+	name: string;
+	id: string;
+}
+
+/** Three projects, each in its own team (a team backs exactly one project). */
+async function seedThreeProjects(): Promise<RailProject[]> {
+	const out: RailProject[] = [];
+	for (const name of ['Alpha', 'Beta', 'Gamma']) {
+		const ws = await seedWorkspace();
+		const project = await seedProject(ws, { name });
+		out.push({ slug: project.slug, name, id: project.id });
+	}
+	return out;
+}
+
+/** Force an explicit rail order, bypassing whatever creation produced. */
+async function setDisplayOrder(ids: string[]): Promise<void> {
+	const { db } = getTestContext();
+	for (const [i, id] of ids.entries()) {
+		await db.query('UPDATE projects SET display_order = $1 WHERE id = $2', [i + 1, id]);
+	}
+}
+
+/** The rail's avatar slugs, in rendered document order. */
+function railSlugs(): string[] {
+	return Array.from(document.querySelectorAll('[data-testid^="project-rail-avatar-"]')).map(
+		(el) => el.getAttribute('data-testid')?.replace('project-rail-avatar-', '') ?? '',
+	);
+}
+
+test('the rail renders projects in display_order, not creation order', async () => {
+	let projects: RailProject[] = [];
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			projects = await seedThreeProjects();
+			// Deliberately the reverse of what creation order would give.
+			await setDisplayOrder([projects[0].id, projects[1].id, projects[2].id]);
+		},
+	});
+
+	await findByTestId(`project-rail-avatar-${projects[2].slug}`, undefined, { timeout: 15_000 });
+	await waitFor(() =>
+		expect(railSlugs()).toEqual([projects[0].slug, projects[1].slug, projects[2].slug]),
+	);
+});
+
+test('Alt+ArrowDown moves a project down the rail, persists it, and announces the move', async () => {
+	let projects: RailProject[] = [];
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			projects = await seedThreeProjects();
+			await setDisplayOrder([projects[0].id, projects[1].id, projects[2].id]);
+		},
+	});
+
+	const [alpha, beta, gamma] = projects;
+	const first = await findByTestId(`project-rail-avatar-${alpha.slug}`, undefined, {
+		timeout: 15_000,
+	});
+	await waitFor(() => expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]));
+
+	first.focus();
+	await user.keyboard('{Alt>}{ArrowDown}{/Alt}');
+
+	// Optimistic: the rail settles before the server confirms.
+	await waitFor(() => expect(railSlugs()).toEqual([beta.slug, alpha.slug, gamma.slug]));
+
+	const status = await findByTestId('project-rail-reorder-status');
+	expect(status.textContent).toBe('Alpha moved to position 2 of 3');
+
+	// And it is the server's order too — reload the index from the API.
+	await waitFor(async () => {
+		const { apiBase, token } = getTestContext();
+		const res = await apiBase('/api/projects', { headers: { Authorization: `Bearer ${token}` } });
+		const body = (await res.json()) as { data: Array<{ id: string; is_internal?: boolean }> };
+		expect(body.data.filter((p) => !p.is_internal).map((p) => p.id)).toEqual([
+			beta.id,
+			alpha.id,
+			gamma.id,
+		]);
+	});
+});
+
+test('Alt+ArrowUp at the top of the rail does nothing', async () => {
+	let projects: RailProject[] = [];
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			projects = await seedThreeProjects();
+			await setDisplayOrder([projects[0].id, projects[1].id, projects[2].id]);
+		},
+	});
+
+	const [alpha, beta, gamma] = projects;
+	const first = await findByTestId(`project-rail-avatar-${alpha.slug}`, undefined, {
+		timeout: 15_000,
+	});
+	await waitFor(() => expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]));
+
+	const put = vi.spyOn(api, 'put');
+	first.focus();
+	await user.keyboard('{Alt>}{ArrowUp}{/Alt}');
+
+	expect(put).not.toHaveBeenCalled();
+	expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]);
+	put.mockRestore();
+});
+
+test('a rejected reorder rolls the rail back', async () => {
+	let projects: RailProject[] = [];
+	const { findByTestId, findByText, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			projects = await seedThreeProjects();
+			await setDisplayOrder([projects[0].id, projects[1].id, projects[2].id]);
+		},
+	});
+
+	const [alpha, beta, gamma] = projects;
+	const first = await findByTestId(`project-rail-avatar-${alpha.slug}`, undefined, {
+		timeout: 15_000,
+	});
+	await waitFor(() => expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]));
+
+	const put = vi.spyOn(api, 'put').mockRejectedValue(new Error('nope'));
+	first.focus();
+	await user.keyboard('{Alt>}{ArrowDown}{/Alt}');
+
+	// The optimistic order is restored once the mutation fails, and the user is told.
+	await waitFor(() => expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]));
+	await findByText(/Failed to reorder projects/);
+	put.mockRestore();
+});
+
+test('a non-superuser gets an inert rail — no reorder handlers, no keyboard move', async () => {
+	let projects: RailProject[] = [];
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			projects = await seedThreeProjects();
+			await setDisplayOrder([projects[0].id, projects[1].id, projects[2].id]);
+			await ctx.db.query('UPDATE users SET is_superuser = false');
+		},
+	});
+
+	const [alpha, beta, gamma] = projects;
+	const first = await findByTestId(`project-rail-avatar-${alpha.slug}`, undefined, {
+		timeout: 15_000,
+	});
+	await waitFor(() => expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]));
+
+	const put = vi.spyOn(api, 'put');
+	first.focus();
+	await user.keyboard('{Alt>}{ArrowDown}{/Alt}');
+
+	expect(put).not.toHaveBeenCalled();
+	expect(railSlugs()).toEqual([alpha.slug, beta.slug, gamma.slug]);
+	put.mockRestore();
+});

--- a/packages/web/test/use-sortable-rail.test.tsx
+++ b/packages/web/test/use-sortable-rail.test.tsx
@@ -1,0 +1,337 @@
+// Unit tests for useSortableRail's gesture state machine: mouse tap-vs-drag
+// threshold, the touch long-press that keeps a swipe a scroll, click
+// suppression after a real drag, pointercancel, the keyboard path, and the
+// enabled gate. Rendered with bare divs — happy-dom has no layout engine, so
+// every rect is zero and the hook falls back to its 44px pitch constant, which
+// makes the slot maths deterministic here. Real geometry (drag against actual
+// avatar positions, edge auto-scroll, touch pointerType) is covered by
+// test/browser/project-rail-reorder{,.mobile}.spec.ts.
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { useSortableRail } from '../src/hooks/use-sortable-rail';
+
+/** The hook's FALLBACK_PITCH_PX — what an unmeasurable happy-dom rail falls back to. */
+const PITCH = 44;
+/** The hook's LONG_PRESS_MS. */
+const LONG_PRESS_MS = 250;
+
+/**
+ * happy-dom's PointerEvent support is spotty, so synthesize pointer events as
+ * MouseEvents carrying the pointer fields the hook reads. Same approach as
+ * use-draggable-fab.test.tsx, plus `pointerType`, which drives this hook's
+ * mouse-threshold vs touch-long-press branch.
+ */
+function pointerEvent(
+	type: string,
+	init: { clientY: number; pointerId?: number; pointerType?: string },
+): MouseEvent {
+	const e = new MouseEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		clientX: 30,
+		clientY: init.clientY,
+		button: 0,
+	});
+	Object.assign(e, {
+		pointerId: init.pointerId ?? 1,
+		isPrimary: true,
+		pointerType: init.pointerType ?? 'mouse',
+	});
+	return e;
+}
+
+const ITEMS = ['alpha', 'beta', 'gamma'];
+
+interface HarnessProps {
+	onReorder: (from: number, to: number) => void;
+	onItemClick?: (slug: string) => void;
+	enabled?: boolean;
+}
+
+function Harness({ onReorder, onItemClick, enabled = true }: HarnessProps) {
+	const rail = useSortableRail<string>({
+		items: ITEMS,
+		enabled,
+		onReorder,
+		labelFor: (item) => item,
+	});
+	return (
+		<div ref={rail.containerRef} data-testid="rail">
+			{ITEMS.map((item, index) => (
+				<div
+					key={item}
+					data-sortable-index={index}
+					data-testid={`wrapper-${item}`}
+					{...rail.getItemProps(index)}
+				>
+					{/* Stands in for the rail's <Link>: the thing a suppressed click must not reach. */}
+					<button type="button" data-testid={`item-${item}`} onClick={() => onItemClick?.(item)}>
+						{item}
+					</button>
+				</div>
+			))}
+			<span data-testid="announcement">{rail.announcement}</span>
+			<span data-testid="dragging">{String(rail.draggingIndex)}</span>
+		</div>
+	);
+}
+
+/** Press on an item, travel to `toY`, release. `startY` defaults to 0. */
+function mouseDrag(
+	wrapper: HTMLElement,
+	toY: number,
+	options: { startY?: number; release?: boolean } = {},
+) {
+	const startY = options.startY ?? 0;
+	fireEvent(wrapper, pointerEvent('pointerdown', { clientY: startY }));
+	fireEvent(document, pointerEvent('pointermove', { clientY: toY }));
+	if (options.release !== false) {
+		fireEvent(document, pointerEvent('pointerup', { clientY: toY }));
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe('mouse: tap vs drag', () => {
+	test('a sub-threshold press is a click, not a reorder', () => {
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} onItemClick={onItemClick} />);
+
+		// 4px of travel — under the hook's 8px DRAG_THRESHOLD_PX.
+		mouseDrag(getByTestId('wrapper-alpha'), 4);
+		fireEvent.click(getByTestId('item-alpha'));
+
+		expect(onReorder).not.toHaveBeenCalled();
+		expect(onItemClick).toHaveBeenCalledWith('alpha');
+	});
+
+	test('dragging one pitch down moves the item one slot and swallows the click', () => {
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} onItemClick={onItemClick} />);
+
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH);
+		expect(onReorder).toHaveBeenCalledWith(0, 1);
+
+		// The browser synthesizes a click after the drop; it must not navigate.
+		fireEvent.click(getByTestId('item-alpha'));
+		expect(onItemClick).not.toHaveBeenCalled();
+	});
+
+	test('dragging up moves the item toward the top', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		mouseDrag(getByTestId('wrapper-gamma'), 0, { startY: PITCH * 2 });
+		expect(onReorder).toHaveBeenCalledWith(2, 0);
+	});
+
+	test('travel is clamped to the ends of the list', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH * 10);
+		expect(onReorder).toHaveBeenCalledWith(0, 2);
+	});
+
+	test('a drag that returns to its own slot commits nothing but still swallows the click', () => {
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} onItemClick={onItemClick} />);
+
+		const wrapper = getByTestId('wrapper-alpha');
+		fireEvent(wrapper, pointerEvent('pointerdown', { clientY: 0 }));
+		fireEvent(document, pointerEvent('pointermove', { clientY: PITCH }));
+		fireEvent(document, pointerEvent('pointermove', { clientY: 0 }));
+		fireEvent(document, pointerEvent('pointerup', { clientY: 0 }));
+
+		expect(onReorder).not.toHaveBeenCalled();
+		fireEvent.click(getByTestId('item-alpha'));
+		expect(onItemClick).not.toHaveBeenCalled();
+	});
+
+	test('the lifted item is reported as dragging until release', () => {
+		const { getByTestId } = render(<Harness onReorder={vi.fn()} />);
+
+		mouseDrag(getByTestId('wrapper-beta'), PITCH, { release: false });
+		expect(getByTestId('dragging').textContent).toBe('1');
+
+		fireEvent(document, pointerEvent('pointerup', { clientY: PITCH }));
+		expect(getByTestId('dragging').textContent).toBe('null');
+	});
+
+	test('pointercancel aborts without committing a move', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH, { release: false });
+		fireEvent(document, pointerEvent('pointercancel', { clientY: PITCH }));
+
+		expect(onReorder).not.toHaveBeenCalled();
+		expect(getByTestId('dragging').textContent).toBe('null');
+	});
+
+	test('events from a different pointer are ignored mid-gesture', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		fireEvent(getByTestId('wrapper-alpha'), pointerEvent('pointerdown', { clientY: 0 }));
+		fireEvent(document, pointerEvent('pointermove', { clientY: PITCH, pointerId: 99 }));
+		fireEvent(document, pointerEvent('pointerup', { clientY: PITCH, pointerId: 99 }));
+
+		expect(onReorder).not.toHaveBeenCalled();
+	});
+});
+
+describe('touch: long-press vs scroll', () => {
+	test('moving before the hold completes is a scroll and never reorders', () => {
+		vi.useFakeTimers();
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		const wrapper = getByTestId('wrapper-alpha');
+		fireEvent(wrapper, pointerEvent('pointerdown', { clientY: 0, pointerType: 'touch' }));
+		// Past the 8px touch slop before the timer fires — the user meant to scroll.
+		fireEvent(document, pointerEvent('pointermove', { clientY: 40, pointerType: 'touch' }));
+		act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 50));
+		fireEvent(document, pointerEvent('pointermove', { clientY: PITCH * 2, pointerType: 'touch' }));
+		fireEvent(document, pointerEvent('pointerup', { clientY: PITCH * 2, pointerType: 'touch' }));
+
+		expect(onReorder).not.toHaveBeenCalled();
+		expect(getByTestId('dragging').textContent).toBe('null');
+	});
+
+	test('holding still past the long press lifts the item, then dragging reorders', () => {
+		vi.useFakeTimers();
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		const wrapper = getByTestId('wrapper-alpha');
+		fireEvent(wrapper, pointerEvent('pointerdown', { clientY: 0, pointerType: 'touch' }));
+		act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 10));
+		expect(getByTestId('dragging').textContent).toBe('0');
+
+		fireEvent(document, pointerEvent('pointermove', { clientY: PITCH, pointerType: 'touch' }));
+		fireEvent(document, pointerEvent('pointerup', { clientY: PITCH, pointerType: 'touch' }));
+		expect(onReorder).toHaveBeenCalledWith(0, 1);
+	});
+
+	test('a tap released before the hold completes stays a tap', () => {
+		vi.useFakeTimers();
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} onItemClick={onItemClick} />);
+
+		const wrapper = getByTestId('wrapper-alpha');
+		fireEvent(wrapper, pointerEvent('pointerdown', { clientY: 0, pointerType: 'touch' }));
+		act(() => vi.advanceTimersByTime(LONG_PRESS_MS - 100));
+		fireEvent(document, pointerEvent('pointerup', { clientY: 0, pointerType: 'touch' }));
+		// The timer must not fire after release and strand a lifted item.
+		act(() => vi.advanceTimersByTime(500));
+
+		expect(onReorder).not.toHaveBeenCalled();
+		expect(getByTestId('dragging').textContent).toBe('null');
+		fireEvent.click(getByTestId('item-alpha'));
+		expect(onItemClick).toHaveBeenCalledWith('alpha');
+	});
+});
+
+describe('keyboard', () => {
+	test('Alt+ArrowDown moves the item down and announces the new position', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		fireEvent.keyDown(getByTestId('wrapper-alpha'), { key: 'ArrowDown', altKey: true });
+
+		expect(onReorder).toHaveBeenCalledWith(0, 1);
+		expect(getByTestId('announcement').textContent).toBe('alpha moved to position 2 of 3');
+	});
+
+	test('Alt+ArrowUp moves the item up', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		fireEvent.keyDown(getByTestId('wrapper-gamma'), { key: 'ArrowUp', altKey: true });
+		expect(onReorder).toHaveBeenCalledWith(2, 1);
+	});
+
+	test('it stops at the ends of the list', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		fireEvent.keyDown(getByTestId('wrapper-alpha'), { key: 'ArrowUp', altKey: true });
+		fireEvent.keyDown(getByTestId('wrapper-gamma'), { key: 'ArrowDown', altKey: true });
+		expect(onReorder).not.toHaveBeenCalled();
+	});
+
+	test('an unmodified arrow key is left to the browser and the screen reader', () => {
+		const onReorder = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} />);
+
+		fireEvent.keyDown(getByTestId('wrapper-alpha'), { key: 'ArrowDown' });
+		fireEvent.keyDown(getByTestId('wrapper-alpha'), { key: 'Enter', altKey: true });
+		expect(onReorder).not.toHaveBeenCalled();
+	});
+});
+
+describe('enabled gate', () => {
+	test('a disabled rail neither drags nor responds to the keyboard', () => {
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(
+			<Harness onReorder={onReorder} onItemClick={onItemClick} enabled={false} />,
+		);
+
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH * 2);
+		fireEvent.keyDown(getByTestId('wrapper-alpha'), { key: 'ArrowDown', altKey: true });
+
+		expect(onReorder).not.toHaveBeenCalled();
+		// …and an ordinary click still reaches the link underneath.
+		fireEvent.click(getByTestId('item-alpha'));
+		expect(onItemClick).toHaveBeenCalledWith('alpha');
+	});
+});
+
+describe('item props', () => {
+	test('native dragging is suppressed, since rail items are anchors', () => {
+		const { getByTestId } = render(<Harness onReorder={vi.fn()} />);
+		const wrapper = getByTestId('wrapper-alpha');
+
+		expect(wrapper.getAttribute('draggable')).toBe('false');
+		// Chromium's link-drag would otherwise hijack the gesture and cancel it.
+		const dragStart = new Event('dragstart', { bubbles: true, cancelable: true });
+		fireEvent(wrapper, dragStart);
+		expect(dragStart.defaultPrevented).toBe(true);
+	});
+
+	test('only the lifted item takes touch-action away from the scrolling rail', () => {
+		const { getByTestId } = render(<Harness onReorder={vi.fn()} />);
+		expect(getByTestId('wrapper-alpha').style.touchAction).toBe('manipulation');
+
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH, { release: false });
+		expect(getByTestId('wrapper-alpha').style.touchAction).toBe('none');
+		expect(getByTestId('wrapper-beta').style.touchAction).toBe('manipulation');
+	});
+});
+
+describe('click suppression cannot get stuck', () => {
+	test('a drop with no synthesized click does not swallow the next press click', () => {
+		const onReorder = vi.fn();
+		const onItemClick = vi.fn();
+		const { getByTestId } = render(<Harness onReorder={onReorder} onItemClick={onItemClick} />);
+
+		// A real drag arms the suppression, but no click follows (released over dead space).
+		mouseDrag(getByTestId('wrapper-alpha'), PITCH);
+		expect(onReorder).toHaveBeenCalledWith(0, 1);
+
+		// A fresh press must clear the stale flag so this click lands.
+		fireEvent(getByTestId('wrapper-beta'), pointerEvent('pointerdown', { clientY: 0 }));
+		fireEvent(document, pointerEvent('pointerup', { clientY: 0 }));
+		fireEvent.click(getByTestId('item-beta'));
+		expect(onItemClick).toHaveBeenCalledWith('beta');
+	});
+});

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -700,6 +700,35 @@ export async function mockRailProjects(
 }
 
 /**
+ * Narrow the project rail to a known set of *real* projects, preserving the
+ * server's own ordering of them.
+ *
+ * The sibling `mockRailProjects` injects synthetic clones, which is right for
+ * pure layout specs but useless for reorder specs — the clone slugs don't exist,
+ * so a real `PUT /api/project-display-order` would reject them. This keeps every
+ * row the server actually returned (so ids, slugs, and `display_order` are all
+ * genuine and the reorder round-trips for real) and merely hides the projects
+ * other parallel workers created, which would otherwise make rail order
+ * unpredictable. Internal (HQ) rows are always kept — HQ renders outside the
+ * sortable list.
+ */
+export async function scopeRailToProjects(page: Page, slugs: string[]): Promise<void> {
+	const keep = new Set(slugs);
+	await page.route('**/api/projects', async (route) => {
+		// A request still in flight when the page tears down rejects here; letting
+		// it through keeps that teardown race out of the test's failure report.
+		try {
+			const res = await route.fetch();
+			const json = (await res.json()) as { data: Array<Record<string, unknown>> };
+			const data = json.data.filter((p) => p.is_internal === true || keep.has(p.slug as string));
+			await route.fulfill({ response: res, body: JSON.stringify({ ...json, data }) });
+		} catch {
+			await route.continue().catch(() => {});
+		}
+	});
+}
+
+/**
  * Inflate the marketplace catalog to `count` teams so the New Project dialog's team
  * list is guaranteed to overflow, whatever the committed `marketplace/` folder ships.
  * The extra entries are clones of a real one, so every field the dialog reads is

--- a/test/browser/project-rail-reorder.mobile.spec.ts
+++ b/test/browser/project-rail-reorder.mobile.spec.ts
@@ -1,0 +1,164 @@
+// Decision-tree points 2 + 3: the touch path cannot be synthesized by the test
+// runner's mouse — `use-sortable-rail` branches on `pointerType === 'touch'` to
+// pick long-press activation over the mouse threshold, and only real Chromium
+// touch events (dispatched over CDP, with `hasTouch` on the context) produce
+// that pointer type. happy-dom has neither touch events nor layout, so the
+// ordering contract and the keyboard path live in
+// packages/web/test/project-rail-reorder.test.tsx instead.
+
+import type { CDPSession, Locator, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import {
+	createProjectAndClearPlanning,
+	scopeRailToProjects,
+	uniqueName,
+	waitForPageLoad,
+} from './helpers';
+
+// Touch events only reach the page when the context advertises touch support.
+test.use({ hasTouch: true });
+
+/** How long `use-sortable-rail` waits before a press becomes a drag (LONG_PRESS_MS). */
+const LONG_PRESS_MS = 250;
+
+async function touchDrag(
+	page: Page,
+	from: { x: number; y: number },
+	to: { x: number; y: number },
+	options: { holdMs: number },
+): Promise<void> {
+	const client: CDPSession = await page.context().newCDPSession(page);
+	try {
+		await client.send('Input.dispatchTouchEvent', {
+			type: 'touchStart',
+			touchPoints: [{ x: from.x, y: from.y }],
+		});
+		if (options.holdMs > 0) await page.waitForTimeout(options.holdMs);
+		const steps = 10;
+		for (let i = 1; i <= steps; i++) {
+			await client.send('Input.dispatchTouchEvent', {
+				type: 'touchMove',
+				touchPoints: [
+					{
+						x: from.x + ((to.x - from.x) * i) / steps,
+						y: from.y + ((to.y - from.y) * i) / steps,
+					},
+				],
+			});
+		}
+		await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+	} finally {
+		await client.detach().catch(() => {});
+	}
+}
+
+/**
+ * The drawer's rail. Below `md` the persistent rail is `display: none` rather
+ * than unmounted, so both rails are in the DOM and every unscoped rail locator
+ * would match twice.
+ */
+function drawerRail(page: Page): Locator {
+	return page.getByTestId('mobile-nav-drawer').getByTestId('project-rail-scroll');
+}
+
+/** The drawer rail's avatar slugs, top to bottom. */
+async function railOrder(page: Page): Promise<string[]> {
+	return drawerRail(page)
+		.locator('[data-testid^="project-rail-avatar-"]')
+		.evaluateAll((els) =>
+			els.map((el) => el.getAttribute('data-testid')?.replace('project-rail-avatar-', '') ?? ''),
+		);
+}
+
+/** Box of one avatar in the drawer rail, by slug. */
+async function avatarBox(page: Page, slug: string) {
+	const box = await drawerRail(page)
+		.locator(`[data-testid="project-rail-avatar-${slug}"]`)
+		.boundingBox();
+	if (!box) throw new Error(`missing layout box for ${slug}`);
+	return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+/** Three real projects, the rail scoped to them, and the mobile drawer open. */
+async function openDrawerWithProjects(page: Page, token: string, label: string) {
+	const projects = [];
+	for (const suffix of ['A', 'B', 'C']) {
+		projects.push(
+			await createProjectAndClearPlanning(page, '', token, {
+				name: uniqueName(`${label} ${suffix}`),
+				description: 'E2E mobile project-rail reordering.',
+			}),
+		);
+	}
+	await scopeRailToProjects(
+		page,
+		projects.map((p) => p.slug),
+	);
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+	// Below `md` the rail only exists inside the side drawer.
+	await page.getByTestId('mobile-nav-toggle').click();
+	await expect(page.getByTestId('mobile-nav-drawer')).toBeVisible({ timeout: 15_000 });
+	await expect(drawerRail(page).locator('[data-testid^="project-rail-avatar-"]')).toHaveCount(3, {
+		timeout: 15_000,
+	});
+
+	// Each project is created on top of the last, so the rail is C, B, A.
+	return { projects, initialOrder: [projects[2].slug, projects[1].slug, projects[0].slug] };
+}
+
+test('a quick touch-drag on an avatar is a scroll, not a reorder', async ({
+	page,
+	sharedWorkspace,
+}) => {
+	const { initialOrder } = await openDrawerWithProjects(
+		page,
+		sharedWorkspace.token,
+		'Touch Scroll',
+	);
+	expect(await railOrder(page)).toEqual(initialOrder);
+
+	let reorderCalls = 0;
+	page.on('request', (r) => {
+		if (new URL(r.url()).pathname === '/api/project-display-order') reorderCalls++;
+	});
+
+	const first = await avatarBox(page, initialOrder[0]);
+	const last = await avatarBox(page, initialOrder[2]);
+
+	// No hold: the finger moves straight away, which the hook must read as a scroll.
+	await touchDrag(page, first, last, { holdMs: 0 });
+
+	await page.waitForTimeout(500);
+	expect(reorderCalls).toBe(0);
+	expect(await railOrder(page)).toEqual(initialOrder);
+});
+
+test('press-and-hold then drag reorders the rail on touch', async ({ page, sharedWorkspace }) => {
+	const { initialOrder } = await openDrawerWithProjects(page, sharedWorkspace.token, 'Touch Hold');
+	expect(await railOrder(page)).toEqual(initialOrder);
+
+	const first = await avatarBox(page, initialOrder[0]);
+	const last = await avatarBox(page, initialOrder[2]);
+
+	const savePut = page.waitForResponse(
+		(r) =>
+			new URL(r.url()).pathname === '/api/project-display-order' && r.request().method() === 'PUT',
+	);
+	await touchDrag(page, first, last, { holdMs: LONG_PRESS_MS + 150 });
+	expect((await savePut).status()).toBe(200);
+
+	await expect
+		.poll(() => railOrder(page))
+		.toEqual([initialOrder[1], initialOrder[2], initialOrder[0]]);
+});
+
+test('a tap on an avatar still opens the project', async ({ page, sharedWorkspace }) => {
+	const { initialOrder } = await openDrawerWithProjects(page, sharedWorkspace.token, 'Touch Tap');
+
+	const box = await avatarBox(page, initialOrder[0]);
+	await page.touchscreen.tap(box.x, box.y);
+
+	await expect(page).toHaveURL(new RegExp(`/projects/${initialOrder[0]}(/|$)`));
+});

--- a/test/browser/project-rail-reorder.spec.ts
+++ b/test/browser/project-rail-reorder.spec.ts
@@ -1,0 +1,192 @@
+// Decision-tree point 1: a drag gesture is only meaningful against real CSS
+// layout — the assertions read boundingBox() to find where an avatar sits and to
+// aim the pointer at a neighbour's slot, and the hook measures item pitch from
+// getBoundingClientRect. happy-dom has no layout engine (every rect is zeros)
+// and no pointer capture, so the ordering contract, the keyboard path, the
+// superuser gate, and rollback are covered in
+// packages/web/test/project-rail-reorder.test.tsx and the pure geometry in
+// packages/web/test/list-reorder.test.ts; what needs Chromium lives here.
+
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import {
+	createProjectAndClearPlanning,
+	mockRailProjects,
+	scopeRailToProjects,
+	uniqueName,
+	waitForPageLoad,
+} from './helpers';
+
+/** The rail's avatar slugs, top to bottom. */
+async function railOrder(page: Page): Promise<string[]> {
+	return page
+		.getByTestId('project-rail-scroll')
+		.locator('[data-testid^="project-rail-avatar-"]')
+		.evaluateAll((els) =>
+			els.map((el) => el.getAttribute('data-testid')?.replace('project-rail-avatar-', '') ?? ''),
+		);
+}
+
+/** Press on `from`'s centre and drag to `to`'s centre, crossing the 8px threshold. */
+async function dragOnto(page: Page, from: Locator, to: Locator): Promise<void> {
+	const a = await from.boundingBox();
+	const b = await to.boundingBox();
+	if (!a || !b) throw new Error('missing layout boxes');
+	await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2);
+	await page.mouse.down();
+	// Several steps so the gesture passes the drag threshold before it lands.
+	await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 12 });
+	await page.mouse.up();
+}
+
+/** Three real projects, with the rail scoped to exactly them (plus HQ). */
+async function seedThreeProjects(page: Page, token: string, label: string) {
+	const projects = [];
+	for (const suffix of ['A', 'B', 'C']) {
+		projects.push(
+			await createProjectAndClearPlanning(page, '', token, {
+				name: uniqueName(`${label} ${suffix}`),
+				description: 'E2E project-rail reordering.',
+			}),
+		);
+	}
+	await scopeRailToProjects(
+		page,
+		projects.map((p) => p.slug),
+	);
+	// Each project is created on top of the last, so the rail is C, B, A.
+	return { projects, initialOrder: [projects[2].slug, projects[1].slug, projects[0].slug] };
+}
+
+test('dragging an avatar down the rail reorders it, and the new order survives a reload', async ({
+	page,
+	sharedWorkspace,
+}) => {
+	const { projects, initialOrder } = await seedThreeProjects(
+		page,
+		sharedWorkspace.token,
+		'Reorder',
+	);
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+	const scroller = page.getByTestId('project-rail-scroll');
+	await expect(scroller.locator('[data-testid^="project-rail-avatar-"]')).toHaveCount(3, {
+		timeout: 15_000,
+	});
+	expect(await railOrder(page)).toEqual(initialOrder);
+
+	const first = page.getByTestId(`project-rail-avatar-${initialOrder[0]}`);
+	const last = page.getByTestId(`project-rail-avatar-${initialOrder[2]}`);
+
+	// Mutation landing is not the same as the rail re-rendering, so wait for the
+	// PUT *and* the index refetch it invalidates before asserting on order.
+	const savePut = page.waitForResponse(
+		(r) =>
+			new URL(r.url()).pathname === '/api/project-display-order' && r.request().method() === 'PUT',
+	);
+	const refetch = page.waitForResponse(
+		(r) => new URL(r.url()).pathname === '/api/projects' && r.request().method() === 'GET',
+	);
+	await dragOnto(page, first, last);
+	const [putRes] = await Promise.all([savePut, refetch]);
+	expect(putRes.status()).toBe(200);
+
+	const moved = [initialOrder[1], initialOrder[2], initialOrder[0]];
+	await expect.poll(() => railOrder(page)).toEqual(moved);
+
+	// It is genuinely persisted, not just optimistic state.
+	await page.reload();
+	await waitForPageLoad(page);
+	await expect(scroller.locator('[data-testid^="project-rail-avatar-"]')).toHaveCount(3, {
+		timeout: 15_000,
+	});
+	expect(await railOrder(page)).toEqual(moved);
+	expect(projects).toHaveLength(3);
+});
+
+test('dragging an avatar up the rail moves it toward the top', async ({
+	page,
+	sharedWorkspace,
+}) => {
+	const { initialOrder } = await seedThreeProjects(page, sharedWorkspace.token, 'Reorder Up');
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+	await expect(
+		page.getByTestId('project-rail-scroll').locator('[data-testid^="project-rail-avatar-"]'),
+	).toHaveCount(3, { timeout: 15_000 });
+	expect(await railOrder(page)).toEqual(initialOrder);
+
+	const savePut = page.waitForResponse(
+		(r) =>
+			new URL(r.url()).pathname === '/api/project-display-order' && r.request().method() === 'PUT',
+	);
+	await dragOnto(
+		page,
+		page.getByTestId(`project-rail-avatar-${initialOrder[2]}`),
+		page.getByTestId(`project-rail-avatar-${initialOrder[0]}`),
+	);
+	expect((await savePut).status()).toBe(200);
+
+	await expect
+		.poll(() => railOrder(page))
+		.toEqual([initialOrder[2], initialOrder[0], initialOrder[1]]);
+});
+
+test('a plain click on an avatar still navigates — the drag never swallows a tap', async ({
+	page,
+	sharedWorkspace,
+}) => {
+	const { initialOrder } = await seedThreeProjects(page, sharedWorkspace.token, 'Reorder Click');
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+	const avatar = page.getByTestId(`project-rail-avatar-${initialOrder[0]}`);
+	await expect(avatar).toBeVisible({ timeout: 15_000 });
+
+	await avatar.click();
+	await expect(page).toHaveURL(new RegExp(`/projects/${initialOrder[0]}(/|$)`));
+	// A click is not a reorder.
+	expect(await railOrder(page)).toEqual(initialOrder);
+});
+
+test('the rail auto-scrolls while dragging toward its bottom edge on an overflowing list', async ({
+	page,
+	sharedWorkspace,
+}) => {
+	// Synthetic clones (rather than 20 real projects) guarantee the rail overflows
+	// whatever else is on this shared server. Their ids don't exist server-side, so
+	// the drop's reorder call is stubbed — persistence is asserted in the first
+	// test; what is under test here is only that the rail scrolls under the finger.
+	await mockRailProjects(page, { keepSlug: sharedWorkspace.projectSlug, clones: 20 });
+	await page.route('**/api/project-display-order', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: [] }),
+		}),
+	);
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	const scroller = page.getByTestId('project-rail-scroll');
+	const avatars = scroller.locator('[data-testid^="project-rail-avatar-"]');
+	await expect(avatars.first()).toBeVisible({ timeout: 15_000 });
+	// The mocked index must actually overflow the rail for this test to mean anything.
+	expect(await scroller.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(true);
+
+	const box = await scroller.boundingBox();
+	const topBox = await avatars.first().boundingBox();
+	if (!box || !topBox) throw new Error('missing layout boxes');
+
+	await page.mouse.move(topBox.x + topBox.width / 2, topBox.y + topBox.height / 2);
+	await page.mouse.down();
+	// Park the pointer inside the bottom edge zone and let the rAF loop run.
+	await page.mouse.move(topBox.x + topBox.width / 2, box.y + box.height - 4, { steps: 10 });
+	await expect
+		.poll(() => scroller.evaluate((el) => el.scrollTop), { timeout: 5_000 })
+		.toBeGreaterThan(0);
+	await page.mouse.up();
+});


### PR DESCRIPTION
Rail order was derived (`created_at DESC`), so the project you work in every day drifted down the rail as newer ones were created. It is now user-controlled: drag an avatar where you want it.

## What changed

**Schema** - `projects.display_order` (migration `042`, ascending, `1` = topmost). The backfill assigns positions in the order the rail already rendered, so upgrading an existing instance is a visual no-op. New projects insert at `MIN(display_order) - 1` so they keep landing on top without renumbering anything; values drift negative and self-heal, because every reorder renumbers the visible list back to `1..N`. Sort key everywhere is `display_order ASC, created_at DESC` - the tiebreak preserves the old newest-first behaviour for rows that tie.

**API** - `PUT /api/project-display-order` takes the full ordered id list and renumbers in one `unnest … WITH ORDINALITY` statement, so a partial ordering is never visible. It rejects archived, internal, unknown, and duplicate ids with a 400, and reuses the existing `broadcastProjectsChanged` signal on the global `projects:global` room so other open tabs re-order live.

It is a *collection*-level route, so it carries `requireSuperuser` rather than `requireProjectAccessMiddleware`, and it lives outside the `/projects/…` tree alongside the existing `/project-intakes` - Hono's `/projects/:projectId/*` middleware pattern also matches `/projects/<word>` (the wildcard matches the empty rest), so a route nested there is resolved as a project slug and 404s before its handler runs.

**Gesture** - `use-sortable-rail` hand-rolls the drag on Pointer Events, following the existing `use-draggable-fab` precedent rather than adding a DnD library (the repo has none):

- **mouse** - press and drag past an 8px threshold;
- **touch** - press and hold 250ms, because the rail itself scrolls vertically and a bare touch-drag would fight it. A swipe still scrolls exactly as before;
- **keyboard** - `Alt+ArrowUp`/`Alt+ArrowDown` on a focused avatar, announced through an `aria-live` region. Alt-modified so it never shadows browser scrolling or a screen reader's own arrow navigation;
- the dragged item and its displaced neighbours translate *inside* the scroll container, so `overflow-y-auto` never has a lifted element to clip - no portal needed;
- the rail auto-scrolls when the pointer nears an edge of an overflowing list.

**Scope** - the order applies everywhere `useAllVisibleProjects()` is consumed (rail, home dashboard, task/settings/marketplace pickers), so the app has one consistent notion of project order. Reordering is superuser-only, matching the rail's create button and archive/unarchive, since `display_order` is global to the instance. HQ and the "+" button keep their exact current positions and are not sortable.

## Three bugs the browser tier caught

Worth calling out, because none would have shown up in a component test:

1. Rail items are `<a>` elements, and Chromium's **native link-drag** hijacks the gesture and fires `pointercancel` - no reorder ever started. Fixed with `draggable={false}` plus `onDragStart` prevention.
2. Calling `setPointerCapture` on `pointerdown` **retargets the click** that ends an ordinary press from the inner `<a>` to the wrapper, so tapping a project stopped navigating. Capture now happens only once the gesture lifts, where suppressing the click is the intent anyway.
3. The document listeners must be attached **synchronously** from `pointerdown`. Binding them from a state-driven effect loses fast gestures - a stepped pointer can emit its whole move sequence inside the frame React takes to re-render.

A latent stuck-state bug is also closed: a drop that produced no synthesized click left the click-suppression flag armed and would have swallowed the next legitimate click.

## Testing

| Tier | Coverage | Tests |
|---|---|---|
| Migration | `042` data preservation: column shape, rows survive, backfill order, index | 5 |
| Server | reorder persists, create-lands-on-top, 403 for board user/anon, 400 for duplicate/unknown/archived/internal/empty, all-or-nothing | 13 |
| Web pure-logic | `moveItem` / `targetIndexForOffset` / `shiftForIndex` incl. clamping and degenerate pitch | 16 |
| Web component | renders in `display_order`, keyboard move + announcement, no-op at the top, rollback + toast on failure, inert for non-superuser | 5 |
| Playwright desktop | drag down + reload persists, drag up, click still navigates, edge auto-scroll | 4 |
| Playwright mobile | quick swipe scrolls (no reorder), press-and-hold drags, tap navigates | 3 |

Touch is driven through CDP `Input.dispatchTouchEvent` with `hasTouch` on the context - Playwright's mouse produces `pointerType: 'mouse'`, which would exercise the wrong activation path. The 143 existing project-related server tests and the existing rail component/browser specs are unchanged and green.

## Docs

- `docs/concepts/projects-and-teams.md` - new "Reordering the project rail" section covering all three input methods.
- `.dev/architecture.md` - `display_order` semantics, the route and its gate, and the broadcast reuse.
- No MCP tool is added and `list_projects` keeps its alphabetical `ORDER BY p.name`, so `docs/reference/mcp-api.md`, `SKILL.md`, and `llms.txt` are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_014yWMvB7onGukynhWmPcWVp)_