### PR TITLE
fix(tasks): stop the assignee reading "Running" when no agent is running

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -847,6 +847,22 @@ absorbs sibling queued wakeups for the same task → marks the run terminal → 
 task blockers (waking dependents when the last blocker clears) → fires task automations.
 Instance agents (CEO/Coach) select work across *all* teams here.
 
+**Stranded-run recovery.** A `heartbeat_runs` row is inserted `queued` and only flips to
+`running` (stamping `started_at`) once a credential is resolved and the credential lock
+held, so both states can strand — and while either persists the run counts as *active*,
+which blocks reassignment on its task and reads as live agent activity in the UI. The ~30 s
+orphan pass (`services/orphan-detector.ts`) therefore reaps both, each aged against the only
+clock it has: a `running` row against `started_at` (30 s safety window), a `queued` row
+against `created_at` (the 120 s grace window, which spans the whole not-yet-started phase).
+Both arms are guarded by the in-process live-run registry — the run id is registered the
+moment the row is inserted, so a run whose host-side driver still owns it (waiting on the
+credential lock, say) is skipped and only a row whose driver has vanished is failed. The two
+kinds are distinguished only by their recorded `error` (`Orphaned: run never started` vs
+`Orphaned: process no longer running`); the retry/approval escalation is shared.
+`healStaleRunState` is the inverse pass and deliberately counts `queued` as active, so it
+repairs the *surroundings* (execution locks, agent `runtime_status`, claimed wakeups) but
+never the run row itself.
+
 **Run.** `agent-runner.ts` builds the run context (provider/runtime resolution, MCP
 descriptors, egress proxy, ssh-agent socket, container env), starts a `heartbeat_runs`
 row, and drives a streaming `docker exec` of the runtime CLI. The long-lived Docker streams
@@ -1139,9 +1155,10 @@ class before interpolation; `killRunProcesses` is its run-id specialization). Th
   awaited `JobManager.killLiveRunProcesses()` reaps every live run's tree (per-kill bounded,
   whole pass raced against its own timer) — the runner's own abort-kill would race
   `process.exit`. Chat teardown then reaps its session trees.
-- **Orphan tick**: when the ~30 s orphan detector marks a `running` run whose process vanished as
-  failed, it also fires `killRunProcesses` against the task's project container (task-less runs
-  skipped — the boot sweep is their backstop).
+- **Orphan tick**: when the ~30 s orphan detector marks a stranded run failed — a `running` one
+  whose process vanished, or a `queued` one whose driver died before it ever started — it also
+  fires `killRunProcesses` against the task's project container (task-less runs skipped — the boot
+  sweep is their backstop). The kill is a no-op for a run that never started, and harmless.
 - **Boot sweep** (crash backstop): `reconcileOnStartup`'s fourth container pass
   (`sweepDanglingContainerProcesses`) scans each running container's `/proc`
   (`DockerClient.listHezoProcesses` — emits only pids carrying a marker, an

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -63,6 +63,31 @@ The practical upshot: keep discussion, decisions, and hand-offs on the task. Wha
 lands in the thread is inherited by the next agent that picks the task up — so the
 conversation compounds instead of evaporating between runs.
 
+## Assignee and run state
+
+Every task has one **assignee**: the agent that owns it. The task view shows the assignee
+alongside a badge for what that agent is doing on this task right now:
+
+- **Running** - the assignee is executing a run on the task at this moment.
+- **Queued** - a run has been created for the assignee but has not started yet. This is
+  normal while it waits its turn, most often behind another run sharing the same AI
+  provider credential. Hover the info icon to see the recorded reason.
+- **Idle** - no run of the assignee's is in flight on this task.
+
+You cannot change the assignee while the task has a run in flight, whether that run is
+running or still queued. Swapping the owner mid-run would leave the task's work orphaned,
+so Hezo holds the field until the run finishes. The assignee field is locked in that case
+and hovering the info icon explains which of the three cases applies.
+
+More than one agent can work a single task, so a run belonging to someone other than the
+assignee (a reviewer, for example) also holds the assignee field. When that happens the
+assignee still reads **Idle**, because the badge describes the assignee and not whoever
+else is active on the task.
+
+If a run is stranded - its process vanished, or it never managed to start - Hezo notices
+within a couple of minutes and marks it failed, which releases the task and returns the
+assignee to **Idle**. You do not need to restart Hezo to clear a stuck task.
+
 ## Cancelling or redirecting work
 
 Plans change — a task gets superseded, folded into another, or dropped. When a manager

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -311,10 +311,12 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
             COALESCE(ma_ps.title, m_ps.display_name) AS progress_summary_updated_by_name,
             (SELECT count(*)::int FROM task_comments ic WHERE ic.task_id = i.id) AS comment_count,
             ra.run_count, ra.total_duration_seconds, ca.total_cost_cents,
-            EXISTS (
-              SELECT 1 FROM heartbeat_runs hr
-              WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
-            ) AS has_active_run,
+            (ar.status IS NOT NULL) AS has_active_run,
+            CASE WHEN ar.status IS NOT NULL THEN json_build_object(
+              'status', ar.status,
+              'member_id', ar.member_id,
+              'queued_reason', ar.queued_reason
+            ) ELSE NULL END AS active_run,
             lr.status AS last_run_status,
             lr.run_id AS last_run_id,
             lr.comment_id AS last_run_comment_id,
@@ -359,6 +361,16 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        ORDER BY hr.finished_at DESC NULLS LAST, hr.started_at DESC
        LIMIT 1
      ) lr ON true
+     LEFT JOIN LATERAL (
+       -- The task's current non-terminal run, preferring one that is actually
+       -- executing over one still waiting to start, so the UI can label the two
+       -- states apart instead of calling both "running".
+       SELECT hr.status, hr.member_id, hr.queued_reason
+       FROM heartbeat_runs hr
+       WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
+       ORDER BY (hr.status = 'running') DESC, hr.created_at DESC
+       LIMIT 1
+     ) ar ON true
      LEFT JOIN LATERAL (
        SELECT count(*) FILTER (WHERE hr.started_at IS NOT NULL)::int AS run_count,
               COALESCE(sum(

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -20,7 +20,9 @@ const MAX_RETRIES = 3;
 const SAFETY_WINDOW_SECONDS = 30;
 /** How long DB state may disagree with the absence of any active run before
  * the heal pass repairs it. Long enough to cover the dispatch window (status
- * flips active before the run row lands) and normal completion bookkeeping. */
+ * flips active before the run row lands) and normal completion bookkeeping.
+ * Doubles as the age a `queued` run must reach before the orphan pass will
+ * reap it, since that window likewise spans the whole not-yet-started phase. */
 export const STALE_STATE_GRACE_SECONDS = 120;
 
 export interface DetectOrphansOpts {
@@ -39,6 +41,16 @@ export async function detectOrphans(
 	wsManager?: WebSocketManager,
 	opts?: DetectOrphansOpts,
 ): Promise<number> {
+	// Both non-terminal states can be stranded, and each needs its own clock.
+	// A `running` run has a `started_at` to age against. A `queued` one never
+	// started — `started_at` is NULL — so it ages against `created_at`, and it
+	// gets the longer grace window because the gap between the row landing and
+	// the run going live legitimately covers credential-lock waits and container
+	// setup. Without this arm a queued row whose driver died before
+	// `markHeartbeatRunRunning` is never reaped: it pins the task's
+	// `has_active_run` (blocking reassignment and reading as a live run in the
+	// UI) until the next server restart, since `healStaleRunState` counts
+	// `queued` as active too.
 	const orphans = await db.query<{
 		id: string;
 		member_id: string;
@@ -47,32 +59,49 @@ export async function detectOrphans(
 		project_id: string | null;
 		container_id: string | null;
 		process_loss_retry_count: number;
+		status: HeartbeatRunStatus;
 	}>(
-		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.process_loss_retry_count,
+		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.process_loss_retry_count, hr.status,
 		        (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id) AS project_id,
 		        (SELECT p.container_id FROM projects p JOIN tasks t ON t.project_id = p.id
 		         WHERE t.id = hr.task_id) AS container_id
 		 FROM heartbeat_runs hr
-		 WHERE hr.status = $1::heartbeat_run_status
-		   AND hr.started_at < now() - ($2 || ' seconds')::interval`,
-		[HeartbeatRunStatus.Running, String(SAFETY_WINDOW_SECONDS)],
+		 WHERE (hr.status = $1::heartbeat_run_status
+		        AND hr.started_at < now() - ($2 || ' seconds')::interval)
+		    OR (hr.status = $3::heartbeat_run_status
+		        AND hr.created_at < now() - ($4 || ' seconds')::interval)`,
+		[
+			HeartbeatRunStatus.Running,
+			String(SAFETY_WINDOW_SECONDS),
+			HeartbeatRunStatus.Queued,
+			String(STALE_STATE_GRACE_SECONDS),
+		],
 	);
 
 	let orphanCount = 0;
 
 	for (const run of orphans.rows) {
+		// The live registry is populated the moment the run row is inserted
+		// (`onRunRegistered` in agent-runner), so a queued run still owned by a
+		// host-side driver — waiting on the credential lock, say — is skipped
+		// here exactly like a healthy running one.
 		if (liveRunIds.has(run.id)) continue;
 
 		orphanCount++;
+
+		const error =
+			run.status === HeartbeatRunStatus.Queued
+				? 'Orphaned: run never started'
+				: 'Orphaned: process no longer running';
 
 		await db.query(
 			`UPDATE heartbeat_runs
 			 SET status = $2::heartbeat_run_status,
 			     finished_at = now(),
-			     error = 'Orphaned: process no longer running',
+			     error = $3,
 			     process_loss_retry_count = process_loss_retry_count + 1
 			 WHERE id = $1`,
-			[run.id, HeartbeatRunStatus.Failed],
+			[run.id, HeartbeatRunStatus.Failed, error],
 		);
 
 		// Task-less runs can't resolve a container here; the startup sweep is
@@ -96,7 +125,7 @@ export async function detectOrphans(
 			task_id: run.task_id,
 			project_id: run.project_id,
 			status: HeartbeatRunStatus.Failed,
-			error: 'Orphaned: process no longer running',
+			error,
 		});
 
 		if (run.process_loss_retry_count + 1 < MAX_RETRIES) {

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -103,10 +103,11 @@ async function createTask(coId: string): Promise<string> {
 
 describe('detectOrphans', () => {
 	it('returns 0 when no orphaned runs exist', async () => {
-		// Clean state — no running heartbeat runs
+		// Clean state — no non-terminal heartbeat runs of either kind
 		await db.query(
-			`DELETE FROM heartbeat_runs WHERE team_id = $1 AND status = $2::heartbeat_run_status`,
-			[teamId, HeartbeatRunStatus.Running],
+			`DELETE FROM heartbeat_runs
+			 WHERE team_id = $1 AND status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+			[teamId, HeartbeatRunStatus.Running, HeartbeatRunStatus.Queued],
 		);
 
 		const count = await detectOrphans(db, new Set());
@@ -144,8 +145,9 @@ describe('detectOrphans', () => {
 
 	it('resets member_agents.runtime_status from active to idle when no other live run remains', async () => {
 		await db.query(
-			`DELETE FROM heartbeat_runs WHERE team_id = $1 AND status = $2::heartbeat_run_status`,
-			[teamId, HeartbeatRunStatus.Running],
+			`DELETE FROM heartbeat_runs
+			 WHERE team_id = $1 AND status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+			[teamId, HeartbeatRunStatus.Running, HeartbeatRunStatus.Queued],
 		);
 		await setAgentActive(agentId);
 		await insertOrphanRun(agentId, teamId);
@@ -214,10 +216,11 @@ describe('detectOrphans', () => {
 	});
 
 	it('returns correct orphan count for multiple orphans', async () => {
-		// Remove all existing running runs
+		// Remove all existing non-terminal runs
 		await db.query(
-			`DELETE FROM heartbeat_runs WHERE team_id = $1 AND status = $2::heartbeat_run_status`,
-			[teamId, HeartbeatRunStatus.Running],
+			`DELETE FROM heartbeat_runs
+			 WHERE team_id = $1 AND status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+			[teamId, HeartbeatRunStatus.Running, HeartbeatRunStatus.Queued],
 		);
 
 		// Insert 3 orphaned runs (no PIDs)
@@ -227,6 +230,115 @@ describe('detectOrphans', () => {
 
 		const count = await detectOrphans(db, new Set());
 		expect(count).toBe(3);
+	});
+});
+
+describe('detectOrphans for runs stranded before they started', () => {
+	/** A `queued` run has no `started_at`, so it ages against `created_at`. */
+	async function insertQueuedRun(age: string, opts: { taskId?: string } = {}): Promise<string> {
+		const result = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, created_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - $5::interval)
+			 RETURNING id`,
+			[teamId, agentId, opts.taskId ?? null, HeartbeatRunStatus.Queued, age],
+		);
+		return result.rows[0].id;
+	}
+
+	async function clearRuns(): Promise<void> {
+		await db.query(
+			`DELETE FROM heartbeat_runs
+			 WHERE team_id = $1 AND status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+			[teamId, HeartbeatRunStatus.Running, HeartbeatRunStatus.Queued],
+		);
+	}
+
+	it('fails a queued run whose driver never started it, and frees the state it pinned', async () => {
+		await clearRuns();
+		const taskId = await createTask(teamId);
+		const lockId = await insertLock(agentId, taskId);
+		await setAgentActive(agentId);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+
+		const count = await detectOrphans(db, new Set());
+		expect(count).toBe(1);
+
+		const run = await db.query<{ status: string; error: string; finished_at: string | null }>(
+			'SELECT status, error, finished_at FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(run.rows[0].error).toBe('Orphaned: run never started');
+		expect(run.rows[0].finished_at).not.toBeNull();
+
+		// The point of the reap: the task stops reading as having an active run,
+		// which is what blocks reassignment and shows the agent as busy.
+		const active = await db.query<{ has_active_run: boolean }>(
+			`SELECT EXISTS (
+			   SELECT 1 FROM heartbeat_runs hr
+			   WHERE hr.task_id = $1 AND hr.status IN ('running', 'queued')
+			 ) AS has_active_run`,
+			[taskId],
+		);
+		expect(active.rows[0].has_active_run).toBe(false);
+
+		const lock = await db.query<{ released_at: string | null }>(
+			'SELECT released_at FROM execution_locks WHERE id = $1',
+			[lockId],
+		);
+		expect(lock.rows[0].released_at).not.toBeNull();
+
+		const agent = await db.query<{ runtime_status: string }>(
+			'SELECT runtime_status FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.Idle);
+	});
+
+	it('leaves a queued run alone while its driver still holds it (waiting on a credential lock)', async () => {
+		await clearRuns();
+		const runId = await insertQueuedRun('10 minutes');
+
+		const count = await detectOrphans(db, new Set([runId]));
+		expect(count).toBe(0);
+
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Queued);
+	});
+
+	it('leaves a queued run alone inside the grace window', async () => {
+		await clearRuns();
+		const runId = await insertQueuedRun('5 seconds');
+
+		const count = await detectOrphans(db, new Set());
+		expect(count).toBe(0);
+
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Queued);
+
+		await clearRuns();
+	});
+
+	it('reports the two stranded kinds with distinct errors in one pass', async () => {
+		await clearRuns();
+		const queuedId = await insertQueuedRun('10 minutes');
+		const runningId = await insertOrphanRun(agentId, teamId);
+
+		expect(await detectOrphans(db, new Set())).toBe(2);
+
+		const runs = await db.query<{ id: string; error: string }>(
+			'SELECT id, error FROM heartbeat_runs WHERE id = ANY($1::uuid[])',
+			[[queuedId, runningId]],
+		);
+		const errorById = new Map(runs.rows.map((r) => [r.id, r.error]));
+		expect(errorById.get(queuedId)).toBe('Orphaned: run never started');
+		expect(errorById.get(runningId)).toBe('Orphaned: process no longer running');
 	});
 });
 

--- a/packages/server/test/tasks-extended.test.ts
+++ b/packages/server/test/tasks-extended.test.ts
@@ -496,6 +496,120 @@ describe('tasks list — assignee_type and has_active_run', () => {
 	});
 });
 
+describe('single-task GET — active_run', () => {
+	async function getTask() {
+		const res = await app.request(
+			`/api/projects/${otherProjectSlug}/tasks/${taskInProgressUrgent}`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		return (await res.json()).data;
+	}
+
+	async function insertRun(
+		status: 'running' | 'queued',
+		opts: { member?: string; queuedReason?: string } = {},
+	): Promise<string> {
+		const row = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, queued_reason)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, $6) RETURNING id`,
+			[
+				opts.member ?? memberId,
+				teamId,
+				taskInProgressUrgent,
+				status,
+				status === 'running' ? new Date().toISOString() : null,
+				opts.queuedReason ?? null,
+			],
+		);
+		return row.rows[0].id;
+	}
+
+	const cleanup = (id: string) => db.query(`DELETE FROM heartbeat_runs WHERE id = $1`, [id]);
+
+	it('is null when the task has no non-terminal run', async () => {
+		const task = await getTask();
+		expect(task.active_run).toBeNull();
+		expect(task.has_active_run).toBe(false);
+	});
+
+	it('reports a running run with the owning member', async () => {
+		const runId = await insertRun('running');
+		try {
+			const task = await getTask();
+			expect(task.has_active_run).toBe(true);
+			expect(task.active_run).toMatchObject({ status: 'running', member_id: memberId });
+		} finally {
+			await cleanup(runId);
+		}
+	});
+
+	it('reports a queued run as queued, carrying its recorded reason', async () => {
+		const runId = await insertRun('queued', {
+			queuedReason: 'waiting for prior run on this credential',
+		});
+		try {
+			const task = await getTask();
+			// The distinction the UI needs: still blocks reassignment, but nothing
+			// is executing yet, so it must not be reported as running.
+			expect(task.has_active_run).toBe(true);
+			expect(task.active_run).toMatchObject({
+				status: 'queued',
+				member_id: memberId,
+				queued_reason: 'waiting for prior run on this credential',
+			});
+		} finally {
+			await cleanup(runId);
+		}
+	});
+
+	it('prefers the executing run when the task carries both', async () => {
+		const queuedId = await insertRun('queued');
+		const runningId = await insertRun('running');
+		try {
+			const task = await getTask();
+			expect(task.active_run.status).toBe('running');
+		} finally {
+			await cleanup(queuedId);
+			await cleanup(runningId);
+		}
+	});
+
+	it("reports another agent's run under that agent's id, not the assignee's", async () => {
+		const other = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, display_name, member_type)
+			 VALUES ($1, 'Reviewer', 'agent') RETURNING id`,
+			[teamId],
+		);
+		const otherMemberId = other.rows[0].id;
+		const runId = await insertRun('running', { member: otherMemberId });
+		try {
+			const task = await getTask();
+			expect(task.has_active_run).toBe(true);
+			expect(task.active_run.member_id).toBe(otherMemberId);
+			expect(task.active_run.member_id).not.toBe(task.assignee_id);
+		} finally {
+			await cleanup(runId);
+			await db.query(`DELETE FROM members WHERE id = $1`, [otherMemberId]);
+		}
+	});
+
+	it('clears once the run reaches a terminal status', async () => {
+		const runId = await insertRun('running');
+		await db.query(
+			`UPDATE heartbeat_runs SET status = 'failed', finished_at = now() WHERE id = $1`,
+			[runId],
+		);
+		try {
+			const task = await getTask();
+			expect(task.has_active_run).toBe(false);
+			expect(task.active_run).toBeNull();
+		} finally {
+			await cleanup(runId);
+		}
+	});
+});
+
 describe('tasks list — has_unread_admin_mention', () => {
 	const findTask = (data: any[], id: string) => data.find((i: any) => i.id === id);
 

--- a/packages/web/src/components/agent-status-label.tsx
+++ b/packages/web/src/components/agent-status-label.tsx
@@ -1,5 +1,5 @@
 import { AgentRuntimeStatus, BUDGET_PAUSE_STATUSES } from '@hezo/shared';
-import { agentRuntimeStatusMeta } from '../lib/status-meta';
+import { agentRuntimeStatusMeta, type BadgeMeta } from '../lib/status-meta';
 import { Badge } from './ui/badge';
 import { StatusDot } from './ui/status-dot';
 
@@ -14,6 +14,13 @@ interface AgentStatusLabelProps {
 	 * amber dot when budget-paused, and nothing at all when idle.
 	 */
 	variant?: 'badge' | 'sidebar';
+	/**
+	 * Overrides the badge derived from `runtimeStatus`, for callers whose pill
+	 * describes something other than the agent's own runtime status — the task
+	 * sidebar labels the *run* on the task ("Queued" vs "Running"). Ignored by the
+	 * `sidebar` variant, which renders a dot rather than a pill.
+	 */
+	badge?: BadgeMeta;
 	className?: string;
 }
 
@@ -21,6 +28,7 @@ export function AgentStatusLabel({
 	name,
 	runtimeStatus,
 	variant = 'badge',
+	badge: badgeOverride,
 	className = '',
 }: AgentStatusLabelProps) {
 	if (variant === 'sidebar') {
@@ -40,7 +48,7 @@ export function AgentStatusLabel({
 		);
 	}
 
-	const badge = agentRuntimeStatusMeta(runtimeStatus);
+	const badge = badgeOverride ?? agentRuntimeStatusMeta(runtimeStatus);
 	return (
 		<span className={`inline-flex min-w-0 items-center gap-1.5 ${className}`}>
 			<span className="min-w-0 truncate">{name}</span>

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -3,6 +3,7 @@ import {
 	AgentRuntimeStatus,
 	CAPTAIN_AGENT_SLUG,
 	DEFAULT_EFFORT,
+	HeartbeatRunStatus,
 	HQ_PROJECT_SLUG,
 	TaskPriority,
 	TaskStatus,
@@ -16,6 +17,7 @@ import type { CommentSkeleton } from '../../hooks/use-comments';
 import type { ExecutionLockState } from '../../hooks/use-execution-locks';
 import { useQueuedWakeups } from '../../hooks/use-queued-wakeups';
 import type { Task, useUpdateTask } from '../../hooks/use-tasks';
+import { TASK_RUN_STATUS_META } from '../../lib/status-meta';
 import { AgentLink } from '../agent-link';
 import { AgentStatusLabel } from '../agent-status-label';
 import { TaskStatusBadge } from '../task-status-badge';
@@ -84,6 +86,33 @@ export function TaskSidebar({
 		?.filter((a) => a.admin_status !== 'disabled')
 		.filter((a) => !isInternalProject || a.slug === CAPTAIN_AGENT_SLUG);
 
+	// Reassignment is blocked whenever the task carries any non-terminal run —
+	// that mirrors the server, which 409s on a queued run just as it does on a
+	// running one, and on any agent's run rather than only the assignee's. The
+	// pill, though, labels *the assignee*, so it stays Idle unless the active run
+	// is theirs, and distinguishes a run that is executing from one still waiting.
+	const activeRun = task.active_run ?? null;
+	const assigneeOwnsRun = activeRun !== null && activeRun.member_id === task.assignee_id;
+	const assigneeRunBadge = assigneeOwnsRun ? TASK_RUN_STATUS_META[activeRun.status] : undefined;
+	const assigneeLock = !activeRun
+		? null
+		: !assigneeOwnsRun
+			? {
+					content: 'Cannot change assignee while another agent has a run on this task',
+					label: 'Assignee locked: another agent is running',
+				}
+			: activeRun.status === HeartbeatRunStatus.Queued
+				? {
+						content: `Cannot change assignee while a run is queued on this task${
+							activeRun.queued_reason ? ` - ${activeRun.queued_reason}` : ''
+						}`,
+						label: 'Assignee locked: run queued',
+					}
+				: {
+						content: 'Cannot change assignee while an agent is running on this task',
+						label: 'Assignee locked: agent is running',
+					};
+
 	return (
 		<>
 			<div
@@ -134,7 +163,7 @@ export function TaskSidebar({
 					<span className="text-text-3 block mb-1 uppercase tracking-wider font-medium">
 						Assignee
 					</span>
-					{task.has_active_run ? (
+					{assigneeLock ? (
 						<div className="flex items-center gap-1 w-full text-[13px] text-text-1 px-1 py-0.5">
 							{assignedAgent ? (
 								<AgentLink
@@ -145,21 +174,20 @@ export function TaskSidebar({
 								>
 									<AgentStatusLabel
 										name={assignedAgent.title}
-										runtimeStatus={AgentRuntimeStatus.Active}
+										runtimeStatus={AgentRuntimeStatus.Idle}
+										badge={assigneeRunBadge}
 										className="min-w-0"
 									/>
 								</AgentLink>
 							) : (
 								<AgentStatusLabel
 									name="—"
-									runtimeStatus={AgentRuntimeStatus.Active}
+									runtimeStatus={AgentRuntimeStatus.Idle}
+									badge={assigneeRunBadge}
 									className="flex-1 min-w-0"
 								/>
 							)}
-							<InfoTooltip
-								content="Cannot change assignee while an agent is running on this task"
-								label="Assignee locked: agent is running"
-							/>
+							<InfoTooltip content={assigneeLock.content} label={assigneeLock.label} />
 						</div>
 					) : (
 						<>

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -1,3 +1,4 @@
+import type { HeartbeatRunStatus } from '@hezo/shared';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { api } from '../lib/api';
@@ -12,6 +13,14 @@ export interface QueuedWakeup {
 	blocker_task_id: string | null;
 	blocker_identifier: string | null;
 	blocker_project_slug: string | null;
+}
+
+export interface ActiveRun {
+	status: typeof HeartbeatRunStatus.Running | typeof HeartbeatRunStatus.Queued;
+	/** The agent the run belongs to — not necessarily the task's assignee. */
+	member_id: string;
+	/** Why the run is still waiting, when the server recorded a reason. */
+	queued_reason: string | null;
 }
 
 export interface Task {
@@ -30,6 +39,15 @@ export interface Task {
 	assignee_slug: string | null;
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
+	/**
+	 * The task's current non-terminal run, when there is one. `has_active_run` is
+	 * the same fact as a boolean; this carries the detail needed to tell an
+	 * executing run apart from one still waiting to start, and to know whose run
+	 * it is (any agent's run on the task blocks reassignment, not just the
+	 * assignee's). Only the single-task endpoint returns it — list rows get the
+	 * boolean alone, hence optional rather than nullable.
+	 */
+	active_run?: ActiveRun | null;
 	/** Number of agent runs that have started on this task (excludes queued). */
 	run_count: number;
 	/** Summed wall-clock duration of finished runs, in seconds. */

--- a/packages/web/src/lib/status-meta.ts
+++ b/packages/web/src/lib/status-meta.ts
@@ -2,6 +2,7 @@ import {
 	AgentRuntimeStatus,
 	ApprovalType,
 	formatTaskStatus,
+	HeartbeatRunStatus,
 	TaskPriority,
 	TaskStatus,
 } from '@hezo/shared';
@@ -73,6 +74,20 @@ export function agentRuntimeStatusMeta(status: string): BadgeMeta {
 		AGENT_RUNTIME_STATUS_META[AgentRuntimeStatus.Idle]
 	);
 }
+
+/**
+ * Badge meta for a task's current non-terminal run. Distinct from the agent
+ * runtime statuses above: this describes *the run*, so a run that exists but has
+ * not begun executing reads "Queued" rather than borrowing the cyan `live`
+ * signal, which stays reserved for an agent actually working.
+ */
+export const TASK_RUN_STATUS_META: Record<
+	typeof HeartbeatRunStatus.Running | typeof HeartbeatRunStatus.Queued,
+	BadgeMeta
+> = {
+	[HeartbeatRunStatus.Running]: { color: 'live', label: 'Running' },
+	[HeartbeatRunStatus.Queued]: { color: 'yellow', label: 'Queued' },
+};
 
 const APPROVAL_TYPE_COLORS: Record<ApprovalType, BadgeColor> = {
 	[ApprovalType.Strategy]: 'purple',

--- a/packages/web/test/task-assignee-status.test.tsx
+++ b/packages/web/test/task-assignee-status.test.tsx
@@ -3,12 +3,25 @@ import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
-async function insertActiveRun(memberId: string, teamId: string, taskId: string) {
+async function insertActiveRun(
+	memberId: string,
+	teamId: string,
+	taskId: string,
+	opts: { status?: 'running' | 'queued'; queuedReason?: string } = {},
+) {
+	const { status = 'running', queuedReason = null } = opts;
 	const { db } = getTestContext();
 	await db.query(
-		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-		 VALUES ($1, $2, $3, 'running', now())`,
-		[memberId, teamId, taskId],
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, queued_reason)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, $6)`,
+		[
+			memberId,
+			teamId,
+			taskId,
+			status,
+			status === 'running' ? new Date().toISOString() : null,
+			queuedReason,
+		],
 	);
 }
 
@@ -88,4 +101,82 @@ test('assignee shows Running on this ticket when has_active_run is true', async 
 		expect(assignee.textContent).toContain('Running');
 	});
 	expect(assignee.querySelector('[aria-label="Assignee locked: agent is running"]')).not.toBeNull();
+});
+
+test('assignee shows Queued, not Running, while the run has yet to start', async () => {
+	let projectSlug = '';
+	let taskIdentifier = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Waiting Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Waiting Ticket',
+				assignee_id: ws.agents[0].id,
+			});
+			await insertActiveRun(ws.agents[0].id, ws.team.id, task.id, {
+				status: 'queued',
+				queuedReason: 'waiting for prior run on this credential',
+			});
+			projectSlug = project.slug;
+			taskIdentifier = task.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projectSlug, taskId: taskIdentifier.toLowerCase() },
+	});
+
+	const assignee = await findByTestId('task-assignee', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(assignee.textContent).toContain('Queued');
+	});
+	expect(assignee.textContent).not.toContain('Running');
+
+	// Still locked — the server 409s on a queued run too — but the tooltip says why.
+	const lock = assignee.querySelector('[aria-label="Assignee locked: run queued"]');
+	expect(lock).not.toBeNull();
+	expect(assignee.querySelector('[aria-label="Change assignee"]')).toBeNull();
+});
+
+test('assignee stays Idle when the active run belongs to a different agent', async () => {
+	let projectSlug = '';
+	let taskIdentifier = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Shared Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Shared Ticket',
+				assignee_id: ws.agents[0].id,
+			});
+			// A second agent (a reviewer, say) is the one running on the task.
+			const other = ws.agents.find((a) => a.id !== ws.agents[0].id);
+			if (!other) throw new Error('expected the roster to hold more than one agent');
+			await insertActiveRun(other.id, ws.team.id, task.id);
+			projectSlug = project.slug;
+			taskIdentifier = task.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projectSlug, taskId: taskIdentifier.toLowerCase() },
+	});
+
+	const assignee = await findByTestId('task-assignee', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(
+			assignee.querySelector('[aria-label="Assignee locked: another agent is running"]'),
+		).not.toBeNull();
+	});
+	// The pill describes the assignee, and the assignee is not the one running.
+	expect(assignee.textContent).toContain('Idle');
+	expect(assignee.textContent).not.toContain('Running');
+	expect(assignee.querySelector('[aria-label="Change assignee"]')).toBeNull();
 });


### PR DESCRIPTION
The task sidebar could show the cyan **Running** pill and lock the assignee dropdown while nothing was executing - indefinitely, with the Agent Queue panel showing no running row at all. Three things combined.

## What was wrong

**1. The pill was a literal, not a status.** `task-sidebar.tsx` branched on `has_active_run` and passed `AgentRuntimeStatus.Active` hardcoded, so the badge meant "this task has an active run row", never "this agent is running". The agent's real `runtime_status` was never consulted.

**2. `queued` rendered as "Running".** `has_active_run` is `status IN ('running','queued')`. A run row is inserted `queued` and only flips to `running` once the credential lock is held, so a run parked on `waiting for prior run on this credential` read as live.

**3. Nothing reaped a stranded `queued` row.** `detectOrphans` selects `status = 'running' AND started_at < now() - 30s`; a queued row has `started_at IS NULL` and could never match. `healStaleRunState` counts `queued` as active, so it repaired the surroundings but never the row.

The stranding path: if `runAgent` throws between `createHeartbeatRun` and the first terminal write, job-manager's catch calls `onAgentComplete`, which releases the execution lock and idles the agent but **never writes `heartbeat_runs.status`**. Lock gone, agent idle, row pinned at `queued` until the next restart - which is exactly the reported symptom.

## The fix

**Reaper (`orphan-detector.ts`).** `detectOrphans` now covers both non-terminal states, each aged against the only clock it has: `running` against `started_at` (30s safety window), `queued` against `created_at` (the 120s grace window, which spans the whole not-yet-started phase). Both arms keep the `liveRunIds` guard - the run id is registered the moment the row is inserted, so a run whose driver still owns it (waiting on the credential lock) is skipped and only a row whose driver vanished is failed. The kinds differ only in recorded error text (`Orphaned: run never started` vs `Orphaned: process no longer running`); retry/approval escalation is shared. The existing broadcast unsticks the UI live, without a reload.

**API (`routes/tasks.ts`).** The task detail query returns the run's shape instead of just a boolean: a lateral yields the current non-terminal run, preferring an executing one over a queued one, and `active_run { status, member_id, queued_reason }` rides alongside the unchanged `has_active_run`. The list query keeps its `EXISTS` - list rows only need the boolean, and a lateral per row is wasted work.

**UI (`task-sidebar.tsx`, `status-meta.ts`, `agent-status-label.tsx`).** The assignee now reads **Running** only for the assignee's executing run, **Queued** (with the reason in the tooltip) while it waits, and **Idle** when the active run belongs to a different agent - a reviewer's run no longer claims the assignee is working. Reassignment stays blocked in all three cases, matching the server's 409; the tooltip names which case applies. Queued gets its own yellow badge rather than borrowing the cyan `live` signal, which stays reserved for an agent actually working.

## Tests

- `orphan-detector.test.ts` - a stale queued run is failed and frees the state it pinned (task no longer reads as having an active run, lock released, agent idled); a queued run held in `liveRunIds` is left alone; a queued run inside the grace window is left alone; both stranded kinds are reported with distinct errors in one pass.
- `tasks-extended.test.ts` - `active_run` is null with no run, reports a running run with its owning member, reports a queued run as queued with its recorded reason, prefers the executing run when both exist, reports another agent's run under that agent's id, and clears on a terminal status.
- `task-assignee-status.test.tsx` - queued renders **Queued** not Running with the dropdown still locked; a different agent's run leaves the assignee **Idle** but still locked.

Full local run: shared 164 passed, server 5772 passed / 18 skipped, web tier green. `typecheck` and `biome check` clean (the only warnings on touched files are pre-existing unused `teamSlug` vars).

## Docs

- `.dev/architecture.md` gains a **Stranded-run recovery** paragraph and an updated **Orphan tick** bullet covering the queued arm.
- `docs/concepts/tasks.md` gains an **Assignee and run state** section for the Running/Queued/Idle badge and the assignee lock.
- No CLI flag, env var, MCP tool, or REST route name changed, so `docs/reference/*`, `SKILL.md` and `llms.txt` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SXQ9iFX77tEDRoqo155MW

---
_Generated by [Claude Code](https://claude.ai/code/session_016SXQ9iFX77tEDRoqo155MW)_