### PR TITLE
feat(web): demote the GitHub connector on teams that don't touch code

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1714,6 +1714,18 @@ connectors UI treats a non-revoked, non-failed local row as **connected the
 moment it exists** (`statusOf`/`connectorStatus` short-circuit `kind='local'` to `active`)
 rather than showing it a meaningless "Pending connect" OAuth affordance.
 
+**GitHub's row is roster-aware.** GitHub is not an `mcp_connections` row until someone
+connects it (`POST …/connectors/ensure` materializes it), so the project Connectors page
+renders it from the OAuth connection alone. Whether it reads as a *setup step* is derived
+from the roster: the project payload carries `code_agent_count` (roster agents with
+`member_agents.touches_code`, alongside `repo_count`), and a project with no code-touching
+agent, no repo, and no GitHub connection renders the row **last** with a neutral `Optional`
+badge instead of the amber "Pending connect". This is the UI counterpart of the repo-setup
+gate in `job-manager.ts`, which likewise fires only for a `touches_code` agent — a roster
+like the shipped `investment`/`influencer` marketplace teams (entirely non-code) will never
+request a repo, so offering GitHub as pending work would invite the operator to finish
+something that is never needed. Any of the three signals promotes the row back.
+
 `kind='api'` is a **direct-REST connector with no MCP server** — for backends that expose a
 plain HTTP API rather than MCP (e.g. Google's APIs). Its `config` carries
 `{ base_url, allowed_hosts, auth: { placement: 'header'|'query', name, scheme? }, docs_url? }`

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -190,6 +190,19 @@ Manage connections two ways:
   project or back to the global scope. New connectors pick their scope in the Add form the
   same way.
 
+### GitHub on a project that doesn't write code
+
+GitHub is offered on every project, but it is only a *setup step* for a team that actually
+works with repositories. Hezo decides that from the roster: an agent is marked **Touches
+code** when it reads or writes repository code, and only those agents ever need a repo.
+
+On a project where nobody touches code - an investment team, a marketing team, any roster
+built from a non-engineering template - GitHub sits at the bottom of the Connectors list
+with a neutral **Optional** badge instead of the amber **Pending connect**, so it doesn't
+read as unfinished setup. It stays one click away if you want agents to use the GitHub MCP
+server anyway. Hire a code-touching agent, or attach a repository, and GitHub moves back to
+the top of the list as a real setup step.
+
 ## Reconnecting a revoked connector
 
 Revoking a connector clears its stored token or API key so agents lose access immediately,

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -136,6 +136,9 @@ projectsRoutes.get('/projects', async (c) => {
        (SELECT count(*) FROM member_agents ma JOIN members mm ON mm.id = ma.id
           WHERE mm.team_id = p.team_id AND ma.runtime_status = 'active'::agent_runtime_status)::int
           AS running_agents_count,
+       (SELECT count(*) FROM member_agents ma2 JOIN members mm2 ON mm2.id = ma2.id
+          WHERE mm2.team_id = p.team_id AND ma2.touches_code)::int
+          AS code_agent_count,
        (SELECT COALESCE(sum(ce.amount_cents), 0) FROM cost_entries ce
           WHERE ce.project_id = p.id AND ce.created_at >= date_trunc('day', now()))::int
           AS today_spend_cents,
@@ -437,6 +440,8 @@ projectsRoutes.get('/projects/:projectId', async (c) => {
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
        (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts2.placeholders}))::int AS open_task_count,
        (SELECT count(*) FROM goals g WHERE g.project_id = p.id AND g.archived_at IS NULL)::int AS open_goal_count,
+       (SELECT count(*) FROM member_agents ma JOIN members mm ON mm.id = ma.id
+          WHERE mm.team_id = p.team_id AND ma.touches_code)::int AS code_agent_count,
        (SELECT pi.updated_at FROM project_icons pi WHERE pi.project_id = p.id) AS icon_updated_at
      FROM projects p
      WHERE p.id = $1 AND p.team_id = $2`,

--- a/packages/server/test/projects-dashboard-stats.test.ts
+++ b/packages/server/test/projects-dashboard-stats.test.ts
@@ -90,3 +90,34 @@ it('a project with no active agents and no spend reports zeros', async () => {
 	expect(quiet.running_agents_count).toBe(0);
 	expect(quiet.today_spend_cents).toBe(0);
 });
+
+// `code_agent_count` is how the web client learns whether a team does git work at
+// all — the Connectors page uses it to decide whether GitHub is a pending setup
+// step or an optional extra. It has to be on both the index and the detail payload.
+it('project payloads count the roster agents flagged touches_code', async () => {
+	const projectRes = await app.request(`/api/projects/${projectId}`, {
+		headers: authHeader(token),
+	});
+	expect(projectRes.status).toBe(200);
+	// The agent was created without touches_code, so the team does no git work.
+	expect((await projectRes.json()).data.code_agent_count).toBe(0);
+
+	const indexRes = await app.request('/api/projects', { headers: authHeader(token) });
+	const before = (
+		(await indexRes.json()).data as Array<{ id: string; code_agent_count: number }>
+	).find((x) => x.id === projectId);
+	expect(before?.code_agent_count).toBe(0);
+
+	await db.query(`UPDATE member_agents SET touches_code = true WHERE id = $1`, [agentId]);
+
+	const afterDetail = await app.request(`/api/projects/${projectId}`, {
+		headers: authHeader(token),
+	});
+	expect((await afterDetail.json()).data.code_agent_count).toBe(1);
+
+	const afterIndex = await app.request('/api/projects', { headers: authHeader(token) });
+	const after = (
+		(await afterIndex.json()).data as Array<{ id: string; code_agent_count: number }>
+	).find((x) => x.id === projectId);
+	expect(after?.code_agent_count).toBe(1);
+});

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -110,11 +110,14 @@ export function useUpdateAgent(projectId: string, agentId: string) {
 			omitOptimistic: ['system_prompt', 'system_prompt_change_summary'],
 			// budgetStatus carries the per-agent window limits the Budget page reads,
 			// so a cap edit here must refetch it (staleTime would otherwise serve the
-			// old caps for up to a minute).
+			// old caps for up to a minute). The project payload aggregates the roster's
+			// `touches_code` into `code_agent_count` (which decides whether Connectors
+			// treats GitHub as a setup step), so it needs the same treatment.
 			invalidateOnSettled: [
 				queryKeys.projects.agents(projectId),
 				queryKeys.projects.agentSystemPrompt(projectId, agentId),
 				queryKeys.projects.budgetStatus(projectId),
+				queryKeys.projects.detail(projectId),
 			],
 			errorMessage: 'Failed to update agent',
 		},
@@ -259,6 +262,9 @@ export function useOnboardAgent(projectId: string) {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.agents(projectId) });
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.tasks(projectId) });
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.approvals(projectId) });
+			// A hire changes the roster's `code_agent_count`, which the Connectors page
+			// reads to decide how prominently to offer GitHub.
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -37,6 +37,12 @@ export interface Project {
 	agent_count: number;
 	/** Agents currently running on this project's team (runtime_status = active). */
 	running_agents_count: number;
+	/**
+	 * Agents on this team flagged `touches_code` - 0 means the team does no git work.
+	 * Drives whether the Connectors page treats GitHub as a pending setup step or as
+	 * an optional extra. Optional because older/partial payloads may omit it.
+	 */
+	code_agent_count?: number;
 	/** Spend on this project so far today (UTC), in cents. */
 	today_spend_cents: number;
 	/** Most recent task update, falling back to the project's creation time. */

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -29,6 +29,7 @@ import {
 	useEnsureConnector,
 	useOAuthConnections,
 } from '../../../hooks/use-oauth-connections';
+import { useProject } from '../../../hooks/use-projects';
 import { queryKeys } from '../../../lib/query-keys';
 
 interface ConnectorsSearch {
@@ -67,6 +68,22 @@ function ConnectorsPage() {
 	const githubConnection = oauthConnections.find((c) => c.provider === 'github') ?? null;
 	const isEmpty = connectors.length === 0 && oauthConnections.length === 0;
 
+	// GitHub is offered on every project, but it is only a *setup step* for a team that
+	// actually does git work. A team whose roster has no `touches_code` agent never trips
+	// the repo-setup gate, so an amber "Pending connect" would be inviting the operator to
+	// finish something that will never be needed. Any one of these promotes it back:
+	// a code-touching agent is hired, a repo is attached, or GitHub is connected anyway.
+	const { data: project, isPending: projectPending } = useProject(projectId);
+	const gitRelevant =
+		(project?.code_agent_count ?? 0) > 0 ||
+		(project?.repo_count ?? 0) > 0 ||
+		githubConnection !== null;
+	// Hold the row back until the project resolves so it doesn't render at the top and
+	// then jump to the bottom (or vice versa) one tick later.
+	const githubRow = projectPending ? null : (
+		<GitHubRow projectId={projectId} connection={githubConnection} optional={!gitRelevant} />
+	);
+
 	const [showAdd, setShowAdd] = useState(false);
 
 	return (
@@ -97,7 +114,7 @@ function ConnectorsPage() {
 			{showAdd && <AddConnectorForm projectId={projectId} onClose={() => setShowAdd(false)} />}
 
 			<ul className="space-y-3" data-testid="connectors-list">
-				<GitHubRow projectId={projectId} connection={githubConnection} />
+				{gitRelevant && githubRow}
 				{connectors
 					.filter((connector) => connector.name !== 'github')
 					.map((connector) => (
@@ -109,6 +126,7 @@ function ConnectorsPage() {
 							focusRef={connector.id === focus ? focusRef : undefined}
 						/>
 					))}
+				{!gitRelevant && githubRow}
 			</ul>
 
 			<InfiniteScrollSentinel
@@ -360,15 +378,17 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 interface GitHubRowProps {
 	projectId: string;
 	connection: OAuthConnection | null;
+	/** No agent on this team touches code, so GitHub is an extra rather than a setup step. */
+	optional?: boolean;
 }
 
-function GitHubRow({ projectId, connection }: GitHubRowProps) {
+function GitHubRow({ projectId, connection, optional = false }: GitHubRowProps) {
 	const deleteConn = useDeleteOAuthConnection(projectId);
 	const ensure = useEnsureConnector(projectId);
 	const [deviceConnectorId, setDeviceConnectorId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const status = connection ? 'active' : 'pending';
+	const status = connection ? 'active' : optional ? 'optional' : 'pending';
 	const connecting = ensure.isPending;
 
 	const startConnect = async () => {
@@ -383,7 +403,7 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 
 	return (
 		<li
-			className="rounded-lg border p-4 border-border"
+			className={`rounded-lg border p-4 ${optional ? 'border-dashed border-border/60' : 'border-border'}`}
 			data-testid="connector-row"
 			data-connector-name="github"
 			data-status={status}
@@ -415,6 +435,11 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 								scopes: {connection.scopes.join(' ')}
 							</p>
 						</>
+					) : optional ? (
+						<p className="text-xs text-text-3 mt-1">
+							No agents on this team touch code, so nothing here needs a repo. Connect GitHub only
+							if you want agents to work with repos or call the GitHub MCP server.
+						</p>
 					) : (
 						<p className="text-xs text-text-2 mt-1">
 							One connection covers both git operations (clone, push, SSH-key registration) and the
@@ -815,7 +840,11 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 	);
 }
 
-function StatusBadge({ status }: { status: 'pending' | 'active' | 'failed' | 'revoked' }) {
+function StatusBadge({
+	status,
+}: {
+	status: 'pending' | 'active' | 'failed' | 'revoked' | 'optional';
+}) {
 	if (status === 'active') {
 		return (
 			<Badge className="bg-success-soft text-success-soft-fg border-success">
@@ -834,6 +863,11 @@ function StatusBadge({ status }: { status: 'pending' | 'active' | 'failed' | 're
 	}
 	if (status === 'revoked') {
 		return <Badge>Revoked</Badge>;
+	}
+	// Deliberately neutral, not the warning colours below - "optional" is a resting
+	// state, not an unfinished setup step.
+	if (status === 'optional') {
+		return <Badge>Optional</Badge>;
 	}
 	return (
 		<Badge className="bg-warning-soft text-warning-soft-fg border-warning">Pending connect</Badge>

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -1,5 +1,5 @@
 import { createGitHubSim, type GitHubSim } from '@hezo/server/test/helpers/github-sim';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
@@ -134,6 +134,18 @@ async function seedGlobalConnector(name: string, url: string): Promise<{ id: str
 	return r.rows[0];
 }
 
+// Clear `touches_code` across the whole roster, turning the seeded App Team into
+// a team that does no git work (the shape of the shipped investment/influencer
+// marketplace teams, whose rosters are entirely non-code).
+async function clearTouchesCode(ws: SeededWorkspace): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`UPDATE member_agents SET touches_code = false
+		   WHERE id IN (SELECT id FROM members WHERE team_id = $1)`,
+		[ws.team.id],
+	);
+}
+
 const CONNECTORS_ROUTE = '/projects/$projectId/connectors';
 
 let sim: GitHubSim | null = null;
@@ -151,7 +163,7 @@ afterEach(async () => {
 	for (const k of Object.keys(savedEnv)) delete savedEnv[k];
 });
 
-test('lists a seeded MCP connector alongside the always-present GitHub row', async () => {
+test('lists a seeded MCP connector above the GitHub row on a code-touching team', async () => {
 	let slug = '';
 	const { findByText, getByTestId, router } = await renderApp({
 		initialPath: '/',
@@ -164,15 +176,107 @@ test('lists a seeded MCP connector alongside the always-present GitHub row', asy
 	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
 
 	await findByText('Connectors', { selector: 'h1' });
-	// The GitHub row is rendered unconditionally.
 	await findByText('GitHub');
 	// The seeded saas connector renders as its own row with its url.
 	await findByText('linear');
 	await findByText('https://mcp.linear.example/mcp');
 
-	// The GitHub row, with no connection, shows the pending-connect affordance.
+	// The App Team roster has `touches_code` agents, so GitHub is a real setup
+	// step: pending-connect affordance, and first in the list.
 	const list = getByTestId('connectors-list');
-	expect(list.querySelector('[data-connector-name="github"][data-status="pending"]')).toBeTruthy();
+	await waitFor(() => {
+		expect(
+			list.querySelector('[data-connector-name="github"][data-status="pending"]'),
+		).toBeTruthy();
+	});
+	expect(list.firstElementChild?.getAttribute('data-connector-name')).toBe('github');
+});
+
+test('demotes GitHub to an optional row when no agent on the team touches code', async () => {
+	let slug = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await clearTouchesCode(ws);
+			await seedSaasConnector(ws, { name: 'linear', url: 'https://mcp.linear.example/mcp' });
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('Connectors', { selector: 'h1' });
+	await findByText('linear');
+
+	// Still offered - just not as an unfinished setup step: neutral "Optional"
+	// badge instead of the amber "Pending connect", and last in the list.
+	const list = getByTestId('connectors-list');
+	await waitFor(() => {
+		expect(
+			list.querySelector('[data-connector-name="github"][data-status="optional"]'),
+		).toBeTruthy();
+	});
+	expect(list.querySelector('[data-connector-name="github"][data-status="pending"]')).toBeNull();
+	const githubRow = list.lastElementChild as HTMLElement;
+	expect(githubRow.getAttribute('data-connector-name')).toBe('github');
+	await findByText('Optional');
+	await findByText(/No agents on this team touch code/);
+	// The connect affordance is still there — demoted, not hidden.
+	expect(within(githubRow).getByTestId('connector-connect')).toBeTruthy();
+});
+
+test('promotes GitHub back to the top once an agent is flagged as touching code', async () => {
+	let ws!: SeededWorkspace;
+	let engineerId = '';
+	const { findByRole, findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const engineer = ws.agents.find((a) => a.slug === 'engineer');
+			if (!engineer) throw new Error('engineer missing from seeded workspace');
+			engineerId = engineer.id;
+			await clearTouchesCode(ws);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: ws.internalSlug } });
+	await waitFor(() => {
+		expect(
+			getByTestId('connectors-list').querySelector(
+				'[data-connector-name="github"][data-status="optional"]',
+			),
+		).toBeTruthy();
+	});
+
+	// Turn "Touches code" back on from the agent's own settings page. Saving must
+	// refresh the project payload the Connectors page reads, not leave the stale
+	// `code_agent_count` in the query cache for its full staleTime.
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: ws.internalSlug, agentId: engineerId },
+	});
+	const checkbox = (await findByRole(
+		'checkbox',
+		{ name: /Touches code/i },
+		{
+			timeout: 15_000,
+		},
+	)) as HTMLInputElement;
+	expect(checkbox.checked).toBe(false);
+	fireEvent.click(checkbox);
+	fireEvent.submit(checkbox.closest('form') as HTMLFormElement);
+
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: ws.internalSlug } });
+	await findByText('Connectors', { selector: 'h1' });
+	await waitFor(
+		() => {
+			const list = getByTestId('connectors-list');
+			expect(
+				list.querySelector('[data-connector-name="github"][data-status="pending"]'),
+			).toBeTruthy();
+			expect(list.firstElementChild?.getAttribute('data-connector-name')).toBe('github');
+		},
+		{ timeout: 15_000 },
+	);
 });
 
 test('the Add form creates a project-scoped connector and auto-probes OAuth', async () => {


### PR DESCRIPTION
## Problem

The GitHub card on a project's Connectors page was a literal JSX element rendered first in the list, and its badge was derived only from "is there a GitHub OAuth connection" — nothing about the project fed into it.

So a project whose roster does no git work — an **investment** or **influencer** team, whose marketplace manifests mark every role `touches_code: false` — was shown an amber **Pending connect**, implying an unfinished setup step it will never need. Those agents never trip the repo-setup gate in `job-manager.ts`, so a repo is never requested for them.

## Approach

The signal already existed per-agent (`member_agents.touches_code`) and the server already gated repo setup on it — it had just never been aggregated to the project level or surfaced to the web client.

- **Server** (`routes/projects.ts`): both project selects now carry `code_agent_count`, a count of roster agents with `touches_code`, mirroring the existing `running_agents_count` subquery. No migration — the column has been there since the baseline schema.
- **Connectors page**: when there is no code-touching agent, no repo, **and** no GitHub connection, the row renders **last** with a neutral `Optional` badge and a line explaining why, instead of first with the warning badge. The Connect button is unchanged — demoted, not hidden. Any one of the three signals promotes it back to the top, so a Blank project self-corrects on its first code-touching hire.
- `StatusBadge` gains an `optional` branch, deliberately neutral rather than the warning colours — "optional" is a resting state, not unfinished setup.
- **Cache**: agent update and hire now also invalidate the project detail query, so a `touches_code` change is reflected without waiting out the 60s `staleTime`.

The rule is applied uniformly rather than special-casing team origin — a fresh Blank project reads Optional until it hires an agent that touches code. Settings → Git is untouched, and remains the escape hatch either way.

## Tests

`packages/web/test/connectors-page.test.tsx` (component tier — no layout, viewport, or WebSocket dependency):

- code-touching roster → GitHub first, `data-status="pending"`
- roster with `touches_code` cleared → GitHub last, `data-status="optional"`, explanatory copy present, Connect button still there
- flipping **Touches code** on from the agent settings page promotes the row back to the top — this one covers the new invalidation

`packages/server/test/projects-dashboard-stats.test.ts` asserts `code_agent_count` on both the index and detail payloads, before and after flagging an agent.

All 16 tests in the connectors suite pass (13 pre-existing unchanged), plus `bun run typecheck` and `bun run check`.

## Docs

- `docs/mcp/connecting-mcp-servers.md` — new "GitHub on a project that doesn't write code" section explaining the Optional state and what promotes it.
- `.dev/architecture.md` — a roster-aware-GitHub-row note in the connectors section, tying the UI rule to the `job-manager.ts` repo-setup gate it mirrors.

No CLI, MCP tool, or REST route name changed, so the generated surfaces (`mcp-api.md`, `SKILL.md`, `llms.txt`) are unaffected.