### PR TITLE
fix(db): honour libpq sslmode semantics for external Postgres

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2022,6 +2022,23 @@ credentials occluded, query params dropped except `sslmode`) and only that is pa
 `buildApp`, surfaced at the superuser-only `GET /api/database-info` for the Settings →
 General Database card.
 
+**External TLS (`sslmode`).** node-postgres 8 reads `prefer`/`require`/`verify-ca` as
+aliases for `verify-full`, which no other Postgres client does and which pg 9 drops.
+Since managed providers (DigitalOcean, RDS, Azure) sign with a private CA, that reading
+rejects connection strings `psql` accepts. `normalizePostgresUrl`
+(`src/db/postgres-url.ts`) opts the string into pg-connection-string's libpq semantics
+(`uselibpqcompat=true`) for exactly the modes the two readings disagree on, leaving
+`no-verify` (which would flip back to verifying) and bare `verify-ca` (which would throw)
+untouched. It is applied in `PostgresDb.connect` — the single pool construction site, so
+it is unbypassable — and an explicit `ssl` option would not work there, since
+node-postgres merges the parsed connection string *over* the caller's config. The same
+function reports the resulting `PostgresTlsPosture`, which `openDatabase` renders into the
+startup line so a `require` connection visibly says "certificate not verified".
+Connect failures are classified by `src/db/postgres-connect-errors.ts`: deterministic
+causes (rejected certificate, bad credentials, missing database) skip the retry backoff and
+carry targeted guidance instead of the generic TLS advice. Delete the normalizer when pg
+reaches v9.
+
 **Asset storage.** Asset blobs (task attachments + the project assets library) live behind
 the `AssetStore` interface (`src/assets/store.ts`:
 `write`/`read`/`delete`/`deleteProjectAssets`/`close`, keyed `projectId/assetId` — teams

--- a/.dev/hosted-architecture.md
+++ b/.dev/hosted-architecture.md
@@ -375,7 +375,7 @@ other tenant's hostname.
 |---|---|---|
 | `HEZO_PORT` | `3100` | behind local Caddy |
 | `HEZO_DATA_DIR` | `/var/lib/hezo` | scratch only — DB and assets are external |
-| `HEZO_DATABASE_URL` | `postgres://hezo_t_<id>:<pw>@<cluster-private-host>:25060/hezo_t_<id>?sslmode=require` | per-tenant role + database |
+| `HEZO_DATABASE_URL` | `postgres://hezo_t_<id>:<pw>@<cluster-private-host>:25060/hezo_t_<id>?sslmode=require` | per-tenant role + database. `require` is libpq-semantic (see `.dev/architecture.md` § Storage): encrypted, certificate not verified — accepted here because the host is the cluster's private VPC address. Verifying it would mean `sslmode=verify-full&sslrootcert=` with the DO cluster CA placed by provisioning. |
 | `HEZO_DATABASE_POOL_SIZE` | `4` | keeps cluster connection math sane |
 | `HEZO_ASSET_STORAGE_URL` | `s3://<KEY>:<SECRET>@<region>.digitaloceanspaces.com/hezo-t-<shortid>?region=…` | per-bucket key |
 | `HEZO_WEB_URL` | `https://<sub>.app.hezo.ai` | also the SSO `aud` |

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -28,7 +28,9 @@ runcmd:
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into
   # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
-  # provision.sh persists them into the service's env file:
+  # provision.sh persists them into the service's env file. sslmode=require encrypts
+  # without verifying the certificate; for verified TLS use sslmode=verify-full plus
+  # &sslrootcert=/etc/hezo/db-ca.crt when the provider signs with its own CA (most do).
   # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]
   # - [ sh, -c, "echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' >> /etc/hezo/deploy.env" ]
   # - [ sh, -c, "echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' >> /etc/hezo/deploy.env" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -24,7 +24,11 @@
 #   HEZO_DOMAIN_OVERRIDE   use this domain instead of <public-ip>.sslip.io
 #                          (point an A record at the host first; Caddy gets a cert for it)
 #   HEZO_DATABASE_URL      managed/external Postgres 14+ connection string
-#                          (postgres://user:pass@host:5432/hezo?sslmode=verify-full).
+#                          (postgres://user:pass@host:5432/hezo?sslmode=require).
+#                          sslmode follows libpq rules: require encrypts without
+#                          verifying the certificate; for verified TLS use
+#                          sslmode=verify-full, adding &sslrootcert=/etc/hezo/db-ca.crt
+#                          when the provider signs with its own CA (most do).
 #                          Persisted into /etc/hezo/hezo.env on first provision; omit to
 #                          use the embedded database on the VM's disk (the default).
 #   HEZO_ASSET_STORAGE_URL S3-compatible object storage for asset files

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -45,9 +45,11 @@ Be clear-eyed about what changes: **your business content — tasks, comments, d
 is stored as ordinary database rows**, so with an external database that content lives
 with your database provider and travels the network. Hezo checks the server version at
 startup and shows the connection target (credentials occluded, never the full URL) under
-**Settings → Storage → Database**. Use TLS (`sslmode=verify-full`), prefer private
-networking, and treat the provider's at-rest encryption and access controls as part of
-your security posture. Secrets are unaffected — see below.
+**Settings → Storage → Database**. Use TLS: `sslmode=verify-full` encrypts *and* proves
+you are talking to the right server, where `sslmode=require` only encrypts - see
+[TLS and sslmode](/docs/deployment/configuration#tls-and-sslmode). Prefer private networking,
+and treat the provider's at-rest encryption and access controls as part of your security
+posture. Secrets are unaffected — see below.
 
 ## Encrypted where it counts
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -79,6 +79,11 @@ backups. Each backend is one setting, adoptable independently:
      hezo --data-dir /var/lib/hezo
    ```
 
+   Most managed providers sign their database certificates with their own CA, so
+   `verify-full` also needs the provider's CA certificate:
+   `?sslmode=verify-full&sslrootcert=/etc/hezo/db-ca.crt`. See
+   [TLS and sslmode](/docs/deployment/configuration#tls-and-sslmode).
+
 4. **Verify at startup.** Hezo checks both backends and fails fast with guidance if
    the database is older than 14 or the bucket is unreachable. The startup log shows
    `Using external Postgres at …` and `Asset storage: S3-compatible (…)`, and

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -17,7 +17,7 @@ handy for baking defaults into a service definition while still overriding per r
 |---|---|---|---|
 | `--port <port>` | `HEZO_PORT` | `3100` | Port the server and web app listen on (1–65535). |
 | `--data-dir <path>` | `HEZO_DATA_DIR` | `~/.hezo/` | Where Hezo stores its database, encrypted secrets, and assets. Still required with an external database or S3 asset storage — workspaces and keys live here. |
-| `--database-url <url>` | `HEZO_DATABASE_URL` | — | Connection string for an [external Postgres](#using-an-external-postgres) (`postgres://user:password@host:5432/hezo`). Omit to use the embedded database under the data directory (the default). |
+| `--database-url <url>` | `HEZO_DATABASE_URL` | — | Connection string for an [external Postgres](#using-an-external-postgres) (`postgres://user:password@host:5432/hezo`). Its `sslmode` follows standard libpq rules - see [TLS and sslmode](#tls-and-sslmode). Omit to use the embedded database under the data directory (the default). |
 | — | `HEZO_DATABASE_POOL_SIZE` | `10` | Connection-pool size for the external database (2–100). Ignored for the embedded database. |
 | `--asset-storage-url <url>` | `HEZO_ASSET_STORAGE_URL` | — | [S3-compatible object storage](#storing-assets-in-s3-compatible-object-storage) for asset files (`s3://KEY:SECRET@endpoint/bucket[/prefix]`). Omit to store assets on the local filesystem under the data directory (the default). |
 | `--master-key <phrase>` | `HEZO_MASTER_KEY` | — | The twelve-word master key, to set up or unlock without the web gate. |
@@ -86,9 +86,9 @@ Requirements and recommendations:
 
 - **PostgreSQL 14 or newer.** The version is checked at startup.
 - **Use TLS.** With an external database your tasks, comments, and documents travel the
-  network and live with the provider — prefer `sslmode=verify-full` and private
-  networking. [Secrets remain encrypted](/docs/concepts/your-data) with the master key
-  either way.
+  network and live with the provider. Set `sslmode` deliberately - see
+  [TLS and sslmode](#tls-and-sslmode) for what each mode does and does not protect against.
+  [Secrets remain encrypted](/docs/concepts/your-data) with the master key either way.
 - **Keep the database close to the server.** Hezo's background scheduling polls every
   1–5 seconds, so every millisecond of round-trip latency counts. Same-host,
   same-VPC, or same-region placement is strongly recommended.
@@ -101,6 +101,47 @@ Requirements and recommendations:
 - `hezo backup` / `hezo restore` work against an external database too — including
   **moving an existing embedded instance to hosted Postgres** (and back). See
   [Backup & recovery](/docs/deployment/backup-and-recovery).
+
+### TLS and sslmode
+
+Hezo reads `sslmode` from the connection string exactly as `psql` and libpq do, so a
+connection string copied from your provider's dashboard behaves the same way in Hezo as
+it does in any other Postgres client:
+
+| `sslmode` | Encrypted | Certificate verified | Notes |
+|---|---|---|---|
+| *(omitted)* | No | - | **Plaintext.** There is no implicit TLS - set `sslmode` explicitly. |
+| `disable` | No | - | Plaintext. Only over a trusted private network. |
+| `prefer` | Yes | No | Same protection as `require` in Hezo. |
+| `require` | Yes | No | Encrypted, but an interceptor can present any certificate. |
+| `verify-ca` | Yes | Chain only | Needs `sslrootcert`. The host name is not checked. |
+| `verify-full` | Yes | Chain + host name | **Recommended.** |
+| `no-verify` | Yes | No | Same as `require`; accepted for compatibility. |
+
+Hezo logs the mode it resolved on every start, so you can confirm what you actually got:
+
+```
+Using external Postgres at postgres://••••:••••@db.internal:5432/hezo?sslmode=require
+  (server 16.4, pool max 10, TLS encrypted, certificate not verified ...)
+```
+
+**Verifying against a provider-private CA.** Managed Postgres (DigitalOcean, AWS RDS,
+Azure) and most self-hosted servers present a certificate signed by their own CA rather
+than a public one, so `verify-full` on its own fails with *"self signed certificate in
+certificate chain"*. Download the provider's CA certificate and point `sslrootcert` at
+it - this is the recommended setup:
+
+```sh
+# DigitalOcean: Databases → your cluster → Connection details → Download CA certificate
+sudo install -m 644 ca-certificate.crt /etc/hezo/db-ca.crt
+
+HEZO_DATABASE_URL="postgres://hezo:••••@db-postgresql-lon1-12345-do-user-0.db.ondigitalocean.com:25060/hezo?sslmode=verify-full&sslrootcert=/etc/hezo/db-ca.crt" \
+  hezo --data-dir /var/lib/hezo
+```
+
+The `PGSSLMODE` environment variable is honoured only when the connection string carries
+no `sslmode` of its own, and node-postgres reads it strictly (every verifying mode means
+full verification). Put `sslmode` in the URL rather than relying on it.
 
 ## Storing assets in S3-compatible object storage
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -77,7 +77,9 @@ runcmd:
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into
   # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
-  # provision.sh persists them into the service's env file:
+  # provision.sh persists them into the service's env file. sslmode=require encrypts
+  # without verifying the certificate; for verified TLS use sslmode=verify-full plus
+  # &sslrootcert=/etc/hezo/db-ca.crt when the provider signs with its own CA (most do).
   # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]
   # - [ sh, -c, "echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' >> /etc/hezo/deploy.env" ]
   # - [ sh, -c, "echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' >> /etc/hezo/deploy.env" ]
@@ -124,8 +126,9 @@ postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require
   round-trip latency low. Same-VPC/private networking is ideal.
 - **Use the direct or session-pooled connection**, never a transaction-mode pooler
   (PgBouncer in transaction mode breaks the locks Hezo uses to coordinate migrations).
-- **Use TLS** — `sslmode=require` at minimum, `sslmode=verify-full` where your provider
-  supports it.
+- **Use TLS** — `sslmode=require` encrypts the connection but does not verify the
+  server's certificate. For verified TLS use `sslmode=verify-full`, adding
+  `&sslrootcert=/etc/hezo/db-ca.crt` if your provider signs with its own CA (most do).
 
 Full requirements: [Configuration → Using an external
 Postgres](/docs/deployment/configuration#using-an-external-postgres).
@@ -196,6 +199,16 @@ The concrete version for a DigitalOcean Droplet deployed with the snippet above:
 
    ```
    postgres://doadmin:PASSWORD@db-postgresql-fra1-12345-do-user-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+   ```
+
+   DigitalOcean signs cluster certificates with its own CA, so `sslmode=require`
+   encrypts without verifying them. For verified TLS, download the cluster's CA from
+   **Connection details → Download CA certificate**, put it on the Droplet, and extend
+   the URL:
+
+   ```sh
+   sudo install -m 644 ca-certificate.crt /etc/hezo/db-ca.crt
+   # ...?sslmode=verify-full&sslrootcert=/etc/hezo/db-ca.crt
    ```
 
 2. **Assets:** create a [Spaces](https://www.digitalocean.com/products/spaces) bucket

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,7 +40,9 @@ hezo --disable-telemetry         # turn off the anonymous daily usage report (on
 By default the database is embedded and lives under the data directory. With
 `--database-url` (or `HEZO_DATABASE_URL`) Hezo runs against an external PostgreSQL 14+
 instead — see [Using an external Postgres](/docs/deployment/configuration) for
-requirements (TLS, latency, pooling).
+requirements (TLS, latency, pooling) and
+[TLS and sslmode](/docs/deployment/configuration#tls-and-sslmode) for what each `sslmode`
+protects against.
 
 Uploaded asset files live under the data directory by default. With
 `--asset-storage-url` (or `HEZO_ASSET_STORAGE_URL`) they live in any S3-compatible

--- a/packages/server/src/db/drivers/postgres.ts
+++ b/packages/server/src/db/drivers/postgres.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import type { Db, Queryable, QueryResult, SessionLockHandle } from '../database';
+import { normalizePostgresUrl } from '../postgres-url';
 import { TxContext } from './tx-context';
 
 // Parser parity with PGlite (the conformance suite is the executable
@@ -54,8 +55,13 @@ export class PostgresDb implements Db {
 	/** Create the pool and prove basic connectivity with one round-trip. */
 	static async connect(options: PostgresConnectOptions): Promise<PostgresDb> {
 		const url = new URL(options.url);
+		// Every pool in the codebase is built here, so normalizing the string at
+		// this one point makes libpq `sslmode` semantics unbypassable. Note that
+		// an explicit `ssl` option alongside `connectionString` would NOT work:
+		// node-postgres merges the parsed string over the caller's config, so a
+		// URL carrying `sslmode` silently wins.
 		const pool = new pg.Pool({
-			connectionString: options.url,
+			connectionString: normalizePostgresUrl(options.url).url,
 			max: Math.max(MIN_POOL_SIZE, options.max ?? 10),
 			// Checkout starvation (e.g. a transaction leak eating the pool) must
 			// fail loudly, not hang requests forever.

--- a/packages/server/src/db/open.ts
+++ b/packages/server/src/db/open.ts
@@ -5,7 +5,9 @@ import { openPersistentDb } from './client';
 import type { Db } from './database';
 import { PgliteDb } from './drivers/pglite';
 import { ExternalDbError } from './migrate-errors';
+import { connectFailureHint, isRetryableConnectError } from './postgres-connect-errors';
 import { assertExternalPostgresCompatible } from './postgres-preflight';
+import { describeTlsPosture, normalizePostgresUrl } from './postgres-url';
 
 const log = logger.child('db-open');
 
@@ -86,6 +88,9 @@ export async function openDatabase(options: OpenDatabaseOptions): Promise<Opened
 			break;
 		} catch (err) {
 			lastError = err;
+			// A rejected certificate or bad credentials fail identically on every
+			// attempt — spending the backoff on them only delays the guidance.
+			if (!isRetryableConnectError(err)) break;
 			if (attempt < CONNECT_ATTEMPTS) {
 				log.warn(
 					`Could not reach the external database at ${redacted} (attempt ${attempt}/${CONNECT_ATTEMPTS}); retrying…`,
@@ -96,19 +101,23 @@ export async function openDatabase(options: OpenDatabaseOptions): Promise<Opened
 	}
 	if (!db) {
 		const causeMsg = lastError instanceof Error ? lastError.message : String(lastError);
+		const hint =
+			connectFailureHint(lastError) ??
+			'Check that the connection string is correct and the server is reachable from this host.';
 		throw new ExternalDbError(
-			`Could not connect to the external database at ${redacted}. ` +
-				`Check that the connection string is correct, the server is reachable from this host, ` +
-				`and TLS settings match the provider's requirements (most hosted Postgres need ` +
-				`sslmode=require or sslmode=verify-full). (cause: ${causeMsg})`,
+			`Could not connect to the external database at ${redacted}. ${hint} (cause: ${causeMsg})`,
 			lastError,
 		);
 	}
 
 	try {
 		const preflight = await assertExternalPostgresCompatible(db);
+		// The effective TLS posture is stated on every boot: `sslmode=require`
+		// encrypts without authenticating the server, and that is worth seeing
+		// rather than assuming.
+		const tls = describeTlsPosture(normalizePostgresUrl(options.databaseUrl).tls);
 		log.info(
-			`Using external Postgres at ${redacted} (server ${preflight.serverVersion}, pool max ${max ?? 10})`,
+			`Using external Postgres at ${redacted} (server ${preflight.serverVersion}, pool max ${max ?? 10}, ${tls})`,
 		);
 		return {
 			db,

--- a/packages/server/src/db/postgres-connect-errors.ts
+++ b/packages/server/src/db/postgres-connect-errors.ts
@@ -1,0 +1,153 @@
+/**
+ * Classification of external-Postgres connect failures into operator guidance.
+ *
+ * The failure that matters most here is a TLS chain rejection: it is by far the
+ * most common way a correct connection string fails, it is entirely
+ * deterministic (so retrying is wasted time), and the generic "check your TLS
+ * settings" advice actively points the wrong way when the certificate itself is
+ * the problem rather than the mode.
+ *
+ * Matching is on `err.code` first because the OpenSSL/Node error constants are
+ * stable across Node and Bun, with a message regex as a fallback for wrappers
+ * that drop the code and for runtime wording drift (Node appends a
+ * `--use-system-ca` suggestion; Bun's OpenSSL build writes "self signed" where
+ * Node writes "self-signed").
+ */
+
+interface FailureKind {
+	/** Error codes and SQLSTATEs that identify this failure. */
+	codes: string[];
+	/** Message fallbacks for errors that arrive without a code. */
+	patterns: RegExp[];
+	/** Whether the failure repeats identically, making a retry pointless. */
+	deterministic: boolean;
+	hint: string;
+}
+
+/** Ordered: the first match wins, so the specific TLS cases come before the rest. */
+const FAILURE_KINDS: FailureKind[] = [
+	{
+		codes: [
+			'SELF_SIGNED_CERT_IN_CHAIN',
+			'DEPTH_ZERO_SELF_SIGNED_CERT',
+			'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+			'UNABLE_TO_GET_ISSUER_CERT',
+			'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+			'CERT_UNTRUSTED',
+		],
+		patterns: [
+			/self[- ]signed certificate/i,
+			/unable to verify the first certificate/i,
+			/unable to get (local )?issuer certificate/i,
+		],
+		deterministic: true,
+		hint:
+			"The database's TLS certificate is signed by a CA this host does not trust. " +
+			'That is normal for DigitalOcean, AWS RDS, Azure and self-hosted Postgres, which ' +
+			'sign with a provider-private CA. Either download the provider CA certificate and ' +
+			'use sslmode=verify-full&sslrootcert=/path/to/ca.crt (verified, recommended), or ' +
+			'use sslmode=require to encrypt without verifying the certificate.',
+	},
+	{
+		codes: ['CERT_HAS_EXPIRED', 'CERT_NOT_YET_VALID'],
+		patterns: [/certificate has expired/i, /certificate is not yet valid/i],
+		deterministic: true,
+		hint:
+			"The database's TLS certificate is expired or not yet valid. Check the clock on " +
+			'this host, then renew or rotate the certificate with your provider.',
+	},
+	{
+		codes: ['ERR_TLS_CERT_ALTNAME_INVALID'],
+		patterns: [/hostname\/ip does not match/i, /altname/i],
+		deterministic: true,
+		hint:
+			'The database host name does not match its TLS certificate. Connect using the host ' +
+			'name the certificate was issued for, or drop to sslmode=require to skip the ' +
+			'hostname check.',
+	},
+	{
+		codes: [],
+		patterns: [/does not support SSL connections/i],
+		deterministic: true,
+		hint:
+			'The server refused TLS - it is running with ssl=off. Enable TLS on the server, or ' +
+			'use sslmode=disable only if the connection stays on a trusted private network.',
+	},
+	{
+		codes: ['28P01', '28000'],
+		patterns: [],
+		deterministic: true,
+		hint: 'The database rejected the credentials. Check the user name and password in the connection string.',
+	},
+	{
+		codes: ['3D000'],
+		patterns: [],
+		deterministic: true,
+		hint: 'The database named in the connection string does not exist. Create it, or point the URL at an existing database.',
+	},
+	{
+		codes: ['ECONNREFUSED'],
+		patterns: [],
+		deterministic: false,
+		hint: 'Nothing is listening on that host and port. Check the port and that the database allows connections from this host.',
+	},
+	{
+		codes: ['ENOTFOUND', 'EAI_AGAIN'],
+		patterns: [],
+		deterministic: false,
+		hint: 'The database host name did not resolve. Check the host name and this machine DNS settings.',
+	},
+	{
+		codes: ['ETIMEDOUT'],
+		patterns: [],
+		deterministic: false,
+		hint: 'The connection timed out. Check firewall and trusted-source rules between this host and the database.',
+	},
+];
+
+const MAX_CAUSE_DEPTH = 3;
+
+/** Flatten an error and its `cause` chain into codes and messages to match on. */
+function collect(err: unknown): { codes: Set<string>; message: string } {
+	const codes = new Set<string>();
+	const messages: string[] = [];
+	let current: unknown = err;
+	for (let depth = 0; depth <= MAX_CAUSE_DEPTH && current; depth++) {
+		if (typeof current !== 'object') {
+			messages.push(String(current));
+			break;
+		}
+		const record = current as { code?: unknown; message?: unknown; cause?: unknown };
+		if (typeof record.code === 'string') codes.add(record.code);
+		if (typeof record.message === 'string') messages.push(record.message);
+		current = record.cause;
+	}
+	return { codes, message: messages.join(' ') };
+}
+
+function classify(err: unknown): FailureKind | undefined {
+	const { codes, message } = collect(err);
+	return FAILURE_KINDS.find(
+		(kind) =>
+			kind.codes.some((code) => codes.has(code)) ||
+			kind.patterns.some((pattern) => pattern.test(message)),
+	);
+}
+
+/**
+ * Actionable one-liner for a connect failure, or undefined when the cause isn't
+ * one we can say anything specific about.
+ */
+export function connectFailureHint(err: unknown): string | undefined {
+	return classify(err)?.hint;
+}
+
+/**
+ * Whether retrying could plausibly succeed. A rejected certificate or a bad
+ * password fails identically every time, so the retry loop should stop rather
+ * than spend its backoff re-proving it. DNS and sockets stay retryable - they
+ * genuinely are transient while a freshly provisioned host settles.
+ */
+export function isRetryableConnectError(err: unknown): boolean {
+	return !classify(err)?.deterministic;
+}

--- a/packages/server/src/db/postgres-url.ts
+++ b/packages/server/src/db/postgres-url.ts
@@ -1,0 +1,201 @@
+/**
+ * TLS normalization for the external-Postgres connection string.
+ *
+ * node-postgres 8 resolves `sslmode` through pg-connection-string's legacy
+ * branch, where `prefer`, `require` and `verify-ca` are all treated as aliases
+ * for `verify-full` — full chain *and* hostname verification against the host's
+ * public CA store. No other Postgres client reads them that way: libpq (and so
+ * `psql`, and so every connection string a managed provider hands out) treats
+ * `require` as "encrypt, do not verify the certificate". Managed Postgres
+ * (DigitalOcean, AWS RDS, Azure) and most self-hosted servers present a
+ * certificate signed by a provider-private CA, so the legacy reading rejects
+ * them with "self signed certificate in certificate chain" on a URL that `psql`
+ * connects with happily.
+ *
+ * pg-connection-string already implements libpq semantics behind an opt-in
+ * `uselibpqcompat=true` query parameter, and makes them the default in its next
+ * major (shipping with pg 9). Opting the URL in is therefore forward-compatible
+ * rather than a workaround.
+ *
+ * DELETE THIS MODULE AND ITS CALL SITE IN `drivers/postgres.ts` WHEN pg REACHES
+ * v9: pg-connection-string v3 throws when the parameter is supplied on a parser
+ * that already defaults to libpq semantics.
+ */
+
+/** What the resolved TLS configuration actually protects against. */
+export type PostgresTlsPosture =
+	/** No TLS at all - the session is plaintext. */
+	| 'none'
+	/** Encrypted, but the server certificate is not verified. */
+	| 'encrypted'
+	/** Certificate chain verified against a CA; hostname not checked. */
+	| 'verified-ca'
+	/** Certificate chain and hostname both verified. */
+	| 'verified'
+	/** Not a parseable URL - the posture can't be determined here. */
+	| 'unspecified';
+
+export interface NormalizedPostgresUrl {
+	/** The connection string to hand to node-postgres. */
+	url: string;
+	/** Effective TLS posture once node-postgres has resolved the string. */
+	tls: PostgresTlsPosture;
+}
+
+const LIBPQ_COMPAT_PARAM = 'uselibpqcompat=true';
+
+/** Query params that make pg-connection-string load key material from disk. */
+const SSL_FILE_PARAMS = ['sslcert', 'sslkey', 'sslrootcert'] as const;
+
+interface PostureInput {
+	sslmode: string | undefined;
+	/** A `sslrootcert=` path is present, so a CA is supplied explicitly. */
+	hasCaFile: boolean;
+	/** Any of the ssl file params is present - enough to switch TLS on. */
+	hasSslFile: boolean;
+	/** Whether libpq semantics govern the `sslmode` reading. */
+	libpq: boolean;
+	pgSslMode: string | undefined;
+}
+
+/**
+ * Mirror of pg-connection-string's resolution plus node-postgres' `PGSSLMODE`
+ * fallback, reduced to the operator-facing question "what does this protect
+ * against". Kept in lockstep with the parser it describes: matching is exact
+ * (the parser switches on the literal token, so `REQUIRE` matches no branch and
+ * lands on the verify-everything default).
+ */
+function tlsPosture(input: PostureInput): PostgresTlsPosture {
+	const { sslmode, hasCaFile, hasSslFile, libpq, pgSslMode } = input;
+
+	if (sslmode === undefined) {
+		// The file params alone switch TLS on with the verify-everything default.
+		if (hasSslFile) return 'verified';
+		// node-postgres reads PGSSLMODE only when the URL configures no TLS at
+		// all, and maps every verifying mode onto a plain `ssl: true`.
+		switch (pgSslMode) {
+			case 'no-verify':
+				return 'encrypted';
+			case 'prefer':
+			case 'require':
+			case 'verify-ca':
+			case 'verify-full':
+				return 'verified';
+			default:
+				return 'none';
+		}
+	}
+
+	if (sslmode === 'disable') return 'none';
+
+	if (libpq) {
+		switch (sslmode) {
+			case 'prefer':
+				return 'encrypted';
+			case 'require':
+				// A supplied CA upgrades `require` to chain verification with the
+				// hostname check disabled.
+				return hasCaFile ? 'verified-ca' : 'encrypted';
+			case 'verify-ca':
+				return 'verified-ca';
+			default:
+				// `verify-full`, and any token the parser doesn't recognise, leave
+				// the verify-everything default in place. `no-verify` is not a libpq
+				// mode and lands here too, which is precisely why the normalizer
+				// never opts it in.
+				return 'verified';
+		}
+	}
+
+	return sslmode === 'no-verify' ? 'encrypted' : 'verified';
+}
+
+/**
+ * Rewrite an external-Postgres connection string so `sslmode` carries its libpq
+ * meaning, and report the TLS posture that results.
+ *
+ * Only the modes that the two readings actually disagree on are touched, and
+ * only where opting in is safe:
+ *
+ * - `prefer` / `require` are opted in - this is the fix.
+ * - `verify-ca` is opted in only alongside `sslrootcert`; without one the libpq
+ *   branch *throws*, so the string is left to resolve as it does today.
+ * - `no-verify` is left alone: it is not a libpq mode, so opting in would fall
+ *   through to the verify-everything default and silently re-enable
+ *   verification on deployments that work today.
+ * - `disable`, `verify-full`, an absent `sslmode`, and an explicit operator
+ *   `uselibpqcompat` are all left byte-identical.
+ */
+export function normalizePostgresUrl(
+	raw: string,
+	env: Record<string, string | undefined> = process.env,
+): NormalizedPostgresUrl {
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		// Defensive only - openDatabase rejects non-URL strings before this runs.
+		return { url: raw, tls: 'unspecified' };
+	}
+
+	// pg-connection-string folds the query by assigning each entry in order, so
+	// a repeated param resolves to its LAST occurrence; `get()` returns the first.
+	const last = (key: string): string | undefined => {
+		const all = parsed.searchParams.getAll(key);
+		return all.length > 0 ? all[all.length - 1] : undefined;
+	};
+
+	const sslmode = last('sslmode');
+	const hasCaFile = last('sslrootcert') !== undefined;
+	const hasSslFile = SSL_FILE_PARAMS.some((p) => last(p) !== undefined);
+	const posture = (libpq: boolean): PostgresTlsPosture =>
+		tlsPosture({ sslmode, hasCaFile, hasSslFile, libpq, pgSslMode: env.PGSSLMODE });
+
+	// An explicit setting either way is the operator's decision. The parser
+	// compares against the literal 'true', so anything else selects the legacy
+	// reading.
+	const explicitCompat = last('uselibpqcompat');
+	if (explicitCompat !== undefined) {
+		return { url: raw, tls: posture(explicitCompat === 'true') };
+	}
+
+	const optIn =
+		sslmode === 'prefer' || sslmode === 'require' || (sslmode === 'verify-ca' && hasCaFile);
+	if (!optIn) return { url: raw, tls: posture(false) };
+
+	return { url: appendQueryParam(raw, parsed, LIBPQ_COMPAT_PARAM), tls: posture(true) };
+}
+
+/**
+ * Append to the query without round-tripping through `URL.toString()`, which
+ * re-encodes values the operator wrote by hand (a unix-socket `host=/var/run/…`
+ * becomes `%2Fvar%2Frun%2F…`, a space in `options=` becomes `+`). A fragment is
+ * the one case that needs the round-trip, since a raw append would land the
+ * param inside it.
+ */
+function appendQueryParam(raw: string, parsed: URL, param: string): string {
+	if (parsed.hash) {
+		const [key, value] = param.split('=');
+		parsed.searchParams.set(key, value);
+		return parsed.toString();
+	}
+	// A trailing bare `?` parses to an empty search but already opens the query.
+	const separator = parsed.search ? '&' : raw.endsWith('?') ? '' : '?';
+	return `${raw}${separator}${param}`;
+}
+
+/** One-line operator-facing rendering of a posture, for the startup log. */
+export function describeTlsPosture(tls: PostgresTlsPosture): string {
+	switch (tls) {
+		case 'none':
+			return 'TLS off (no encryption)';
+		case 'encrypted':
+			return 'TLS encrypted, certificate not verified (use sslmode=verify-full to verify)';
+		case 'verified-ca':
+			return 'TLS verified against the supplied CA (hostname not checked)';
+		case 'verified':
+			return 'TLS verified (CA + hostname)';
+		default:
+			return 'TLS unknown';
+	}
+}

--- a/packages/server/test/bun/database-pg-driver.bun.test.ts
+++ b/packages/server/test/bun/database-pg-driver.bun.test.ts
@@ -4,9 +4,35 @@
 // Postgres via HEZO_TEST_DATABASE_URL (the test-postgres CI job provides
 // one); skips silently otherwise.
 import { describe, expect, it } from 'bun:test';
+import pg from 'pg';
 import { PostgresDb } from '../../src/db/drivers/postgres';
+import { normalizePostgresUrl } from '../../src/db/postgres-url';
 
 const url = process.env.HEZO_TEST_DATABASE_URL;
+
+// Needs no server: proves the connection-string parser resolves TLS the same
+// way on the production runtime as it does under Node in the vitest tier.
+describe('sslmode resolution on the Bun runtime', () => {
+	it('reads sslmode=require as encrypted-but-unverified, matching libpq', () => {
+		const { url: normalized, tls } = normalizePostgresUrl(
+			'postgres://u:p@db.example:5432/hezo?sslmode=require',
+			{},
+		);
+		expect(tls).toBe('encrypted');
+		expect(new pg.Client({ connectionString: normalized }).connectionParameters.ssl).toEqual({
+			rejectUnauthorized: false,
+		});
+	});
+
+	it('leaves sslmode=verify-full fully verifying', () => {
+		const { url: normalized, tls } = normalizePostgresUrl(
+			'postgres://u:p@db.example:5432/hezo?sslmode=verify-full',
+			{},
+		);
+		expect(tls).toBe('verified');
+		expect(new pg.Client({ connectionString: normalized }).connectionParameters.ssl).toEqual({});
+	});
+});
 
 describe.skipIf(!url)('PostgresDb on the Bun runtime', () => {
 	it('connects, queries with parity-parsed types, and closes', async () => {

--- a/packages/server/test/db-open-external-coverage.test.ts
+++ b/packages/server/test/db-open-external-coverage.test.ts
@@ -141,6 +141,49 @@ describe('openDatabase (external Postgres path)', () => {
 		expect(connectMock).toHaveBeenCalledTimes(3);
 	});
 
+	it('fails fast on a rejected certificate and names the CA remedy', async () => {
+		setLogLevel('error');
+		connectMock.mockRejectedValue(
+			Object.assign(new Error('self signed certificate in certificate chain'), {
+				code: 'SELF_SIGNED_CERT_IN_CHAIN',
+			}),
+		);
+
+		await expect(
+			openDatabase({ dataDir: '/unused', databaseUrl: URL_WITH_SECRET }),
+		).rejects.toSatisfy((err: unknown) => {
+			expect(err).toBeInstanceOf(ExternalDbError);
+			const msg = (err as Error).message;
+			expect(msg).toContain('signed by a CA this host does not trust');
+			expect(msg).toContain('sslrootcert=/path/to/ca.crt');
+			// The old catch-all guidance pointed the wrong way for this failure.
+			expect(msg).not.toContain('most hosted Postgres need');
+			return true;
+		});
+		// Deterministic failure — no backoff spent re-proving it.
+		expect(connectMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports the effective TLS posture when the connection succeeds', async () => {
+		const messages: string[] = [];
+		const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+			messages.push(args.map(String).join(' '));
+		});
+		setLogLevel('info');
+		connectMock.mockResolvedValue(fakePostgresDb());
+		try {
+			await openDatabase({
+				dataDir: '/unused',
+				databaseUrl: `${URL_WITH_SECRET}?sslmode=require`,
+			});
+		} finally {
+			spy.mockRestore();
+		}
+		const line = messages.find((m) => m.includes('Using external Postgres'));
+		expect(line).toBeDefined();
+		expect(line).toContain('TLS encrypted, certificate not verified');
+	});
+
 	it('closes the connection and rethrows when the version preflight fails', async () => {
 		const db = fakePostgresDb({ serverVersionNum: 130_000, serverVersion: '13.2' });
 		connectMock.mockResolvedValue(db);

--- a/packages/server/test/db-postgres-connect-errors.test.ts
+++ b/packages/server/test/db-postgres-connect-errors.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { connectFailureHint, isRetryableConnectError } from '../src/db/postgres-connect-errors';
+
+function err(code: string, message = 'boom'): Error {
+	return Object.assign(new Error(message), { code });
+}
+
+describe('connectFailureHint', () => {
+	it('names the CA remedy for every untrusted-chain code', () => {
+		for (const code of [
+			'SELF_SIGNED_CERT_IN_CHAIN',
+			'DEPTH_ZERO_SELF_SIGNED_CERT',
+			'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+			'UNABLE_TO_GET_ISSUER_CERT',
+			'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+			'CERT_UNTRUSTED',
+		]) {
+			expect(connectFailureHint(err(code)), code).toMatch(/sslrootcert=\/path\/to\/ca\.crt/);
+		}
+	});
+
+	it('classifies on the message when the code is missing', () => {
+		// Wrappers drop `code`, and the wording differs between runtimes: Node
+		// writes "self-signed", Bun's OpenSSL build writes "self signed".
+		for (const message of [
+			'self signed certificate in certificate chain',
+			'self-signed certificate in certificate chain',
+			'unable to verify the first certificate',
+			'unable to get local issuer certificate',
+		]) {
+			expect(connectFailureHint(new Error(message)), message).toMatch(/does not trust/);
+		}
+	});
+
+	it('walks the cause chain', () => {
+		const wrapped = new Error('could not connect', { cause: err('SELF_SIGNED_CERT_IN_CHAIN') });
+		expect(connectFailureHint(wrapped)).toMatch(/does not trust/);
+		expect(isRetryableConnectError(wrapped)).toBe(false);
+	});
+
+	it('distinguishes expiry, hostname mismatch and a server refusing TLS', () => {
+		expect(connectFailureHint(err('CERT_HAS_EXPIRED'))).toMatch(/expired or not yet valid/);
+		expect(connectFailureHint(err('ERR_TLS_CERT_ALTNAME_INVALID'))).toMatch(
+			/does not match its TLS certificate/,
+		);
+		expect(connectFailureHint(new Error('The server does not support SSL connections'))).toMatch(
+			/running with ssl=off/,
+		);
+	});
+
+	it('explains credential, database and socket failures', () => {
+		expect(connectFailureHint(err('28P01'))).toMatch(/rejected the credentials/);
+		expect(connectFailureHint(err('3D000'))).toMatch(/does not exist/);
+		expect(connectFailureHint(err('ECONNREFUSED'))).toMatch(/Nothing is listening/);
+		expect(connectFailureHint(err('ENOTFOUND'))).toMatch(/did not resolve/);
+		expect(connectFailureHint(err('ETIMEDOUT'))).toMatch(/timed out/);
+	});
+
+	it('says nothing it cannot back up', () => {
+		expect(connectFailureHint(err('EWHATEVER', 'something odd'))).toBeUndefined();
+		expect(connectFailureHint('a bare string')).toBeUndefined();
+		expect(connectFailureHint(undefined)).toBeUndefined();
+	});
+});
+
+describe('isRetryableConnectError', () => {
+	it('stops on failures that repeat identically', () => {
+		for (const code of ['SELF_SIGNED_CERT_IN_CHAIN', 'CERT_HAS_EXPIRED', '28P01', '3D000']) {
+			expect(isRetryableConnectError(err(code)), code).toBe(false);
+		}
+	});
+
+	it('stops on a server that has TLS switched off', () => {
+		expect(isRetryableConnectError(new Error('The server does not support SSL connections'))).toBe(
+			false,
+		);
+	});
+
+	it('keeps retrying transient ones — DNS and sockets settle after a boot', () => {
+		for (const code of ['ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNRESET']) {
+			expect(isRetryableConnectError(err(code)), code).toBe(true);
+		}
+		expect(isRetryableConnectError(new Error('connection refused by host'))).toBe(true);
+	});
+});

--- a/packages/server/test/db-postgres-tls.test.ts
+++ b/packages/server/test/db-postgres-tls.test.ts
@@ -1,0 +1,102 @@
+// Behavioural cover for the external-Postgres TLS path: a fake server that
+// speaks just enough of the startup protocol to reach the handshake, presenting
+// a certificate signed by a CA this host does not trust — the exact shape of
+// every managed provider (DigitalOcean, RDS, Azure) and the failure this fix is
+// about. No real Postgres involved.
+//
+// Node tier only: Bun cannot wrap a server-side `tls.TLSSocket` around an
+// already-connected socket, which the SSLRequest handshake requires. TLS on the
+// production runtime is covered by test/bun/database-pg-driver.bun.test.ts
+// against a real server; the connection-string resolution this fix turns on is
+// pure JS and therefore runtime-independent (asserted under Bun there too).
+import net from 'node:net';
+import tls from 'node:tls';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PostgresDb } from '../src/db/drivers/postgres';
+import { connectFailureHint, isRetryableConnectError } from '../src/db/postgres-connect-errors';
+import { generateSelfSignedCert } from './helpers/self-signed-cert';
+
+/** Postgres' SSLRequest body: an 8-byte message carrying this request code. */
+const SSL_REQUEST_CODE = 80_877_103;
+
+interface FakeTlsServer {
+	port: number;
+	/** True once a TLS handshake completed, i.e. the client accepted the cert. */
+	handshakeCompleted: () => boolean;
+	close: () => Promise<void>;
+}
+
+/**
+ * Answer the SSLRequest with `S`, upgrade, then drop the connection as soon as
+ * the handshake settles. Dropping immediately keeps a passing handshake from
+ * waiting out the driver's connection timeout.
+ */
+async function startFakeTlsServer(cert: string, key: string): Promise<FakeTlsServer> {
+	let completed = false;
+	const server = net.createServer((socket) => {
+		socket.once('data', (chunk) => {
+			if (chunk.length < 8 || chunk.readInt32BE(4) !== SSL_REQUEST_CODE) {
+				socket.destroy();
+				return;
+			}
+			socket.write('S');
+			const secured = new tls.TLSSocket(socket, { isServer: true, cert, key });
+			secured.on('error', () => secured.destroy());
+			secured.once('secure', () => {
+				completed = true;
+				secured.destroy();
+			});
+		});
+		socket.on('error', () => socket.destroy());
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (typeof address === 'string' || address === null) throw new Error('no port');
+	return {
+		port: address.port,
+		handshakeCompleted: () => completed,
+		close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	};
+}
+
+describe('external Postgres TLS against a provider-private CA', () => {
+	let server: FakeTlsServer | undefined;
+
+	afterEach(async () => {
+		await server?.close();
+		server = undefined;
+	});
+
+	async function connectExpectingFailure(sslmode: string): Promise<unknown> {
+		const { cert, key } = await generateSelfSignedCert('localhost');
+		server = await startFakeTlsServer(cert, key);
+		const url = `postgres://u:p@localhost:${server.port}/hezo?sslmode=${sslmode}`;
+		try {
+			const db = await PostgresDb.connect({ url });
+			await db.close();
+			throw new Error('expected the connection to fail after the handshake');
+		} catch (err) {
+			return err;
+		}
+	}
+
+	it('completes the handshake under sslmode=require despite the untrusted CA', async () => {
+		const err = await connectExpectingFailure('require');
+		// The fix: TLS is negotiated and the certificate is accepted, so the
+		// connection dies on the dropped socket rather than on verification.
+		expect(server?.handshakeCompleted()).toBe(true);
+		expect(connectFailureHint(err) ?? '').not.toMatch(/does not trust/);
+		// A dropped socket is transient, so the open path should still retry.
+		expect(isRetryableConnectError(err)).toBe(true);
+	}, 15_000);
+
+	it('still rejects an untrusted certificate under sslmode=verify-full', async () => {
+		const err = await connectExpectingFailure('verify-full');
+		expect(server?.handshakeCompleted()).toBe(false);
+		// Classified from a real TLS error object, not a synthetic one.
+		expect(connectFailureHint(err)).toMatch(/sslrootcert=\/path\/to\/ca\.crt/);
+		expect(connectFailureHint(err)).toMatch(/sslmode=require to encrypt without verifying/);
+		// Deterministic, so the open path must not spend its backoff on it.
+		expect(isRetryableConnectError(err)).toBe(false);
+	}, 15_000);
+});

--- a/packages/server/test/db-postgres-url.test.ts
+++ b/packages/server/test/db-postgres-url.test.ts
@@ -1,0 +1,242 @@
+import pg from 'pg';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	describeTlsPosture,
+	normalizePostgresUrl,
+	type PostgresTlsPosture,
+} from '../src/db/postgres-url';
+
+const BASE = 'postgres://u:p@db.example:5432/hezo';
+
+/**
+ * Resolve a connection string exactly as node-postgres will. The Client
+ * constructor is pure config resolution — it opens no socket, resolves no DNS,
+ * and registers no timers — so this asserts on the real parser without a
+ * server.
+ */
+function resolvedSsl(url: string): unknown {
+	return new pg.Client({ connectionString: url }).connectionParameters.ssl;
+}
+
+describe('normalizePostgresUrl', () => {
+	let prevSslMode: string | undefined;
+	let prevRootCert: string | undefined;
+
+	beforeEach(() => {
+		prevSslMode = process.env.PGSSLMODE;
+		prevRootCert = process.env.PGSSLROOTCERT;
+		delete process.env.PGSSLMODE;
+		delete process.env.PGSSLROOTCERT;
+	});
+
+	afterEach(() => {
+		if (prevSslMode === undefined) delete process.env.PGSSLMODE;
+		else process.env.PGSSLMODE = prevSslMode;
+		if (prevRootCert === undefined) delete process.env.PGSSLROOTCERT;
+		else process.env.PGSSLROOTCERT = prevRootCert;
+	});
+
+	describe('the modes it opts in', () => {
+		it('makes sslmode=require mean encrypted-but-unverified, as libpq does', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=require`);
+			expect(out.url).toBe(`${BASE}?sslmode=require&uselibpqcompat=true`);
+			expect(out.tls).toBe<PostgresTlsPosture>('encrypted');
+			// This is the whole bug: without the opt-in it resolves to `{}`, i.e.
+			// full verification against the public CA store, which every
+			// provider-private CA fails.
+			expect(resolvedSsl(`${BASE}?sslmode=require`)).toEqual({});
+			expect(resolvedSsl(out.url)).toEqual({ rejectUnauthorized: false });
+		});
+
+		it('opts sslmode=prefer in the same way', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=prefer`);
+			expect(out.url).toBe(`${BASE}?sslmode=prefer&uselibpqcompat=true`);
+			expect(out.tls).toBe<PostgresTlsPosture>('encrypted');
+			expect(resolvedSsl(out.url)).toEqual({ rejectUnauthorized: false });
+		});
+
+		it('reports require + sslrootcert as CA-verified rather than merely encrypted', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=require&sslrootcert=/etc/hezo/ca.crt`);
+			expect(out.url).toContain('uselibpqcompat=true');
+			expect(out.tls).toBe<PostgresTlsPosture>('verified-ca');
+		});
+
+		it('opts verify-ca in only when a CA file is supplied', () => {
+			const withCa = normalizePostgresUrl(`${BASE}?sslmode=verify-ca&sslrootcert=/etc/hezo/ca.crt`);
+			expect(withCa.url).toContain('uselibpqcompat=true');
+			expect(withCa.tls).toBe<PostgresTlsPosture>('verified-ca');
+		});
+	});
+
+	describe('the modes it deliberately leaves alone', () => {
+		it('never opts no-verify in — doing so would silently re-enable verification', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=no-verify`);
+			expect(out.url).toBe(`${BASE}?sslmode=no-verify`);
+			expect(out.tls).toBe<PostgresTlsPosture>('encrypted');
+			expect(resolvedSsl(out.url)).toEqual({ rejectUnauthorized: false });
+			// The trap this guards: `no-verify` is not a libpq mode, so under the
+			// libpq branch it falls through to the verify-everything default.
+			expect(resolvedSsl(`${BASE}?sslmode=no-verify&uselibpqcompat=true`)).toEqual({});
+		});
+
+		it('never opts verify-ca in without a CA file — the libpq branch throws there', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=verify-ca`);
+			expect(out.url).toBe(`${BASE}?sslmode=verify-ca`);
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+			expect(() => resolvedSsl(out.url)).not.toThrow();
+			expect(() => resolvedSsl(`${BASE}?sslmode=verify-ca&uselibpqcompat=true`)).toThrow(
+				/requires specifying a CA/,
+			);
+		});
+
+		it('leaves verify-full byte-identical and still fully verifying', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=verify-full`);
+			expect(out.url).toBe(`${BASE}?sslmode=verify-full`);
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+			expect(resolvedSsl(out.url)).toEqual({});
+		});
+
+		it('leaves sslmode=disable alone', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=disable`);
+			expect(out.url).toBe(`${BASE}?sslmode=disable`);
+			expect(out.tls).toBe<PostgresTlsPosture>('none');
+			expect(resolvedSsl(out.url)).toBe(false);
+		});
+
+		it('reports a URL with no sslmode as plaintext, and does not touch it', () => {
+			const out = normalizePostgresUrl(BASE);
+			expect(out.url).toBe(BASE);
+			expect(out.tls).toBe<PostgresTlsPosture>('none');
+			// node-postgres does not imply TLS from the scheme.
+			expect(resolvedSsl(out.url)).toBe(false);
+		});
+
+		it('treats an unrecognised sslmode as verifying, matching the parser default', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=allow`);
+			expect(out.url).toBe(`${BASE}?sslmode=allow`);
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+			expect(resolvedSsl(out.url)).toEqual({});
+		});
+
+		it('does not case-fold — the parser matches the literal token', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=REQUIRE`);
+			expect(out.url).toBe(`${BASE}?sslmode=REQUIRE`);
+			// Matches no branch either way, so it lands on verify-everything.
+			expect(resolvedSsl(out.url)).toEqual({});
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+		});
+
+		it('reports TLS on when only ssl file params are given', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslrootcert=/etc/hezo/ca.crt`);
+			expect(out.url).toBe(`${BASE}?sslrootcert=/etc/hezo/ca.crt`);
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+		});
+	});
+
+	describe('operator overrides', () => {
+		it('respects an explicit uselibpqcompat=true and adds nothing', () => {
+			const url = `${BASE}?sslmode=require&uselibpqcompat=true`;
+			const out = normalizePostgresUrl(url);
+			expect(out.url).toBe(url);
+			expect(out.tls).toBe<PostgresTlsPosture>('encrypted');
+		});
+
+		it('respects an explicit opt-out and reports the legacy posture', () => {
+			const url = `${BASE}?sslmode=require&uselibpqcompat=false`;
+			const out = normalizePostgresUrl(url);
+			expect(out.url).toBe(url);
+			expect(out.tls).toBe<PostgresTlsPosture>('verified');
+			expect(resolvedSsl(url)).toEqual({});
+		});
+	});
+
+	describe('query-string handling', () => {
+		it('resolves a repeated sslmode to its last occurrence, as the parser does', () => {
+			// The parser assigns each query entry in order, so the last wins;
+			// URLSearchParams.get() would report the first and pick the wrong branch.
+			const out = normalizePostgresUrl(`${BASE}?sslmode=require&sslmode=disable`);
+			expect(out.url).toBe(`${BASE}?sslmode=require&sslmode=disable`);
+			expect(out.tls).toBe<PostgresTlsPosture>('none');
+			expect(resolvedSsl(out.url)).toBe(false);
+		});
+
+		it('does not double up the separator after a trailing bare question mark', () => {
+			const out = normalizePostgresUrl(`${BASE}?`);
+			expect(out.url).toBe(`${BASE}?`);
+			// And with a param present the separator is an ampersand.
+			expect(normalizePostgresUrl(`${BASE}?sslmode=require`).url).toBe(
+				`${BASE}?sslmode=require&uselibpqcompat=true`,
+			);
+		});
+
+		it('keeps the param out of a fragment', () => {
+			const out = normalizePostgresUrl(`${BASE}?sslmode=require#notes`);
+			expect(out.url).toContain('uselibpqcompat=true');
+			expect(new URL(out.url).searchParams.get('uselibpqcompat')).toBe('true');
+			expect(resolvedSsl(out.url)).toEqual({ rejectUnauthorized: false });
+		});
+
+		it('preserves hand-written values that a URL round-trip would re-encode', () => {
+			const url = 'postgres://u:p@localhost/hezo?sslmode=require&host=/var/run/postgresql';
+			const out = normalizePostgresUrl(url);
+			expect(out.url).toBe(`${url}&uselibpqcompat=true`);
+			expect(out.url).not.toContain('%2F');
+		});
+
+		it('returns an unparseable string untouched', () => {
+			const out = normalizePostgresUrl('host=db.example user=hezo sslmode=require');
+			expect(out.url).toBe('host=db.example user=hezo sslmode=require');
+			expect(out.tls).toBe<PostgresTlsPosture>('unspecified');
+		});
+	});
+
+	describe('PGSSLMODE', () => {
+		it('reports the env posture only when the URL configures no TLS', () => {
+			process.env.PGSSLMODE = 'require';
+			// node-postgres reads the env var into a plain `ssl: true`, i.e. full
+			// verification — the URL is the place to express intent.
+			expect(normalizePostgresUrl(BASE).tls).toBe<PostgresTlsPosture>('verified');
+			expect(resolvedSsl(BASE)).toBe(true);
+
+			process.env.PGSSLMODE = 'no-verify';
+			expect(normalizePostgresUrl(BASE).tls).toBe<PostgresTlsPosture>('encrypted');
+
+			process.env.PGSSLMODE = 'disable';
+			expect(normalizePostgresUrl(BASE).tls).toBe<PostgresTlsPosture>('none');
+		});
+
+		it('is overridden by an sslmode in the URL', () => {
+			process.env.PGSSLMODE = 'verify-full';
+			const out = normalizePostgresUrl(`${BASE}?sslmode=require`);
+			expect(out.tls).toBe<PostgresTlsPosture>('encrypted');
+			expect(resolvedSsl(out.url)).toEqual({ rejectUnauthorized: false });
+		});
+
+		it('reads the env passed in rather than the ambient process env', () => {
+			expect(normalizePostgresUrl(BASE, { PGSSLMODE: 'verify-full' }).tls).toBe<PostgresTlsPosture>(
+				'verified',
+			);
+			expect(normalizePostgresUrl(BASE, {}).tls).toBe<PostgresTlsPosture>('none');
+		});
+	});
+
+	it('produces strings node-postgres still accepts (pg v9 tripwire)', () => {
+		// If this fails after a `pg` major bump: pg-connection-string v3 defaults
+		// to libpq semantics and rejects a redundant `uselibpqcompat`. Delete
+		// src/db/postgres-url.ts and its call site in src/db/drivers/postgres.ts.
+		for (const mode of ['require', 'prefer', 'verify-full', 'disable', 'no-verify', 'verify-ca']) {
+			const { url } = normalizePostgresUrl(`${BASE}?sslmode=${mode}`);
+			expect(() => new pg.Client({ connectionString: url }), mode).not.toThrow();
+		}
+	});
+});
+
+describe('describeTlsPosture', () => {
+	it('names what each posture does and does not protect', () => {
+		expect(describeTlsPosture('none')).toContain('no encryption');
+		expect(describeTlsPosture('encrypted')).toContain('certificate not verified');
+		expect(describeTlsPosture('encrypted')).toContain('sslmode=verify-full');
+		expect(describeTlsPosture('verified-ca')).toContain('hostname not checked');
+		expect(describeTlsPosture('verified')).toContain('CA + hostname');
+	});
+});

--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -62,13 +62,26 @@ export function CreateTaskDialog({
 	const navigate = useNavigate();
 
 	// On open, seed the picker with the passed/active project (only when it's a
-	// user-visible project) and clear any stale assignee. Rising-edge only, so a
-	// pick already in progress is never reset while the dialog stays open.
+	// user-visible project) and clear any stale assignee. The seed is deferred
+	// until the project list is actually available: the dialog can open before
+	// that request resolves, and matching against an empty list would leave the
+	// picker blank for as long as it stays open. Seeding happens at most once
+	// per open, so a pick already in progress is never reset.
 	const prevOpenRef = useRef(false);
+	const seededRef = useRef(false);
 	useEffect(() => {
-		if (selectProject && open && !prevOpenRef.current) {
-			setPickedProjectId(projectId && projects.some((p) => p.slug === projectId) ? projectId : '');
-			setAssigneeId('');
+		if (selectProject && open) {
+			if (!prevOpenRef.current) {
+				seededRef.current = false;
+				setPickedProjectId('');
+				setAssigneeId('');
+			}
+			if (!seededRef.current && projects.length > 0) {
+				setPickedProjectId(
+					projectId && projects.some((p) => p.slug === projectId) ? projectId : '',
+				);
+				seededRef.current = true;
+			}
 		}
 		prevOpenRef.current = open;
 	}, [open, selectProject, projectId, projects]);

--- a/packages/web/test/action-review-add-to-task.test.tsx
+++ b/packages/web/test/action-review-add-to-task.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { buildReviewHandoff } from '../src/components/document-review/review-handoff';
-import { renderApp } from './helpers/render';
+import { clickUntil, renderApp } from './helpers/render';
 import {
 	seedComment,
 	seedDocument,
@@ -255,8 +255,13 @@ test('task context: current task pinned first exactly once; a filter excluding i
 		to: '/projects/$projectId/tasks/$taskId',
 		params: { projectId: ref.projectSlug, taskId: ref.taskId },
 	});
-	const mention = await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
-	await utils.user.click(mention);
+	await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await clickUntil(
+		utils.user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 	await utils.findByTestId('preview-panel');
 	await utils.findByTestId('review-count-chip');
 	await utils.user.click(await utils.findByTestId('review-action-open'));

--- a/packages/web/test/agent-icon-section.test.tsx
+++ b/packages/web/test/agent-icon-section.test.tsx
@@ -6,7 +6,7 @@
 
 import { fireEvent } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
-import { renderApp } from './helpers/render';
+import { clickUntil, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
 
 function pngHeader(): Uint8Array {
@@ -86,11 +86,16 @@ test('uploading an agent avatar swaps to Replace/Remove, and Remove returns to i
 	});
 
 	// Preview state → Save the normalized blob.
-	const save = await findByTestId('agent-icon-save');
+	await findByTestId('agent-icon-save');
 	expect((await findByTestId('agent-icon-preview')).querySelector('img')?.getAttribute('src')).toBe(
 		'blob:preview-url',
 	);
-	await user.click(save);
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="agent-icon-save"]'),
+		() => !!document.querySelector('[data-testid="agent-icon-remove"]'),
+		{ label: 'the avatar Save button' },
+	);
 
 	// Upload succeeded: the section now offers Replace + Remove.
 	await findByTestId('agent-icon-remove', undefined, { timeout: 15_000 });
@@ -98,7 +103,12 @@ test('uploading an agent avatar swaps to Replace/Remove, and Remove returns to i
 	expect((await findByTestId('agent-icon-upload')).textContent).toContain('Replace image');
 
 	// Remove clears the avatar and returns to the initials fallback.
-	await user.click(await findByTestId('agent-icon-remove'));
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="agent-icon-remove"]'),
+		() => !document.querySelector('[data-testid="agent-icon-remove"]'),
+		{ label: 'the avatar Remove button' },
+	);
 	await findByTestId('agent-icon-upload', undefined, { timeout: 15_000 });
 	expect(queryByTestId('agent-icon-remove')).toBeNull();
 	expect((await findByTestId('agent-icon-upload')).textContent).toContain('Upload image');

--- a/packages/web/test/header-new-task.test.tsx
+++ b/packages/web/test/header-new-task.test.tsx
@@ -1,3 +1,5 @@
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
 import { screen, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
@@ -43,6 +45,39 @@ test('the dialog project picker defaults to the currently viewed project', async
 
 	const projectSelect = (await screen.findByTestId('create-task-project')) as HTMLSelectElement;
 	await waitFor(() => expect(projectSelect.value).toBe(projectSlug));
+});
+
+test('the project picker seeds even when the project list arrives after the dialog opens', async () => {
+	const { findByTestId, user, projectSlug } = await renderOnProjectTasks();
+
+	// Hold the project index in flight and drop what's cached, so the dialog
+	// mounts with an empty list — what a real first paint looks like on a slow
+	// connection. The picker must still land on the active project once the
+	// list lands, not stay blank for the life of the dialog.
+	let release!: () => void;
+	const inFlight = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	const routed = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const raw = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (new URL(raw, 'http://localhost').pathname === '/api/projects') await inFlight;
+		return routed(input, init);
+	}) as typeof globalThis.fetch;
+
+	try {
+		queryClient.removeQueries({ queryKey: queryKeys.projects.all() });
+		await user.click(await findByTestId('app-header-new-task'));
+
+		const projectSelect = (await screen.findByTestId('create-task-project')) as HTMLSelectElement;
+		expect(projectSelect.value).toBe('');
+
+		release();
+		await waitFor(() => expect(projectSelect.value).toBe(projectSlug));
+	} finally {
+		release();
+		globalThis.fetch = routed;
+	}
 });
 
 test('the sidebar "+" next to Tasks opens the create-task dialog', async () => {

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -17,7 +17,7 @@ import {
 	Navigate,
 	RouterProvider,
 } from '@tanstack/react-router';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Hono } from 'hono';
 import { StrictMode } from 'react';
@@ -54,8 +54,29 @@ interface TestAppContext {
 }
 
 let activeContext: TestAppContext | null = null;
-let realFetch: typeof globalThis.fetch | null = null;
 let activeQueryClient: QueryClient | null = null;
+
+// Captured once, before any test installs its override, so each test's
+// passthrough is the environment's own fetch rather than the previous test's
+// teardown stub.
+const pristineFetch = globalThis.fetch;
+
+/**
+ * The fetch a torn-down test is left with. The React tree is unmounted by then,
+ * but debounced and in-flight requests from it can still fire; handing those the
+ * real fetch dials happy-dom's default origin, and the connection error arrives
+ * as an unhandled rejection that can fail a run in which every test passed.
+ * Answering locally keeps the failure contained to the caller that is no longer
+ * listening.
+ */
+function tornDownFetch(): Promise<Response> {
+	return Promise.resolve(
+		new Response(JSON.stringify({ error: 'test context torn down' }), {
+			status: 503,
+			headers: { 'Content-Type': 'application/json' },
+		}),
+	);
+}
 
 // One test app per test. Vitest runs in pool=forks with isolate=true so the
 // server module state (logger, etc.) doesn't leak; the only thing that lives
@@ -113,12 +134,7 @@ beforeEach(async () => {
 	// Reroute fetch through the in-process Hono app. Bypasses the real network
 	// entirely; matches the way the dev Vite proxy forwards /api, /oauth, /mcp,
 	// /health, /SKILL.md, and /llms.txt to the server.
-	realFetch = globalThis.fetch;
-	// Close over the captured fetch rather than reading `realFetch` at call
-	// time: a debounced/in-flight request can land after afterEach nulls the
-	// module variable, and the late call would then throw inside the server
-	// route ("realFetch is not a function") instead of completing quietly.
-	const passthroughFetch = realFetch;
+	const passthroughFetch = pristineFetch;
 	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
 		let req: Request;
 		if (input instanceof Request) {
@@ -176,7 +192,17 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	if (realFetch) globalThis.fetch = realFetch;
+	// Let work the just-unmounted tree started settle while its token and app are
+	// still valid. A request that lands after `api.clearToken()` below comes back
+	// 401 with nobody listening, and one unhandled rejection fails the whole run
+	// even when every test passed. Mutations are dropped outright — an in-flight
+	// save has no one left to report to.
+	activeQueryClient?.getMutationCache().clear();
+	singletonQueryClient.getMutationCache().clear();
+	await Promise.all([activeQueryClient?.cancelQueries(), singletonQueryClient.cancelQueries()]);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	globalThis.fetch = tornDownFetch as typeof globalThis.fetch;
 	if (activeQueryClient) {
 		activeQueryClient.clear();
 		activeQueryClient = null;
@@ -199,7 +225,6 @@ afterEach(async () => {
 		}
 	}
 	activeContext = null;
-	realFetch = null;
 });
 
 export function getTestContext(): TestAppContext {
@@ -247,4 +272,69 @@ export async function renderApp(options: RenderOptions) {
 		ctx,
 		router,
 	};
+}
+
+type UserLike = {
+	click: (element: Element) => Promise<void>;
+	hover: (element: Element) => Promise<void>;
+};
+
+interface ClickUntilOptions {
+	timeout?: number;
+	/** Name used in the timeout message. */
+	label?: string;
+}
+
+/**
+ * Click a target whose DOM node a background refetch may replace, and keep
+ * clicking a freshly located node until the effect is observable.
+ *
+ * A query hands back a node reference, but a React Query refetch can re-render
+ * that subtree before the click dispatches — leaving the test holding a
+ * detached node whose handler never fires. The click silently does nothing and
+ * the assertion that follows fails on a timeout that looks like slowness rather
+ * than a lost event. Re-locating on every attempt removes the window entirely.
+ *
+ * `locate` must return the current node (never a captured one) and `settled`
+ * must report the click's observable effect. The trigger has to be idempotent,
+ * since a replaced node can be clicked more than once — this is for "open this
+ * panel" affordances, not toggles.
+ */
+export async function clickUntil(
+	user: UserLike,
+	locate: () => Element | null,
+	settled: () => boolean,
+	options: ClickUntilOptions = {},
+): Promise<void> {
+	await interactUntil((el) => user.click(el), 'clicking', locate, settled, options);
+}
+
+/** `clickUntil` for hover-driven affordances (tooltips, hover cards). */
+export async function hoverUntil(
+	user: UserLike,
+	locate: () => Element | null,
+	settled: () => boolean,
+	options: ClickUntilOptions = {},
+): Promise<void> {
+	await interactUntil((el) => user.hover(el), 'hovering', locate, settled, options);
+}
+
+async function interactUntil(
+	act: (element: Element) => Promise<void>,
+	verb: string,
+	locate: () => Element | null,
+	settled: () => boolean,
+	options: ClickUntilOptions,
+): Promise<void> {
+	const label = options.label ?? 'the target';
+	await waitFor(
+		async () => {
+			if (settled()) return;
+			const target = locate();
+			if (!target?.isConnected) throw new Error(`${label} is not mounted yet`);
+			await act(target);
+			if (!settled()) throw new Error(`${verb} ${label} has not taken effect yet`);
+		},
+		{ timeout: options.timeout ?? 15_000 },
+	);
 }

--- a/packages/web/test/markdown-prose-branches.test.tsx
+++ b/packages/web/test/markdown-prose-branches.test.tsx
@@ -11,7 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { MarkdownProse } from '../src/components/markdown-prose';
-import { getTestContext, renderApp } from './helpers/render';
+import { getTestContext, hoverUntil, renderApp } from './helpers/render';
 import { seedAsset, seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 // ---------------------------------------------------------------------------
@@ -108,23 +108,30 @@ test('hovering a KB-doc mention shows its size (B, KB, and MB forms) and relativ
 
 	const links = await findAllByTestId('kb-mention-link', undefined, { timeout: 20_000 });
 	expect(links).toHaveLength(3);
-	const tiny = links.find((l) => l.textContent?.includes('tiny-notes.md'));
-	const medium = links.find((l) => l.textContent?.includes('medium-notes.md'));
-	const large = links.find((l) => l.textContent?.includes('large-notes.md'));
+	// Re-query on every attempt: a background refetch can swap these nodes out,
+	// and hovering a detached one never opens its tooltip.
+	const linkFor = (name: string) => () =>
+		Array.from(document.querySelectorAll('[data-testid="kb-mention-link"]')).find((l) =>
+			l.textContent?.includes(name),
+		) ?? null;
+	const shows = (pattern: RegExp) => () => pattern.test(document.body.textContent ?? '');
 
 	// Tooltip content renders in a portal on hover: "<size> · updated <relative>".
-	await user.hover(tiny as HTMLElement);
-	await waitFor(() => expect(document.body.textContent).toMatch(/10 B · updated /));
+	await hoverUntil(user, linkFor('tiny-notes.md'), shows(/10 B · updated /), {
+		label: 'the tiny-notes.md mention',
+	});
 	// Freshly seeded → the relative formatter lands in the seconds bucket.
 	expect(document.body.textContent).toMatch(/10 B · updated (now|\d+ seconds? ago)/);
-	await user.unhover(tiny as HTMLElement);
+	await user.unhover(links.find((l) => l.textContent?.includes('tiny-notes.md')) as HTMLElement);
 
-	await user.hover(medium as HTMLElement);
-	await waitFor(() => expect(document.body.textContent).toMatch(/2\.0 KB · updated /));
-	await user.unhover(medium as HTMLElement);
+	await hoverUntil(user, linkFor('medium-notes.md'), shows(/2\.0 KB · updated /), {
+		label: 'the medium-notes.md mention',
+	});
+	await user.unhover(links.find((l) => l.textContent?.includes('medium-notes.md')) as HTMLElement);
 
-	await user.hover(large as HTMLElement);
-	await waitFor(() => expect(document.body.textContent).toMatch(/1\.5 MB · updated /));
+	await hoverUntil(user, linkFor('large-notes.md'), shows(/1\.5 MB · updated /), {
+		label: 'the large-notes.md mention',
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/test/project-doc-preview.test.tsx
+++ b/packages/web/test/project-doc-preview.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
-import { getTestContext, renderApp } from './helpers/render';
+import { clickUntil, getTestContext, renderApp } from './helpers/render';
 import {
 	archiveSeededDocument,
 	type SeededProject,
@@ -172,8 +172,13 @@ test('the task-detail preview panel flags an archived doc in the metadata banner
 		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 	});
 
-	const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
-	await user.click(mention);
+	await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 	const banner = await findByTestId('doc-metadata-banner');
 	expect(banner.textContent).toContain('Archived');
 });
@@ -249,8 +254,13 @@ test('the task-detail preview panel exposes Edit and History deep-links into the
 		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 	});
 
-	const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
-	await user.click(mention);
+	await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 
 	const editLink = (await findByTestId('preview-edit')) as HTMLAnchorElement;
 	const historyLink = (await findByTestId('preview-history')) as HTMLAnchorElement;
@@ -286,7 +296,12 @@ test('a doc mention in a task comment opens the preview panel instead of a new t
 	expect(container.querySelector('[data-testid="doc-mention-preview-link"]')).toBeNull();
 
 	// The new-tab affordance now lives on the panel and points at the standalone preview.
-	await user.click(name);
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
 	expect(openTab.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
 	expect(openTab.getAttribute('target')).toBe('_blank');

--- a/packages/web/test/task-comment-doc-preview.test.tsx
+++ b/packages/web/test/task-comment-doc-preview.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { clickUntil, renderApp } from './helpers/render';
 import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 // A document mention inside a task comment opens in the in-page preview panel
@@ -38,7 +38,12 @@ test('doc mention in a task comment opens the preview panel, not a new tab', asy
 	expect(container.querySelector('[data-testid="doc-mention-preview-link"]')).toBeNull();
 	expect(container.querySelector('[data-testid="preview-panel"]')).toBeNull();
 
-	await user.click(mention);
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 
 	// The panel opens with the document, its rendered body, and an icon-only
 	// open-in-new-tab link sitting immediately before the close button.

--- a/packages/web/test/task-detail.test.tsx
+++ b/packages/web/test/task-detail.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { getTestContext, renderApp } from './helpers/render';
+import { clickUntil, getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 interface SeededSubTask {
@@ -195,10 +195,15 @@ test('bare ticket identifier renders as a tooltip-ed link and navigates to the t
 	const mentionLink = await findByTestId('task-mention-link');
 	expect(mentionLink.textContent).toContain(targetIdentifier);
 
-	await user.click(mentionLink);
+	const targetPath = `/projects/${projSlug}/tasks/${targetIdentifier.toLowerCase()}`;
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="task-mention-link"]'),
+		() => router.state.location.pathname === targetPath,
+		{ label: 'the task mention link' },
+	);
 
 	await findByRole('heading', { name: targetTitle });
-	const targetPath = `/projects/${projSlug}/tasks/${targetIdentifier.toLowerCase()}`;
 	expect(router.state.location.pathname).toBe(targetPath);
 });
 

--- a/packages/web/test/task-preview-action-review.test.tsx
+++ b/packages/web/test/task-preview-action-review.test.tsx
@@ -2,7 +2,7 @@ import { waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { buildReviewHandoff } from '../src/components/document-review/review-handoff';
 import { toast } from '../src/hooks/use-toast';
-import { renderApp } from './helpers/render';
+import { clickUntil, renderApp } from './helpers/render';
 import {
 	seedComment,
 	seedDocument,
@@ -47,8 +47,13 @@ async function openActionDialogFromTask() {
 		params: { projectId: ref.projectSlug, taskId: ref.taskId },
 	});
 
-	const mention = await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
-	await utils.user.click(mention);
+	await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await clickUntil(
+		utils.user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
 	await utils.findByTestId('preview-panel');
 
 	// Count chip appearing means the review-comments query resolved with count > 0,


### PR DESCRIPTION
## The bug

Starting Hezo (or running `hezo backup` / `hezo restore`) against DigitalOcean Managed Postgres failed with `self signed certificate in certificate chain`, on a connection string `psql` connects with happily:

```
HEZO_DATABASE_URL="postgresql://…@db-postgresql-lon1-…ondigitalocean.com:25060/hezo?sslmode=require" ./hezo restore …
→ ExternalDbError: Could not connect … (cause: self signed certificate in certificate chain)
```

`drivers/postgres.ts` passed the raw string to `pg.Pool` and never set `ssl`, so TLS was decided entirely by `pg-connection-string@2.14.0`. Its legacy branch treats `prefer` / `require` / `verify-ca` as **aliases for `verify-full`** — full chain *and* hostname verification against the public CA store. No other Postgres client reads them that way: libpq (so `psql`, so every string a provider hands out) treats `require` as "encrypt, do not verify". Managed Postgres (DigitalOcean, RDS, Azure) and most self-hosted servers sign with a provider-private CA, so the legacy reading rejects them.

This also affects AWS RDS and Azure, and the repo's own docs printed `sslmode=require` for the DigitalOcean one-click deploy — i.e. the documented happy path was broken.

## The fix

`normalizePostgresUrl` (`src/db/postgres-url.ts`) opts the string into pg-connection-string's own libpq semantics, applied in `PostgresDb.connect` — the single pool construction site in `src/`, so it can't be bypassed. Forward-compatible rather than a workaround: pg 9 makes these semantics the default, and the module is commented to be deleted then (guarded by a tripwire test).

Only the modes the two readings disagree on are touched. Two opt-ins would cause harm and are **deliberately skipped** — both verified against the real parser:

| `sslmode` | Opted in? | Why |
|---|---|---|
| `prefer`, `require` | yes | the fix |
| `verify-ca` **with** `sslrootcert` | yes | chain verified, hostname skipped |
| `verify-ca` **without** `sslrootcert` | **no** | the libpq branch *throws* outright |
| `no-verify` | **no** | not a libpq mode — falls through to the verify-everything default, silently **re-enabling** verification on deployments that work today |
| `disable`, `verify-full`, absent | no | identical under both readings |

> An explicit `ssl` option alongside `connectionString` would **not** work: node-postgres merges the parsed string *over* the caller's config, so a URL carrying `sslmode` silently wins. Measured, not assumed.

Alongside it:

- **Connect failures are classified** from `err.code` (`postgres-connect-errors.ts`). A rejected certificate now names the `sslrootcert` remedy instead of the old catch-all that pointed the wrong way, and deterministic causes (bad cert, bad password, missing database) break the retry loop instead of spending 6s of backoff re-proving themselves.
- **The TLS posture is logged every boot**, so `require` visibly reads `TLS encrypted, certificate not verified (use sslmode=verify-full to verify)` rather than weakening silently.

## Security note — read this

`sslmode=require` **stops verifying the certificate**. That is a real weakening versus today's accidental behaviour, and it is intentional: today's reading is stricter than libpq, stricter than every other client, undocumented, and reverted upstream in pg 9. Mitigations: the posture is stated on every boot, the docs now spell out what each mode does and does not protect against, and `sslmode=verify-full&sslrootcert=/path/to/ca.crt` is documented as the verified path (it already worked and was completely undocumented).

Considered and rejected: a Hezo-specific `HEZO_DATABASE_SSL_STRICT` env var. `sslmode=verify-full` *is* the knob; a bespoke variable that changes what a standard connection string means would be worse than the bug.

## Second commit (separable)

`08609a35` is independent and can be split into its own PR. It fixes a **real product bug** found while stabilising the suite: the create-task project picker's seed effect was rising-edge only, so if the dialog opened before `/api/projects` resolved, the match ran against an empty list and the guard blocked every retry — leaving the picker **blank for the life of the dialog**. Users on a slow connection hit this. The regression test holds the request in flight and fails against the old code with exactly that symptom.

It also fixes two harness defects behind a wider set of intermittent failures: a query-then-click race (confirmed by instrumentation — every failing run had `isConnected === false` before the click), and `packages/web` reporting **FAILED with all tests passing** because teardown restored the real `fetch` and a late 401 arrived as an unhandled rejection.

Measured over full `packages/web` runs: **4, 2, 2** failures per run before; **0** after, unhandled rejections gone.

## Verification

- New: `db-postgres-url.test.ts` (full matrix asserted against `pg`'s real resolver + pg-v9 tripwire), `db-postgres-tls.test.ts` (fake server presenting an untrusted cert: `require` completes the handshake, `verify-full` still rejects), `db-postgres-connect-errors.test.ts`.
- Full suite on this base: **5813 server + 36 Bun-native + 1264 web + 164 shared, all passing**; `typecheck` and `check` clean.
- **Not verified:** a live connect to the reporting cluster — that needs production credentials I didn't run with.

## Docs

`docs/deployment/configuration.md` gains a **TLS and sslmode** section: per-mode table, the previously undocumented fact that **omitting `sslmode` means no TLS at all**, `PGSSLMODE` precedence, and a worked DigitalOcean `sslrootcert` recipe. Corrected guidance in `one-click.md` (incl. the exact DO example from the bug), `cloud.md`, `your-data.md`, `cli.md`, and the `deploy/` cloud-init + provision.sh examples. `.dev/architecture.md` documents the normalizer and classifier; `.dev/hosted-architecture.md` notes that per-tenant `require` now means encrypted-but-unverified over the private VPC host.
