### PR TITLE
fix(web): sort the Done task list by last-updated, newest first

### DIFF
--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -252,7 +252,18 @@ export function TaskList({ projectId }: TaskListProps) {
 		const rows = mainRows.filter((t) => !PINNED_STATUS_SET.has(t.status));
 		return {
 			backlogTasks: nestTasksForDisplay(rows.filter((t) => !TERMINAL_STATUS_SET.has(t.status))),
-			doneTasks: nestTasksForDisplay(rows.filter((t) => TERMINAL_STATUS_SET.has(t.status))),
+			// Finished work reads best as a recent-activity log: always most-recently
+			// updated first, independent of the sort dropdown (which governs the
+			// Backlog) — the same treatment the pinned In-progress section gets.
+			// `updated_at` is trigger-maintained server-side, so it's a reliable key;
+			// localeCompare on the ISO string keeps ties stable (falls back to the
+			// server order). Sorting the full Task rows before nesting needs no type
+			// change, and nestTasksForDisplay preserves this sibling order.
+			doneTasks: nestTasksForDisplay(
+				rows
+					.filter((t) => TERMINAL_STATUS_SET.has(t.status))
+					.sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+			),
 		};
 	}, [mainRows, todoListEnabled]);
 

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -231,6 +231,56 @@ test('terminal tasks render in a Done section split out from the Backlog', async
 	expect(backlogSection.querySelector('tbody tr')?.className ?? '').not.toContain('opacity-60');
 });
 
+test('Done section orders tasks by last-updated, most recent first', async () => {
+	let projectSlug = '';
+
+	const { findByTestId, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Done Order Project' });
+			projectSlug = project.slug;
+			const agentId = ws.agents[0].id;
+			// Created in order first -> second -> third.
+			const first = await seedTask(ws, project, { title: 'First done', assignee_id: agentId });
+			const second = await seedTask(ws, project, { title: 'Second done', assignee_id: agentId });
+			const third = await seedTask(ws, project, { title: 'Third done', assignee_id: agentId });
+			// Move to done in an order that is neither the created order nor its
+			// reverse, so `second` is updated last. Each PATCH is a separate awaited
+			// transaction, so the updated_at trigger stamps increasing timestamps.
+			await patchStatus(ws, first.id, 'done');
+			await patchStatus(ws, third.id, 'done');
+			await patchStatus(ws, second.id, 'done');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	await findByText('First done', undefined, { timeout: 10_000 });
+	const doneSection = await findByTestId('task-list-done');
+
+	// Expected reverse-chron-by-updated_at order: Second (updated last), Third,
+	// First. This differs from created_at desc (Third, Second, First) and
+	// created_at asc (First, Second, Third), so it uniquely pins updated_at desc.
+	await waitFor(
+		() => {
+			const titles = Array.from(doneSection.querySelectorAll('tbody tr'))
+				.map((r) => r.textContent ?? '')
+				.filter((t) => t.includes(' done'));
+			const secondIdx = titles.findIndex((t) => t.includes('Second done'));
+			const thirdIdx = titles.findIndex((t) => t.includes('Third done'));
+			const firstIdx = titles.findIndex((t) => t.includes('First done'));
+			expect(secondIdx).toBeGreaterThan(-1);
+			expect(thirdIdx).toBeGreaterThan(secondIdx);
+			expect(firstIdx).toBeGreaterThan(thirdIdx);
+		},
+		{ timeout: 10_000 },
+	);
+});
+
 test('Done section hides when only terminal tasks remain after filtering them out', async () => {
 	let projectSlug = '';
 


### PR DESCRIPTION
## Summary

On a project's task list, the bottom **Done** section (terminal tasks: `done` + `cancelled`) inherited its order from the main list's sort dropdown - default `work_order:asc`, which orders by active-run then blocker then priority then task number. That has no recency component, so finished tasks appeared in an order unrelated to when they were completed.

This change sorts the **Done** section by `updated_at` descending (most recently updated first), so the work someone just finished sits at the top. It mirrors the pinned **In-progress** section, which is already hardcoded to `updated_at:desc` independent of the dropdown.

## What changed

- `packages/web/src/components/task-list.tsx` - in the `useMemo` that splits the main list into Backlog and Done groups, sort the terminal-status rows by `updated_at` descending before nesting. The sort is client-side and scoped to Done only; the sort dropdown still governs the Backlog section.

## Notes

- The sort is scoped to the Done section; the sort dropdown continues to control the Backlog, matching the existing per-section ordering precedent (In-progress is always `updated_at:desc`).
- `tasks.updated_at` is `TIMESTAMPTZ NOT NULL`, auto-bumped on every update by the `trg_tasks_updated` trigger, so it is a reliable sort key. Terminal tasks never have an active run, so no other ordering concern competes.
- `mainRows` are full `Task` objects (they carry `updated_at`), so no type change was needed. `nestTasksForDisplay` preserves sibling input order, so nested Done children inherit the same order. `localeCompare` on the ISO string keeps ties stable.
- Known limitation (pre-existing, not worsened): the sort applies to the Done tasks currently loaded by the infinite query (50/page). For very large Done lists spanning multiple pages, ordering is correct only within what's loaded - the same limitation the current client-side Done/Backlog split already has.

## Testing

- Added a component test to `packages/web/test/task-list.test.tsx` that seeds three tasks, moves them to Done in an order that is neither the created order nor its reverse, and asserts the rendered Done order matches `updated_at` descending (distinguishing it from both `created_at asc` and `created_at desc`).
- `cd packages/web && bunx vitest run test/task-list.test.tsx` - all 12 tests pass, including the new one.
- `turbo typecheck` and the pre-commit build pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCHpvsY1wdnRyHPNUi3dT9)_