### PR TITLE
feat(marketplace): export a live team as a downloadable bundle

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -845,6 +845,20 @@ override. `marketplace/index.json` is the catalog listing.
   `update_agent_system_prompt` where roles carry local customizations) instead of adding
   duplicates. Because instances always fetch the live catalog, a new team `version` reaches them
   automatically.
+- **Export a live team as a bundle.** `GET /api/projects/:projectId/team-bundle`
+  (`services/team-bundle-export.ts`, `exportTeamBundle`) serializes a project's current team
+  into a self-contained `MarketplaceTeamDef` — the inverse of `applyMarketplaceTeamToTeam`. It
+  reads the team's `member_agents` + their `agent_system_prompt` documents, emits the Captain as
+  the top-level `captain` override and the rest as `roster` (reserved slugs / cross-team instance
+  agents excluded; each `reports_to` mapped back to the Captain, a roster slug, or null), derives
+  discovery `keywords` from the team's text (`generateTeamKeywords` in `@hezo/shared` — readable
+  words, not stems, since only the built-in teams carry a hand-authored list), and stamps
+  `version: 1` + a fresh `content_hash` (via `computeContentHash`, reused from the build). It
+  ships **only** roster + prompts — never skills, MCP servers, secrets, or project config. The
+  Team page's **Export team** button (beside Hire agent) fetches it and downloads the JSON
+  client-side; a user submits that file to the Hezo authors on GitHub, whose `build:marketplace`
+  re-derives the hash/version/validation when it lands in the repo. Read-only, project-access
+  gated. (Parallels a future `get_team_bundle` MCP tool if one is added.)
 - **Shipped teams.** Three: **App Team** (`software-development`, the full app-building roster),
   **Social Media Marketing** (`influencer` — brand-strategist, trend-researcher, content-writer,
   media-producer, content-editor, distribution-manager), and **Investment Portfolio**

--- a/docs/concepts/marketplace.md
+++ b/docs/concepts/marketplace.md
@@ -54,6 +54,22 @@ the live marketplace, improvements to the default teams become available automat
 don't need to upgrade Hezo to get them. New projects launched from a team always use its latest
 version, and you can bring an existing team up to date by adding it to the project again.
 
+## Exporting your team
+
+Once you've shaped a team - refined its roster, adjusted reporting lines, tuned each role's
+prompt and settings - you can package that whole state as a **team bundle** and share it. On the
+Team page, the **Export team** button (next to **Hire agent**) opens a short dialog that explains
+what's about to happen, then downloads a single JSON file describing your team.
+
+The bundle captures the team name, description, and summary; every role, from the Captain to each
+teammate, with its reporting line; and each role's system prompt, effort, budgets, and settings.
+It's the same self-contained format the marketplace ships. It does **not** include skills,
+connections, secrets, or project data - those are configured per project, not carried by a team.
+
+To have your team added to the marketplace, send the downloaded file to the Hezo authors on
+GitHub. They review it, generate a changelog, and publish it so anyone can launch a project from
+your team.
+
 ## Where teams come from
 
 The marketplace teams are maintained in the Hezo repository and served from there. A running

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -43,6 +43,7 @@ import { enqueueAddMarketplaceTeamTask } from '../services/marketplace-add-team'
 import { createProjectWithTeam } from '../services/project-create';
 import { createProjectIntake, getOpenProjectIntakeForHome } from '../services/project-intake';
 import { getProjectProgress } from '../services/projects';
+import { exportTeamBundle, TeamBundleExportError } from '../services/team-bundle-export';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -322,6 +323,25 @@ projectsRoutes.post('/projects/:projectId/marketplace-team', async (c) => {
 		return err(c, 'CONFLICT', 'This project cannot receive a team (no CEO or project found)', 409);
 	}
 	return ok(c, result, 201);
+});
+
+// Export the project's team as a self-contained marketplace team bundle
+// (MarketplaceTeamDef JSON). Read-only — any member with project access may
+// download it; the client prompts a file download and the user can send the
+// bundle to the Hezo authors for inclusion in the marketplace. Parallels a
+// future `get_team_bundle` MCP tool should one be added.
+projectsRoutes.get('/projects/:projectId/team-bundle', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	try {
+		const bundle = await exportTeamBundle(db, teamId);
+		return ok(c, bundle);
+	} catch (e) {
+		if (e instanceof TeamBundleExportError) {
+			return err(c, 'CONFLICT', e.message, 409);
+		}
+		throw e;
+	}
 });
 
 // CEO-assisted project creation: open a conversation in HQ where the CEO scopes

--- a/packages/server/src/services/team-bundle-export.ts
+++ b/packages/server/src/services/team-bundle-export.ts
@@ -1,0 +1,183 @@
+/**
+ * Export a **live team's current state** as a self-contained marketplace team
+ * bundle (`MarketplaceTeamDef`) — the inverse of `applyMarketplaceTeamToTeam`.
+ * A user who has evolved a team's roster and prompts can download the bundle and
+ * send it to the Hezo authors on GitHub to have it published to the marketplace.
+ *
+ * The bundle captures exactly what a marketplace team ships: the team metadata,
+ * the Captain override (its partial-resolved system prompt + team context), and
+ * the rest of the roster (each role's prompt, budgets, effort, and reporting
+ * line). It deliberately ships **only** roster + prompts — never skills, MCP
+ * servers, secrets, or project config, which are configured per project and are
+ * not part of a team template (see `.dev/architecture.md` § Team marketplace).
+ *
+ * Discovery `keywords` are generated from the team's own text (only Hezo's
+ * built-in teams carry a hand-authored list); `version` starts at 1. The Hezo
+ * authors' `build:marketplace` re-derives the content hash, version, and
+ * validation when the bundle lands in the repo — so this export is a starting
+ * point for a published team, not a signed artifact.
+ */
+
+import type { AgentEffort } from '@hezo/shared';
+import {
+	CAPTAIN_AGENT_SLUG,
+	generateTeamKeywords,
+	MARKETPLACE_SCHEMA_VERSION,
+	type MarketplaceCaptainOverride,
+	type MarketplaceRosterAgent,
+	type MarketplaceTeamDef,
+	RESERVED_ROSTER_SLUGS,
+} from '@hezo/shared';
+import type { Db } from '../db/database';
+import { toSlug } from '../lib/slug';
+import { getAgentSystemPrompt } from './documents';
+import { computeContentHash } from './marketplace-build';
+
+/** Note attached to the exported bundle's initial changelog entry. */
+export const EXPORTED_TEAM_CHANGELOG_NOTE = 'Exported from a live Hezo team.';
+
+/** A team that cannot be turned into a marketplace bundle (e.g. it has no Captain). */
+export class TeamBundleExportError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'TeamBundleExportError';
+	}
+}
+
+interface MemberRow {
+	id: string;
+	slug: string;
+	title: string;
+	role_description: string;
+	summary: string;
+	team_context: string;
+	default_effort: AgentEffort;
+	heartbeat_interval_min: number;
+	run_timeout_min: number;
+	monthly_budget_cents: number;
+	daily_budget_cents: number;
+	weekly_budget_cents: number;
+	touches_code: boolean;
+	reports_to: string | null;
+}
+
+/**
+ * Assemble a `MarketplaceTeamDef` from a team's live DB state. Throws a
+ * `TeamBundleExportError` when the team has no Captain (a marketplace team's
+ * Captain override is required) or the team row is missing.
+ */
+export async function exportTeamBundle(db: Db, teamId: string): Promise<MarketplaceTeamDef> {
+	const teamRes = await db.query<{
+		name: string;
+		slug: string;
+		description: string;
+		summary: string;
+	}>('SELECT name, slug, description, summary FROM teams WHERE id = $1', [teamId]);
+	const team = teamRes.rows[0];
+	if (!team) throw new TeamBundleExportError('Team not found');
+
+	// Every agent member of this team, oldest first for a stable roster order.
+	// Cross-team instance agents (CEO/Coach) live in HQ, not here, so this scope
+	// already excludes them; the reserved-slug filter below is belt-and-braces.
+	const membersRes = await db.query<MemberRow>(
+		`SELECT ma.id, ma.slug, ma.title, ma.role_description, ma.summary, ma.team_context,
+		        ma.default_effort::text AS default_effort,
+		        ma.heartbeat_interval_min, ma.run_timeout_min,
+		        ma.monthly_budget_cents, ma.daily_budget_cents, ma.weekly_budget_cents,
+		        ma.touches_code, ma.reports_to
+		 FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1
+		 ORDER BY m.created_at ASC, ma.title ASC`,
+		[teamId],
+	);
+	const members = membersRes.rows;
+	const idToSlug = new Map(members.map((m) => [m.id, m.slug]));
+
+	const captainRow = members.find((m) => m.slug === CAPTAIN_AGENT_SLUG);
+	if (!captainRow) {
+		throw new TeamBundleExportError(
+			'This team has no Captain and cannot be exported as a marketplace bundle',
+		);
+	}
+
+	const captain: MarketplaceCaptainOverride = {
+		system_prompt: await getAgentSystemPrompt(db, teamId, captainRow.id),
+		team_context: captainRow.team_context,
+	};
+
+	const rosterRows = members.filter(
+		(m) => m.slug !== CAPTAIN_AGENT_SLUG && !RESERVED_ROSTER_SLUGS.includes(m.slug),
+	);
+	const rosterSlugs = new Set(rosterRows.map((m) => m.slug));
+
+	// Map a member's `reports_to` (a member id) to a slug the marketplace roster
+	// understands: the Captain, or another roster role. A reporting line to anyone
+	// out of the roster (a deleted member, or a cross-team instance agent) becomes
+	// null — the top of the roster — rather than inventing a Captain link.
+	const resolveReportsToSlug = (reportsTo: string | null): string | null => {
+		if (!reportsTo) return null;
+		const slug = idToSlug.get(reportsTo);
+		if (!slug) return null;
+		if (slug === CAPTAIN_AGENT_SLUG) return CAPTAIN_AGENT_SLUG;
+		return rosterSlugs.has(slug) ? slug : null;
+	};
+
+	const roster: MarketplaceRosterAgent[] = [];
+	let sortOrder = 1;
+	for (const m of rosterRows) {
+		roster.push({
+			slug: m.slug,
+			title: m.title,
+			reports_to_slug: resolveReportsToSlug(m.reports_to),
+			sort_order: sortOrder++,
+			role_description: m.role_description,
+			summary: m.summary,
+			team_context: m.team_context,
+			system_prompt: await getAgentSystemPrompt(db, teamId, m.id),
+			default_effort: m.default_effort,
+			heartbeat_interval_min: m.heartbeat_interval_min,
+			run_timeout_min: m.run_timeout_min,
+			monthly_budget_cents: m.monthly_budget_cents,
+			daily_budget_cents: m.daily_budget_cents,
+			weekly_budget_cents: m.weekly_budget_cents,
+			touches_code: m.touches_code,
+		});
+	}
+
+	const summary = team.summary?.trim() ?? '';
+	// A team's `description` is often blank (it's optional); fall back to the
+	// auto-generated summary so the exported bundle still describes itself.
+	const description = team.description?.trim() || summary;
+
+	const keywords = generateTeamKeywords([
+		team.name,
+		description,
+		summary,
+		...roster.map((r) => r.title),
+		...roster.map((r) => r.role_description),
+	]);
+
+	const content = {
+		slug: toSlug(team.slug || team.name),
+		name: team.name,
+		description,
+		summary,
+		captain,
+		roster,
+	};
+
+	return {
+		schema_version: MARKETPLACE_SCHEMA_VERSION,
+		slug: content.slug,
+		name: content.name,
+		description: content.description,
+		summary: content.summary,
+		keywords,
+		version: 1,
+		content_hash: computeContentHash(content),
+		changelog: [{ version: 1, notes: EXPORTED_TEAM_CHANGELOG_NOTE }],
+		captain,
+		roster,
+	};
+}

--- a/packages/server/test/team-bundle-export.test.ts
+++ b/packages/server/test/team-bundle-export.test.ts
@@ -1,0 +1,132 @@
+import {
+	CAPTAIN_AGENT_SLUG,
+	MARKETPLACE_SCHEMA_VERSION,
+	MAX_TEAM_KEYWORD_LENGTH,
+	MAX_TEAM_KEYWORDS,
+	type MarketplaceTeamDef,
+	RESERVED_ROSTER_SLUGS,
+} from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	EXPORTED_TEAM_CHANGELOG_NOTE,
+	exportTeamBundle,
+	TeamBundleExportError,
+} from '../src/services/team-bundle-export';
+import { authHeader, createTestProject, createTestTeam } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+describe('team bundle export', () => {
+	let ctx: ServerTestContext;
+	let teamId: string;
+	let projectSlug: string;
+
+	beforeAll(async () => {
+		ctx = await createTestContext();
+		const teamRes = await createTestTeam(ctx.db, {
+			name: 'Ship It Co',
+			description: 'A team that builds and ships software',
+			marketplace_slug: 'software-development',
+		});
+		teamId = (await teamRes.json()).data.id;
+		projectSlug = (await (await createTestProject(ctx.db, teamId, { name: 'Work' })).json()).data
+			.slug;
+	});
+
+	afterAll(() => destroyTestContext(ctx));
+
+	it('assembles a self-contained marketplace bundle from live team state', async () => {
+		const bundle = await exportTeamBundle(ctx.db, teamId);
+
+		expect(bundle.schema_version).toBe(MARKETPLACE_SCHEMA_VERSION);
+		expect(bundle.version).toBe(1);
+		expect(bundle.content_hash).toMatch(/^[0-9a-f]{64}$/);
+		expect(bundle.changelog).toEqual([{ version: 1, notes: EXPORTED_TEAM_CHANGELOG_NOTE }]);
+		expect(bundle.name).toBe('Ship It Co');
+		// description is present (given at creation); summary comes from the team row.
+		expect(bundle.description).toContain('software');
+
+		// Captain override carries the partial-resolved prompt with {{...}} intact
+		// (not a run-time-resolved prompt) plus its team context.
+		expect(bundle.captain.system_prompt).toContain('{{team_name}}');
+		expect(bundle.captain.team_context.length).toBeGreaterThan(0);
+
+		// Roster is every non-Captain role, never a reserved slug.
+		expect(bundle.roster.length).toBeGreaterThan(0);
+		for (const role of bundle.roster) {
+			expect(role.slug).not.toBe(CAPTAIN_AGENT_SLUG);
+			expect(RESERVED_ROSTER_SLUGS).not.toContain(role.slug);
+			expect(role.system_prompt).toContain('{{team_name}}');
+			// Every roster role reports to the Captain, another roster role, or the top.
+			if (role.reports_to_slug !== null) {
+				const known =
+					role.reports_to_slug === CAPTAIN_AGENT_SLUG ||
+					bundle.roster.some((r) => r.slug === role.reports_to_slug);
+				expect(known).toBe(true);
+			}
+		}
+
+		// sort_order is a dense 1..N sequence.
+		expect(bundle.roster.map((r) => r.sort_order)).toEqual(bundle.roster.map((_, i) => i + 1));
+
+		// Keywords are generated (built-in teams carry hand-authored ones; a live
+		// export derives them) and stay within the marketplace ceilings.
+		expect(bundle.keywords.length).toBeGreaterThan(0);
+		expect(bundle.keywords.length).toBeLessThanOrEqual(MAX_TEAM_KEYWORDS);
+		for (const kw of bundle.keywords) {
+			expect(kw).toBe(kw.toLowerCase());
+			expect(kw.length).toBeLessThanOrEqual(MAX_TEAM_KEYWORD_LENGTH);
+		}
+	});
+
+	it('maps a roster role reporting to another roster role onto that slug', async () => {
+		const before = await exportTeamBundle(ctx.db, teamId);
+		expect(before.roster.length).toBeGreaterThanOrEqual(2);
+		const [first, second] = before.roster;
+
+		// Point the second role at the first role (both are roster members).
+		const firstMember = await ctx.db.query<{ id: string }>(
+			`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			 WHERE m.team_id = $1 AND ma.slug = $2`,
+			[teamId, first.slug],
+		);
+		await ctx.db.query(
+			`UPDATE member_agents SET reports_to = $1
+			 WHERE id = (SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			             WHERE m.team_id = $2 AND ma.slug = $3)`,
+			[firstMember.rows[0].id, teamId, second.slug],
+		);
+
+		const after = await exportTeamBundle(ctx.db, teamId);
+		const reslotted = after.roster.find((r) => r.slug === second.slug);
+		expect(reslotted?.reports_to_slug).toBe(first.slug);
+	});
+
+	it('refuses to export a team with no Captain', async () => {
+		const teamRes = await createTestTeam(ctx.db, { name: 'Captainless' });
+		const captainlessTeamId = (await teamRes.json()).data.id;
+		await ctx.db.query(
+			`DELETE FROM members WHERE team_id = $1 AND id IN
+			 (SELECT id FROM member_agents WHERE slug = $2)`,
+			[captainlessTeamId, CAPTAIN_AGENT_SLUG],
+		);
+		await expect(exportTeamBundle(ctx.db, captainlessTeamId)).rejects.toBeInstanceOf(
+			TeamBundleExportError,
+		);
+	});
+
+	it('serves the bundle over the project-scoped route', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/team-bundle`, {
+			headers: authHeader(ctx.token),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { data: MarketplaceTeamDef };
+		expect(body.data.name).toBe('Ship It Co');
+		expect(body.data.roster.length).toBeGreaterThan(0);
+		expect(body.data.captain.system_prompt).toContain('{{team_name}}');
+	});
+
+	it('rejects an unauthenticated request', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/team-bundle`);
+		expect(res.status).toBe(401);
+	});
+});

--- a/packages/shared/src/search/terms.ts
+++ b/packages/shared/src/search/terms.ts
@@ -230,3 +230,34 @@ export function normalizeKeywords(keywords: readonly string[]): string[] {
 	}
 	return out;
 }
+
+/**
+ * Derive a discovery-keyword list for a team from its own free text (name,
+ * description, summary, role titles/descriptions) — used when a user exports a
+ * live team as a marketplace bundle, since only Hezo's built-in teams carry a
+ * hand-authored `keywords` list. The result is a bag of **readable words** (not
+ * stems): each alphanumeric word of at least `MIN_TERM_LENGTH` characters that
+ * isn't a function word, lowercased, de-duplicated, order-preserving, and capped
+ * at `limit` (default `MAX_TEAM_KEYWORDS`). Function words are checked against
+ * both the raw word and its stem, matching `extractTerms`, so "used" is dropped
+ * along with "use"; the word itself is kept unstemmed so the published list stays
+ * human-reviewable (the stemmer is the matcher's private representation).
+ */
+export function generateTeamKeywords(
+	texts: readonly string[],
+	limit: number = MAX_TEAM_KEYWORDS,
+): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const text of texts) {
+		for (const word of text.toLowerCase().match(/[a-z0-9]+/g) ?? []) {
+			if (out.length >= limit) return out;
+			if (word.length < MIN_TERM_LENGTH || STOPWORDS.has(word)) continue;
+			if (STOPWORDS.has(stemTerm(word))) continue;
+			if (seen.has(word)) continue;
+			seen.add(word);
+			out.push(word);
+		}
+	}
+	return out;
+}

--- a/packages/shared/test/search-terms.test.ts
+++ b/packages/shared/test/search-terms.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	extractTerms,
+	generateTeamKeywords,
 	MAX_TEAM_KEYWORD_LENGTH,
 	MAX_TEAM_KEYWORDS,
 	normalizeKeywords,
@@ -78,6 +79,45 @@ describe('normalizeKeywords', () => {
 		// Stems are a matcher implementation detail; storing them in a published
 		// marketplace file would freeze one matcher version into the data.
 		expect(normalizeKeywords(['engineering'])).toEqual(['engineering']);
+	});
+});
+
+describe('generateTeamKeywords', () => {
+	it('produces readable, de-duplicated words and drops function words / short tokens', () => {
+		const kw = generateTeamKeywords([
+			'Social Media Marketing',
+			'A team that grows your social reach and drafts content',
+			'Content Writer',
+		]);
+		// Readable words (not stems), function words ("that", "and", "your") and
+		// short tokens dropped, "social"/"content" de-duplicated across the inputs.
+		expect(kw).toEqual([
+			'social',
+			'media',
+			'marketing',
+			'team',
+			'grows',
+			'reach',
+			'drafts',
+			'content',
+			'writer',
+		]);
+	});
+
+	it('drops function words that only surface after stemming', () => {
+		// "uses" → "use", "wants" → "want" are stopwords; "app" survives.
+		expect(generateTeamKeywords(['this uses and wants an app'])).toEqual(['app']);
+	});
+
+	it('keeps whole words rather than stems, so the list stays human-reviewable', () => {
+		expect(generateTeamKeywords(['engineering marketing'])).toEqual(['engineering', 'marketing']);
+	});
+
+	it('caps the list and never breaches the marketplace keyword ceilings', () => {
+		const many = Array.from({ length: MAX_TEAM_KEYWORDS + 20 }, (_, i) => `word${i}`).join(' ');
+		const kw = generateTeamKeywords([many]);
+		expect(kw.length).toBe(MAX_TEAM_KEYWORDS);
+		expect(teamKeywordsError(kw)).toBeNull();
 	});
 });
 

--- a/packages/web/src/components/export-team-dialog.tsx
+++ b/packages/web/src/components/export-team-dialog.tsx
@@ -1,0 +1,106 @@
+import type { MarketplaceTeamDef } from '@hezo/shared';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Download, Loader2, Upload } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from '../hooks/use-toast';
+import { ApiError, api } from '../lib/api';
+import { downloadTextFile } from '../lib/download-file';
+import { Button } from './ui/button';
+import { DialogContent } from './ui/dialog';
+
+// Where a publisher sends their exported bundle. A new-issue link (not a raw repo
+// URL) so the flow lands on the contribution surface with the file attached.
+const HEZO_SUBMIT_URL = 'https://github.com/hezo-ai/hezo/issues/new';
+
+/**
+ * "Export team" control shown on the Team page beside "Hire agent". Opens a
+ * dialog that explains what a team bundle is, then downloads the team's current
+ * state as a self-contained marketplace bundle (`MarketplaceTeamDef` JSON) the
+ * user can submit to the Hezo authors for inclusion in the marketplace. The JSON
+ * is fetched from `GET /api/projects/:projectId/team-bundle` and written to a
+ * file client-side (see {@link downloadTextFile}).
+ */
+export function ExportTeamButton({ projectId }: { projectId: string }) {
+	const [open, setOpen] = useState(false);
+	const [exporting, setExporting] = useState(false);
+
+	async function handleExport() {
+		setExporting(true);
+		try {
+			const bundle = await api.get<MarketplaceTeamDef>(`/api/projects/${projectId}/team-bundle`);
+			const filename = `${bundle.slug || 'team'}-team-bundle.json`;
+			// Tab-indented to match the committed marketplace/teams/*.json style, with
+			// a trailing newline so the file is diff-clean if committed as-is.
+			downloadTextFile(filename, `${JSON.stringify(bundle, null, '\t')}\n`, 'application/json');
+			setOpen(false);
+		} catch (e) {
+			toast.error(e instanceof ApiError ? e.message : 'Failed to export the team bundle');
+		} finally {
+			setExporting(false);
+		}
+	}
+
+	return (
+		<Dialog.Root open={open} onOpenChange={setOpen}>
+			<Dialog.Trigger asChild>
+				<Button variant="secondary" data-testid="export-team-button">
+					<Upload className="w-4 h-4" /> Export team
+				</Button>
+			</Dialog.Trigger>
+			<DialogContent size="lg" data-testid="export-team-dialog">
+				<Dialog.Title className="text-base font-semibold mb-2">
+					Export team as a bundle
+				</Dialog.Title>
+				<Dialog.Description className="text-[13px] text-text-2 mb-4 leading-relaxed">
+					This packages your team's current state into a single JSON file - a team bundle - and
+					downloads it to your device. It's the same self-contained format the team marketplace
+					ships.
+				</Dialog.Description>
+
+				<div className="rounded-md border border-border-subtle bg-surface-2 p-3 mb-4">
+					<p className="text-[12px] uppercase tracking-wide text-text-3 font-medium mb-2">
+						What's included
+					</p>
+					<ul className="text-[13px] text-text-2 space-y-1 list-disc pl-4">
+						<li>The team name, description, and summary</li>
+						<li>Every role - the Captain and each teammate - with its reporting line</li>
+						<li>Each role's system prompt, effort, budgets, and settings</li>
+					</ul>
+					<p className="text-[12px] text-text-3 mt-2 leading-relaxed">
+						Skills, connections, secrets, and project data are not included - those are configured
+						per project, not carried by a team.
+					</p>
+				</div>
+
+				<p className="text-[13px] text-text-2 mb-5 leading-relaxed">
+					To get your team added to the marketplace, send the downloaded file to the Hezo authors on{' '}
+					<a
+						href={HEZO_SUBMIT_URL}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-accent hover:underline"
+					>
+						GitHub
+					</a>
+					.
+				</p>
+
+				<div className="flex justify-end gap-2">
+					<Dialog.Close asChild>
+						<Button variant="ghost" disabled={exporting}>
+							Cancel
+						</Button>
+					</Dialog.Close>
+					<Button onClick={handleExport} disabled={exporting} data-testid="export-team-confirm">
+						{exporting ? (
+							<Loader2 className="w-4 h-4 animate-spin" />
+						) : (
+							<Download className="w-4 h-4" />
+						)}
+						Export & download
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/src/routes/projects/$projectId/agents/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Globe, Plus, UserPlus } from 'lucide-react';
 import { agentPageParams } from '../../../../components/agent-link';
 import { AgentStatusLabel } from '../../../../components/agent-status-label';
+import { ExportTeamButton } from '../../../../components/export-team-dialog';
 import { OrgChartTree } from '../../../../components/org-chart-tree';
 import { Button } from '../../../../components/ui/button';
 import { EmptyState } from '../../../../components/ui/empty-state';
@@ -55,12 +56,13 @@ function TeamPage() {
 	return (
 		<div className="grid grid-cols-1 lg:grid-cols-[1fr_240px] lg:gap-6">
 			<div className="min-w-0">
-				<div className="flex items-center justify-end mb-4">
+				<div className="flex items-center justify-end gap-2 mb-4">
 					<Link to="/projects/$projectId/agents/hire" params={{ projectId }}>
 						<Button>
 							<UserPlus className="w-4 h-4" /> Hire agent
 						</Button>
 					</Link>
+					<ExportTeamButton projectId={projectId} />
 				</div>
 
 				<div

--- a/packages/web/test/team-export.test.tsx
+++ b/packages/web/test/team-export.test.tsx
@@ -1,0 +1,49 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { downloadTextFile } from '../src/lib/download-file';
+import { renderApp } from './helpers/render';
+import { seedWorkspace } from './helpers/seed';
+
+// The actual Blob + <a download> plumbing lives in downloadTextFile and is
+// exercised elsewhere; here we assert the Export team flow calls it with the
+// right filename and a valid bundle body, after the explain-first dialog.
+vi.mock('../src/lib/download-file', () => ({ downloadTextFile: vi.fn() }));
+
+test('Export team explains the bundle, then downloads it', async () => {
+	let projectSlug = '';
+	const { findByTestId, findByText, getByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			projectSlug = ws.internalSlug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents',
+		params: { projectId: projectSlug },
+	});
+
+	// The button sits beside "Hire agent" on the Team page.
+	const exportBtn = await findByTestId('export-team-button');
+	await user.click(exportBtn);
+
+	// The dialog explains what's about to happen before anything downloads.
+	await findByTestId('export-team-dialog');
+	await findByText("What's included");
+	const githubLink = await findByText('GitHub');
+	expect(githubLink.getAttribute('href')).toContain('github.com/hezo-ai/hezo');
+	expect(downloadTextFile).not.toHaveBeenCalled();
+
+	await user.click(getByTestId('export-team-confirm'));
+
+	await waitFor(() => expect(downloadTextFile).toHaveBeenCalledTimes(1));
+	const [filename, content, mime] = (downloadTextFile as ReturnType<typeof vi.fn>).mock.calls[0];
+	expect(filename).toMatch(/-team-bundle\.json$/);
+	expect(mime).toBe('application/json');
+	// The body is the real bundle fetched from the backend.
+	const bundle = JSON.parse(content as string);
+	expect(bundle.name).toBe('Demo Team');
+	expect(bundle.roster.length).toBeGreaterThan(0);
+	expect(bundle.captain.system_prompt).toContain('{{team_name}}');
+});


### PR DESCRIPTION
## What

Adds a way for users to bundle and publish a team's current state for the marketplace. A new **Export team** button sits beside **Hire agent** on the Team page. It opens an explain-first dialog, then downloads the team's current state as a self-contained marketplace team bundle (`MarketplaceTeamDef` JSON) that the user can send to the Hezo authors on GitHub to have published.

## How

- **`GET /api/projects/:projectId/team-bundle`** (`services/team-bundle-export.ts`, `exportTeamBundle`) serializes the project's team into a `MarketplaceTeamDef` - the inverse of `applyMarketplaceTeamToTeam`:
  - reads the team's `member_agents` + their `agent_system_prompt` documents;
  - emits the Captain as the top-level `captain` override and the rest as `roster` (reserved slugs and cross-team instance agents excluded; each `reports_to` mapped back to the Captain, a roster slug, or null);
  - derives discovery `keywords` from the team's text; stamps `version: 1` + a fresh `content_hash` (reusing `computeContentHash` from the build);
  - ships **only** roster + prompts - never skills, connections, secrets, or project config.
  - Read-only, project-access gated. Parallels a future `get_team_bundle` MCP tool should one be added.
- **`generateTeamKeywords`** (`@hezo/shared`) generates a readable keyword list from a team's own text (name, description, summary, role titles/descriptions), since only the built-in teams carry a hand-authored `keywords` list. Readable words (not stems), de-duplicated, capped at `MAX_TEAM_KEYWORDS`.
- **`ExportTeamButton`** (`components/export-team-dialog.tsx`) fetches the bundle and downloads it client-side via the existing `downloadTextFile` helper. The dialog explains what's included (and what isn't) and points the user to GitHub to submit it.

## Testing

- **Shared** (`search-terms.test.ts`): `generateTeamKeywords` - readable words, function-word/short-token dropping (incl. post-stem), whole-words-not-stems, and the ceiling cap.
- **Server** (`team-bundle-export.test.ts`): bundle structure (schema/version/hash/changelog, Captain override with `{{...}}` intact, roster excludes reserved slugs, dense `sort_order`, keyword ceilings), roster-to-roster reporting-line mapping, no-Captain refusal, the route (200 + shape), and unauthenticated 401.
- **Web** (`team-export.test.tsx`): the explain-then-download flow - button beside Hire agent, dialog content + GitHub link, nothing downloaded until confirm, then `downloadTextFile` called with a `*-team-bundle.json` filename and a valid bundle body.

## Docs

- `.dev/architecture.md` § Team marketplace - the export path.
- `docs/concepts/marketplace.md` - a user-facing "Exporting your team" section.

No MCP tool was added, so the generated MCP surfaces (`mcp-api.md`, `SKILL.md`, `llms.txt`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)