### PR TITLE
fix(deploy): stop unattended upgrades restarting Hezo into a locked state

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,7 +10,7 @@ host** — not to a managed-container PaaS. These artifacts automate that host s
 
 | Path | Purpose |
 |---|---|
-| `provision.sh` | The canonical, self-contained installer. Installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down. Single source of truth — everything else runs it. |
+| `provision.sh` | The canonical, self-contained installer. Installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, exempts Hezo from needrestart's automatic restarts, and locks the firewall down. Single source of truth — everything else runs it. |
 | `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
 | `aws/` | CloudFormation **Launch Stack** template (`hezo.cfn.yaml`) — an EC2 VM whose UserData runs `provision.sh`. See [`aws/README.md`](aws/README.md). |
 | `gcp/` | **Open in Cloud Shell** deploy — `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) with a guided `tutorial.md`. See [`gcp/README.md`](gcp/README.md). |
@@ -42,6 +42,13 @@ env file — see `docs/deployment/one-click.md` § Using managed data hosting. I
 browser on first run and shown once, so the deploy lands you at the setup gate and
 you finish there (master key → admin password → connect a model). Password auth
 makes exposing that URL safe.
+
+Unattended upgrades: Ubuntu's post-upgrade `needrestart` hook restarts services
+running against replaced libraries, which would leave Hezo **locked** (its master
+key is in memory only) until an operator unlocked it from the browser. The script
+drops `/etc/needrestart/conf.d/hezo.conf` so the restart is reported but never
+performed - patches still install on schedule, and the restart is taken
+deliberately. See `docs/deployment/self-hosting.md` § Keeping the host patched.
 
 Firewall posture: only **80/443** are public; **3100** (the Hezo server) and
 **20000–29999** (the per-run egress proxy) stay host-local, while the Docker

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -13,7 +13,8 @@
 #   2. downloads the arch-matched `hezo` binary from GitHub Releases
 #   3. installs Caddy as a reverse proxy with automatic HTTPS + WebSocket passthrough
 #   4. installs systemd units (a first-boot unit that derives the public URL, then Hezo)
-#   5. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
+#   5. exempts Hezo from needrestart's automatic restarts (it comes back locked)
+#   6. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
 #
 # It never sets the master key: that is generated in the browser on first run and
 # shown once, so it cannot be pre-seeded. After boot, open the printed URL and
@@ -247,7 +248,28 @@ WantedBy=multi-user.target
 EOF
 
 # ---------------------------------------------------------------------------
-# 7. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
+# 7. Hold Hezo back from unattended-upgrade restarts
+#    Ubuntu runs needrestart from the APT hook in automatic mode, so a security
+#    upgrade replacing a library the binary maps (the C library among them)
+#    restarts the service with no prompt. Hezo keeps its master key in memory
+#    only and comes back locked, so an unattended restart takes agent execution
+#    offline until someone unlocks it from the browser gate - minutes if you are
+#    awake, hours if it lands overnight. Patches still install on schedule; the
+#    restart becomes yours to make when you can unlock it straight after.
+#    See docs/deployment/self-hosting.md § Keeping the host patched.
+# ---------------------------------------------------------------------------
+install -d /etc/needrestart/conf.d
+cat >/etc/needrestart/conf.d/hezo.conf <<'EOF'
+# Managed by Hezo provision.sh.
+# Hezo comes back locked after a restart (its master key lives in memory only),
+# so an unattended restart takes agent execution offline until an operator
+# unlocks it. needrestart still reports Hezo as needing a restart - check with
+# `needrestart -b -r l` - it just must never perform one on its own.
+$nrconf{override_rc} = { qr(^hezo\.service$) => 0 };
+EOF
+
+# ---------------------------------------------------------------------------
+# 8. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
 #    but let the Docker bridge reach the host (agents call back over docker0).
 #    See docs/deployment/self-hosting.md § Networking & firewall.
 # ---------------------------------------------------------------------------
@@ -263,7 +285,7 @@ if command -v ufw >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Enable (and, outside image builds, start) everything
+# 9. Enable (and, outside image builds, start) everything
 # ---------------------------------------------------------------------------
 systemctl daemon-reload
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -49,7 +49,10 @@ On first boot the snippet:
 - downloads the latest **`hezo`** binary for the server's CPU architecture,
 - puts **Caddy** in front for **automatic HTTPS** with a real certificate - no domain
   required (see [How the HTTPS URL works](#how-the-https-url-works)),
-- runs Hezo under **systemd** so it restarts on boot and after a crash, and
+- runs Hezo under **systemd** so it restarts on boot and after a crash,
+- exempts Hezo from the automatic service restarts that follow an **unattended
+  security upgrade**, so a background patch never leaves it sitting locked (see
+  [Keeping the host patched](/docs/deployment/self-hosting#keeping-the-host-patched)), and
 - locks the **firewall** down so only the web ports (80/443) are public.
 
 It deliberately does **not** set your master key - that's generated in your browser

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -342,3 +342,52 @@ You can always upgrade by replacing the binary yourself. On startup Hezo runs an
 required database migrations automatically - the embedded database is migrated on a
 copy and swapped in only on success (the previous copy is kept aside), so an upgrade
 is safe to roll back. See [Backup & recovery](/docs/deployment/backup-and-recovery).
+
+## Keeping the host patched
+
+This section is about patching the **operating system** under Hezo, not Hezo
+itself. On Ubuntu and Debian, `unattended-upgrades` installs security updates on
+its own daily schedule. After each one a helper called `needrestart` runs from
+the package manager's hook and, in the automatic mode Ubuntu uses there,
+restarts every service still running against a library the upgrade replaced.
+That is the right default for most daemons: a patched file on disk does nothing
+for a process that still has the old code mapped in memory.
+
+Hezo is the exception, because it cannot bring itself back. Its master key is
+held in memory only and never written to disk, so any restart outside the in-app
+update flow above brings the instance up **locked**, with agent execution
+stopped until someone opens the browser gate and unlocks it. An unattended
+restart therefore turns a routine background patch into an outage lasting until
+you happen to notice - a couple of minutes if you are at your desk, the whole
+night if it lands at 3am.
+
+The one-click deploy installs an exemption at
+`/etc/needrestart/conf.d/hezo.conf` so that never happens:
+
+```perl
+$nrconf{override_rc} = { qr(^hezo\.service$) => 0 };
+```
+
+Patches still download and install on the usual schedule. `needrestart` still
+*reports* that Hezo wants a restart - it simply no longer performs one, so the
+restart is yours to make at a moment when you can unlock right afterwards. If
+you set the service up by hand rather than through the one-click deploy, write
+that file yourself.
+
+**The trade-off is that you have to come back for it.** Until you restart, Hezo
+keeps running against the pre-patch copy of the library, so a fix for something
+like a C-library vulnerability is not yet live in the running process. Check for
+a pending restart whenever you are on the box:
+
+```sh
+sudo needrestart -b -r l      # lists services running against replaced libraries
+```
+
+If `hezo.service` is listed, restart it and unlock it in the browser:
+
+```sh
+sudo systemctl restart hezo
+```
+
+Kernel upgrades need a full reboot, which locks Hezo the same way, so they are a
+natural moment to take both together.

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -16,7 +16,35 @@ test.describe.configure({ mode: 'serial' });
 let server: ChildProcess | null = null;
 let dataDir: string;
 
+/**
+ * Shape of `/api/status`. While the boot sequence runs, the pre-ready handler
+ * answers 200 with `starting: true` and the current phase; once the real app is
+ * serving, the payload carries `masterKeyState` instead.
+ */
+interface GateStatus {
+	starting?: boolean;
+	phase?: string;
+	detail?: string;
+	masterKeyState?: string;
+}
+
+async function fetchGateStatus(): Promise<GateStatus | null> {
+	try {
+		const res = await fetch(`http://localhost:${GATE_SERVER_PORT}/api/status`);
+		if (!res.ok) return null;
+		return (await res.json()) as GateStatus;
+	} catch {
+		return null; // Not listening yet.
+	}
+}
+
 async function startGateServer(opts: { reset: boolean }): Promise<void> {
+	// A previous attempt (a Playwright retry re-enters the test body without
+	// running afterAll) may still hold the fixed port. Leaving it up would let the
+	// readiness poll below succeed against the *stale* server while the newly
+	// spawned one fails to bind, so every retry would assert against the wrong
+	// instance's state.
+	await stopGateServer();
 	const args = [
 		'run',
 		'src/index.ts',
@@ -45,17 +73,27 @@ async function startGateServer(opts: { reset: boolean }): Promise<void> {
 		},
 		stdio: 'ignore',
 	});
+	// A 200 from /api/status is NOT readiness: the pre-ready handler answers it
+	// from the moment the socket accepts, while migrations, seeding and workspace
+	// setup are still running and the SPA is showing a boot progress screen. Wait
+	// for the real app's payload so the first assertion isn't racing the migration
+	// replay a `--reset` start always performs.
 	const deadline = Date.now() + 60_000;
+	let lastPhase = 'unknown';
 	while (Date.now() < deadline) {
-		try {
-			const res = await fetch(`http://localhost:${GATE_SERVER_PORT}/api/status`);
-			if (res.ok) return;
-		} catch {
-			// Not listening yet.
+		const status = await fetchGateStatus();
+		if (status) {
+			if (status.phase === 'error') {
+				throw new Error(`master-key-gate server failed to start: ${status.detail ?? 'unknown'}`);
+			}
+			if (!status.starting && status.masterKeyState) return;
+			lastPhase = status.phase ?? lastPhase;
 		}
 		await new Promise((r) => setTimeout(r, 250));
 	}
-	throw new Error('master-key-gate server did not become ready on :3102');
+	throw new Error(
+		`master-key-gate server did not become ready on :${GATE_SERVER_PORT} (last phase: ${lastPhase})`,
+	);
 }
 
 async function stopGateServer(): Promise<void> {


### PR DESCRIPTION
## The problem

A live instance was stopping at unpredictable times. The journal on the affected host shows why:

```
06:07:41  apt-daily-upgrade.timer  → apt-daily-upgrade.service
06:08:32  unattended-upgrades installs: libc6, libc-bin, libpam0g, libpam-modules,
          libkrb5-3, libnss3, libsqlite3-0, ncurses, perl, python3.12, openssh-*, …
06:11:05  systemd[1]: Stopping hezo.service - Hezo...
06:11:07  supervisor restarts
06:11:52  apt-daily-upgrade.service: Deactivated successfully
```

`needrestart` runs from the APT post-invoke hook after every dpkg run, and Ubuntu patches it so that
**when invoked from that hook the default restart mode is `a` (automatic)** - stated verbatim in the
shipped `/etc/needrestart/needrestart.conf`:

> `# UBUNTU: the default restart mode when running as part of the APT hook is 'a'`

`hezo` maps `libc.so.6`, so a libc6 upgrade puts it on needrestart's list and it gets restarted with
no prompt. The same pass restarted `systemd-networkd`, `systemd-timesyncd`, `ModemManager`,
`packagekit` and `fwupd` - the tell that this was needrestart and nothing Hezo-specific.

For almost any other daemon that behaviour is correct: a patched file on disk does nothing for a
process still running the old code in memory. Hezo is the exception, because **it cannot bring itself
back**. The master key is held in memory only and never written to disk, so the restart brings the
instance up **locked**, with agent execution stopped until a human opens the browser gate. On the
affected host that was 3 minutes because someone happened to be awake; overnight it would have sat
locked until noticed. And it recurs daily - `apt-daily-upgrade.timer` fires every morning.

## The fix

`provision.sh` now installs `/etc/needrestart/conf.d/hezo.conf`:

```perl
$nrconf{override_rc} = { qr(^hezo\.service$) => 0 };
```

Patches still download and install on the normal schedule, and needrestart still *reports* that Hezo
wants a restart - it just no longer performs one, so the restart is taken deliberately at a moment
the operator can unlock straight afterwards.

All four deploy paths (cloud-init, GCP, AWS CloudFormation, DigitalOcean Marketplace image) funnel
through `provision.sh`, so the single edit covers every one.

**The trade-off is deliberate and documented:** until the operator restarts, Hezo keeps running
against the pre-patch copy of the library. The new docs section makes that explicit and gives
`needrestart -b -r l` as the way to check for a pending restart, noting that kernel reboots (which
lock Hezo the same way) are the natural moment to take both together.

## Verification

- `bash -n deploy/provision.sh` clean.
- Extracted the needrestart block verbatim, ran it into a sandbox, and loaded the result in perl: the
  heredoc writes a **single** backslash (compiles as `(?^:^hezo\.service$)`; a doubled one would show
  as `\\.`), it matches `hezo.service`, and it does **not** match `hezo-firstboot.service`,
  `caddy.service` or `docker.service` - so the sibling unit still gets restarted as normal, which a
  looser `^hezo` pattern would have broken.
- `docs-bundle.test.ts` green; `bun run --cwd packages/server build:docs` regenerates cleanly at 39
  docs with `docs/reference/mcp-api.md` unchanged.

One note for reviewers on how *not* to verify this: `needrestart -b -r l` lists everything needing a
restart **including** units set to `0`, so "still listed" does not mean the override failed. The proof
is that `dbus.service` appears in that list while the stock `needrestart.conf` already sets
`qr(^dbus) => 0`. That is also why the docs say needrestart keeps *reporting* Hezo and only stops
acting.

## Docs

`deploy/` is doc-bearing, so this carries the same-PR docs pass:

- `docs/deployment/self-hosting.md` - new `## Keeping the host patched` section.
- `docs/deployment/one-click.md` - added to "What it sets up", linked to that section.
- `deploy/README.md` - table row plus a paragraph in "How it works".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jxM98r2ZXVSgP6XpMgmZT
