### PR TITLE
Update product headline to "Built to deliver."

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <strong>Your own team of AI agents. Built to ship.</strong>
+  <strong>Your own team of AI agents. Built to get things done.</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <strong>Your own team of AI agents. Built to get things done.</strong>
+  <strong>Your own team of AI agents. Built to deliver.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "Your own team of AI agents. Built to get things done.",
+	"description": "Your own team of AI agents. Built to deliver.",
 	"private": true,
 	"license": "GPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "Your own team of AI agents. Built to ship.",
+	"description": "Your own team of AI agents. Built to get things done.",
 	"private": true,
 	"license": "GPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,19 +11,19 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
 		/>
-		<title>Hezo - Your own team of AI agents. Built to get things done.</title>
+		<title>Hezo - Your own team of AI agents. Built to deliver.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo - Your own team of AI agents. Built to get things done." />
+		<meta property="og:title" content="Hezo - Your own team of AI agents. Built to deliver." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo - Your own team of AI agents. Built to get things done." />
+		<meta name="twitter:title" content="Hezo - Your own team of AI agents. Built to deliver." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -11,19 +11,19 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
 		/>
-		<title>Hezo - Your own team of AI agents. Built to ship.</title>
+		<title>Hezo - Your own team of AI agents. Built to get things done.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo - Your own team of AI agents. Built to ship." />
+		<meta property="og:title" content="Hezo - Your own team of AI agents. Built to get things done." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo - Your own team of AI agents. Built to ship." />
+		<meta name="twitter:title" content="Hezo - Your own team of AI agents. Built to get things done." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
## What

Updates the product headline to **"Your own team of AI agents. Built to deliver."**, matching the corresponding change on the hezo.ai website homepage ([website#93](https://github.com/hezo-ai/website/pull/93)).

The lead is unchanged; the closing clause changes from "Built to ship." to **"Built to deliver."**

## Changes

- `package.json` - the `description` field.
- `README.md` - the hero `<strong>` headline.
- `packages/web/index.html` - the `<title>`, `og:title`, and `twitter:title`.

The historical `CHANGELOG.md` entries that mention the old wording are left untouched (they record past PRs).

## Notes

Copy-only change - no behaviour, API, route, or schema change. The old wording lived only in the four surfaces above; no `docs/` page or `.dev/` architecture reference was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zeYcUuCVHmNGnurmZrQUa