### PR TITLE
fix(oauth,egress): stop MCP token-refresh log flood and demote SSE teardown noise

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1651,7 +1651,16 @@ single **generic** refresh fn is registered at startup (`registerGenericOAuthRef
 handles any connection carrying `token_url` + `client_id` in its metadata (decrypting the
 host-only client secret when present), so refresh is now **real** for broker connections
 rather than the historically GitHub-inert no-op; a provider-specific fn still wins over the
-generic one where registered. Deleting a project (or its team) purges the project's
+generic one where registered. Every flow that mints a connection therefore has to persist
+**both** `token_url` and `client_id` on its metadata — the auth-code and MCP DCR callbacks
+included, not just the device-flow broker. Omitting `client_id` makes the generic fn throw
+before any network call, and because a failed refresh is swallowed and never advances
+`expires_at`, the connection silently keeps serving its original access token until the
+upstream 401s. A failed refresh now backs off per connection (30 s doubling to a 15 min
+ceiling, cleared on success) so a structurally broken connection can't re-attempt on every
+proxied request, and records the reason on the backing connector's `mcp_connections.auth_error`
+(cleared on the next success) so it surfaces on the Connectors page rather than only in the
+log. Deleting a project (or its team) purges the project's
 connections and their token secrets (access, refresh, and client secret) before the cascade,
 so no encrypted token orphans in the vault.
 

--- a/packages/server/migrations/045_oauth_mcp_client_id_backfill.sql
+++ b/packages/server/migrations/045_oauth_mcp_client_id_backfill.sql
@@ -1,0 +1,25 @@
+-- Backfill oauth_connections.metadata.client_id for MCP connections created by
+-- the auth-code / DCR callbacks.
+--
+-- Those callbacks persisted token_url + authorize_url but not the client id they
+-- had just used for the code exchange. The generic host-side refresh
+-- (services/oauth/generic-refresh.ts) needs token_url AND client_id, so it threw
+-- before any network call and every such connection was permanently stuck on its
+-- original access token -- silently, since the failure was swallowed and the
+-- connector kept reporting healthy.
+--
+-- The client id is recoverable: the DCR registration is cached on the connector
+-- row at mcp_connections.config.dcr.client_id. Copy it across for any linked
+-- connection still missing it.
+--
+-- Additive and data-preserving: `||` merges into the existing metadata object, so
+-- resource_url / token_url / authorize_url and any other keys are untouched, and
+-- a connection that already carries a client_id is left alone.
+
+UPDATE oauth_connections oc
+SET metadata   = oc.metadata || jsonb_build_object('client_id', mc.config -> 'dcr' ->> 'client_id'),
+    updated_at = now()
+FROM mcp_connections mc
+WHERE mc.oauth_connection_id = oc.id
+  AND oc.metadata ->> 'client_id' IS NULL
+  AND mc.config -> 'dcr' ->> 'client_id' IS NOT NULL;

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -169,6 +169,10 @@ oauthRoutes.get('/oauth/callback', async (c) => {
 				resource_url: payload.resourceUrl,
 				token_url: payload.manualConfig.token_url,
 				authorize_url: payload.manualConfig.authorize_url,
+				// The generic host-side refresh reads token_url + client_id straight off
+				// this metadata, so the client id the exchange just used has to be kept.
+				// Omitting it leaves the connection permanently unrefreshable.
+				client_id: payload.manualConfig.client_id,
 			},
 		},
 	);
@@ -644,6 +648,9 @@ oauthRoutes.get('/oauth/mcp-callback', async (c) => {
 				resource_url: payload.resourceUrl,
 				token_url: payload.manualConfig.token_url,
 				authorize_url: payload.manualConfig.authorize_url,
+				// Same as the plain auth-code callback: without client_id the generic
+				// refresh throws before any network call and the token goes stale.
+				client_id: payload.manualConfig.client_id,
 			},
 		});
 	} catch (e) {

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -954,9 +954,22 @@ class RunProxyInstance {
 	/** A connection to the real upstream failed (refused, DNS, timeout, TLS).
 	 * Logs the target and the error's system-level fields so the cause is
 	 * diagnosable — `code` distinguishes ECONNREFUSED (upstream refused) from
-	 * ENOTFOUND (DNS) from ETIMEDOUT — then returns a 502 to the agent. */
+	 * ENOTFOUND (DNS) from ETIMEDOUT — then returns a 502 to the agent.
+	 *
+	 * One shape reaching here is not a failure: `this.closed`, i.e. our own
+	 * `close()` aborting in-flight upstreams at run end (proxy.ts `close`). A
+	 * long-lived Streamable-HTTP SSE channel is always in flight at that point, so
+	 * every run touching a hosted MCP would otherwise report a failure per stream
+	 * on the way out. That case logs at debug; everything else still warns.
+	 *
+	 * `headers_sent` rides on the metadata rather than gating the level: it
+	 * separates "the upstream never answered" (a genuine connect/DNS/TLS failure)
+	 * from "the response had started and the stream died mid-flight", and the two
+	 * are worth telling apart in a report without silencing either. */
 	private onForwardError(res: ServerResponse, err: Error, target?: UpstreamTarget): void {
-		log.warn('egress upstream request failed', this.failureMeta(err, target));
+		const meta = { ...this.failureMeta(err, target), headers_sent: res.headersSent };
+		if (this.closed) log.debug('egress upstream aborted by run teardown', meta);
+		else log.warn('egress upstream request failed', meta);
 		this.finishError(res, err);
 	}
 

--- a/packages/server/src/services/oauth/token-resolver.ts
+++ b/packages/server/src/services/oauth/token-resolver.ts
@@ -10,6 +10,37 @@ const log = logger.child('oauth-token-resolver');
 
 const REFRESH_WINDOW_MS = 60_000;
 
+/**
+ * Backoff for a connection whose refresh keeps failing. The sweep runs from the
+ * egress substitution path on *every* proxied request carrying a placeholder —
+ * i.e. every MCP call — and a failed refresh never advances `expires_at`, so a
+ * permanently broken connection would otherwise be retried hundreds of times a
+ * minute, flooding the log and hammering the provider's token endpoint. Doubling
+ * from 30s to a 15min ceiling keeps a transient failure recovering quickly while
+ * a structurally broken one settles to four attempts an hour.
+ */
+const REFRESH_BACKOFF_BASE_MS = 30_000;
+const REFRESH_BACKOFF_MAX_MS = 15 * 60_000;
+
+interface RefreshFailure {
+	attempts: number;
+	nextAttemptAt: number;
+}
+
+const failures = new Map<string, RefreshFailure>();
+
+function backoffDelay(attempts: number): number {
+	return Math.min(REFRESH_BACKOFF_BASE_MS * 2 ** (attempts - 1), REFRESH_BACKOFF_MAX_MS);
+}
+
+/** Record a failed attempt and return the resulting backoff state. */
+function recordFailure(connectionId: string, now: number): RefreshFailure {
+	const attempts = (failures.get(connectionId)?.attempts ?? 0) + 1;
+	const next = { attempts, nextAttemptAt: now + backoffDelay(attempts) };
+	failures.set(connectionId, next);
+	return next;
+}
+
 export interface RefreshResult {
 	accessToken: string;
 	refreshToken?: string | null;
@@ -48,6 +79,7 @@ export function registerGenericRefreshFn(fn: GenericRefreshFn): void {
 export function clearRefreshFns(): void {
 	refreshFns.clear();
 	genericRefreshFn = null;
+	failures.clear();
 }
 
 /**
@@ -86,6 +118,10 @@ export async function refreshExpiringTokens(deps: ConnectionStoreDeps): Promise<
 	await Promise.all(
 		candidates.rows
 			.filter((r) => r.has_refresh && (refreshFns.has(r.provider) || genericRefreshFn != null))
+			// A connection whose last refresh failed stays out of the sweep until its
+			// backoff elapses — silently, since logging every suppressed retry would
+			// reproduce the flood this exists to stop.
+			.filter((r) => (failures.get(r.id)?.nextAttemptAt ?? 0) <= now)
 			.map((r) => refreshConnection(deps, r.id)),
 	);
 }
@@ -141,14 +177,59 @@ async function doRefresh(deps: ConnectionStoreDeps, connectionId: string): Promi
 			refreshToken: result.refreshToken ?? null,
 			expiresAt: result.expiresAt ?? null,
 		});
+		failures.delete(conn.id);
+		// Best-effort, and outside the refresh's own success/failure accounting: a
+		// bookkeeping error here must not be reported as a failed refresh.
+		await clearConnectorAuthError(deps, conn.id).catch((err) =>
+			log.debug('could not clear connector auth error', { error: (err as Error).message }),
+		);
 		log.info('oauth token refreshed', { id: conn.id, provider: conn.provider });
 	} catch (e) {
+		const message = (e as Error).message;
+		const state = recordFailure(conn.id, Date.now());
 		log.warn('oauth token refresh failed', {
 			id: conn.id,
 			provider: conn.provider,
-			error: (e as Error).message,
+			error: message,
+			attempts: state.attempts,
+			retry_in_s: Math.round((state.nextAttemptAt - Date.now()) / 1000),
 		});
+		// Record it on the connector too, so a stale token is visible on the
+		// Connectors page instead of only in the log. Best-effort: a failure here
+		// must not mask the refresh failure we are already reporting.
+		await recordConnectorAuthError(deps, conn.id, `token refresh: ${message}`).catch((err) =>
+			log.debug('could not record connector auth error', { error: (err as Error).message }),
+		);
 	}
+}
+
+/**
+ * Mirror a refresh failure onto the MCP connector backed by this connection.
+ * Keyed on `oauth_connection_id`, so a connection with no connector (a repo or
+ * broker-only connection) is a harmless no-op and no cross-service import is
+ * needed.
+ */
+async function recordConnectorAuthError(
+	deps: ConnectionStoreDeps,
+	connectionId: string,
+	reason: string,
+): Promise<void> {
+	await deps.db.query(
+		`UPDATE mcp_connections SET auth_error = $1, updated_at = now()
+		 WHERE oauth_connection_id = $2 AND auth_error IS DISTINCT FROM $1`,
+		[reason, connectionId],
+	);
+}
+
+async function clearConnectorAuthError(
+	deps: ConnectionStoreDeps,
+	connectionId: string,
+): Promise<void> {
+	await deps.db.query(
+		`UPDATE mcp_connections SET auth_error = NULL, updated_at = now()
+		 WHERE oauth_connection_id = $1 AND auth_error IS NOT NULL`,
+		[connectionId],
+	);
 }
 
 export async function loadSecretValue(

--- a/packages/server/test/bun/egress-streaming.bun.test.ts
+++ b/packages/server/test/bun/egress-streaming.bun.test.ts
@@ -333,4 +333,67 @@ describe('EgressProxy streaming + teardown under Bun', () => {
 			await new Promise<void>((r) => upstream.close(() => r()));
 		}
 	}, 40_000);
+
+	// The warn path is the one an operator acts on, so it has to keep firing for a
+	// real connectivity failure (refused / DNS / TLS) even as teardown-induced
+	// aborts are demoted to debug. Lives in the Bun tier because the upstream leg
+	// is Bun's HTTP client: under Node the same scenario reports a different error
+	// shape, so a vitest assertion here would not reflect production.
+	const FAILURE_LINE = 'egress upstream request failed';
+
+	/** The logger routes every level through console.log with the level in the text. */
+	async function captureLogs(fn: () => Promise<void>): Promise<string[]> {
+		const lines: string[] = [];
+		const original = console.log;
+		console.log = (...args: unknown[]) => {
+			lines.push(args.map(String).join(' '));
+		};
+		try {
+			await fn();
+		} finally {
+			console.log = original;
+		}
+		return lines;
+	}
+
+	test('still warns when the upstream never answers at all', async () => {
+		// Bind then release a port so the proxy's upstream connect is refused. CONNECT
+		// still succeeds (it only bridges into the per-host MITM server), so the
+		// failure lands on the forwarded request with no response headers sent.
+		const dead = createHttpsServer({});
+		await new Promise<void>((r) => dead.listen(0, '127.0.0.1', () => r()));
+		const deadPort = (dead.address() as { port: number }).port;
+		await new Promise<void>((r) => dead.close(() => r()));
+
+		await insertSecret('DEAD_UPSTREAM', 'tok', ['localhost']);
+		const runId = `dead-upstream-${process.pid}`;
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+
+		try {
+			let response = '';
+			const lines = await captureLogs(async () => {
+				const tls = await tunnelTo(allocated.proxyPort, 'localhost', deadPort);
+				const done = new Promise<void>((resolve) => {
+					tls.on('data', (c: Buffer) => {
+						response += c.toString();
+						if (response.includes('\r\n\r\n')) resolve();
+					});
+					tls.on('close', () => resolve());
+					tls.on('error', () => resolve());
+				});
+				tls.write(
+					`GET /mcp HTTP/1.1\r\nHost: localhost:${deadPort}\r\n` +
+						`Authorization: Bearer __HEZO_SECRET_DEAD_UPSTREAM__\r\n\r\n`,
+				);
+				await done;
+				tls.destroy();
+			});
+			expect(response).toContain('502');
+			const warned = lines.filter((l) => l.includes(FAILURE_LINE));
+			expect(warned.length).toBe(1);
+			expect(warned[0]).toContain('[warn]');
+		} finally {
+			await proxy.releaseRunProxy(runId);
+		}
+	}, 40_000);
 });

--- a/packages/server/test/instance-connectors.test.ts
+++ b/packages/server/test/instance-connectors.test.ts
@@ -269,6 +269,16 @@ describe('instance connector OAuth (admin auth-start)', () => {
 		);
 		expect(secretRow.rows[0].name).toMatch(/^OAUTH_MCP_/);
 
+		// The DCR client id has to land on the connection metadata, not just in
+		// mcp_connections.config.dcr — the generic host-side refresh reads it from
+		// there and cannot refresh the token without it.
+		const meta = await db.query<{ metadata: Record<string, unknown> }>(
+			`SELECT metadata FROM oauth_connections WHERE id = $1`,
+			[after!.oauth_connection_id],
+		);
+		expect(meta.rows[0].metadata.client_id).toBe(fake.lastClientId());
+		expect(meta.rows[0].metadata.token_url).toBeTruthy();
+
 		// Authorized → injected into runs again.
 		const forRun = await loadConnectorsForRun(db);
 		expect(forRun.find((r) => r.name === 'higgsfield')?.oauth_connection_id).toBeTruthy();

--- a/packages/server/test/migrate-045-oauth-mcp-client-id-backfill.test.ts
+++ b/packages/server/test/migrate-045-oauth-mcp-client-id-backfill.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '045_oauth_mcp_client_id_backfill.sql';
+
+interface MetadataRow {
+	metadata: Record<string, unknown>;
+}
+
+/**
+ * The auth-code / DCR callbacks persisted token_url but not client_id, leaving the
+ * generic host-side refresh unable to run. The migration recovers the client id
+ * from the connector's cached DCR registration. Three shapes have to be right:
+ * the broken row is repaired, an already-correct row is not rewritten, and a row
+ * with no DCR registration to recover from is left alone rather than getting a
+ * null client_id (which would still fail the refresh, but noisily and wrongly).
+ */
+describe('045_oauth_mcp_client_id_backfill migration', () => {
+	let h: DataPreservationHarness;
+	let brokenId: string;
+	let alreadySetId: string;
+	let noDcrId: string;
+
+	async function seedConnection(
+		provider: string,
+		metadata: Record<string, unknown>,
+	): Promise<string> {
+		const secret = await h.db.query<{ id: string }>(
+			`INSERT INTO secrets (name, encrypted_value) VALUES ($1, 'enc') RETURNING id`,
+			[`OAUTH_${provider.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`],
+		);
+		const conn = await h.db.query<{ id: string }>(
+			`INSERT INTO oauth_connections
+			   (provider, provider_account_id, provider_account_label, access_token_secret_id, metadata)
+			 VALUES ($1, $2, $3, $4, $5::jsonb)
+			 RETURNING id`,
+			[provider, `${provider}:acct`, provider, secret.rows[0].id, JSON.stringify(metadata)],
+		);
+		return conn.rows[0].id;
+	}
+
+	async function seedConnector(
+		name: string,
+		config: Record<string, unknown>,
+		oauthConnectionId: string,
+	): Promise<void> {
+		await h.db.query(
+			`INSERT INTO mcp_connections (name, kind, config, oauth_connection_id)
+			 VALUES ($1, 'saas', $2::jsonb, $3)`,
+			[name, JSON.stringify(config), oauthConnectionId],
+		);
+	}
+
+	async function metadataOf(id: string): Promise<Record<string, unknown>> {
+		const r = await h.db.query<MetadataRow>(
+			`SELECT metadata FROM oauth_connections WHERE id = $1`,
+			[id],
+		);
+		return r.rows[0].metadata;
+	}
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// The bug: token_url present, client_id missing, DCR registration cached.
+		brokenId = await seedConnection('mcp:broken', {
+			resource_url: 'https://mcp.example.com/mcp',
+			token_url: 'https://auth.example.com/token',
+			authorize_url: 'https://auth.example.com/authorize',
+		});
+		await seedConnector(
+			'broken-connector',
+			{ url: 'https://mcp.example.com/mcp', dcr: { client_id: 'dcr-client-recovered' } },
+			brokenId,
+		);
+
+		// Control: a device-flow style connection that already recorded its client id.
+		alreadySetId = await seedConnection('mcp:already-set', {
+			token_url: 'https://auth.example.com/token',
+			client_id: 'original-client-id',
+		});
+		await seedConnector(
+			'already-set-connector',
+			{ url: 'https://other.example.com/mcp', dcr: { client_id: 'dcr-should-not-win' } },
+			alreadySetId,
+		);
+
+		// Control: nothing to recover from.
+		noDcrId = await seedConnection('mcp:no-dcr', {
+			token_url: 'https://auth.example.com/token',
+		});
+		await seedConnector('no-dcr-connector', { url: 'https://third.example.com/mcp' }, noDcrId);
+
+		await h.applyTarget(TARGET);
+	});
+
+	afterAll(() => h.close());
+
+	it('backfills client_id from the connector DCR registration', async () => {
+		expect((await metadataOf(brokenId)).client_id).toBe('dcr-client-recovered');
+	});
+
+	it('preserves the other metadata keys on the repaired row', async () => {
+		const metadata = await metadataOf(brokenId);
+		expect(metadata.resource_url).toBe('https://mcp.example.com/mcp');
+		expect(metadata.token_url).toBe('https://auth.example.com/token');
+		expect(metadata.authorize_url).toBe('https://auth.example.com/authorize');
+	});
+
+	it('leaves an existing client_id untouched', async () => {
+		expect((await metadataOf(alreadySetId)).client_id).toBe('original-client-id');
+	});
+
+	it('does not write a null client_id when there is no DCR registration', async () => {
+		const metadata = await metadataOf(noDcrId);
+		expect('client_id' in metadata).toBe(false);
+		expect(metadata.token_url).toBe('https://auth.example.com/token');
+	});
+
+	it('preserves every pre-existing row and its connector link', async () => {
+		const rows = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM oauth_connections WHERE id = ANY($1::uuid[])`,
+			[[brokenId, alreadySetId, noDcrId]],
+		);
+		expect(rows.rows[0].c).toBe(3);
+		const links = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM mcp_connections WHERE oauth_connection_id IS NOT NULL`,
+		);
+		expect(links.rows[0].c).toBe(3);
+	});
+});

--- a/packages/server/test/oauth-routes-authcode-branches.test.ts
+++ b/packages/server/test/oauth-routes-authcode-branches.test.ts
@@ -305,6 +305,28 @@ describe('auth-code/start → authorize → /oauth/callback success', () => {
 		expect(conn.rows.length).toBe(1);
 		expect(conn.rows[0].expires_at).toBeTruthy();
 	});
+
+	it('persists the refresh material (token_url + client_id) on the connection metadata', async () => {
+		// The generic host-side refresh reads both off metadata and throws before any
+		// network call if either is missing, which would leave the connection stuck on
+		// its first access token forever — silently, since the failure is swallowed.
+		const startRes = await startAuthCode({
+			provider: 'refreshable',
+			manual_config: manualConfig(),
+			server_url: `${sim.baseUrl}/resource`,
+		});
+		const authUrl = ((await startRes.json()) as { data: { auth_url: string } }).data.auth_url;
+		const redirect = await fetch(authUrl, { redirect: 'manual' });
+		const loc = new URL(redirect.headers.get('location')!);
+		const cb = await app.request(`${loc.pathname}?${loc.searchParams.toString()}`);
+		expect(cb.status).toBe(200);
+
+		const conn = await db.query<{ metadata: Record<string, unknown> }>(
+			`SELECT metadata FROM oauth_connections WHERE provider = 'refreshable'`,
+		);
+		expect(conn.rows[0].metadata.client_id).toBe('client-1');
+		expect(conn.rows[0].metadata.token_url).toBe(`${sim.baseUrl}/token`);
+	});
 });
 
 describe('POST /projects/:projectId/oauth/auth-code/start validation', () => {

--- a/packages/server/test/oauth-token-resolver.test.ts
+++ b/packages/server/test/oauth-token-resolver.test.ts
@@ -252,3 +252,128 @@ describe('refreshExpiringTokens', () => {
 		expect(decrypt(accessRow.rows[0].encrypted_value, key)).toBe('via-provider');
 	});
 });
+
+describe('failed-refresh backoff', () => {
+	it('attempts a failing connection once, then skips it on the next sweep', async () => {
+		const conn = await makeConnection({
+			provider: 'backoff-1',
+			providerAccountId: 'b1',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let attempts = 0;
+		registerRefreshFn('backoff-1', async () => {
+			attempts += 1;
+			throw new Error('token endpoint exploded');
+		});
+
+		// The sweep runs on every proxied request; without a backoff each of these
+		// would re-attempt (and re-log) because a failure never advances expires_at.
+		await refreshExpiringTokens({ db, masterKeyManager });
+		await refreshExpiringTokens({ db, masterKeyManager });
+		await refreshExpiringTokens({ db, masterKeyManager });
+
+		expect(attempts).toBe(1);
+		// Still a candidate — the row is untouched, it is the backoff holding it back.
+		const after = await getConnection({ db, masterKeyManager }, conn.id);
+		expect(after?.expiresAt?.getTime()).toBeLessThan(Date.now());
+	});
+
+	it('does not hold back a different connection', async () => {
+		await makeConnection({
+			provider: 'backoff-2',
+			providerAccountId: 'b2',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		await makeConnection({
+			provider: 'backoff-3',
+			providerAccountId: 'b3',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let healthy = 0;
+		registerRefreshFn('backoff-2', async () => {
+			throw new Error('nope');
+		});
+		registerRefreshFn('backoff-3', async () => {
+			healthy += 1;
+			return { accessToken: 'fresh', expiresAt: new Date(Date.now() + 3_600_000) };
+		});
+
+		await refreshExpiringTokens({ db, masterKeyManager });
+		await refreshExpiringTokens({ db, masterKeyManager });
+
+		// The healthy one leaves the candidate set by being refreshed, not by backoff.
+		expect(healthy).toBe(1);
+	});
+
+	it('clears the backoff once a refresh succeeds', async () => {
+		await makeConnection({
+			provider: 'backoff-4',
+			providerAccountId: 'b4',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let calls = 0;
+		registerRefreshFn('backoff-4', async () => {
+			calls += 1;
+			if (calls === 1) throw new Error('transient');
+			return { accessToken: 'fresh', expiresAt: new Date(Date.now() + 3_600_000) };
+		});
+
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+		// Suppressed while backed off…
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+		// …and clearRefreshFns resets the backoff state between tests, so a fresh
+		// registration is attempted again rather than inheriting the old timer.
+		clearRefreshFns();
+		registerRefreshFn('backoff-4', async () => {
+			calls += 1;
+			return { accessToken: 'fresh', expiresAt: new Date(Date.now() + 3_600_000) };
+		});
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(2);
+	});
+
+	it('records the failure on the backing connector and clears it on success', async () => {
+		const conn = await makeConnection({
+			provider: 'backoff-5',
+			providerAccountId: 'b5',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, oauth_connection_id)
+			 VALUES ('backoff-connector', 'saas', '{}'::jsonb, $1)`,
+			[conn.id],
+		);
+
+		registerRefreshFn('backoff-5', async () => {
+			throw new Error('generic refresh needs token_url + client_id in connection metadata');
+		});
+		await refreshExpiringTokens({ db, masterKeyManager });
+
+		const failed = await db.query<{ auth_error: string | null }>(
+			`SELECT auth_error FROM mcp_connections WHERE oauth_connection_id = $1`,
+			[conn.id],
+		);
+		expect(failed.rows[0].auth_error).toContain('token refresh');
+		expect(failed.rows[0].auth_error).toContain('token_url + client_id');
+
+		clearRefreshFns();
+		registerRefreshFn('backoff-5', async () => ({
+			accessToken: 'fresh',
+			expiresAt: new Date(Date.now() + 3_600_000),
+		}));
+		await refreshExpiringTokens({ db, masterKeyManager });
+
+		const recovered = await db.query<{ auth_error: string | null }>(
+			`SELECT auth_error FROM mcp_connections WHERE oauth_connection_id = $1`,
+			[conn.id],
+		);
+		expect(recovered.rows[0].auth_error).toBe(null);
+	});
+});

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -672,7 +672,10 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 							Skill file imported
 						</p>
 					)}
-					{connector.auth_error && status !== 'active' && (
+					{/* Shown for an active connector too: a token whose refresh keeps
+					    failing leaves the row activated but unusable, and the error is
+					    the only signal the operator gets. Cleared on reconnect. */}
+					{connector.auth_error && (
 						<p className="text-xs text-danger-soft-fg mt-2">{connector.auth_error}</p>
 					)}
 					{error && <p className="text-xs text-danger-soft-fg mt-2">{error}</p>}

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -404,9 +404,9 @@ function InstanceConnectorRow({
 			{connector.kind === 'saas' && status === 'active' && (
 				<AdminMethodAccess connector={connector} />
 			)}
-			{connector.auth_error && status === 'failed' && (
-				<p className="text-xs text-danger mt-1">{connector.auth_error}</p>
-			)}
+			{/* Not gated on status === 'failed': a stale-token refresh failure is
+			    recorded on a row that stays 'active', and would otherwise be invisible. */}
+			{connector.auth_error && <p className="text-xs text-danger mt-1">{connector.auth_error}</p>}
 			{rowError && <p className="text-xs text-danger mt-1">{rowError}</p>}
 			{rowInfo && <p className="text-xs text-text-3 mt-1">{rowInfo}</p>}
 			<ConfirmDialog

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -624,6 +624,35 @@ test('an active non-GitHub connector renders Disconnect and revokes', async () =
 	await findByTestId('connector-connect');
 });
 
+test('an active connector still surfaces a recorded auth error', async () => {
+	// A token whose refresh keeps failing (the resolver records it on the connector)
+	// leaves the row activated but unusable. The error used to be gated on a
+	// non-active status, so exactly the case worth seeing was the one hidden.
+	let slug = '';
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			const connector = await seedSaasConnector(ws, {
+				name: 'linear',
+				url: 'https://mcp.linear.example/mcp',
+			});
+			const oauth = await seedGithubOAuth(['repo']);
+			await markConnectorActive(connector.id, oauth.id);
+			const { db } = getTestContext();
+			await db.query(`UPDATE mcp_connections SET auth_error = $2 WHERE id = $1`, [
+				connector.id,
+				'token refresh: generic refresh needs token_url + client_id in connection metadata',
+			]);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('linear');
+	await findByText(/token refresh: generic refresh needs token_url/);
+});
+
 test('a pending connector offers Remove, which deletes it from the project', async () => {
 	let slug = '';
 	const { findByText, getByTestId, router } = await renderApp({


### PR DESCRIPTION
## What prompted this

Two unrelated warning families were flooding the prod console. Both traced to source:

```
[warn] <oauth-token-resolver> oauth token refresh failed {... "error":"generic refresh needs token_url + client_id in connection metadata"}
[warn] <egress-proxy> egress upstream request failed {... "host":"mcp.higgsfield.ai","path":"/mcp","code":"ECONNRESET"}
```

## 1. The token-refresh flood is a real, silent breakage

The generic host-side refresh (`services/oauth/generic-refresh.ts`) needs both `token_url` **and** `client_id` in `oauth_connections.metadata`, and throws before any network I/O if either is missing. The MCP auth-code and DCR callbacks (`routes/oauth.ts`) persisted `token_url` + `authorize_url` but **omitted `client_id`** - even though it was in scope and already stored at `mcp_connections.config.dcr.client_id`. The device-flow broker path did it correctly.

Because `doRefresh` swallows the throw and never advances `expires_at`, the sweep - which runs from the egress substitution path on *every* proxied request carrying a placeholder (i.e. every MCP call) - retried the same broken connections hundreds of times a minute, permanently serving a stale token that 401s upstream while the connector still showed healthy.

**Fix:**
- Persist `client_id` on both callbacks' connection metadata.
- Migration `045` backfills existing rows from `mcp_connections.config.dcr.client_id` (additive jsonb merge; ships a data-preservation test).
- Per-connection backoff on a failing refresh (30s doubling to a 15min ceiling, cleared on success) so a broken connection can't re-attempt on every request.
- Record the reason on `mcp_connections.auth_error` and surface it on the Connectors page even for an active row, so a stale-token connection is visible instead of only in the log.

  > Note: a connector whose DCR registration was never cached cannot be backfilled and still needs a manual reconnect - which the `auth_error` surfacing now makes visible.

## 2. The ECONNRESET lines are teardown noise

A run's own `close()` aborts in-flight upstreams at run end, and a long-lived Streamable-HTTP SSE channel (`GET /mcp`, `GET /`) is always in flight then, so every run touching a hosted MCP logged a `warn` per stream on the way out (two hosts ~175ms apart in one run is the destroy-loop signature).

**Fix:** demote the `this.closed` (teardown) case to `debug`; keep a real `warn` for genuine connect failures (refused / DNS / TLS), and tag `headers_sent` on the metadata so a mid-stream drop stays distinguishable in a report. Guarded by a Bun-tier test, since the upstream leg is Bun's HTTP client and Node reports a different error shape (a vitest assertion there would pass with or without the fix).

## Testing

- `bun run test --package server --pattern oauth` - 23 files, 217 tests (token-resolver backoff + connector `auth_error`, both callbacks persist `client_id`, DCR flow metadata).
- `bun run test --package server --pattern egress` - 75 tests.
- `bun run test --package server --pattern migrate-045` - data-preservation test.
- `bun test test/bun/egress-streaming.bun.test.ts` - teardown vs genuine-failure log levels (verified it fails when the `warn` branch is removed).
- `bun run test --package web --pattern connectors-page` - active connector still surfaces a recorded `auth_error`.
- `typecheck` + `check` clean.

## Docs

`.dev/architecture.md` token-refresh section updated (client_id-required rule, per-connection backoff, `auth_error` surfacing). No user-facing `docs/` change beyond a connector correctly showing an error state; `docs/reference/mcp-api.md` regenerated identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbpdPmuy2wUPaifGu3gdoP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbpdPmuy2wUPaifGu3gdoP)_