### PR TITLE
fix(deploy): provision swap so low-RAM VPSes don't OOM-kill Hezo

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,7 +10,7 @@ host** — not to a managed-container PaaS. These artifacts automate that host s
 
 | Path | Purpose |
 |---|---|
-| `provision.sh` | The canonical, self-contained installer. Installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down. Single source of truth — everything else runs it. |
+| `provision.sh` | The canonical, self-contained installer. Creates a swap file (default 4 GB, `HEZO_SWAP_SIZE`) so low-RAM hosts don't get OOM-killed, installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down. Single source of truth — everything else runs it. |
 | `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
 | `aws/` | CloudFormation **Launch Stack** template (`hezo.cfn.yaml`) — an EC2 VM whose UserData runs `provision.sh`. See [`aws/README.md`](aws/README.md). |
 | `gcp/` | **Open in Cloud Shell** deploy — `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) with a guided `tutorial.md`. See [`gcp/README.md`](gcp/README.md). |
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.
 throwaway VM/droplet:
 
 1. **Local VM:** `multipass launch 24.04 --cloud-init cloud-init/hezo.cloud-config.yaml`,
-   then check `systemctl is-active hezo caddy` and
+   then check `swapon --show` lists `/swapfile`, `systemctl is-active hezo caddy`, and
    `curl -s http://127.0.0.1:3100/health` → `{"ok":true}`. (Multipass has no public
    IP — set `HEZO_DOMAIN_OVERRIDE` to a local name to exercise Caddy.)
 2. **Throwaway droplet:** create a small droplet with the cloud-init, then from your

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -6,10 +6,14 @@
 # "Startup script" field when creating an Ubuntu server (2 GB RAM+ recommended).
 # Works as-is on DigitalOcean, Hetzner, Vultr, Linode, and AWS Lightsail.
 #
-# On first boot it installs Docker, downloads Hezo, sets up automatic HTTPS via
-# Caddy, and starts Hezo under systemd. After ~2 minutes, open the URL it derives
-# (https://<public-ip>.sslip.io) and finish the short in-browser setup: create
-# your master key, set an admin password, and connect a model.
+# On first boot it creates a 4 GB swap file (so low-RAM boxes don't get OOM-killed),
+# installs Docker, downloads Hezo, sets up automatic HTTPS via Caddy, and starts Hezo
+# under systemd. After ~2 minutes, open the URL it derives (https://<public-ip>.sslip.io)
+# and finish the short in-browser setup: create your master key, set an admin
+# password, and connect a model.
+#
+# OPTIONAL - change the swap size (default 4G, auto-shrunk to fit the disk): set
+# HEZO_SWAP_SIZE below (e.g. 2G, or 0 to disable). Existing swap is left untouched.
 #
 # OPTIONAL — use your own domain instead of sslip.io: point an A record at the
 # server, then uncomment and edit the HEZO_DOMAIN_OVERRIDE line under runcmd.
@@ -24,6 +28,8 @@ packages:
   - curl
 
 runcmd:
+  # To change the swap size (default 4G; set 0 to disable), set this before the curl line:
+  # - [ sh, -c, "echo 'HEZO_SWAP_SIZE=2G' >> /etc/environment" ]
   # To use your own domain, set this before the curl line (A record must point here first):
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -9,11 +9,12 @@
 #   • you can also just SSH into a box and run it by hand
 #
 # What it does, idempotently:
-#   1. installs Docker Engine and starts it (Hezo needs the host Docker socket)
-#   2. downloads the arch-matched `hezo` binary from GitHub Releases
-#   3. installs Caddy as a reverse proxy with automatic HTTPS + WebSocket passthrough
-#   4. installs systemd units (a first-boot unit that derives the public URL, then Hezo)
-#   5. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
+#   1. ensures a swap file exists (default 4 GB) so low-RAM hosts don't get OOM-killed
+#   2. installs Docker Engine and starts it (Hezo needs the host Docker socket)
+#   3. downloads the arch-matched `hezo` binary from GitHub Releases
+#   4. installs Caddy as a reverse proxy with automatic HTTPS + WebSocket passthrough
+#   5. installs systemd units (a first-boot unit that derives the public URL, then Hezo)
+#   6. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
 #
 # It never sets the master key: that is generated in the browser on first run and
 # shown once, so it cannot be pre-seeded. After boot, open the printed URL and
@@ -35,6 +36,10 @@
 #                          (s3://KEY:SECRET@endpoint/bucket[/prefix]). Persisted into
 #                          /etc/hezo/hezo.env on first provision; omit for local disk.
 #   HEZO_DATABASE_POOL_SIZE  connection-pool size for the external database (2-100).
+#   HEZO_SWAP_SIZE         size of the swap file this script creates so low-RAM hosts
+#                          don't OOM (default 4G; accepts 4G / 4096M). Set 0 to disable.
+#                          Auto-shrinks to fit the disk when 4G plus headroom won't fit,
+#                          and is skipped when the host already has active swap.
 #   HEZO_RELEASE_TAG       pin a release tag (default: latest)
 #   HEZO_IMAGE_BUILD       set to 1 when baking a machine image (e.g. the DigitalOcean
 #                          Marketplace Packer build). Installs and enables everything but
@@ -69,7 +74,124 @@ fi
 log() { echo "[hezo-provision] $*"; }
 
 # ---------------------------------------------------------------------------
-# 1. Docker Engine
+# 1. Swap file — give low-RAM hosts a memory cushion so the install itself and
+#    the running services (Hezo + agent containers) don't get OOM-killed. The
+#    cheapest droplets ship as little as 512 MB RAM with no swap. Written as a
+#    standalone helper so the first-boot unit can reuse it: a machine-image
+#    build (HEZO_IMAGE_BUILD=1) defers swap creation to the user's first boot so
+#    no /swapfile is baked into the snapshot.
+# ---------------------------------------------------------------------------
+install -d /usr/local/sbin
+cat >/usr/local/sbin/hezo-ensure-swap.sh <<'EOF'
+#!/usr/bin/env bash
+# Idempotently ensure a swap file exists. Safe to run repeatedly and on every
+# boot: a no-op when the host already has active swap. Never aborts the caller —
+# a host that forbids swapon just logs a warning and exits 0.
+#
+#   HEZO_SWAP_SIZE  desired size (default 4G; accepts 4G / 4096M / integer MiB).
+#                   Set 0/off/none to disable. Auto-shrinks to fit the disk.
+set -uo pipefail
+
+SWAPFILE="/swapfile"
+HEADROOM_MIB=2048 # keep at least this much free disk beyond the swap file
+FLOOR_MIB=512     # don't bother creating swap smaller than this
+
+log() { echo "[hezo-swap] $*"; }
+
+REQUEST="${HEZO_SWAP_SIZE:-4G}"
+case "${REQUEST,,}" in
+	0 | off | none | no | false | disabled)
+		log "swap disabled (HEZO_SWAP_SIZE=${REQUEST})"
+		exit 0
+		;;
+esac
+
+# Already have swap somewhere? Respect it and do nothing.
+if [[ -n "$(swapon --show=NAME --noheadings 2>/dev/null)" ]]; then
+	log "swap already active; leaving it as-is"
+	exit 0
+fi
+
+# Parse the requested size to MiB (4G / 4096M / bare integer MiB).
+size_to_mib() {
+	local v="${1,,}" num unit
+	num="${v%[gm]}"
+	unit="${v#"${num}"}"
+	[[ "${num}" =~ ^[0-9]+$ ]] || {
+		echo ""
+		return
+	}
+	case "${unit}" in
+		g) echo $((num * 1024)) ;;
+		m | "") echo "${num}" ;;
+		*) echo "" ;;
+	esac
+}
+
+want_mib="$(size_to_mib "${REQUEST}")"
+if [[ -z "${want_mib}" || "${want_mib}" -lt 1 ]]; then
+	log "unrecognised HEZO_SWAP_SIZE='${REQUEST}'; skipping swap setup"
+	exit 0
+fi
+
+# A leftover /swapfile from a previous run: just switch it on and persist.
+if [[ -f "${SWAPFILE}" ]]; then
+	if swapon "${SWAPFILE}" 2>/dev/null; then
+		grep -q "^${SWAPFILE} " /etc/fstab 2>/dev/null || echo "${SWAPFILE} none swap sw 0 0" >>/etc/fstab
+		log "enabled existing ${SWAPFILE}"
+	else
+		log "could not enable existing ${SWAPFILE}; leaving it in place"
+	fi
+	exit 0
+fi
+
+# Disk headroom guard ("if possible"): never fill the root filesystem.
+avail_bytes="$(df --output=avail -B1 / 2>/dev/null | tail -1 | tr -d ' ')"
+if [[ "${avail_bytes}" =~ ^[0-9]+$ ]]; then
+	avail_mib=$((avail_bytes / 1024 / 1024))
+	usable_mib=$((avail_mib - HEADROOM_MIB))
+	if ((usable_mib < FLOOR_MIB)); then
+		log "only ${avail_mib} MiB free on /; too little for swap after ${HEADROOM_MIB} MiB headroom — skipping"
+		exit 0
+	fi
+	if ((want_mib > usable_mib)); then
+		log "shrinking swap from ${want_mib} MiB to ${usable_mib} MiB to fit the disk"
+		want_mib="${usable_mib}"
+	fi
+fi
+
+log "creating ${want_mib} MiB swap at ${SWAPFILE}"
+if ! fallocate -l "${want_mib}M" "${SWAPFILE}" 2>/dev/null; then
+	if ! dd if=/dev/zero of="${SWAPFILE}" bs=1M count="${want_mib}" status=none 2>/dev/null; then
+		log "failed to allocate ${SWAPFILE}; skipping swap setup"
+		rm -f "${SWAPFILE}"
+		exit 0
+	fi
+fi
+chmod 600 "${SWAPFILE}"
+if ! mkswap "${SWAPFILE}" >/dev/null 2>&1; then
+	log "mkswap failed; skipping swap setup"
+	rm -f "${SWAPFILE}"
+	exit 0
+fi
+grep -q "^${SWAPFILE} " /etc/fstab 2>/dev/null || echo "${SWAPFILE} none swap sw 0 0" >>/etc/fstab
+if ! swapon "${SWAPFILE}" 2>/dev/null; then
+	log "swapon failed (host may forbid swap); ${SWAPFILE} stays in fstab for next boot"
+	exit 0
+fi
+log "swap is on: $(swapon --show=NAME,SIZE --noheadings | tr '\n' ' ')"
+EOF
+chmod +x /usr/local/sbin/hezo-ensure-swap.sh
+
+# Create swap now for the direct/cloud-init/AWS/GCP paths, before the memory-heavy
+# Docker + Caddy installs. Skipped for machine-image builds (see the heredoc note
+# above); the first-boot unit creates it on the end user's real first boot instead.
+if [[ "${HEZO_IMAGE_BUILD:-}" != "1" ]]; then
+	HEZO_SWAP_SIZE="${HEZO_SWAP_SIZE:-4G}" /usr/local/sbin/hezo-ensure-swap.sh || log "swap setup skipped"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Docker Engine
 # ---------------------------------------------------------------------------
 if ! command -v docker >/dev/null 2>&1; then
 	log "Installing Docker Engine…"
@@ -79,7 +201,7 @@ systemctl enable --now docker
 log "Docker is running."
 
 # ---------------------------------------------------------------------------
-# 2. Hezo binary
+# 3. Hezo binary
 # ---------------------------------------------------------------------------
 case "$(uname -m)" in
 	x86_64) ARCH="x64" ;;
@@ -101,7 +223,7 @@ curl -fsSL -o /usr/local/bin/hezo "${BINARY_URL}"
 chmod +x /usr/local/bin/hezo
 
 # ---------------------------------------------------------------------------
-# 3. Data dir + environment file (never overwrite an operator-edited env file)
+# 4. Data dir + environment file (never overwrite an operator-edited env file)
 # ---------------------------------------------------------------------------
 install -d -m 700 /etc/hezo
 install -d -m 755 "${DATA_DIR}"
@@ -125,14 +247,15 @@ EOF
 	done
 fi
 
-# Persist the optional domain override so the first-boot unit can read it.
-if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
+# Persist optional settings the first-boot unit reads (domain override, swap size).
+if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" || -n "${HEZO_SWAP_SIZE:-}" ]]; then
 	install -m 600 /dev/null "${DEPLOY_ENV}"
-	echo "HEZO_DOMAIN_OVERRIDE=${HEZO_DOMAIN_OVERRIDE}" >"${DEPLOY_ENV}"
+	[[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]] && echo "HEZO_DOMAIN_OVERRIDE=${HEZO_DOMAIN_OVERRIDE}" >>"${DEPLOY_ENV}"
+	[[ -n "${HEZO_SWAP_SIZE:-}" ]] && echo "HEZO_SWAP_SIZE=${HEZO_SWAP_SIZE}" >>"${DEPLOY_ENV}"
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Caddy (reverse proxy, automatic HTTPS, WebSocket passthrough)
+# 5. Caddy (reverse proxy, automatic HTTPS, WebSocket passthrough)
 # ---------------------------------------------------------------------------
 if ! command -v caddy >/dev/null 2>&1; then
 	log "Installing Caddy…"
@@ -171,7 +294,7 @@ EOF
 [[ -f /etc/caddy/hezo.env ]] || echo 'HEZO_SITE_ADDRESS=:80' >/etc/caddy/hezo.env
 
 # ---------------------------------------------------------------------------
-# 5. First-boot unit: derive the public URL, wire it into Caddy + Hezo
+# 6. First-boot unit: derive the public URL, wire it into Caddy + Hezo
 # ---------------------------------------------------------------------------
 cat >/usr/local/sbin/hezo-firstboot.sh <<'EOF'
 #!/usr/bin/env bash
@@ -184,6 +307,13 @@ SENTINEL="/var/lib/hezo/.firstboot-done"
 [[ -f "${SENTINEL}" ]] && exit 0
 
 [[ -f /etc/hezo/deploy.env ]] && . /etc/hezo/deploy.env
+
+# Ensure host swap exists before Caddy/Hezo start (no-op if already active). On the
+# machine-image path this is where swap first gets created, since provision.sh
+# skipped it at build time.
+if [[ -x /usr/local/sbin/hezo-ensure-swap.sh ]]; then
+	HEZO_SWAP_SIZE="${HEZO_SWAP_SIZE:-}" /usr/local/sbin/hezo-ensure-swap.sh || true
+fi
 
 if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
 	DOMAIN="${HEZO_DOMAIN_OVERRIDE}"
@@ -225,7 +355,7 @@ WantedBy=multi-user.target
 EOF
 
 # ---------------------------------------------------------------------------
-# 6. Hezo systemd unit (mirrors docs/deployment/self-hosting.md)
+# 7. Hezo systemd unit (mirrors docs/deployment/self-hosting.md)
 # ---------------------------------------------------------------------------
 cat >/etc/systemd/system/hezo.service <<'EOF'
 [Unit]
@@ -247,7 +377,7 @@ WantedBy=multi-user.target
 EOF
 
 # ---------------------------------------------------------------------------
-# 7. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
+# 8. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
 #    but let the Docker bridge reach the host (agents call back over docker0).
 #    See docs/deployment/self-hosting.md § Networking & firewall.
 # ---------------------------------------------------------------------------
@@ -263,7 +393,7 @@ if command -v ufw >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Enable (and, outside image builds, start) everything
+# 9. Enable (and, outside image builds, start) everything
 # ---------------------------------------------------------------------------
 systemctl daemon-reload
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -45,6 +45,9 @@ uses the portable [cloud-init snippet](#deploy-it) below.
 
 On first boot the snippet:
 
+- creates a **4 GB swap file** so a low-RAM server doesn't get OOM-killed while
+  installing and running (auto-shrunk to fit the disk, and skipped if the box already
+  has swap - size it with `HEZO_SWAP_SIZE`, or set `0` to disable),
 - installs **Docker** and starts it (Hezo runs each project's agents in a container),
 - downloads the latest **`hezo`** binary for the server's CPU architecture,
 - puts **Caddy** in front for **automatic HTTPS** with a real certificate - no domain
@@ -59,6 +62,7 @@ setup screen; you take it from there.
 ## Deploy it
 
 1. **Create an Ubuntu server** on your provider - 2 GB RAM or more is a good start.
+   The deploy also adds a 4 GB swap file, so it still comes up on a smaller box.
 2. **Paste the snippet below** into the provider's user-data field (each provider
    calls it something slightly different - see [Where to paste it](#where-to-paste-it)).
 3. **Create the server and wait ~2 minutes** for first boot to finish.
@@ -72,6 +76,9 @@ package_update: true
 packages:
   - curl
 runcmd:
+  # To change the swap size (default 4G; set 0 to disable), uncomment and edit this
+  # before the curl line runs:
+  # - [ sh, -c, "echo 'HEZO_SWAP_SIZE=2G' >> /etc/environment" ]
   # To use your own domain instead of sslip.io, point an A record at this server, then
   # uncomment the next line and set your domain (do it before the curl line runs):
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -17,6 +17,17 @@ keys, and the spend.
 - Your **master key** (created on first run; see
   [First-run setup](/docs/getting-started/first-run)).
 
+**Low-RAM host?** Agent containers are memory-hungry, so on a small box (under ~2 GB
+RAM) add swap or the kernel may OOM-kill Hezo. The
+[one-click deploy](/docs/deployment/one-click) sets up a 4 GB swap file for you; on a
+manual install, add one yourself:
+
+```sh
+sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile
+sudo mkswap /swapfile && sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
 ## The data directory
 
 Everything Hezo keeps lives in one place - the **data directory** (default `~/.hezo/`):


### PR DESCRIPTION
## Problem

Deploying to the cheapest cloud VPSes (e.g. a 512 MB DigitalOcean droplet) fails: the box has no swap, so the Hezo worker is OOM-killed on startup (exit 137) and the systemd service restart-loops. This is the reported symptom:

```
hezo.service: A process of this unit has been killed by the OOM killer.
<supervisor> Worker exited with code 137; supervisor exiting
hezo.service: Failed with result 'oom-kill'.
```

`Restart=always` doesn't help when the process OOMs on start - the box just needs usable memory. The provisioning flow created no host swap.

## Change

`deploy/provision.sh` (the single installer every provider path runs) now provisions a swap file **before** the memory-heavy Docker/Caddy installs and before Hezo starts.

- **New idempotent helper `/usr/local/sbin/hezo-ensure-swap.sh`** (written by `provision.sh`, reused by the first-boot unit):
  - Default **4 GB**, configurable via `HEZO_SWAP_SIZE` (`0`/`off` disables).
  - **Skips if the host already has active swap** (respects providers that pre-provision it).
  - **Auto-shrinks to fit the disk** ("if possible") - keeps ~2 GiB free-disk headroom, and skips entirely if there isn't room.
  - Persists `/swapfile` in `/etc/fstab` so it survives reboots.
  - **Never aborts the install** - a host that forbids `swapon` just logs a warning and continues (fail-open).
- **Machine-image safe:** gated off under `HEZO_IMAGE_BUILD=1` so no `/swapfile` is baked into the DigitalOcean Marketplace snapshot. `hezo-firstboot.sh` runs the helper on the end user's real first boot instead, so every provider path (cloud-init, AWS, GCP, DO image, manual) gets swap.
- `HEZO_SWAP_SIZE` is persisted to `deploy.env` so a custom size reaches the first-boot path.

No per-provider wrapper (AWS CloudFormation, GCP startup script, cloud-init YAML) changed - they all run `provision.sh` and inherit swap automatically.

## Docs

Same-PR docs-alignment pass:
- `deploy/cloud-init/hezo.cloud-config.yaml` - header note + optional `HEZO_SWAP_SIZE` example.
- `docs/deployment/one-click.md` - "What it sets up" bullet, RAM guidance, and the in-sync snippet.
- `docs/deployment/self-hosting.md` - low-RAM swap note for manual installs (they don't run `provision.sh`).
- `deploy/README.md` - installer summary + a `swapon --show` verification check.

## Verification

`provision.sh` has no unit-test tier (it provisions a host), so this was verified with static checks plus a sandboxed run of the helper's full control flow:
- `bash -n` on `provision.sh` and both embedded scripts (helper + first-boot).
- Unit-tested the size parser (`4G`/`4096M`/bare int/garbage -> 11 cases).
- Sandboxed integration test of every branch (redirecting the swapfile/fstab paths and shimming `swapon`/`mkswap`/`fallocate`/`df`): disabled, already-active, create-with-plenty-of-disk, shrink-to-fit, too-little-disk skip, unrecognised size, `swapon`-fails-keeps-fstab, leftover-file reuse, empty-size default, and idempotent re-run - all pass.
- Confirmed the edited `docs/` pages contain no em/en dashes (per the terminology rule).

End-to-end (recommended before merge, on a throwaway box): `multipass launch 24.04 --cloud-init deploy/cloud-init/hezo.cloud-config.yaml`, then `swapon --show` lists `/swapfile`, `systemctl is-active hezo caddy`, and the original 512 MB droplet reaches `active (running)` instead of OOM-looping.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LubL2r7c9ZoChjcvS1Vwcv)_