### PR TITLE
feat(chat): queue messages while the CEO replies, hold to interrupt

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -658,6 +658,23 @@ turn survives a process restart, so `reconcileOnStartup` clears orphaned non-ter
 `chat_messages` (deletes empty `streaming`/`pending` placeholders, marks partial ones
 `interrupted`) — an abandoned turn never lingers as a stuck "thinking" bubble.
 
+**Chatbox message queue (client-side) + the batched turn it flushes.** The composer stays usable
+while a reply streams. Enter (or a tap of the send button) **queues** into a per-thread list held
+in `useChat` — client state only, never a `chat_messages` row, so a reload drops it; that is the
+deliberate trade against a `queued` status + migration. A queued message renders as a dashed
+bubble at the tail of the thread and can be removed until dispatch. When the thread goes idle
+(reply complete, failed, *or* interrupted, so nothing is stranded by a bad turn) the whole queue
+flushes as **one** `POST /api/chat/messages` carrying an ordered `messages: [{text,
+attachment_ids}]` batch. `sendTurn`'s `messages` param inserts each as its own complete user row
+(own bubble, own attachments, all broadcast) and then runs a **single** assistant turn, whose
+prompt therefore sees every queued message — N separate turns would yield N replies, the first
+answering stale context. The route (`parseMessageBatch`) accepts the single-message shape too, so
+external channel ingest is unchanged; `MAX_BATCH_MESSAGES` caps a batch at 20. **Interrupting is
+the deliberate path**: holding the send button past `LONG_PRESS_MS` (`use-long-press.ts`), or
+⌘/Ctrl+Enter, posts immediately, and the existing interrupt above does the rest server-side. It is
+only offered while a reply is actually running (`streaming && !sending`) — during the pre-flight
+window there is no turn to abort, so the control queues and says so.
+
 **Automatic, agent-driven chat memory.** Each turn's prompt carries the agent's **long-term
 memory** (`chat_memories`, one markdown row per member, no revision history) plus the full
 **active window** — the non-compacted `chat_messages`, which *is* the short-term memory. The

--- a/docs/chat/overview.md
+++ b/docs/chat/overview.md
@@ -12,6 +12,37 @@ up a project or a task, get a status read across the org, or just think out loud
 long-term memory, so it remembers your preferences and past decisions across the
 conversation.
 
+## Sending while the CEO is still replying
+
+You don't have to wait for a reply to finish before typing the next thing. While the
+CEO is working, the send button changes to **Queue**:
+
+- **Press Enter (or tap Queue)** and your message is parked, not sent. It shows up at
+  the bottom of the conversation as a dashed bubble, and the header shows how many
+  are waiting.
+- **Changed your mind?** Every queued message has a **✕** next to it. Removing one
+  drops it completely - it never reaches the CEO. The **✕** disappears once the
+  queue has been sent, because by then there is nothing to take back.
+- **When the reply finishes**, everything you queued is sent together, and the CEO
+  answers all of it in one go rather than replying to your first message before it
+  has seen the rest.
+
+### Cutting in
+
+Sometimes you want to stop the CEO mid-answer - you spotted a mistake, or you meant
+something else. That is deliberate, so it takes a deliberate action:
+
+- **Hold the send button.** Hold it down and it fills up, then changes to
+  **Send now**. Let go and the current reply stops where it is (it stays in the
+  conversation, marked as interrupted) and your message starts a fresh answer. Let go
+  early, or drag your finger or cursor off the button, and nothing is interrupted.
+- **Or press Cmd+Enter** (**Ctrl+Enter** on Windows and Linux) for the same thing
+  from the keyboard.
+
+Anything already queued stays queued behind the message you cut in with. The queue
+lives in your browser, so it is per conversation thread and does not survive a page
+reload.
+
 ## Conversation threads
 
 The chatbox supports **multiple parallel threads**, so you can keep separate lines of

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -164,25 +164,28 @@ chatRoutes.post('/chat/messages', async (c) => {
 	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
 
 	const body = await c.req.json().catch(() => ({}));
-	const text = typeof body.text === 'string' ? body.text.trim() : '';
-	const attachmentIds: string[] = Array.isArray(body.attachment_ids)
-		? body.attachment_ids.filter((id: unknown): id is string => typeof id === 'string')
-		: [];
-	// A message needs either text or at least one attachment.
-	if (!text && attachmentIds.length === 0) {
+	// Either one message (`text` + `attachment_ids`) or an ordered batch
+	// (`messages`) — the chatbox flushes its queue as a batch so several messages
+	// post as their own bubbles and a single reply answers all of them.
+	const batch = parseMessageBatch(body);
+	if (!batch) {
 		return err(c, 'BAD_REQUEST', 'Message text or an attachment is required', 400);
 	}
+	if (batch.length > MAX_BATCH_MESSAGES) {
+		return err(c, 'BAD_REQUEST', `At most ${MAX_BATCH_MESSAGES} messages per turn`, 400);
+	}
+	const allAttachmentIds = batch.flatMap((m) => m.attachmentIds);
 
 	// Every attachment must be an HQ-project asset (i.e. uploaded via /chat/assets).
-	if (attachmentIds.length > 0) {
+	if (allAttachmentIds.length > 0) {
 		const db = c.get('db');
 		const hqProjectId = await resolveHqProjectId(db);
 		if (!hqProjectId) return err(c, 'UNAVAILABLE', 'HQ project not found', 503);
 		const matched = await db.query<{ id: string }>(
-			`SELECT id FROM assets WHERE id = ANY($1::uuid[]) AND project_id = $2`,
-			[attachmentIds, hqProjectId],
+			`SELECT DISTINCT id FROM assets WHERE id = ANY($1::uuid[]) AND project_id = $2`,
+			[allAttachmentIds, hqProjectId],
 		);
-		if (matched.rows.length !== attachmentIds.length) {
+		if (matched.rows.length !== new Set(allAttachmentIds).size) {
 			return err(c, 'BAD_REQUEST', 'One or more attachments are invalid', 400);
 		}
 	}
@@ -211,16 +214,17 @@ chatRoutes.post('/chat/messages', async (c) => {
 
 	try {
 		const result = await manager.sendTurn({
-			text,
+			text: batch[0].text,
 			channel: ChatChannel.Web,
 			conversationId,
 			authorUserId,
-			attachmentIds,
+			messages: batch,
 		});
 		return ok(
 			c,
 			{
 				user_message_id: result.userMessageId,
+				user_message_ids: result.userMessageIds,
 				assistant_message_id: result.assistantMessageId,
 				conversation_id: result.conversationId,
 			},
@@ -230,6 +234,35 @@ chatRoutes.post('/chat/messages', async (c) => {
 		return err(c, 'CEO_UNAVAILABLE', (e as Error).message, 503);
 	}
 });
+
+/** Hard cap on a single turn's queued-message batch. */
+const MAX_BATCH_MESSAGES = 20;
+
+/**
+ * Normalize a send body into an ordered batch of user messages. Accepts the
+ * single-message shape (`text` / `attachment_ids`) or the batch shape
+ * (`messages: [{ text, attachment_ids }]`). Returns null when nothing sendable
+ * is present — every message needs text or at least one attachment.
+ */
+function parseMessageBatch(
+	body: Record<string, unknown>,
+): Array<{ text: string; attachmentIds: string[] }> | null {
+	const ids = (raw: unknown): string[] =>
+		Array.isArray(raw) ? raw.filter((id): id is string => typeof id === 'string') : [];
+	const raw = Array.isArray(body.messages)
+		? body.messages
+		: [{ text: body.text, attachment_ids: body.attachment_ids }];
+	const batch: Array<{ text: string; attachmentIds: string[] }> = [];
+	for (const entry of raw) {
+		if (typeof entry !== 'object' || entry === null) return null;
+		const m = entry as Record<string, unknown>;
+		const text = typeof m.text === 'string' ? m.text.trim() : '';
+		const attachmentIds = ids(m.attachment_ids);
+		if (!text && attachmentIds.length === 0) return null;
+		batch.push({ text, attachmentIds });
+	}
+	return batch.length > 0 ? batch : null;
+}
 
 // List conversation threads (open by default), newest activity first — drives the
 // web thread switcher.

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -393,6 +393,15 @@ export class ChatSessionManager {
 		externalThreadId?: string | null;
 		authorUserId?: string | null;
 		attachmentIds?: string[];
+		/**
+		 * Ordered batch of user messages to post as this turn's input. Each becomes
+		 * its own message row (own bubble, own timestamp, own attachments) and then
+		 * ONE reply answers all of them — what the web chatbox's message queue
+		 * flushes when a reply finishes. Sending them as N separate turns instead
+		 * would produce N replies, the first of which answers stale context.
+		 * Supersedes `text`/`attachmentIds` when non-empty.
+		 */
+		messages?: Array<{ text: string; attachmentIds?: string[] }>;
 		/** Conversation mode when creating (default assistant). Existing rows keep their kind. */
 		kind?: ChatConversationKind;
 		/** External sender display label for multi-party (coworker) transcripts. */
@@ -405,7 +414,12 @@ export class ChatSessionManager {
 		injectedContext?: string;
 		/** Title when creating the conversation (coworker threads are titled at birth). */
 		title?: string;
-	}): Promise<{ userMessageId: string; assistantMessageId: string; conversationId: string }> {
+	}): Promise<{
+		userMessageId: string;
+		userMessageIds: string[];
+		assistantMessageId: string;
+		conversationId: string;
+	}> {
 		const ctx = await this.resolveConversationForInput(input);
 		const convo = this.getConvoRuntime(ctx.conversationId);
 		// Serialize turns *within this conversation*: chain on the prior send so two
@@ -425,11 +439,17 @@ export class ChatSessionManager {
 			text: string;
 			authorUserId?: string | null;
 			attachmentIds?: string[];
+			messages?: Array<{ text: string; attachmentIds?: string[] }>;
 			authorLabel?: string | null;
 			injectedContext?: string;
 		},
 		ctx: ConversationContext,
-	): Promise<{ userMessageId: string; assistantMessageId: string; conversationId: string }> {
+	): Promise<{
+		userMessageId: string;
+		userMessageIds: string[];
+		assistantMessageId: string;
+		conversationId: string;
+	}> {
 		const session = await this.ensureSession();
 		const { conversationId, channel } = ctx;
 		const isCoworker = ctx.kind === ChatConversationKind.Coworker;
@@ -461,46 +481,57 @@ export class ChatSessionManager {
 			await convo.current.promise.catch(() => undefined);
 		}
 
-		const userMessageId = await this.insertMessage({
-			conversationId,
-			role: ChatMessageRole.User,
-			channel,
-			status: ChatMessageStatus.Complete,
-			content: input.text,
-			authorUserId: input.authorUserId ?? null,
-			authorLabel: input.authorLabel ?? null,
-			completed: true,
-		});
-		// Link any uploaded files to the user message, then resolve their metadata so
-		// the sent bubble streams in with its attachment chips already attached.
-		const attachmentIds = input.attachmentIds ?? [];
-		let userAttachments: CommentAttachment[] = [];
-		if (attachmentIds.length > 0) {
-			await this.deps.db.query(
-				`INSERT INTO chat_message_attachments (chat_message_id, asset_id)
-				 SELECT $1::uuid, asset FROM UNNEST($2::uuid[]) AS asset`,
-				[userMessageId, attachmentIds],
+		// One turn can carry several user messages (a flushed chatbox queue). Each is
+		// its own row and its own bubble; a single reply below answers all of them.
+		const batch =
+			input.messages && input.messages.length > 0
+				? input.messages
+				: [{ text: input.text, attachmentIds: input.attachmentIds }];
+		const userMessageIds: string[] = [];
+		for (const message of batch) {
+			const userMessageId = await this.insertMessage({
+				conversationId,
+				role: ChatMessageRole.User,
+				channel,
+				status: ChatMessageStatus.Complete,
+				content: message.text,
+				authorUserId: input.authorUserId ?? null,
+				authorLabel: input.authorLabel ?? null,
+				completed: true,
+			});
+			userMessageIds.push(userMessageId);
+			// Link any uploaded files to the user message, then resolve their metadata so
+			// the sent bubble streams in with its attachment chips already attached.
+			const attachmentIds = message.attachmentIds ?? [];
+			let userAttachments: CommentAttachment[] = [];
+			if (attachmentIds.length > 0) {
+				await this.deps.db.query(
+					`INSERT INTO chat_message_attachments (chat_message_id, asset_id)
+					 SELECT $1::uuid, asset FROM UNNEST($2::uuid[]) AS asset`,
+					[userMessageId, attachmentIds],
+				);
+				userAttachments =
+					(
+						await loadChatMessageAttachments(
+							this.deps.db,
+							[userMessageId],
+							this.deps.masterKeyManager,
+						)
+					).get(userMessageId) ?? [];
+			}
+			// Every thread is visible in the web view (coworker threads read-only), so
+			// every turn broadcasts — the web renders the stored conversation live.
+			this.broadcastStart(
+				conversationId,
+				userMessageId,
+				ChatMessageRole.User,
+				channel,
+				message.text,
+				userAttachments,
 			);
-			userAttachments =
-				(
-					await loadChatMessageAttachments(
-						this.deps.db,
-						[userMessageId],
-						this.deps.masterKeyManager,
-					)
-				).get(userMessageId) ?? [];
 		}
+		const userMessageId = userMessageIds[userMessageIds.length - 1];
 		await this.touchConversation(conversationId);
-		// Every thread is visible in the web view (coworker threads read-only), so
-		// every turn broadcasts — the web renders the stored conversation live.
-		this.broadcastStart(
-			conversationId,
-			userMessageId,
-			ChatMessageRole.User,
-			channel,
-			input.text,
-			userAttachments,
-		);
 
 		const assistantMessageId = await this.insertMessage({
 			conversationId,
@@ -530,7 +561,7 @@ export class ChatSessionManager {
 			trackBackground(promise.then(() => this.maybeCompact(ctx)));
 		}
 
-		return { userMessageId, assistantMessageId, conversationId };
+		return { userMessageId, userMessageIds, assistantMessageId, conversationId };
 	}
 
 	/** Tear the live session down; the next turn re-allocates a fresh one. */

--- a/packages/server/test/chat-message-queue.test.ts
+++ b/packages/server/test/chat-message-queue.test.ts
@@ -1,0 +1,258 @@
+import { readFileSync } from 'node:fs';
+import { ChatChannel, DEFAULT_TEAM_ID } from '@hezo/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '../src/crypto/encryption';
+import { getHostPromptPath } from '../src/services/agent-runner';
+import { ChatSessionManager } from '../src/services/chat-session-manager';
+import type { ExecLogChunk } from '../src/services/docker';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { WebSocketManager } from '../src/services/ws';
+import { buildApp } from '../src/startup';
+import { authHeader, createStubDocker } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+const claudeLine = (obj: unknown) => `${JSON.stringify(obj)}\n`;
+const assistantText = (text: string) =>
+	claudeLine({
+		type: 'assistant',
+		message: { role: 'assistant', content: [{ type: 'text', text }] },
+	});
+const resultEvent = () =>
+	claudeLine({ type: 'result', usage: { input_tokens: 5, output_tokens: 3 } });
+
+type ExecOpts = { signal?: AbortSignal; onChunk?: (c: ExecLogChunk) => void | Promise<void> };
+
+/**
+ * A reply exec, as opposed to the auto-title run that streams alongside it off
+ * its own `-title` prompt file (see `turnPrompt`'s `slot`).
+ */
+function replyPromptFile(env: string[] | undefined): string | null {
+	const prompt = (env ?? []).find((e) => e.startsWith('HEZO_PROMPT_FILE='));
+	if (!prompt || prompt.endsWith('-title.txt')) return null;
+	return prompt.slice('HEZO_PROMPT_FILE='.length);
+}
+
+/**
+ * Docker stub that answers each chat-turn exec and records the prompt file each
+ * reply was pointed at, so a test can count how many reply turns actually ran.
+ */
+function replyDocker(turns: string[]) {
+	return createStubDocker({
+		execCreate: async (_id: string, config: { Env?: string[] }) => {
+			const prompt = replyPromptFile(config.Env);
+			if (!prompt) return 'aux';
+			turns.push(prompt);
+			return 'turn';
+		},
+		execStart: async (execId: string, opts: ExecOpts = {}) => {
+			if (execId !== 'turn') return { stdout: '', stderr: '' };
+			const onChunk = opts.onChunk ?? (() => undefined);
+			await onChunk({ stream: 'stdout', text: assistantText('On it.') });
+			await onChunk({ stream: 'stdout', text: resultEvent() });
+			return { stdout: '', stderr: '' };
+		},
+	});
+}
+
+// The web chatbox parks messages typed while a reply streams and flushes the whole
+// queue when the thread goes idle. It flushes as ONE turn carrying several user
+// messages — N separate turns would produce N replies, the first of which answers
+// stale context. These cover the server half of that: the batch shape on
+// `sendTurn`, its route, and the single reply it yields.
+describe('chat message queue flush (batched user messages)', () => {
+	let ctx: ServerTestContext;
+
+	beforeEach(async () => {
+		ctx = await createTestContext();
+		const key = ctx.masterKeyManager.getKey();
+		if (!key) throw new Error('master key unavailable');
+		await ctx.db.query(
+			`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
+			 VALUES ('anthropic', 'api_key', 'test', $1, true, 'verified', 'claude-sonnet-4-6')`,
+			[encrypt('sk-ant-test', key)],
+		);
+		await ctx.db.query(
+			`UPDATE projects SET container_id = 'hq-container', container_status = 'running'
+			 WHERE team_id = $1 AND is_internal = true`,
+			[DEFAULT_TEAM_ID],
+		);
+	});
+	afterEach(() => destroyTestContext(ctx));
+
+	function makeManager(docker: ReturnType<typeof createStubDocker>) {
+		const wsManager = new WebSocketManager();
+		const logs = new LogStreamBroker();
+		logs.setWsManager(wsManager);
+		return new ChatSessionManager({
+			db: ctx.db,
+			docker,
+			masterKeyManager: ctx.masterKeyManager,
+			serverPort: 0,
+			dataDir: ctx.dataDir,
+			wsManager,
+			logs,
+		});
+	}
+
+	async function waitForComplete(assistantMessageId: string) {
+		await vi.waitFor(async () => {
+			const r = await ctx.db.query<{ status: string }>(
+				`SELECT status::text AS status FROM chat_messages WHERE id = $1`,
+				[assistantMessageId],
+			);
+			expect(r.rows[0]?.status).toBe('complete');
+		});
+	}
+
+	async function userMessages(conversationId: string) {
+		const r = await ctx.db.query<{ content: string }>(
+			`SELECT content FROM chat_messages
+			 WHERE conversation_id = $1 AND role = 'user' ORDER BY created_at ASC`,
+			[conversationId],
+		);
+		return r.rows.map((row) => row.content);
+	}
+
+	it('posts each queued message as its own row, then one reply for all of them', async () => {
+		const turns: string[] = [];
+		const manager = makeManager(replyDocker(turns));
+
+		const result = await manager.sendTurn({
+			text: 'first',
+			channel: ChatChannel.Web,
+			messages: [
+				{ text: 'what is blocking the release?' },
+				{ text: 'also check the Coach backlog' },
+				{ text: 'and who owns the 041 test?' },
+			],
+		});
+		await waitForComplete(result.assistantMessageId);
+
+		// Three user bubbles, in the order they were queued…
+		expect(await userMessages(result.conversationId)).toEqual([
+			'what is blocking the release?',
+			'also check the Coach backlog',
+			'and who owns the 041 test?',
+		]);
+		expect(result.userMessageIds).toHaveLength(3);
+		// …and exactly one assistant row, from exactly one exec.
+		const assistants = await ctx.db.query<{ count: number }>(
+			`SELECT COUNT(*)::int AS count FROM chat_messages
+			 WHERE conversation_id = $1 AND role = 'assistant'`,
+			[result.conversationId],
+		);
+		expect(assistants.rows[0].count).toBe(1);
+		expect(turns).toHaveLength(1);
+	});
+
+	it('composes every queued message into the single turn prompt', async () => {
+		// The prompt file is written before the exec and deleted after it, so read it
+		// mid-exec — this is the assertion that the CEO actually sees all of the
+		// queued messages rather than only the first.
+		let promptBody = '';
+		const docker = createStubDocker({
+			execCreate: async (_id: string, config: { Env?: string[] }) => {
+				const containerPath = replyPromptFile(config.Env);
+				if (!containerPath) return 'aux';
+				const key =
+					containerPath
+						.split('/')
+						.pop()
+						?.replace(/\.txt$/, '') ?? '';
+				const hq = await ctx.db.query<{ id: string }>(
+					`SELECT id FROM projects WHERE team_id = $1 AND is_internal = true`,
+					[DEFAULT_TEAM_ID],
+				);
+				promptBody = readFileSync(
+					getHostPromptPath(ctx.dataDir, DEFAULT_TEAM_ID, hq.rows[0].id, key),
+					'utf8',
+				);
+				return 'turn';
+			},
+			execStart: async (execId: string, opts: ExecOpts = {}) => {
+				if (execId !== 'turn') return { stdout: '', stderr: '' };
+				const onChunk = opts.onChunk ?? (() => undefined);
+				await onChunk({ stream: 'stdout', text: assistantText('Ack.') });
+				await onChunk({ stream: 'stdout', text: resultEvent() });
+				return { stdout: '', stderr: '' };
+			},
+		});
+		const manager = makeManager(docker);
+
+		const result = await manager.sendTurn({
+			text: 'q1',
+			channel: ChatChannel.Web,
+			messages: [{ text: 'first question' }, { text: 'second question' }],
+		});
+		await waitForComplete(result.assistantMessageId);
+
+		expect(promptBody).toContain('first question');
+		expect(promptBody).toContain('second question');
+	});
+
+	it('falls back to the single-message shape when no batch is given', async () => {
+		const turns: string[] = [];
+		const manager = makeManager(replyDocker(turns));
+
+		const result = await manager.sendTurn({ text: 'just the one', channel: ChatChannel.Web });
+		await waitForComplete(result.assistantMessageId);
+
+		expect(await userMessages(result.conversationId)).toEqual(['just the one']);
+		expect(result.userMessageIds).toEqual([result.userMessageId]);
+	});
+
+	it('accepts a batch over POST /api/chat/messages and rejects a malformed one', async () => {
+		const turns: string[] = [];
+		const docker = replyDocker(turns);
+		const wsManager = new WebSocketManager();
+		const logs = new LogStreamBroker();
+		logs.setWsManager(wsManager);
+		const manager = new ChatSessionManager({
+			db: ctx.db,
+			docker,
+			masterKeyManager: ctx.masterKeyManager,
+			serverPort: 0,
+			dataDir: ctx.dataDir,
+			wsManager,
+			logs,
+		});
+		const app = buildApp(
+			ctx.db,
+			ctx.masterKeyManager,
+			{ dataDir: ctx.dataDir, webUrl: '' },
+			docker,
+			wsManager,
+			undefined,
+			logs,
+			null,
+			null,
+			undefined,
+			undefined,
+			manager,
+		);
+		const headers = { ...authHeader(ctx.token), 'content-type': 'application/json' };
+
+		const res = await app.request('/api/chat/messages', {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ messages: [{ text: 'one' }, { text: 'two' }] }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as {
+			data: { user_message_ids: string[]; assistant_message_id: string; conversation_id: string };
+		};
+		expect(body.data.user_message_ids).toHaveLength(2);
+		await waitForComplete(body.data.assistant_message_id);
+		expect(await userMessages(body.data.conversation_id)).toEqual(['one', 'two']);
+
+		// An entry with neither text nor an attachment is not sendable.
+		const bad = await app.request('/api/chat/messages', {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ messages: [{ text: 'ok' }, { text: '   ' }] }),
+		});
+		expect(bad.status).toBe(400);
+
+		await manager.stop();
+	});
+});

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -11,12 +11,14 @@ import {
 	FileVideo,
 	History,
 	Image as ImageIcon,
+	ListPlus,
 	Loader2,
 	Lock,
 	Maximize2,
 	MessageSquare,
 	Minimize2,
 	Plus,
+	StepForward,
 	X,
 } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
@@ -24,6 +26,7 @@ import { useAutoGrowTextarea } from '../../hooks/use-auto-grow-textarea';
 import {
 	type ChatConversationSummary,
 	type ChatMessage,
+	type QueuedChatMessage,
 	readStoredThreadId,
 	useChat,
 	useChatConversations,
@@ -32,6 +35,8 @@ import {
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
 import { useFileAttachments } from '../../hooks/use-file-attachments';
+import { LONG_PRESS_MS, useLongPress } from '../../hooks/use-long-press';
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { useHqProject } from '../../hooks/use-projects';
 import { useUploadChatAttachment } from '../../hooks/use-upload-chat-attachment';
 import { copyToClipboard } from '../../lib/clipboard';
@@ -49,10 +54,20 @@ import { Tooltip } from '../ui/tooltip';
 /**
  * Floating chat with the CEO, pinned bottom-right (on portrait mobile screens
  * the launcher can be dragged elsewhere). Talks to the single global CEO
- * conversation; messages stream in over the `chat:global` WebSocket room. Sending a
- * new message while a reply is in flight interrupts it (handled server-side) and
- * starts a fresh turn. The CEO is the instance-level singleton living in the HQ
- * team, so every reply is labelled `CEO · HQ`.
+ * conversation; messages stream in over the `chat:global` WebSocket room. The CEO
+ * is the instance-level singleton living in the HQ team, so every reply is
+ * labelled `CEO · HQ`.
+ *
+ * The composer stays usable while a reply streams, and the send button is the
+ * only thing that changes to say what will happen — no banner above the input:
+ *
+ * - **Queue** (the default, and what Enter or a tap does): the message parks as a
+ *   dashed bubble and can be pulled back out until the queue flushes. The whole
+ *   queue then posts as ONE turn, so a single reply answers all of it.
+ * - **Send now** (deliberate: hold the button, or ⌘/Ctrl+Enter): posts straight
+ *   away, which server-side aborts the in-flight reply and starts a fresh turn.
+ *   Only offered while a reply is actually running — before that there is
+ *   nothing to interrupt, so holding does nothing and pressing queues.
  */
 interface ChatWidgetProps {
 	/** Open state is lifted to the shell so sibling surfaces (the floating
@@ -82,6 +97,9 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		loaded,
 		unread,
 		compactedCount,
+		queue,
+		enqueue,
+		dequeue,
 		conversationId: activeConversationId,
 	} = useChat(open, selectedConversationId);
 	const {
@@ -186,27 +204,74 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 	// conversation; there is no special "Main" default anymore.
 	const threadLabel = (t: (typeof conversations)[number]) => t.title?.trim() || 'New thread';
 
-	const submit = () => {
+	// The thread is busy from the moment a send leaves until its reply settles.
+	// `canInterrupt` narrows that to a reply that is actually running: during
+	// `sending` the turn hasn't started server-side yet, so there is nothing to
+	// abort and the only honest option is to queue.
+	const busy = sending || streaming;
+	const canInterrupt = streaming && !sending;
+	const hasContent = draft.trim().length > 0 || visibleAttachments.length > 0;
+	const canSubmit = !activeReadOnly && hasContent && uploading.length === 0;
+
+	/**
+	 * Commit the draft. `sendNow` is the deliberate interrupt (button held, or
+	 * ⌘/Ctrl+Enter); everything else queues while the thread is busy. A `sendNow`
+	 * that arrives before the turn has started still queues — see `canInterrupt`.
+	 */
+	const submit = (sendNow = false) => {
+		// A message needs text or at least one attachment; files still uploading
+		// block. Coworker (team-channel) threads are read-only here — never send.
+		if (!canSubmit) return;
 		const text = draft.trim();
-		// A message needs text or at least one attachment. Block while a send is in
-		// flight or a reply is streaming — prevents the impatient double-click
-		// (seeing the optimistic bubble "stuck" during the egress check) that used
-		// to spawn duplicate CEO turns. Files still uploading also block the send.
-		// Coworker (team-channel) threads are read-only here — never send.
-		if (
-			activeReadOnly ||
-			(!text && visibleAttachments.length === 0) ||
-			uploading.length > 0 ||
-			sending ||
-			streaming
-		) {
-			return;
-		}
 		const attachments = visibleAttachments;
 		setDraft('');
 		setPendingAttachmentIds([]);
+		if (busy && !(sendNow && canInterrupt)) {
+			enqueue(text, attachments);
+			return;
+		}
 		send(text, attachments).catch(() => undefined);
 	};
+
+	// Holding the button arms the interrupt; `armed` flips at the threshold so the
+	// button can say what a release will do before the finger lifts.
+	const longPress = useLongPress({
+		onPress: () => submit(false),
+		onLongPress: () => submit(true),
+		enabled: canInterrupt && canSubmit,
+	});
+	// ⌘/Ctrl is the keyboard route to the same armed state, tracked globally so the
+	// button morphs on the modifier alone — the consequence is visible before Enter.
+	const [modifierHeld, setModifierHeld] = useState(false);
+	useEffect(() => {
+		if (!open) return;
+		const isModifier = (e: KeyboardEvent) => e.key === 'Meta' || e.key === 'Control';
+		const onDown = (e: KeyboardEvent) => isModifier(e) && setModifierHeld(true);
+		const onUp = (e: KeyboardEvent) => isModifier(e) && setModifierHeld(false);
+		// Tabbing away can swallow the keyup, which would strand the button armed.
+		const onBlur = () => setModifierHeld(false);
+		window.addEventListener('keydown', onDown);
+		window.addEventListener('keyup', onUp);
+		window.addEventListener('blur', onBlur);
+		return () => {
+			window.removeEventListener('keydown', onDown);
+			window.removeEventListener('keyup', onUp);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, [open]);
+
+	// Touch has no modifier key, so the tooltip teaches the gesture instead of a shortcut.
+	const coarsePointer = useMediaQuery('(pointer: coarse)');
+	const armed = canInterrupt && canSubmit && (longPress.armed || modifierHeld);
+	const buttonHint = !busy
+		? 'Send message'
+		: armed
+			? 'Send now - stops the current reply'
+			: !canInterrupt
+				? 'Queue - sends when the CEO is ready'
+				: coarsePointer
+					? 'Queue - hold to send now'
+					: 'Queue (Enter) - hold, or Cmd/Ctrl Enter, to send now';
 
 	const handleNewThread = async () => {
 		const res = (await createThread().catch(() => null)) as {
@@ -301,6 +366,16 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 						{streaming && (
 							<span data-testid="chat-header-dots" className="pl-0.5">
 								<Dots />
+							</span>
+						)}
+						{/* Parked messages live at the bottom of the thread, so the count rides
+						    up here to survive scrolling away from them. */}
+						{queue.length > 0 && (
+							<span
+								data-testid="chat-queue-count"
+								className="rounded-sm border border-purple-soft-fg bg-purple-soft px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-purple-soft-fg"
+							>
+								{queue.length} queued
 							</span>
 						)}
 					</div>
@@ -563,6 +638,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 									{messages.map((m) => (
 										<MessageBubble key={m.id} message={m} projectSlug={hq?.slug} />
 									))}
+									{queue.length > 0 && <QueuedMessages queue={queue} onRemove={dequeue} />}
 								</div>
 
 								<div className="border-t border-border p-3">
@@ -613,7 +689,7 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 											onKeyDown={(e) => {
 												if (e.key === 'Enter' && !e.shiftKey) {
 													e.preventDefault();
-													submit();
+													submit(e.metaKey || e.ctrlKey);
 												}
 											}}
 											rows={1}
@@ -621,27 +697,64 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 											placeholder={
 												activeReadOnly
 													? `Read-only — reply from ${channelDisplayName(activeThread?.channel ?? '')}`
-													: 'Ask the CEO anything, across every project…'
+													: busy
+														? 'Queue your next message…'
+														: 'Ask the CEO anything, across every project…'
 											}
 											data-testid="chat-input"
-											className="max-h-32 min-h-[2.25rem] flex-1 resize-none overflow-y-auto bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+											// `min-w-0` lets the row absorb the send button's widened labelled
+											// states: a textarea's intrinsic min width would otherwise push
+											// the composer past the panel edge on a 375px viewport.
+											className="max-h-32 min-h-[2.25rem] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
 										/>
-										<button
-											type="button"
-											onClick={submit}
-											disabled={
-												activeReadOnly ||
-												(!draft.trim() && visibleAttachments.length === 0) ||
-												uploading.length > 0 ||
-												sending ||
-												streaming
-											}
-											aria-label="Send message"
-											data-testid="chat-send"
-											className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
-										>
-											<ArrowRight className="h-4 w-4" />
-										</button>
+										<Tooltip content={buttonHint} side="top">
+											<button
+												type="button"
+												{...longPress.handlers}
+												disabled={!canSubmit}
+												aria-label={buttonHint}
+												data-testid="chat-send"
+												data-mode={!busy ? 'send' : armed ? 'send-now' : 'queue'}
+												// `overflow-hidden` clips the hold sweep to the pill; the label
+												// sits above it. Width animates as it morphs between the bare
+												// circle and the two labelled states.
+												className={`relative flex h-9 shrink-0 items-center justify-center gap-1.5 overflow-hidden rounded-full text-[11px] font-semibold uppercase tracking-wide transition-colors disabled:opacity-40 ${
+													busy && !armed
+														? 'w-auto px-3 bg-purple-soft text-purple-soft-fg hover:bg-purple-soft/80'
+														: busy
+															? 'w-auto px-3 bg-accent-solid text-accent-solid-fg hover:bg-accent-hover'
+															: 'w-9 bg-accent-solid text-accent-solid-fg hover:bg-accent-hover'
+												}`}
+											>
+												{/* The hold's own progress bar: accent sweeps across the soft
+												    violet over LONG_PRESS_MS, then `armed` flips the whole pill. */}
+												{busy && !armed && longPress.pressing && (
+													<span
+														aria-hidden
+														data-testid="chat-send-sweep"
+														style={
+															{ '--chat-hold-ms': `${LONG_PRESS_MS}ms` } as React.CSSProperties
+														}
+														className="chat-hold-sweep absolute inset-0 bg-accent-solid/25"
+													/>
+												)}
+												<span className="relative flex items-center gap-1.5">
+													{!busy ? (
+														<ArrowRight className="h-4 w-4" />
+													) : armed ? (
+														<>
+															<StepForward className="h-3.5 w-3.5" />
+															Send now
+														</>
+													) : (
+														<>
+															<ListPlus className="h-3.5 w-3.5" />
+															Queue
+														</>
+													)}
+												</span>
+											</button>
+										</Tooltip>
 									</div>
 								</div>
 							</FileDropZone>
@@ -672,6 +785,56 @@ function channelChip(t: ChatConversationSummary): string | null {
 	const inTopic = t.external_thread_id?.includes(':') ?? false;
 	if (t.channel === 'telegram') return inTopic ? 'TG TOPIC' : 'TG DM';
 	return `${t.channel.toUpperCase()} DM`;
+}
+
+/**
+ * Messages parked for the next turn, rendered at the tail of the thread exactly
+ * where they will land. Dashed and violet: clearly the operator's own voice,
+ * clearly not sent yet. Each carries its own remove control, which exists for
+ * precisely as long as removal is possible — once the queue flushes these become
+ * ordinary sent bubbles and there is nothing left to pull back.
+ */
+function QueuedMessages({
+	queue,
+	onRemove,
+}: {
+	queue: readonly QueuedChatMessage[];
+	onRemove: (id: string) => void;
+}) {
+	return (
+		<div className="flex flex-col gap-1.5" data-testid="chat-queue">
+			<span className="text-eyebrow self-end px-1 text-purple-soft-fg">
+				Up next{' '}
+				<span className="font-normal normal-case tracking-normal text-text-3">
+					sends when the reply finishes
+				</span>
+			</span>
+			{queue.map((m) => (
+				<div key={m.id} className="flex items-center justify-end gap-1.5">
+					<button
+						type="button"
+						onClick={() => onRemove(m.id)}
+						aria-label={`Remove "${m.text}" from the queue`}
+						data-testid="chat-queue-remove"
+						className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border text-text-3 hover:border-border-strong hover:text-text-1"
+					>
+						<X className="h-3 w-3" />
+					</button>
+					<div
+						data-testid="chat-queued-message"
+						className="max-w-[80%] rounded-2xl rounded-br-sm border border-dashed border-purple-soft-fg bg-purple-soft px-3.5 py-2 text-sm leading-relaxed text-text-2 whitespace-pre-wrap"
+					>
+						{m.text}
+						{m.attachments.length > 0 && (
+							<span className="mt-1 block text-[11px] text-text-3">
+								{m.attachments.length} file{m.attachments.length > 1 ? 's' : ''} attached
+							</span>
+						)}
+					</div>
+				</div>
+			))}
+		</div>
+	);
 }
 
 /** The small uppercase eyebrow above each bubble ("YOU" / "CEO · HQ"). */

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -10,7 +10,7 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSocket } from '../contexts/socket-context';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
@@ -34,6 +34,32 @@ interface ConversationData {
 	/** How many older messages have been compacted into long-term memory. */
 	compacted_count: number;
 }
+
+/**
+ * A message parked while the CEO is mid-reply. It has not reached the server, so
+ * it can still be pulled back out; the whole queue flushes as one turn the moment
+ * the reply settles.
+ */
+export interface QueuedChatMessage {
+	id: string;
+	text: string;
+	attachments: CommentAttachment[];
+}
+
+/** One message on its way to the server (a send in flight). */
+interface OutboundChatMessage {
+	text: string;
+	attachments: CommentAttachment[];
+}
+
+/** Queue bucket for the default web thread, which has no caller-supplied id. */
+const DEFAULT_THREAD_QUEUE_KEY = '__default__';
+
+/** Stable identity for "no queue" so it never re-triggers effects. */
+const EMPTY_QUEUE: readonly QueuedChatMessage[] = Object.freeze([]);
+
+let queuedMessageSeq = 0;
+const nextQueuedMessageId = () => `queued-${++queuedMessageSeq}`;
 
 /**
  * Unread badge state for the minimized launcher. The CEO conversation has no
@@ -164,15 +190,22 @@ export function useChat(active: boolean, conversationId?: string) {
 	// thread resolves to a concrete id in the query response). Used to filter WS
 	// events so another thread's stream never lands in this cache entry.
 	const resolvedIdRef = useRef<string | null>(conversationId ?? null);
-	// In-flight send: the user's text is shown optimistically (with a pending
+	// In-flight send: the user's messages are shown optimistically (with a pending
 	// assistant placeholder) while the server warms the session / egress check, so
 	// the operator gets immediate feedback instead of a ~10s blank. Cleared when the
 	// real user message arrives over WS, or when the send settles (incl. failure).
+	// It's a list because a flushed queue sends several messages as one turn.
 	const [pending, setPending] = useState<{
-		text: string;
 		at: string;
-		attachments: CommentAttachment[];
+		messages: OutboundChatMessage[];
 	} | null>(null);
+	// Messages parked while a reply streams, bucketed per thread so switching
+	// threads (or closing the panel) never drops or misdelivers a queued message.
+	// Client-side only: a reload loses the queue, which is the accepted cost of not
+	// making a parked message a `chat_messages` row + migration.
+	const [queues, setQueues] = useState<Record<string, QueuedChatMessage[]>>({});
+	const queueKey = conversationId ?? DEFAULT_THREAD_QUEUE_KEY;
+	const queue = queues[queueKey] ?? EMPTY_QUEUE;
 	// The socket handler is wired once; this ref lets it read the live open state
 	// (whether the chat is currently visible) without re-subscribing every toggle.
 	const activeRef = useRef(active);
@@ -287,10 +320,14 @@ export function useChat(active: boolean, conversationId?: string) {
 	}, [subscribe, queryClient, conversationId]);
 
 	const sendMutation = useMutation({
-		mutationFn: ({ text, attachmentIds }: { text: string; attachmentIds: string[] }) =>
+		// Always the batch shape: one turn carries N user messages, so a flushed
+		// queue posts each as its own bubble and a single reply answers all of them.
+		mutationFn: (batch: OutboundChatMessage[]) =>
 			api.post('/api/chat/messages', {
-				text,
-				attachment_ids: attachmentIds,
+				messages: batch.map((m) => ({
+					text: m.text,
+					attachment_ids: m.attachments.map((a) => a.id),
+				})),
 				...(conversationId ? { conversation_id: conversationId } : {}),
 			}),
 		onError: (error: { message?: string }) => {
@@ -303,22 +340,22 @@ export function useChat(active: boolean, conversationId?: string) {
 	});
 
 	const serverMessages = query.data?.messages ?? [];
-	// Append the optimistic user bubble + a pending assistant "thinking" placeholder
+	// Append the optimistic user bubbles + a pending assistant "thinking" placeholder
 	// while a send is in flight (an assistant row with empty streaming content renders
 	// the existing typing indicator). They're dropped the moment the real rows arrive.
 	const messages: ChatMessage[] =
 		pending !== null
 			? [
 					...serverMessages,
-					{
-						id: 'optimistic-user',
+					...pending.messages.map((m, i) => ({
+						id: `optimistic-user-${i}`,
 						role: 'user' as ChatMessageRole,
 						channel: 'web' as ChatChannel,
 						status: 'complete' as ChatMessageStatus,
-						content: pending.text,
+						content: m.text,
 						created_at: pending.at,
-						attachments: pending.attachments,
-					},
+						attachments: m.attachments,
+					})),
 					{
 						id: 'optimistic-assistant',
 						role: 'assistant' as ChatMessageRole,
@@ -330,21 +367,80 @@ export function useChat(active: boolean, conversationId?: string) {
 				]
 			: serverMessages;
 	const streaming = messages.some((m) => m.role === 'assistant' && m.status === 'streaming');
+	const sending = pending !== null;
 
+	// Stable across renders so the flush effect below can depend on it honestly
+	// rather than suppressing the dependency.
+	const { mutateAsync } = sendMutation;
+	const sendBatch = useCallback(
+		(batch: OutboundChatMessage[]) => {
+			if (batch.length === 0) return Promise.resolve();
+			setPending({ at: new Date().toISOString(), messages: batch });
+			return mutateAsync(batch);
+		},
+		[mutateAsync],
+	);
+
+	/**
+	 * Post immediately. While a reply is streaming the server aborts it (keeping the
+	 * partial as `interrupted`) and starts a fresh turn — that's the interrupt.
+	 */
 	const send = (text: string, attachments: CommentAttachment[] = []) => {
 		const trimmed = text.trim();
 		if (!trimmed && attachments.length === 0) return Promise.resolve();
-		setPending({ text: trimmed, at: new Date().toISOString(), attachments });
-		return sendMutation.mutateAsync({ text: trimmed, attachmentIds: attachments.map((a) => a.id) });
+		return sendBatch([{ text: trimmed, attachments }]);
 	};
+
+	/** Park a message for the next turn. Nothing has reached the server yet. */
+	const enqueue = (text: string, attachments: CommentAttachment[] = []) => {
+		const trimmed = text.trim();
+		if (!trimmed && attachments.length === 0) return;
+		setQueues((prev) => ({
+			...prev,
+			[queueKey]: [
+				...(prev[queueKey] ?? []),
+				{ id: nextQueuedMessageId(), text: trimmed, attachments },
+			],
+		}));
+	};
+
+	/** Pull a message back out. Only possible before the queue has been dispatched. */
+	const dequeue = (id: string) => {
+		setQueues((prev) => ({
+			...prev,
+			[queueKey]: (prev[queueKey] ?? []).filter((m) => m.id !== id),
+		}));
+	};
+
+	// Flush the queue as one turn the moment the thread goes idle — after a reply
+	// completes, fails, or is interrupted, so a parked message is never lost to a
+	// turn that went wrong. The ref guards the window between clearing the queue and
+	// `pending` landing, where this effect would otherwise re-enter and double-post.
+	const flushingRef = useRef(false);
+	useEffect(() => {
+		if (streaming || sending || queue.length === 0 || flushingRef.current) return;
+		flushingRef.current = true;
+		setQueues((prev) => ({ ...prev, [queueKey]: [] }));
+		// A rejected flush is already surfaced by the mutation's `onError` toast;
+		// swallow it here so it doesn't surface again as an unhandled rejection.
+		sendBatch(queue.map((m) => ({ text: m.text, attachments: m.attachments })))
+			.catch(() => undefined)
+			.finally(() => {
+				flushingRef.current = false;
+			});
+	}, [streaming, sending, queue, queueKey, sendBatch]);
 
 	return {
 		messages,
 		send,
 		streaming,
-		sending: pending !== null,
+		sending,
 		loaded: !query.isPending,
 		unread,
+		// Messages parked for the next turn, plus the two ways to change that queue.
+		queue,
+		enqueue,
+		dequeue,
 		// The server-resolved id of the active thread (the default web thread when
 		// no id was passed) — drives the switcher's selected value.
 		conversationId: query.data?.conversation_id,

--- a/packages/web/src/hooks/use-long-press.ts
+++ b/packages/web/src/hooks/use-long-press.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** How long a pointer must stay down before the alternate action arms. */
+export const LONG_PRESS_MS = 450;
+
+interface LongPressOptions {
+	/** Fired by a quick tap/click, or by keyboard activation. */
+	onPress: () => void;
+	/** Fired on release after the hold passed {@link LONG_PRESS_MS}. */
+	onLongPress: () => void;
+	/** When false the hold never arms and every activation is a plain press. */
+	enabled?: boolean;
+	delayMs?: number;
+}
+
+/**
+ * Press-and-hold as a second action on one control. A quick tap fires `onPress`;
+ * holding past `delayMs` flips `armed` and the release fires `onLongPress`.
+ *
+ * `armed` is the point of the hook: it lets the control show what a release will
+ * do *before* the finger lifts, which is the only way to teach the gesture on
+ * touch, where there is no modifier key to hold. Dragging off the control (or a
+ * cancelled pointer) aborts without firing either action.
+ *
+ * Keyboard activation arrives as a bare `click` with no preceding pointer
+ * sequence, so it always takes the plain-press path — the pointer handlers mark
+ * the click they synthesize so it isn't counted twice.
+ */
+export function useLongPress({
+	onPress,
+	onLongPress,
+	enabled = true,
+	delayMs = LONG_PRESS_MS,
+}: LongPressOptions) {
+	const [armed, setArmed] = useState(false);
+	// Rendered state (not just the ref) so a control can show the hold in progress
+	// — a progress sweep, a press affordance — while the threshold runs down.
+	const [pressing, setPressing] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pressingRef = useRef(false);
+	const armedRef = useRef(false);
+	// A pointer sequence that already resolved also emits a `click`; this swallows
+	// that one so the press doesn't fire twice.
+	const pointerHandledRef = useRef(false);
+
+	const clearTimer = useCallback(() => {
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	// A press left open by an unmount (the panel closes mid-hold) must not fire
+	// its timer into a gone component.
+	useEffect(() => clearTimer, [clearTimer]);
+
+	// Losing the enabling condition mid-hold (the reply finishes while the finger
+	// is down) disarms — releasing then does the plain press, which is what the
+	// button now reads as.
+	useEffect(() => {
+		if (enabled) return;
+		clearTimer();
+		armedRef.current = false;
+		setPressing(false);
+		setArmed(false);
+	}, [enabled, clearTimer]);
+
+	const cancel = useCallback(() => {
+		clearTimer();
+		pressingRef.current = false;
+		armedRef.current = false;
+		setPressing(false);
+		setArmed(false);
+	}, [clearTimer]);
+
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent<HTMLElement>) => {
+			// Secondary buttons open menus; they're never an activation.
+			if (e.button !== 0) return;
+			pressingRef.current = true;
+			pointerHandledRef.current = false;
+			if (!enabled) return;
+			setPressing(true);
+			clearTimer();
+			timerRef.current = setTimeout(() => {
+				timerRef.current = null;
+				if (!pressingRef.current) return;
+				armedRef.current = true;
+				setArmed(true);
+			}, delayMs);
+		},
+		[enabled, delayMs, clearTimer],
+	);
+
+	const onPointerUp = useCallback(
+		(e: React.PointerEvent<HTMLElement>) => {
+			if (e.button !== 0 || !pressingRef.current) return;
+			const wasArmed = armedRef.current;
+			cancel();
+			pointerHandledRef.current = true;
+			if (wasArmed) onLongPress();
+			else onPress();
+		},
+		[cancel, onLongPress, onPress],
+	);
+
+	// Dragging off the control is the escape hatch: nothing fires. The flag stops
+	// the browser's subsequent click from firing the press we just abandoned.
+	const onPointerLeave = useCallback(() => {
+		if (!pressingRef.current) return;
+		cancel();
+		pointerHandledRef.current = true;
+	}, [cancel]);
+
+	const onClick = useCallback(() => {
+		if (pointerHandledRef.current) {
+			pointerHandledRef.current = false;
+			return;
+		}
+		onPress();
+	}, [onPress]);
+
+	return {
+		/** True once the hold passed the threshold — drives the "release does X" affordance. */
+		armed,
+		/** True for the whole hold, including before it arms — drives progress affordances. */
+		pressing,
+		handlers: {
+			onPointerDown,
+			onPointerUp,
+			onPointerLeave,
+			onPointerCancel: onPointerLeave,
+			onClick,
+			// A touch-hold would otherwise raise the platform callout mid-gesture.
+			onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
+		},
+	};
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -237,6 +237,30 @@ html.dark,
 	}
 }
 
+/* Hold-to-arm sweep on the chat composer's Queue button. Pressing and holding
+   fills the button with the accent over the long-press threshold, so the gesture
+   shows its own progress before the button flips to "Send now" (see
+   use-long-press.ts, whose LONG_PRESS_MS sets `--chat-hold-ms`). Under
+   reduced-motion the sweep is dropped entirely — a snap-to-full fill would read
+   as already armed; the label + colour swap at the threshold still carries it. */
+@keyframes chat-hold-sweep {
+	from {
+		transform: scaleX(0);
+	}
+	to {
+		transform: scaleX(1);
+	}
+}
+.chat-hold-sweep {
+	transform-origin: left center;
+	animation: chat-hold-sweep var(--chat-hold-ms, 450ms) linear forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+	.chat-hold-sweep {
+		display: none;
+	}
+}
+
 @theme {
 	--color-bg: var(--bg);
 	--color-surface: var(--surface);

--- a/packages/web/test/chat-queue.test.tsx
+++ b/packages/web/test/chat-queue.test.tsx
@@ -1,0 +1,221 @@
+import type { ChatMessage } from '@hezo/web/hooks/use-chat';
+import { LONG_PRESS_MS } from '@hezo/web/hooks/use-long-press';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// Queue-and-interrupt in the CEO chatbox. The harness builds the backend without a
+// ChatSessionManager (chat endpoints 503) and stubs WebSocket, so these seed the
+// conversation cache `useChat` reads from to put the thread into a streaming state,
+// then drive the composer. Everything asserted here is DOM + local queue state, so
+// it belongs in the component tier rather than Playwright.
+
+const now = () => new Date().toISOString();
+
+/** Put the thread into "CEO is mid-reply" — a streaming assistant row with text. */
+function seedStreaming() {
+	const messages: ChatMessage[] = [
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'what is blocking the release?',
+			created_at: now(),
+		},
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: 'Two things. QA is holding on',
+			created_at: now(),
+		},
+	];
+	queryClient.setQueryData(queryKeys.chatConversation(), {
+		conversation_id: 'test-convo',
+		messages,
+		compacted_count: 0,
+	});
+}
+
+/** Settle the streamed reply so the thread goes idle and the queue flushes. */
+function settleReply() {
+	queryClient.setQueryData(queryKeys.chatConversation(), {
+		conversation_id: 'test-convo',
+		messages: [
+			{
+				id: 'u1',
+				role: 'user',
+				channel: 'web',
+				status: 'complete',
+				content: 'what is blocking the release?',
+				created_at: now(),
+			},
+			{
+				id: 'a1',
+				role: 'assistant',
+				channel: 'web',
+				status: 'complete',
+				content: 'Two things. QA is holding on the migration test.',
+				created_at: now(),
+			},
+		] satisfies ChatMessage[],
+		compacted_count: 0,
+	});
+}
+
+async function openChatMidReply() {
+	const app = await renderApp({ initialPath: '/home' });
+	(await app.findByTestId('chat-launcher')).click();
+	await app.findByTestId('chat-input');
+	seedStreaming();
+	await app.findByTestId('chat-header-dots');
+	return app;
+}
+
+test('the composer stays usable while the CEO is replying', async () => {
+	const { findByTestId, getByTestId, user } = await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	const send = getByTestId('chat-send') as HTMLButtonElement;
+
+	// Previously both were locked for the whole reply.
+	expect(input.disabled).toBe(false);
+	await user.type(input, 'also check the Coach backlog');
+	expect(send.disabled).toBe(false);
+	// The button says what pressing it does, rather than sending.
+	expect(send.dataset.mode).toBe('queue');
+	expect(send.textContent).toContain('Queue');
+});
+
+test('Enter queues while streaming, and the queued message can be removed again', async () => {
+	const { findByTestId, getByTestId, queryByTestId, findByText, queryByText, user } =
+		await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'also check the Coach backlog{Enter}');
+
+	// It parks as a queued bubble rather than posting…
+	await findByText('also check the Coach backlog');
+	expect(getByTestId('chat-queued-message')).toBeTruthy();
+	// …the header count reflects it, and the composer is clear for the next one.
+	expect(getByTestId('chat-queue-count').textContent).toContain('1 queued');
+	expect(input.value).toBe('');
+
+	await user.type(input, 'and who owns the 041 test?{Enter}');
+	await waitFor(() => expect(getByTestId('chat-queue-count').textContent).toContain('2 queued'));
+
+	// Removing one drops it entirely — nothing was ever sent.
+	const removes = document.querySelectorAll('[data-testid="chat-queue-remove"]');
+	expect(removes.length).toBe(2);
+	await user.click(removes[0] as HTMLElement);
+	await waitFor(() => expect(queryByText('also check the Coach backlog')).toBeNull());
+	expect(getByTestId('chat-queue-count').textContent).toContain('1 queued');
+
+	// Removing the last one takes the whole queue affordance away.
+	await user.click(document.querySelector('[data-testid="chat-queue-remove"]') as HTMLElement);
+	await waitFor(() => expect(queryByTestId('chat-queue')).toBeNull());
+	expect(queryByTestId('chat-queue-count')).toBeNull();
+});
+
+test('the queue flushes as one send when the reply settles', async () => {
+	const { findByTestId, getByTestId, queryByTestId, user } = await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'first queued{Enter}');
+	await user.type(input, 'second queued{Enter}');
+	expect(getByTestId('chat-queue-count').textContent).toContain('2 queued');
+
+	// Record what actually goes over the wire: the claim is ONE request carrying
+	// both messages in order, not two requests (which would be two CEO replies).
+	const sends: unknown[] = [];
+	const realFetch = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (url.includes('/api/chat/messages') && init?.method === 'POST') {
+			sends.push(JSON.parse(String(init.body)));
+		}
+		return realFetch(input, init);
+	}) as typeof fetch;
+
+	try {
+		settleReply();
+		await waitFor(() => expect(queryByTestId('chat-queue')).toBeNull());
+		await waitFor(() => expect(sends).toHaveLength(1));
+		expect(sends[0]).toMatchObject({
+			messages: [
+				{ text: 'first queued', attachment_ids: [] },
+				{ text: 'second queued', attachment_ids: [] },
+			],
+		});
+	} finally {
+		globalThis.fetch = realFetch;
+	}
+});
+
+test('Cmd+Enter sends immediately instead of queueing', async () => {
+	const { findByTestId, queryByTestId, user } = await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'stop, do this instead');
+	fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+
+	// Nothing parks — it goes out as its own turn, which the server turns into an
+	// interrupt of the in-flight reply.
+	expect(queryByTestId('chat-queue')).toBeNull();
+	expect(input.value).toBe('');
+});
+
+test('holding the button arms Send now, and dragging off aborts the hold', async () => {
+	const { findByTestId, getByTestId, queryByTestId, user } = await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'stop, do this instead');
+	const send = getByTestId('chat-send') as HTMLButtonElement;
+	expect(send.dataset.mode).toBe('queue');
+
+	// Hold past the threshold: the button flips to the interrupt.
+	fireEvent.pointerDown(send, { button: 0 });
+	await waitFor(() => expect(send.dataset.mode).toBe('send-now'), {
+		timeout: LONG_PRESS_MS + 500,
+	});
+	expect(send.textContent).toContain('Send now');
+
+	// Dragging off before release aborts: nothing sent, nothing queued, draft kept.
+	fireEvent.pointerLeave(send);
+	await waitFor(() => expect(send.dataset.mode).toBe('queue'));
+	expect(queryByTestId('chat-queue')).toBeNull();
+	expect(input.value).toBe('stop, do this instead');
+});
+
+test('a quick tap on the held button queues rather than interrupting', async () => {
+	const { findByTestId, getByTestId, user } = await openChatMidReply();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'can wait');
+	const send = getByTestId('chat-send') as HTMLButtonElement;
+
+	// Down and straight back up — well inside the threshold.
+	fireEvent.pointerDown(send, { button: 0 });
+	fireEvent.pointerUp(send, { button: 0 });
+
+	await waitFor(() => expect(getByTestId('chat-queued-message').textContent).toContain('can wait'));
+});
+
+test('with nothing streaming the button is a plain send and never arms', async () => {
+	const { findByTestId, getByTestId, user } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('chat-launcher')).click();
+
+	const input = (await findByTestId('chat-input')) as HTMLTextAreaElement;
+	await user.type(input, 'hello');
+	const send = getByTestId('chat-send') as HTMLButtonElement;
+	expect(send.dataset.mode).toBe('send');
+
+	// There is no reply to interrupt, so holding must not offer one.
+	fireEvent.pointerDown(send, { button: 0 });
+	await new Promise((r) => setTimeout(r, LONG_PRESS_MS + 100));
+	expect(send.dataset.mode).toBe('send');
+});


### PR DESCRIPTION
The chatbox composer locked for the whole reply, so a follow-up thought had to wait. It stays usable now, and **the send button is the only thing that changes** - no banner above the input.

Design was reviewed as an interactive prototype before implementation.

## Queue is the default

**Enter, or a tap**, parks the message instead of sending it:

- It renders as a dashed violet bubble at the tail of the thread, under an "Up next" label, exactly where it will land.
- Each carries its own **✕**. Removing one drops it completely - nothing reaches the server, no message row is written. The **✕** exists for precisely as long as removal is possible.
- A `N queued` pill joins the header dots so the count survives scrolling away from the bubbles, reusing the pattern the header dots already established.
- The queue is per thread, so switching threads or closing the panel never drops or misdelivers one.

When the thread goes idle - reply complete, failed, **or** interrupted, so nothing is stranded by a turn that went wrong - the whole queue flushes as **one turn**.

## Cutting in is deliberate

**Hold the send button** past `LONG_PRESS_MS` (450ms) and the accent sweeps across it, then it flips to **Send now** with a stop-bar glyph; releasing there interrupts. Releasing early queues. **Dragging off mid-hold aborts** - neither queues nor sends. `⌘/Ctrl+Enter` arms the same state instantly for keyboard users, and a keyboard activation of the button always takes the safe path and queues.

Because it is a pointer gesture rather than a mobile special case, the same hold works with a mouse - so there is no separate mobile control to find.

It is only offered while a reply is **actually running** (`streaming && !sending`). During the pre-flight window there is no turn to abort, so the control queues and the tooltip says so rather than promising an interrupt it cannot perform.

## Server

The interrupt itself needed **no** server work - a second `POST /api/chat/messages` already aborts the prior turn and keeps the partial as `interrupted`.

The flush did need one addition. `sendTurn` takes an ordered `messages` batch: each entry becomes its own complete user row (own bubble, own timestamp, own attachments, all broadcast), then a **single** assistant turn runs, so its prompt sees every queued message. N separate turns would yield N replies, the first answering stale context. The route (`parseMessageBatch`) still accepts the single-message shape, so external channel ingest is untouched; a batch is capped at 20.

## Trade-off worth knowing

The queue is **client-side**, so a page reload drops it. That is deliberate: it is a seconds-long hold, and persisting it would mean `chat_messages` rows in a `queued` status plus a migration. Called out in `.dev/architecture.md`.

## Tests

- **Server** (`chat-message-queue.test.ts`) - a batch yields N user rows and exactly one assistant row from one exec; the composed prompt file actually contains every queued message; the single-message shape still works; the route accepts a batch and rejects an unsendable entry.
- **Component** (`chat-queue.test.tsx`) - composer stays live mid-reply; Enter queues and the bubble can be removed again; the flush is asserted on the **request body** (one POST, both messages, in order); `⌘Enter` sends instead of queueing; holding arms `Send now` and dragging off aborts while keeping the draft; a quick tap queues; nothing arms when there is no reply to interrupt.

`typecheck` and `biome check` are clean.

## Not included, and why

**No Playwright spec.** Reaching the streaming state in the browser tier needs a live CEO turn (container + provider), which the browser harness does not provide, so the queue is unreachable there. The mobile-layout risk that would have justified one - the widened button pushing the composer past 375px - is closed structurally instead, with `min-w-0` on the textarea so the row always absorbs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0121G1LPMz1nXWKaLAu9TPv8)_