### PR TITLE
fix(web): wrap long links in chat bubbles; remember the last chat thread

### DIFF
--- a/docs/chat/overview.md
+++ b/docs/chat/overview.md
@@ -24,6 +24,11 @@ planning, another for an ad-hoc question, and so on.
 
 Each thread keeps its own recent history and streams independently.
 
+The chatbox remembers the thread you switched to, so closing and reopening it - or
+reloading the page - picks that conversation back up instead of dropping you on your main
+thread. The memory is per browser. If the thread you were on has been closed since (by you
+here, in another tab, or on its own chat app), the chatbox falls back to your main thread.
+
 ## How threads work across chat apps
 
 The CEO is also reachable from external chat apps -

--- a/packages/web/src/components/captain-intake-chat.tsx
+++ b/packages/web/src/components/captain-intake-chat.tsx
@@ -99,7 +99,7 @@ export function CaptainIntakeChat({
 							<div className="flex gap-2.5 items-center">
 								<Avatar size="chat" initials={getInitials(comment.author_name ?? captainTitle)} />
 								<div
-									className={`flex-1 min-w-0 rounded-md rounded-bl-sm bg-surface-2 border border-border px-3 py-2.5 ${captainChatBubbleMinHClass} text-[13px] md:text-sm text-text-1 leading-relaxed whitespace-pre-wrap`}
+									className={`flex-1 min-w-0 rounded-md rounded-bl-sm bg-surface-2 border border-border px-3 py-2.5 ${captainChatBubbleMinHClass} text-[13px] md:text-sm text-text-1 leading-relaxed whitespace-pre-wrap wrap-anywhere`}
 								>
 									{text}
 								</div>
@@ -120,7 +120,7 @@ export function CaptainIntakeChat({
 						data-role="admin"
 					>
 						<span className="text-[11px] font-medium text-text-2 pr-0.5">You</span>
-						<div className="max-w-[min(100%,42rem)] rounded-md rounded-br-sm bg-info-soft border border-info-soft-fg/20 px-3 py-2.5 text-[13px] md:text-sm text-text-1 leading-relaxed whitespace-pre-wrap">
+						<div className="max-w-[min(100%,42rem)] rounded-md rounded-br-sm bg-info-soft border border-info-soft-fg/20 px-3 py-2.5 text-[13px] md:text-sm text-text-1 leading-relaxed whitespace-pre-wrap wrap-anywhere">
 							{text}
 						</div>
 						<RelativeTime iso={comment.created_at} className="text-[10px] text-text-3 pr-0.5" />

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -19,13 +19,15 @@ import {
 	Plus,
 	X,
 } from 'lucide-react';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useAutoGrowTextarea } from '../../hooks/use-auto-grow-textarea';
 import {
 	type ChatConversationSummary,
 	type ChatMessage,
+	readStoredThreadId,
 	useChat,
 	useChatConversations,
+	writeStoredThreadId,
 } from '../../hooks/use-chat';
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
@@ -66,9 +68,11 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 	// moves). Must be called before the `if (!open)` early return below.
 	const fab = useDraggableFab('chat');
 	// The selected thread (undefined = the default web thread). The switcher lets the
-	// operator create/switch/close parallel conversation threads.
+	// operator create/switch/close parallel conversation threads. Seeded from the
+	// last thread they switched to, so reopening the chat resumes it rather than
+	// jumping back to the default thread.
 	const [selectedConversationId, setSelectedConversationId] = useState<string | undefined>(
-		undefined,
+		readStoredThreadId,
 	);
 	const {
 		messages,
@@ -80,7 +84,21 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		compactedCount,
 		conversationId: activeConversationId,
 	} = useChat(open, selectedConversationId);
-	const { conversations, createThread, closeThread } = useChatConversations(open);
+	const {
+		conversations,
+		loaded: threadsLoaded,
+		createThread,
+		closeThread,
+	} = useChatConversations(open);
+	// The one writer for the thread selection — dropdown, rail, new thread, and the
+	// fall-back-to-default paths all go through it, so what's rendered and what's
+	// remembered can never drift. `undefined` (back to the server's default web
+	// thread) clears the memory rather than pinning the default's id, keeping the
+	// untouched-switcher case behaving exactly as it did before.
+	const selectThread = useCallback((id: string | undefined) => {
+		setSelectedConversationId(id);
+		writeStoredThreadId(id);
+	}, []);
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
 	// The CEO can only act while the HQ container is up. When it isn't, the chat
@@ -122,6 +140,17 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		if (!el) return;
 		el.scrollTop = el.scrollHeight;
 	}, [lastId, lastLen, streaming, open, expanded]);
+
+	// A remembered thread can be closed later (from the ✕ here, another tab, or its
+	// own platform), and the server still serves a closed thread's history by id —
+	// so a stale id would restore as a thread that reads fine but rejects every
+	// send. Once the thread list has loaded, a selection it doesn't list is dropped
+	// back to the default thread.
+	useEffect(() => {
+		if (!open || !threadsLoaded || !selectedConversationId) return;
+		if (conversations.some((t) => t.id === selectedConversationId)) return;
+		selectThread(undefined);
+	}, [open, threadsLoaded, selectedConversationId, conversations, selectThread]);
 
 	// Escape closes the chat from any open state (anchored or the expanded modal).
 	useEffect(() => {
@@ -183,7 +212,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		const res = (await createThread().catch(() => null)) as {
 			conversation?: { id: string };
 		} | null;
-		if (res?.conversation?.id) setSelectedConversationId(res.conversation.id);
+		if (res?.conversation?.id) selectThread(res.conversation.id);
 	};
 	// Close a thread (defaults to the active one). If it was the active thread, fall
 	// back to the default web thread afterwards.
@@ -191,7 +220,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		const target = id ?? activeConversationId;
 		if (!target) return;
 		await closeThread(target).catch(() => undefined);
-		if (target === activeConversationId) setSelectedConversationId(undefined);
+		if (target === activeConversationId) selectThread(undefined);
 	};
 
 	// Copy the whole conversation as plain text, each turn labelled by speaker.
@@ -354,7 +383,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 										>
 											<button
 												type="button"
-												onClick={() => setSelectedConversationId(t.id)}
+												onClick={() => selectThread(t.id)}
 												className="min-w-0 flex-1 truncate text-left"
 											>
 												{threadLabel(t)}
@@ -398,7 +427,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 												>
 													<button
 														type="button"
-														onClick={() => setSelectedConversationId(t.id)}
+														onClick={() => selectThread(t.id)}
 														className="flex min-w-0 flex-1 items-center gap-1 truncate text-left"
 													>
 														<span className="truncate">{threadLabel(t)}</span>
@@ -433,7 +462,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 								data-testid="chat-thread-select"
 								aria-label="Conversation thread"
 								value={activeConversationId ?? ''}
-								onChange={(e) => setSelectedConversationId(e.target.value || undefined)}
+								onChange={(e) => selectThread(e.target.value || undefined)}
 								className="min-w-0 flex-1 truncate rounded-md border border-border bg-surface px-2 py-1 text-xs text-text-1"
 							>
 								{conversations.length === 0 && <option value="">New thread</option>}
@@ -711,7 +740,12 @@ function MessageBubble({
 		>
 			<RoleLabel>You</RoleLabel>
 			{message.content.length > 0 && (
-				<div className="rounded-2xl rounded-br-sm bg-inverse px-3.5 py-2.5 text-sm leading-relaxed text-inverse-fg whitespace-pre-wrap">
+				// wrap-anywhere (not break-words): the bubble is a fit-content flex
+				// item, so an unbreakable token — a pasted URL — would otherwise set a
+				// min-content width wider than the panel and push the message list into
+				// horizontal scroll. `anywhere` is the one overflow-wrap value that also
+				// shrinks the intrinsic size, keeping the bubble inside max-w-[90%].
+				<div className="rounded-2xl rounded-br-sm bg-inverse px-3.5 py-2.5 text-sm leading-relaxed text-inverse-fg whitespace-pre-wrap wrap-anywhere">
 					{message.content}
 				</div>
 			)}

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -62,6 +62,35 @@ function writeStoredUnread(count: number): void {
 	}
 }
 
+/**
+ * The thread the operator last switched to in the chatbox (same localStorage
+ * convention as the unread tally above). The widget restores it on mount, so
+ * closing and reopening — or a reload, or the remount a bare route forces —
+ * comes back to that conversation instead of snapping to the server's default
+ * web thread. Only an *explicit* switch is recorded, and returning to the default
+ * clears the key, so an operator who never touches the switcher keeps exactly the
+ * old behaviour. A stored id is discarded once the thread list shows it is no
+ * longer open.
+ */
+const CHAT_THREAD_KEY = 'hezo_chat_thread';
+
+export function readStoredThreadId(): string | undefined {
+	try {
+		return localStorage.getItem(CHAT_THREAD_KEY) ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function writeStoredThreadId(id: string | undefined): void {
+	try {
+		if (id) localStorage.setItem(CHAT_THREAD_KEY, id);
+		else localStorage.removeItem(CHAT_THREAD_KEY);
+	} catch {
+		// localStorage may be unavailable (private mode); the selection just won't persist.
+	}
+}
+
 /** A conversation thread in the switcher list. */
 export interface ChatConversationSummary {
 	id: string;

--- a/packages/web/test/chat-thread-persistence.test.tsx
+++ b/packages/web/test/chat-thread-persistence.test.tsx
@@ -1,0 +1,94 @@
+import type { ChatConversationSummary, ChatMessage } from '@hezo/web/hooks/use-chat';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// The chatbox remembers the thread you switched to, so closing and reopening it
+// — or a reload, or the remount a bare route forces — resumes that conversation
+// instead of snapping back to the server's default web thread. Nothing here
+// needs a real layout pass or a live WebSocket, so it stays a component test
+// (decision tree: none of 1-6 apply). Like chat-threads.test.tsx, the harness has
+// no ChatSessionManager (chat endpoints 503), so the query caches the hooks read
+// from are seeded directly.
+
+const now = () => new Date().toISOString();
+
+function msg(id: string, content: string): ChatMessage {
+	return { id, role: 'assistant', channel: 'web', status: 'complete', content, created_at: now() };
+}
+
+function thread(id: string, title: string | null): ChatConversationSummary {
+	return {
+		id,
+		channel: 'web',
+		external_thread_id: null,
+		kind: 'assistant',
+		title,
+		last_activity_at: now(),
+		closed_at: null,
+	};
+}
+
+/** thread-1 is the server's default web thread; thread-2 is a second thread. */
+function seedThreads(threads = [thread('thread-1', 'First'), thread('thread-2', 'Second')]) {
+	queryClient.setQueryData(queryKeys.chatConversations(), { conversations: threads });
+	queryClient.setQueryData(queryKeys.chatConversation(), {
+		conversation_id: 'thread-1',
+		messages: [msg('m1', 'hello from the first thread')],
+		compacted_count: 0,
+	});
+	queryClient.setQueryData(queryKeys.chatConversation('thread-2'), {
+		conversation_id: 'thread-2',
+		messages: [msg('m2', 'hello from the second thread')],
+		compacted_count: 0,
+	});
+}
+
+test('switching threads is remembered, and a later open resumes that thread', async () => {
+	seedThreads();
+	const { findByTestId, findByText, user } = await renderApp({ initialPath: '/home' });
+
+	(await findByTestId('chat-launcher')).click();
+	const select = (await findByTestId('chat-thread-select')) as HTMLSelectElement;
+	expect(select.value).toBe('thread-1');
+
+	await user.selectOptions(select, 'thread-2');
+	expect(await findByText('hello from the second thread')).toBeTruthy();
+
+	// The switch is durable, not just component state: it survives a full remount
+	// of the app shell (what a reload or a bare-route round trip produces).
+	expect(localStorage.getItem('hezo_chat_thread')).toBe('thread-2');
+});
+
+test('a remembered thread is restored on mount instead of the default thread', async () => {
+	localStorage.setItem('hezo_chat_thread', 'thread-2');
+	seedThreads();
+	const { findByTestId, findByText, queryByText } = await renderApp({ initialPath: '/home' });
+
+	(await findByTestId('chat-launcher')).click();
+
+	// Opens straight into the remembered thread — the default thread's history is
+	// never shown.
+	expect(await findByText('hello from the second thread')).toBeTruthy();
+	expect(queryByText('hello from the first thread')).toBeNull();
+	const select = (await findByTestId('chat-thread-select')) as HTMLSelectElement;
+	expect(select.value).toBe('thread-2');
+});
+
+test('a remembered thread that is no longer open falls back to the default thread', async () => {
+	// The remembered thread was closed since (here, in another tab, or on its own
+	// platform) so it is gone from the list. The server would still serve its
+	// history by id, which would restore a thread that reads fine but rejects every
+	// send — so the stale id must be dropped rather than used.
+	localStorage.setItem('hezo_chat_thread', 'thread-gone');
+	seedThreads([thread('thread-1', 'First'), thread('thread-2', 'Second')]);
+	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
+
+	(await findByTestId('chat-launcher')).click();
+
+	expect(await findByText('hello from the first thread')).toBeTruthy();
+	const select = (await findByTestId('chat-thread-select')) as HTMLSelectElement;
+	expect(select.value).toBe('thread-1');
+	expect(localStorage.getItem('hezo_chat_thread')).toBeNull();
+});

--- a/test/browser/chat.spec.ts
+++ b/test/browser/chat.spec.ts
@@ -272,6 +272,107 @@ test.describe('CEO chat widget — responsive layout', () => {
 	});
 });
 
+// Kept in Playwright by decision-tree items 1 & 2 (real CSS layout + a mobile
+// viewport): "did this token wrap or did it widen the panel" is a question only a
+// real layout pass answers — happy-dom reports scrollWidth/clientWidth as 0 and
+// never re-flows text at 375px.
+test.describe('CEO chat widget — long unbreakable content', () => {
+	// No spaces, far wider than the ~420px anchored panel: the pasted-link case
+	// that used to push the whole message list into horizontal scroll.
+	const LONG_URL =
+		'https://www.linkedin.com/feed/update/urn:li:activity:7486869676694818816/?utm_source=share&utm_medium=member_desktop';
+
+	test('a pasted link wraps inside its bubble instead of widening the message list', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		const page = sharedPage;
+
+		const seeded = [
+			{
+				id: 'seed-user',
+				conversation_id: 'conv-wrap',
+				role: 'user',
+				channel: 'web',
+				status: 'complete',
+				content: `i want to post: ${LONG_URL}`,
+				created_at: new Date(Date.UTC(2026, 0, 1, 0, 0)).toISOString(),
+			},
+			{
+				id: 'seed-ceo',
+				conversation_id: 'conv-wrap',
+				role: 'assistant',
+				channel: 'web',
+				status: 'complete',
+				// The CEO side is markdown, so the bare URL autolinks — the anchor has
+				// to wrap too, not just the plain-text user bubble.
+				content: `On it. Source: ${LONG_URL}`,
+				created_at: new Date(Date.UTC(2026, 0, 1, 0, 1)).toISOString(),
+			},
+		];
+
+		// The widget swaps the scrollable message list for an HQ-container notice
+		// unless HQ is healthy — force the instance project to "running".
+		await page.route('**/api/projects', async (route) => {
+			if (route.request().method() !== 'GET') return route.fallback();
+			const response = await route.fetch();
+			const body = (await response.json()) as { data?: Array<Record<string, unknown>> };
+			const data = Array.isArray(body.data)
+				? body.data.map((p) => (p.is_internal ? { ...p, container_status: 'running' } : p))
+				: body.data;
+			await route.fulfill({ response, json: { ...body, data } });
+		});
+		await page.route('**/api/chat/conversation', (route) =>
+			route.fulfill({ json: { data: { conversation_id: 'conv-wrap', messages: seeded } } }),
+		);
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+		await expect(page.getByTestId('chat-panel')).toBeVisible();
+
+		const list = page.getByTestId('chat-messages');
+		const bubbles = {
+			user: page.locator('[data-testid="chat-message"][data-role="user"]'),
+			ceo: page.locator('[data-testid="chat-message"][data-role="ceo"]'),
+		};
+		await expect(bubbles.user).toBeVisible();
+		await expect(bubbles.ceo).toBeVisible();
+
+		// Both breakpoints: the anchored desktop panel and the near-full-screen
+		// mobile sheet are the two widths the bubble has to fit.
+		for (const width of [1280, 375]) {
+			await page.setViewportSize({ width, height: 800 });
+
+			// The list never gains a horizontal scroll range — the bug was the URL
+			// setting a min-content width wider than the panel.
+			await expect
+				.poll(() => list.evaluate((el) => el.scrollWidth - el.clientWidth))
+				.toBeLessThanOrEqual(1);
+
+			const listBox = await list.boundingBox();
+			expect(listBox).not.toBeNull();
+			for (const [role, bubble] of Object.entries(bubbles)) {
+				const box = await bubble.boundingBox();
+				expect(box, `${role} bubble at ${width}px`).not.toBeNull();
+				if (!box || !listBox) continue;
+				expect(box.x, `${role} bubble left edge at ${width}px`).toBeGreaterThanOrEqual(
+					listBox.x - 1,
+				);
+				expect(box.x + box.width, `${role} bubble right edge at ${width}px`).toBeLessThanOrEqual(
+					listBox.x + listBox.width + 1,
+				);
+				// Wrapped, not clipped: the URL alone spans several lines at these widths.
+				expect(box.height, `${role} bubble height at ${width}px`).toBeGreaterThan(40);
+			}
+		}
+	});
+});
+
 // Kept in Playwright by decision-tree item 1 (real CSS layout): the composer
 // auto-grows by measuring its own `scrollHeight` and writing back an inline
 // height. happy-dom reports `scrollHeight` as 0, so the grow/collapse can only


### PR DESCRIPTION
## Word wrap in the chatbox

A pasted URL has no break opportunity, so the plain-text user bubble - which only carried `whitespace-pre-wrap` - set a min-content width wider than the chat panel and pushed the message list into horizontal scroll. The bubble ran off the panel edge instead of wrapping.

The fix is `wrap-anywhere` rather than `break-words`. The bubble is a fit-content flex item (`self-end`), and `overflow-wrap: anywhere` is the one value that also shrinks the intrinsic size, so the bubble stays inside its `max-w-[90%]`. The CEO side already wrapped via `MarkdownProse`'s `break-words`; the two Captain intake bubbles had the same gap as the user bubble and get the same treatment.

## Remembering the last thread

The chatbox now resumes the thread you switched to, so closing and reopening it - or reloading, or the remount a bare route forces - picks that conversation back up instead of snapping to the default web thread. Stored per browser in `localStorage`, the same convention the unread tally already uses.

- Every selection path (dropdown, expanded rail, new thread, close-to-default) goes through one `selectThread` writer, so what is rendered and what is remembered cannot drift.
- Only an explicit switch is recorded, and returning to the default clears the key. An operator who never touches the switcher gets exactly the old behaviour.
- A remembered thread that has since been closed (here, in another tab, or on its own chat app) is dropped once the thread list loads. `GET /api/chat/conversation` still serves a closed thread's history by id, so restoring one would give a conversation that reads fine but rejects every send.

## Tests

- `test/browser/chat.spec.ts` - new Playwright spec: seeds a user message and a CEO message each carrying a long unbreakable URL, then asserts the message list gains no horizontal scroll range and both bubbles stay inside it, at 1280px and 375px. Real layout (`scrollWidth`/`clientWidth`, `boundingBox`), so it belongs in Playwright per the decision tree.
- `packages/web/test/chat-thread-persistence.test.tsx` - new component spec: a switch is remembered, a remembered thread is restored on mount instead of the default, and a stale id falls back to the default and clears the key.

Verified green: `bun run test --skip-browser --pattern chat` (56 tests), the docs guard tests, typecheck, and biome. The full `chat.spec.ts` browser run passes apart from `collapsing the panel keeps the latest message pinned to the bottom`, which fails identically on the unmodified baseline (confirmed by re-running it on a clean tree) - pre-existing, not from this change.

## Docs

`docs/chat/overview.md` gains the remembered-thread behaviour under Conversation threads. `.dev/architecture.md` needs no change: its chat section covers the server thread model, and client-side `localStorage` state isn't described there (the existing `hezo_chat_unread` key isn't either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7NnrQHkHsbzHRSve6ubc1

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7NnrQHkHsbzHRSve6ubc1)_