### PR TITLE
feat(web): show project icons and agent avatars across dashboard and inbox

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -532,7 +532,9 @@ and `asset.deleted` domain events feed the audit log (doc archival rides
 live-refreshes. `project_icons`
 (1:1 with `projects`, `ON DELETE CASCADE`) holds an optional per-project icon image —
 unlike assets the **bytes live in the DB** (a `BYTEA` column) in a dedicated table so the
-hot `projects.*` list query never pulls the blob; it is rendered in the project rail and
+hot `projects.*` list query never pulls the blob; it is rendered on every surface that draws
+a project avatar — the project rail (including the pinned HQ entry, which falls back to a
+building glyph when HQ has no icon) and the home dashboard's Active cards and Other rows — and
 served from a public HMAC-signed read route (`GET /api/projects/:projectId/icon`, the `sig`
 query param is the credential since an `<img>` carries no bearer token). The serialized
 project carries a freshly-signed `icon_url` (null when unset); the client normalizes any
@@ -542,18 +544,24 @@ admin) reuse the same mechanism for agent avatars and the admin's own avatar —
 `BYTEA` table, a freshly-signed `icon_url` threaded onto the serialized agent/user row, and
 a public HMAC-signed read route (`GET /api/agents/:agentId/icon`, `GET /api/users/:userId/icon`).
 The signing/verification is generalized in `lib/entity-icon-urls.ts` (a `basePath` +
-per-entity `keyPurpose`), the client control in `components/icon-upload-section.tsx`; agent
-icons are edited on the agent Settings page (project-access-gated, like other agent config)
-and rendered on the roster/org-chart/agent header, user icons on the global Settings → Users
-page (superuser-gated). No MCP tool — icon upload is a human-only UI action (as for
-`project_icons`). The **CEO and Coach** — the HQ singletons that are identical across every
+per-entity `keyPurpose`), which also owns `signAuthorIconUrl` — the shared resolver every
+*feed* uses to turn a row's author/requester into a signed avatar URL (user icon when the
+actor is human, else the agent icon; best-effort, so a signing failure yields null and the
+row degrades to initials rather than failing the request). The comments feed
+(`routes/comments.ts`), the admin-mentions inbox (`routes/inbox.ts` → `author_icon_url`) and
+the approvals listing (`routes/approvals.ts` → `requested_by_slug` + `requested_by_icon_url`)
+all go through it. The client control is `components/icon-upload-section.tsx`; agent
+icons are edited on the agent Settings page (project-access-gated, like other agent config),
+user icons on the global Settings → Users page (superuser-gated). No MCP tool — icon upload
+is a human-only UI action (as for `project_icons`). The **CEO and Coach** — the HQ singletons that are identical across every
 project — ship a **built-in default avatar** (a committed image under
 `packages/web/public/avatars/`, bundled into the web app); the client resolves an agent's
 effective avatar as `uploaded icon_url ?? defaultAvatarForSlug(slug) ?? initials`
 (`web/src/lib/default-avatars.ts`), so a user upload always overrides the built-in default and
 per-project roles (e.g. the Captain) get no shared default — they show initials until an avatar
 is uploaded. Every agent-avatar surface (org chart, agent header, budget rows, agent-authored
-comments) applies this resolution.
+comments, and the admin inbox — both the home "Needs you" rows and the full inbox's mention /
+approval cards) applies this resolution.
 
 **Governance & misc.** `approvals` (polymorphic board decisions), `audit_log`
 (append-only, project + instance scopes — `project_id` set scopes a row to one project,

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -17,11 +17,15 @@ all belong to that project and nothing leaks between them.
 
 ## Project icon
 
-By default a project shows its initials in the project rail. To give it a distinct look,
+By default a project shows its initials wherever it is listed. To give it a distinct look,
 open the project's **Settings** and upload an image under **Project icon** - it then
-appears as the project's thumbnail in the rail. Pick any common image (PNG, JPEG, WebP,
-GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use **Replace image**
-to swap it or **Remove** to go back to the initials.
+appears as the project's thumbnail everywhere the project is shown with an avatar: the
+project rail and the home dashboard's project cards and rows. Pick any common image (PNG,
+JPEG, WebP, GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use
+**Replace image** to swap it or **Remove** to go back to the initials.
+
+HQ works the same way. Give it an icon and the pinned HQ entry at the bottom of the rail
+shows it in place of the default building symbol.
 
 ## Reordering the project rail
 
@@ -45,11 +49,15 @@ using this Hezo install.
 ## Agent and admin avatars
 
 Agents and the admin user work the same way. Open an agent's **Settings** and upload an
-image under **Agent avatar** to give it a custom picture - it then shows on the team
-roster, the org chart, and the agent's own page in place of its initials. The admin can set
-a personal avatar from the global **Settings → Users** page. Both accept the same image
-formats and are cropped to a square 512×512, with **Replace image** / **Remove** to change
-or clear them.
+image under **Agent avatar** to give it a custom picture - it then shows in place of its
+initials on the org chart, the agent's own page, the budget breakdown, the comments it
+writes, and every row it puts in your inbox (both the **Needs you** list on the home
+dashboard and the full inbox). The admin can set a personal avatar from the global
+**Settings → Users** page. Both accept the same image formats and are cropped to a square
+512×512, with **Replace image** / **Remove** to change or clear them.
+
+The CEO and the Coach ship with a built-in portrait, so they have a face before anyone
+uploads anything. Every other role shows its initials until you give it an avatar.
 
 ## Archiving a project
 

--- a/packages/server/src/lib/entity-icon-urls.ts
+++ b/packages/server/src/lib/entity-icon-urls.ts
@@ -79,6 +79,47 @@ export async function signVersionedIconUrl(
 	return null;
 }
 
+/**
+ * The signed avatar URL for whoever authored/requested a row in a feed: a human
+ * resolves to their `user_icons` image (keyed by `userId`), an agent to its
+ * `agent_icons` image (keyed by `memberId`); an API-key author has neither.
+ *
+ * Best-effort by design — a signing failure (e.g. the master key being
+ * unavailable) yields null so the row degrades to its initials fallback rather
+ * than failing the whole feed. The avatar is purely cosmetic.
+ */
+export async function signAuthorIconUrl(
+	masterKeyManager: MasterKeyManager,
+	author: {
+		userId?: unknown;
+		memberId?: unknown;
+		userIconUpdatedAt?: unknown;
+		agentIconUpdatedAt?: unknown;
+	},
+): Promise<string | null> {
+	try {
+		if (author.userId) {
+			return await signVersionedIconUrl(
+				USER_ICON_URL,
+				author.userId as string,
+				author.userIconUpdatedAt,
+				masterKeyManager,
+			);
+		}
+		if (author.memberId) {
+			return await signVersionedIconUrl(
+				AGENT_ICON_URL,
+				author.memberId as string,
+				author.agentIconUpdatedAt,
+				masterKeyManager,
+			);
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}
+
 export async function verifyEntityIconUrl(
 	keyPurpose: string,
 	id: string,

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -7,6 +7,7 @@ import {
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
+import { signAuthorIconUrl } from '../lib/entity-icon-urls';
 import { resolveAgentId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
@@ -35,6 +36,12 @@ approvalsRoutes.get('/projects/:projectId/approvals', async (c) => {
             co.slug AS team_slug,
             COALESCE(ma.title, m.display_name) AS requested_by_name,
             a.requested_by_member_id,
+            ma.slug AS requested_by_slug,
+            mu.user_id AS requested_by_user_id,
+            (SELECT ui.updated_at FROM user_icons ui WHERE ui.user_id = mu.user_id)
+              AS requested_by_user_icon_updated_at,
+            (SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = a.requested_by_member_id)
+              AS requested_by_agent_icon_updated_at,
             COALESCE(pma.title, pm.display_name) AS payload_member_name,
             pma.slug AS payload_member_slug,
             pp.name AS payload_project_name,
@@ -44,6 +51,7 @@ approvalsRoutes.get('/projects/:projectId/approvals', async (c) => {
      JOIN teams co ON co.id = a.team_id
      LEFT JOIN members m ON m.id = a.requested_by_member_id
      LEFT JOIN member_agents ma ON ma.id = a.requested_by_member_id
+     LEFT JOIN member_users mu ON mu.id = a.requested_by_member_id
      LEFT JOIN members pm ON pm.id = (a.payload->>'member_id')::uuid
      LEFT JOIN member_agents pma ON pma.id = pm.id
      LEFT JOIN projects pp ON pp.id = (a.payload->>'project_id')::uuid
@@ -55,6 +63,21 @@ approvalsRoutes.get('/projects/:projectId/approvals', async (c) => {
      ORDER BY a.created_at DESC`,
 		[teamId, ...statusFilter.split(',').map((s) => s.trim())],
 	);
+
+	// The requester's uploaded avatar (if any), so the inbox can put a face on the
+	// row. The built-in CEO/Coach default is resolved client-side from the slug.
+	const masterKeyManager = c.get('masterKeyManager');
+	for (const row of result.rows) {
+		row.requested_by_icon_url = await signAuthorIconUrl(masterKeyManager, {
+			userId: row.requested_by_user_id,
+			memberId: row.requested_by_member_id,
+			userIconUpdatedAt: row.requested_by_user_icon_updated_at,
+			agentIconUpdatedAt: row.requested_by_agent_icon_updated_at,
+		});
+		delete row.requested_by_user_id;
+		delete row.requested_by_user_icon_updated_at;
+		delete row.requested_by_agent_icon_updated_at;
+	}
 
 	return ok(c, result.rows);
 });

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -5,7 +5,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import { signAssetUrl } from '../lib/asset-urls';
 import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
-import { AGENT_ICON_URL, signVersionedIconUrl, USER_ICON_URL } from '../lib/entity-icon-urls';
+import { signAuthorIconUrl } from '../lib/entity-icon-urls';
 import {
 	apiKeyIdFromAuth,
 	resolveActor,
@@ -47,27 +47,12 @@ async function attachAuthorIcons(
 	rows: Record<string, unknown>[],
 ): Promise<void> {
 	for (const row of rows) {
-		let url: string | null = null;
-		try {
-			if (row.author_user_id) {
-				url = await signVersionedIconUrl(
-					USER_ICON_URL,
-					row.author_user_id as string,
-					row.author_user_icon_updated_at,
-					masterKeyManager,
-				);
-			} else if (row.author_member_id) {
-				url = await signVersionedIconUrl(
-					AGENT_ICON_URL,
-					row.author_member_id as string,
-					row.author_agent_icon_updated_at,
-					masterKeyManager,
-				);
-			}
-		} catch {
-			url = null;
-		}
-		row.author_icon_url = url;
+		row.author_icon_url = await signAuthorIconUrl(masterKeyManager, {
+			userId: row.author_user_id,
+			memberId: row.author_member_id,
+			userIconUpdatedAt: row.author_user_icon_updated_at,
+			agentIconUpdatedAt: row.author_agent_icon_updated_at,
+		});
 		delete row.author_user_id;
 		delete row.author_user_icon_updated_at;
 		delete row.author_agent_icon_updated_at;

--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -1,6 +1,7 @@
 import { ApprovalStatus, AuthType, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
+import { signAuthorIconUrl } from '../lib/entity-icon-urls';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 
@@ -29,6 +30,9 @@ interface AdminMentionRow {
 	comment_public_id: string;
 	content: unknown;
 	author_member_id: string | null;
+	author_user_id: string | null;
+	author_user_icon_updated_at: string | null;
+	author_agent_icon_updated_at: string | null;
 	author_display_name: string | null;
 	author_slug: string | null;
 	created_at: string;
@@ -51,6 +55,11 @@ inboxRoutes.get('/projects/:projectId/inbox/mentions', async (c) => {
 		        p.slug AS project_slug,
 		        bm.comment_id, tc.public_id AS comment_public_id, tc.content,
 		        tc.author_member_id,
+		        tc.author_user_id,
+		        (SELECT ui.updated_at FROM user_icons ui WHERE ui.user_id = tc.author_user_id)
+		          AS author_user_icon_updated_at,
+		        (SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = tc.author_member_id)
+		          AS author_agent_icon_updated_at,
 		        COALESCE(ma.title, m.display_name) AS author_display_name,
 		        ma.slug AS author_slug,
 		        bm.created_at, bm.read_at
@@ -68,25 +77,37 @@ inboxRoutes.get('/projects/:projectId/inbox/mentions', async (c) => {
 		[teamId, auth.userId, archived],
 	);
 
+	const masterKeyManager = c.get('masterKeyManager');
+
 	return ok(
 		c,
-		result.rows.map((r) => ({
-			id: r.id,
-			team_id: r.team_id,
-			team_slug: r.team_slug,
-			task_id: r.task_id,
-			task_identifier: r.task_identifier,
-			task_title: r.task_title,
-			project_slug: r.project_slug,
-			comment_id: r.comment_id,
-			comment_public_id: r.comment_public_id,
-			snippet: buildSnippet(r.content),
-			author_member_id: r.author_member_id,
-			author_display_name: r.author_display_name ?? 'Admin',
-			author_slug: r.author_slug,
-			created_at: r.created_at,
-			read_at: r.read_at,
-		})),
+		await Promise.all(
+			result.rows.map(async (r) => ({
+				id: r.id,
+				team_id: r.team_id,
+				team_slug: r.team_slug,
+				task_id: r.task_id,
+				task_identifier: r.task_identifier,
+				task_title: r.task_title,
+				project_slug: r.project_slug,
+				comment_id: r.comment_id,
+				comment_public_id: r.comment_public_id,
+				snippet: buildSnippet(r.content),
+				author_member_id: r.author_member_id,
+				author_display_name: r.author_display_name ?? 'Admin',
+				author_slug: r.author_slug,
+				// The author's uploaded avatar (if any). The built-in CEO/Coach default
+				// is resolved client-side from the slug; this only carries the upload.
+				author_icon_url: await signAuthorIconUrl(masterKeyManager, {
+					userId: r.author_user_id,
+					memberId: r.author_member_id,
+					userIconUpdatedAt: r.author_user_icon_updated_at,
+					agentIconUpdatedAt: r.author_agent_icon_updated_at,
+				}),
+				created_at: r.created_at,
+				read_at: r.read_at,
+			})),
+		),
 	);
 });
 

--- a/packages/server/test/admin-mentions.test.ts
+++ b/packages/server/test/admin-mentions.test.ts
@@ -352,6 +352,48 @@ describe('GET /teams/:teamId/inbox/mentions', () => {
 		expect(archivedRows.some((m) => m.comment_id === archivedCommentId)).toBe(true);
 		expect(archivedRows.some((m) => m.comment_id === readCommentId)).toBe(false);
 	});
+
+	it('carries the authoring agent’s signed avatar URL, and null when it has no upload', async () => {
+		const taskIdLocal = await insertTask(captainId, 'Mention avatar test');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			architectId,
+			teamId,
+			taskIdLocal,
+		);
+		const noIconComment = await mcpComment(agentToken, taskIdLocal, '@admin before any avatar.');
+
+		const before = await app.request(`/api/projects/${projectSlug}/inbox/mentions`, {
+			headers: authHeader(token),
+		});
+		const beforeRows = (await before.json()).data as Array<{
+			comment_id: string;
+			author_icon_url: string | null;
+		}>;
+		expect(beforeRows.find((m) => m.comment_id === noIconComment)?.author_icon_url).toBeNull();
+
+		// Give the authoring agent an uploaded avatar; the feed should sign a URL for it.
+		await db.query(
+			`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+			 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+			[architectId, Buffer.from([0x89, 0x50, 0x4e])],
+		);
+		const iconComment = await mcpComment(agentToken, taskIdLocal, '@admin now with an avatar.');
+
+		const after = await app.request(`/api/projects/${projectSlug}/inbox/mentions`, {
+			headers: authHeader(token),
+		});
+		const afterRows = (await after.json()).data as Array<{
+			comment_id: string;
+			author_icon_url: string | null;
+		}>;
+		const url = afterRows.find((m) => m.comment_id === iconComment)?.author_icon_url;
+		expect(url).toContain(`/api/agents/${architectId}/icon`);
+		expect(url).toContain('sig=');
+
+		await db.query('DELETE FROM agent_icons WHERE member_id = $1', [architectId]);
+	});
 });
 
 describe('GET /teams/:teamId/inbox/count', () => {

--- a/packages/server/test/approvals.test.ts
+++ b/packages/server/test/approvals.test.ts
@@ -79,6 +79,48 @@ describe('approvals CRUD', () => {
 		expect(resolved.resolved_at).not.toBeNull();
 	});
 
+	it('serializes the requester’s slug and signed avatar URL on the listing', async () => {
+		const createRes = await app.request(`/api/projects/${projectSlug}/approvals`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				type: 'strategy',
+				requested_by_member_id: agentId,
+				payload: { summary: 'Needs a call' },
+			}),
+		});
+		const approvalId = (await createRes.json()).data.id;
+
+		const listOne = await app.request(`/api/projects/${projectSlug}/approvals`, {
+			headers: authHeader(token),
+		});
+		type Row = {
+			id: string;
+			requested_by_slug: string | null;
+			requested_by_icon_url: string | null;
+		};
+		const before = ((await listOne.json()).data as Row[]).find((a) => a.id === approvalId);
+		// The slug is always there (the client needs it for the built-in CEO/Coach
+		// default); the icon URL is null until the requester uploads an avatar.
+		expect(before?.requested_by_slug).toBeTruthy();
+		expect(before?.requested_by_icon_url).toBeNull();
+
+		await db.query(
+			`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+			 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+			[agentId, Buffer.from([0x89, 0x50, 0x4e])],
+		);
+
+		const listTwo = await app.request(`/api/projects/${projectSlug}/approvals`, {
+			headers: authHeader(token),
+		});
+		const after = ((await listTwo.json()).data as Row[]).find((a) => a.id === approvalId);
+		expect(after?.requested_by_icon_url).toContain(`/api/agents/${agentId}/icon`);
+		expect(after?.requested_by_icon_url).toContain('sig=');
+
+		await db.query('DELETE FROM agent_icons WHERE member_id = $1', [agentId]);
+	});
+
 	it('lets the admin modify a pending hire proposal before approving', async () => {
 		const createRes = await app.request(`/api/projects/${projectSlug}/approvals`, {
 			method: 'POST',

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -672,6 +672,13 @@ export interface AdminMentionItem {
 	author_member_id: string | null;
 	author_display_name: string;
 	author_slug: string | null;
+	/**
+	 * Freshly-signed avatar URL for the author (their `user_icons` image when a
+	 * human, its `agent_icons` image when an agent), or null when neither has an
+	 * upload. The built-in CEO/Coach default is resolved client-side from
+	 * `author_slug`; this only carries the upload.
+	 */
+	author_icon_url: string | null;
 	created_at: string;
 	read_at: string | null;
 }

--- a/packages/web/src/components/approval-card.tsx
+++ b/packages/web/src/components/approval-card.tsx
@@ -4,8 +4,10 @@ import { Check, Loader2, Pencil, X } from 'lucide-react';
 import { useState } from 'react';
 import type { Approval } from '../hooks/use-approvals';
 import { useResolveApproval } from '../hooks/use-approvals';
+import { defaultAvatarForSlug } from '../lib/default-avatars';
 import { approvalTypeColor } from '../lib/status-meta';
 import { RepoSetupApprovalModal } from './repo-setup-approval-modal';
+import { Avatar, getInitials } from './ui/avatar';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 
@@ -190,7 +192,18 @@ function CardBody({
 				)}
 			</div>
 			{approval.requested_by_name && (
-				<p className="text-xs text-text-2 mb-1">From: {approval.requested_by_name}</p>
+				// A div, not a p: Avatar renders a div and cannot legally nest in a p.
+				<div className="text-xs text-text-2 mb-1">
+					<Avatar
+						size="sm"
+						initials={getInitials(approval.requested_by_name)}
+						imageUrl={
+							approval.requested_by_icon_url ?? defaultAvatarForSlug(approval.requested_by_slug)
+						}
+						className="mr-1.5 align-middle"
+					/>
+					<span className="align-middle">From: {approval.requested_by_name}</span>
+				</div>
 			)}
 			<div className="text-sm text-text-3 break-words">
 				<ApprovalMessage approval={approval} />

--- a/packages/web/src/components/mention-card.tsx
+++ b/packages/web/src/components/mention-card.tsx
@@ -1,7 +1,9 @@
 import type { AdminMentionItem } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useMarkMentionRead } from '../hooks/use-admin-mentions';
+import { defaultAvatarForSlug } from '../lib/default-avatars';
 import { formatDateTime, formatRelativeTime } from '../lib/format-date';
+import { Avatar, getInitials } from './ui/avatar';
 import { Badge } from './ui/badge';
 
 interface MentionCardProps {
@@ -66,8 +68,16 @@ export function MentionCard({ mention, showTeam = false }: MentionCardProps) {
 					{formatRelativeTime(mention.created_at)}
 				</time>
 			</div>
-			<p className={`text-xs mb-1 ${unread ? 'text-text-1' : 'text-text-2'}`}>
-				<span className={unread ? 'font-semibold' : 'font-medium'}>{author}</span> asked you on{' '}
+			{/* A div, not a p: Avatar renders a div and cannot legally nest in a p. */}
+			<div className={`text-xs mb-1 ${unread ? 'text-text-1' : 'text-text-2'}`}>
+				<Avatar
+					size="sm"
+					initials={getInitials(mention.author_display_name)}
+					imageUrl={mention.author_icon_url ?? defaultAvatarForSlug(mention.author_slug)}
+					className="mr-1.5 align-middle"
+				/>
+				<span className={`align-middle ${unread ? 'font-semibold' : 'font-medium'}`}>{author}</span>{' '}
+				asked you on{' '}
 				<Link
 					to={'/projects/$projectId/tasks/$taskId' as never}
 					params={
@@ -81,7 +91,7 @@ export function MentionCard({ mention, showTeam = false }: MentionCardProps) {
 				>
 					{mention.task_identifier}
 				</Link>
-			</p>
+			</div>
 			{mention.snippet && (
 				<p className="text-sm text-text-3 break-words line-clamp-3">{mention.snippet}</p>
 			)}

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -164,11 +164,20 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 								params={{ projectId: hq.slug }}
 								aria-label={hq.name}
 								data-testid="project-rail-hq"
-								className={`relative w-9 h-9 rounded-full flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-border bg-surface transition-colors ${
-									hqActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
-								}`}
+								// A full-bleed icon drops the border and surface fill (the same rule
+								// `Avatar` follows): keeping them would leave a grey ring between the
+								// image and the active ring. Without an icon, HQ keeps its glyph.
+								className={`relative w-9 h-9 rounded-full flex items-center justify-center overflow-hidden transition-colors ${
+									hq.icon_url
+										? ''
+										: 'text-text-2 hover:text-text-1 hover:bg-surface border border-border bg-surface'
+								} ${hqActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''}`}
 							>
-								<Building2 className="w-4 h-4" />
+								{hq.icon_url ? (
+									<img src={hq.icon_url} alt="" className="w-full h-full object-cover" />
+								) : (
+									<Building2 className="w-4 h-4" />
+								)}
 								<CountOverlayBadge
 									count={hqInbox?.unread ?? 0}
 									testId="project-rail-hq-inbox-badge"

--- a/packages/web/src/hooks/use-approvals.ts
+++ b/packages/web/src/hooks/use-approvals.ts
@@ -22,6 +22,12 @@ export interface Approval {
 	team_slug: string;
 	requested_by_name: string | null;
 	requested_by_member_id: string | null;
+	requested_by_slug: string | null;
+	/**
+	 * The requester's uploaded avatar, or null. The built-in CEO/Coach default is
+	 * resolved client-side from `requested_by_slug`; this only carries the upload.
+	 */
+	requested_by_icon_url: string | null;
 	payload_member_name: string | null;
 	payload_member_slug: string | null;
 	payload_project_name: string | null;

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -5,7 +5,7 @@ import { type ReactNode, useState } from 'react';
 import { CreateProjectWithTeamDialog } from '../../components/create-project-with-team-dialog';
 import { HqContainerNotice } from '../../components/hq-container-notice';
 import { ProjectIntakeHomePanel } from '../../components/project-intake-home-panel';
-import { Avatar, avatarColorFromString, getInitials } from '../../components/ui/avatar';
+import { Avatar, getInitials } from '../../components/ui/avatar';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
@@ -19,6 +19,7 @@ import {
 	useAllVisibleProjects,
 	useHqProject,
 } from '../../hooks/use-projects';
+import { defaultAvatarForSlug } from '../../lib/default-avatars';
 
 function formatMoney(cents: number): string {
 	return `$${(cents / 100).toFixed(2)}`;
@@ -119,6 +120,7 @@ const ACTION_LINK_CLASS =
 function NeedsYouRowShell({
 	tag,
 	tagColor,
+	avatar,
 	children,
 	project,
 	createdAt,
@@ -126,16 +128,24 @@ function NeedsYouRowShell({
 }: {
 	tag: string;
 	tagColor: 'accent' | 'info';
+	/**
+	 * The actor behind the row, shown just before the text (which leads with their
+	 * name). Rows with no identifiable actor pass nothing and get a same-width
+	 * spacer instead, so the list stays aligned — synthesising initials from the
+	 * "An agent" fallback label would show a misleading badge.
+	 */
+	avatar?: ReactNode;
 	children: ReactNode;
 	project: string | null;
 	createdAt: string;
 	actionLink: ReactNode;
 }) {
 	return (
-		<div className="flex items-center gap-3 px-3 py-2.5" data-testid="home-needs-you-row">
+		<div className="flex items-center gap-2 px-3 py-2.5 sm:gap-3" data-testid="home-needs-you-row">
 			<Badge color={tagColor} mono className="shrink-0">
 				{tag}
 			</Badge>
+			{avatar ?? <span aria-hidden className="w-[26px] shrink-0" />}
 			<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{children}</span>
 			<span className="shrink-0 font-mono text-[11px] text-text-3">
 				{project ? `${project} · ` : ''}
@@ -151,6 +161,17 @@ function NeedsYouAction({ approval }: { approval: Approval }) {
 		<NeedsYouRowShell
 			tag="action"
 			tagColor="accent"
+			avatar={
+				approval.requested_by_name ? (
+					<Avatar
+						size="sm"
+						initials={getInitials(approval.requested_by_name)}
+						imageUrl={
+							approval.requested_by_icon_url ?? defaultAvatarForSlug(approval.requested_by_slug)
+						}
+					/>
+				) : undefined
+			}
 			project={approval.payload_project_slug}
 			createdAt={approval.created_at}
 			actionLink={
@@ -173,6 +194,13 @@ function NeedsYouMention({ mention }: { mention: AdminMentionItem }) {
 		<NeedsYouRowShell
 			tag="mention"
 			tagColor="info"
+			avatar={
+				<Avatar
+					size="sm"
+					initials={getInitials(mention.author_display_name)}
+					imageUrl={mention.author_icon_url ?? defaultAvatarForSlug(mention.author_slug)}
+				/>
+			}
 			project={mention.project_slug}
 			createdAt={mention.created_at}
 			actionLink={
@@ -246,10 +274,7 @@ function ActiveProjectCard({
 		<Link to="/projects/$projectId" params={{ projectId: project.slug }}>
 			<Card className="cursor-pointer h-full" data-testid="home-active-card">
 				<div className="flex items-start gap-3">
-					<Avatar
-						initials={getInitials(project.name)}
-						color={avatarColorFromString(project.name)}
-					/>
+					<Avatar initials={getInitials(project.name)} imageUrl={project.icon_url} />
 					<div className="flex flex-col gap-1 min-w-0 flex-1">
 						<div className="flex items-center justify-between gap-2">
 							<h3 className="text-[15px] font-medium text-text-1 truncate">{project.name}</h3>
@@ -290,11 +315,7 @@ function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 			data-testid="home-other-row"
 		>
 			<div className="flex items-center gap-3 px-3 py-2.5 hover:bg-surface-2">
-				<Avatar
-					initials={getInitials(project.name)}
-					color={avatarColorFromString(project.name)}
-					size="sm"
-				/>
+				<Avatar initials={getInitials(project.name)} imageUrl={project.icon_url} size="sm" />
 				<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{project.name}</span>
 				<span className="shrink-0 font-mono text-[11px] text-text-3">
 					{paused ? 'paused' : 'idle'}

--- a/packages/web/test/home-needs-you.test.tsx
+++ b/packages/web/test/home-needs-you.test.tsx
@@ -123,6 +123,79 @@ test('an unread admin mention renders as a mention row linking to the comment wi
 	expect(link.getAttribute('href')).toContain('#comment-');
 });
 
+test('a mention row shows the authoring agent’s uploaded avatar before their name', async () => {
+	const ref = { agentId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mention Avatar Home' });
+			const task = await seedTask(ws, project, { title: 'Avatar Ticket' });
+			const author = ws.agents.find((a) => a.slug === 'architect') ?? ws.agents[0];
+			ref.agentId = author.id;
+			await getTestContext().db.query(
+				`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+				 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+				[author.id, Buffer.from([0x89, 0x50, 0x4e])],
+			);
+			await seedAdminMention(ws, task, '@admin please confirm the rollout window.');
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const row = await findByTestId('home-needs-you-row', undefined, { timeout: 20_000 });
+	const img = row.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/agents/${ref.agentId}/icon`);
+});
+
+test('an action row shows the requesting agent’s uploaded avatar', async () => {
+	const ref = { agentId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Action Avatar Home' });
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			ref.agentId = captain.id;
+			await getTestContext().db.query(
+				`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+				 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+				[captain.id, Buffer.from([0x89, 0x50, 0x4e])],
+			);
+			await seedApproval(ws, project, ApprovalType.PlanReview, captain.id);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const row = await findByTestId('home-needs-you-row', undefined, { timeout: 20_000 });
+	const img = row.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/agents/${ref.agentId}/icon`);
+});
+
+test('an action row with no known requester renders no avatar and keeps its text', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Anonymous Action Home' });
+			// No requested_by_member_id → the "An agent" fallback, which must not be
+			// turned into initials; the row gets the alignment spacer instead.
+			await seedApproval(ws, project, ApprovalType.DesignatedRepoRequest);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const row = await findByTestId('home-needs-you-row', undefined, { timeout: 20_000 });
+	expect(row.querySelector('img')).toBeNull();
+	expect(row.textContent).toContain('An agent');
+	expect(row.textContent).toContain('needs GitHub access to set up the repo');
+});
+
 test('more than five needs-you items collapse behind a "Show N more" link to the inbox', async () => {
 	const { findByTestId, router } = await renderApp({
 		initialPath: '/',

--- a/packages/web/test/home-project-icons.test.tsx
+++ b/packages/web/test/home-project-icons.test.tsx
@@ -1,0 +1,128 @@
+// An uploaded project icon has to follow the project everywhere its avatar is
+// drawn, not just the left rail. The reported bug: you upload an icon on the
+// project's Settings page, and the Home dashboard - the first screen after login
+// - still shows the bare initials. These specs pin the icon onto both Home
+// surfaces (the Active card and the Other-projects row) and onto the rail's
+// pinned HQ entry, which used to hardcode a building glyph. Component tier.
+
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+const PNG_STUB = Buffer.from([0x89, 0x50, 0x4e]);
+
+async function giveProjectAnIcon(projectId: string): Promise<void> {
+	await getTestContext().db.query(
+		`INSERT INTO project_icons (project_id, content_type, data, byte_size, width, height)
+		 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+		[projectId, PNG_STUB],
+	);
+}
+
+test('the Home active card renders the uploaded project icon instead of initials', async () => {
+	const ref = { id: '', name: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Iconic Project' });
+			ref.id = project.id;
+			ref.name = project.name;
+			// A running agent ranks the project into the Active section.
+			await getTestContext().db.query(
+				`UPDATE member_agents SET runtime_status = 'active'::agent_runtime_status WHERE id = $1`,
+				[ws.agents[0].id],
+			);
+			await giveProjectAnIcon(project.id);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const card = await findByTestId('home-active-card', undefined, { timeout: 20_000 });
+	const img = card.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/projects/${ref.id}/icon`);
+	// The initials fallback is replaced, not merely covered.
+	expect(card.textContent).not.toContain('IP');
+});
+
+test('a project with no icon keeps its initials on the Home active card', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Plain Project' });
+			await getTestContext().db.query(
+				`UPDATE member_agents SET runtime_status = 'active'::agent_runtime_status WHERE id = $1`,
+				[ws.agents[0].id],
+			);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const card = await findByTestId('home-active-card', undefined, { timeout: 20_000 });
+	expect(card.querySelector('img')).toBeNull();
+	expect(card.textContent).toContain('PP');
+});
+
+test('the Home Other-projects row renders the uploaded project icon', async () => {
+	const ref = { id: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Quiet Project' });
+			ref.id = project.id;
+			// No running agents and nothing pending → the project lands in "Other".
+			await giveProjectAnIcon(project.id);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const row = await findByTestId('home-other-row', undefined, { timeout: 20_000 });
+	const img = row.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/projects/${ref.id}/icon`);
+});
+
+test('the project rail shows HQ’s uploaded icon in place of the building glyph', async () => {
+	const ref = { hqId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Rail Project' });
+			const hq = await getTestContext().db.query<{ id: string }>(
+				`SELECT id FROM projects WHERE is_internal = true LIMIT 1`,
+			);
+			ref.hqId = hq.rows[0].id;
+			await giveProjectAnIcon(ref.hqId);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const hqEntry = await findByTestId('project-rail-hq', undefined, { timeout: 20_000 });
+	const img = hqEntry.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/projects/${ref.hqId}/icon`);
+});
+
+test('the project rail falls back to the building glyph when HQ has no icon', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Glyph Project' });
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const hqEntry = await findByTestId('project-rail-hq', undefined, { timeout: 20_000 });
+	expect(hqEntry.querySelector('img')).toBeNull();
+	expect(hqEntry.querySelector('svg')).not.toBeNull();
+});

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -91,6 +91,37 @@ test('inbox renders a admin mention card with author + snippet', async () => {
 	await findByText(/should we ship the new auth flow/);
 });
 
+test('a mention card shows the authoring agent’s uploaded avatar next to their name', async () => {
+	let ctx: { projectSlug: string; agentId: string };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Avatar inbox ticket' });
+			const architect = ws.agents.find((a) => a.slug === 'architect');
+			if (!architect) throw new Error('architect agent missing');
+			await getTestContext().db.query(
+				`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+				 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+				[architect.id, Buffer.from([0x89, 0x50, 0x4e])],
+			);
+			await seedAgentAdminMention(ws, task, '@admin who owns the migration?');
+			ctx = { projectSlug: project.slug, agentId: architect.id };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ctx!.projectSlug },
+	});
+
+	const card = await findByTestId('mention-card', undefined, { timeout: 10_000 });
+	const img = card.querySelector<HTMLImageElement>('img');
+	expect(img).not.toBeNull();
+	expect(img?.getAttribute('src') ?? '').toContain(`/api/agents/${ctx!.agentId}/icon`);
+});
+
 test('clicking a mention navigates to the task and marks it read', async () => {
 	let ctx: {
 		projectSlug: string;


### PR DESCRIPTION
## Summary

Two visual-identity gaps on the Home dashboard, both fixed here.

**1. Project icons now follow the project everywhere its avatar is drawn**, not just the left rail. An uploaded icon previously showed only in the rail, so the first screen after login still rendered every project as bare initials.
- Home dashboard **Active cards** and **Other-projects rows** now pass `imageUrl={project.icon_url}` (the object already carried it). Dropped the no-op `color` prop those two call sites passed - `Avatar` is monochrome and ignores it.
- The rail's pinned **HQ entry** now renders HQ's uploaded icon full-bleed, falling back to the `Building2` glyph when HQ has no icon. No server change - `GET /api/projects` already serializes a signed `icon_url`.

**2. Agent avatars now lead every "Needs you" row and inbox card.** The admin's inbox was the one place that named an agent as plain text while comments, the org chart, and budget rows all show its avatar.
- New shared `signAuthorIconUrl` in `lib/entity-icon-urls.ts` resolves a feed row's author/requester to a signed avatar URL (user icon when human, else agent icon; best-effort, so a signing failure degrades to initials rather than failing the request). Extracted from `comments.ts`'s `attachAuthorIcons`, which now calls it.
- `GET /inbox/mentions` returns `author_icon_url` (added to the shared `AdminMentionItem`); `GET /approvals` returns `requested_by_slug` + `requested_by_icon_url`.
- Home's "Needs you" shell gained an avatar slot before the row text for **both** mention and action rows; a row with no identifiable actor (the "An agent" fallback) gets a same-width spacer instead of misleading initials.
- The full inbox's `MentionCard` and `ApprovalCard` show the same avatar (their text wrappers changed `<p>` → `<div>` because `Avatar` renders a div).

Effective avatar resolves as `icon_url ?? defaultAvatarForSlug(slug)`, so an uploaded image always wins and the CEO/Coach keep their built-in portraits.

## Out of scope (deliberate)

Project-name text sites that render no avatar today (sidebar header, task-list badge, archived list, native `<select>` pickers) - the ask was "wherever a project avatar is shown," and these show none. The team roster table also stays as-is; its row shape is shared with marketplace/template rosters that carry no icon data.

While updating the docs I corrected a pre-existing false claim: the user docs said agent avatars show "on the team roster," but the roster table renders no avatars.

## Testing

`bun run test --skip-browser` green (server + web + shared). New/extended coverage, component + server tiers:
- `packages/web/test/home-project-icons.test.tsx` (new): project icon on the Active card, the Other row, and HQ in the rail; initials/glyph fallbacks when no icon.
- `home-needs-you.test.tsx`: agent avatar on a mention row and an action row; the spacer path when the requester is unknown.
- `inbox-mentions.test.tsx`: avatar on `MentionCard`.
- `admin-mentions.test.ts` / `approvals.test.ts`: payloads carry the signed URL (and `null` when no upload).
- Existing `comment-author-icon.test.ts` stays green across the `signAuthorIconUrl` extraction.

## Docs

- `docs/concepts/projects-and-teams.md` - project icon now spans rail + home dashboard + HQ; corrected the agent-avatar surface list.
- `.dev/architecture.md` - home/inbox avatar surfaces and the shared `signAuthorIconUrl` resolver.
- No MCP tool or REST-route rename, so the generated references (`mcp-api.md`, `SKILL.md`, `llms.txt`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D2PgAtsKunKL3e5d6dvqw)_