### PR TITLE
fix(web): show the HQ menu on /home before the first project exists

### DIFF
--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -19,10 +19,19 @@ import { Tooltip } from './ui/tooltip';
  * follow; the backing team's agents close it out under a Team section. The team
  * is presented as the project's own — there is no separate team-level view.
  */
-export function ProjectSidebar({ onCollapse }: { onCollapse?: () => void } = {}) {
+export function ProjectSidebar({
+	onCollapse,
+	projectSlug,
+}: {
+	onCollapse?: () => void;
+	projectSlug?: string;
+} = {}) {
 	const active = useActiveProject();
 	const navigate = useNavigate();
-	const projectId = active?.slug ?? '';
+	// The shell passes an explicit slug so the menu can fall back to HQ on a
+	// non-project route (e.g. /home before the first project is created); on a
+	// project route it passes the active slug, so the two agree.
+	const projectId = projectSlug ?? active?.slug ?? '';
 	const project = useProjectMeta(projectId);
 	const health = useContainerHealth(project);
 	const { data: inboxCount } = useInboxUnreadCount(projectId);
@@ -34,7 +43,7 @@ export function ProjectSidebar({ onCollapse }: { onCollapse?: () => void } = {})
 	const isInternalProject = project?.is_internal ?? false;
 	const hasNoGoals = !isInternalProject && project != null && (project.open_goal_count ?? 0) === 0;
 
-	if (!active) return null;
+	if (!projectId) return null;
 
 	const isInternal = project?.is_internal ?? false;
 	const projectParams = { projectId };

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -30,7 +30,7 @@ import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useMe } from '../hooks/use-me';
 import { useProjectMenuCollapsed } from '../hooks/use-project-menu-collapsed';
-import { useProjectsIndex } from '../hooks/use-projects';
+import { useAllVisibleProjects, useHqProject, useProjectsIndex } from '../hooks/use-projects';
 import { useScrollToBottom } from '../hooks/use-scroll-to-bottom';
 import { useScrollToTop } from '../hooks/use-scroll-to-top';
 import { useStatus } from '../hooks/use-status';
@@ -219,6 +219,14 @@ interface ShellChromeProps {
 function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const active = useActiveProject();
+	const hq = useHqProject();
+	const { projects, isLoading: projectsLoading } = useAllVisibleProjects();
+	// The project whose menu the shell shows. Normally the route's active project;
+	// but before the first project is created there is no project-scoped route, so
+	// fall back to HQ (the one project that always exists) so its menu — the way to
+	// reach HQ's Container/Tasks/etc. — stays viewable and expandable from /home.
+	const menuProjectSlug =
+		active?.slug ?? (!projectsLoading && projects.length === 0 && hq ? hq.slug : null);
 	const [menuCollapsed, setMenuCollapsed] = useProjectMenuCollapsed();
 	const mainRef = useRef<HTMLElement>(null);
 	// The scroll-to-bottom hook needs the <main> element as state (a ref never
@@ -341,18 +349,21 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 					<div className="hidden md:flex h-full">
 						<ProjectRail />
 					</div>
-					{active && !menuCollapsed && (
+					{menuProjectSlug && !menuCollapsed && (
 						<div
 							data-testid="project-menu"
 							className="hidden lg:block w-[208px] shrink-0 h-full overflow-y-auto border-r border-border bg-surface pb-2"
 						>
-							<ProjectSidebar onCollapse={() => setMenuCollapsed(true)} />
+							<ProjectSidebar
+								projectSlug={menuProjectSlug}
+								onCollapse={() => setMenuCollapsed(true)}
+							/>
 						</div>
 					)}
 					{/* Collapsed: a slim expand tab docked to the project rail's right
 					    edge, flush under the app header. Desktop-only — below lg the
 					    project menu is a drawer, so there is nothing to collapse. */}
-					{active && menuCollapsed && (
+					{menuProjectSlug && menuCollapsed && (
 						<Tooltip content="Expand menu" side="right">
 							<button
 								type="button"
@@ -411,9 +422,9 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 					/>
 					<div className="relative flex h-full bg-surface shadow-xl">
 						<ProjectRail showHome />
-						{active && (
+						{menuProjectSlug && (
 							<div className="w-[208px] h-full overflow-y-auto py-2 border-r border-border bg-surface">
-								<ProjectSidebar />
+								<ProjectSidebar projectSlug={menuProjectSlug} />
 							</div>
 						)}
 					</div>

--- a/packages/web/test/chat.test.tsx
+++ b/packages/web/test/chat.test.tsx
@@ -2,7 +2,7 @@ import type { ChatMessage } from '@hezo/web/hooks/use-chat';
 import { toast } from '@hezo/web/hooks/use-toast';
 import { queryClient } from '@hezo/web/lib/query-client';
 import { queryKeys } from '@hezo/web/lib/query-keys';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, waitFor, within } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -101,13 +101,15 @@ test('shows the empty state once history loads', async () => {
 });
 
 test('the header identifies the CEO with the HQ badge and the composer invites cross-project questions', async () => {
-	const { findByTestId, getByTestId, getByText } = await renderApp({ initialPath: '/home' });
+	const { findByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('chat-launcher')).click();
-	await findByTestId('chat-panel');
+	const panel = await findByTestId('chat-panel');
 
-	// Header reads "CEO" alongside the HQ team badge (the CEO lives in HQ).
-	expect(getByText('CEO')).toBeTruthy();
-	expect(getByText('HQ')).toBeTruthy();
+	// Header reads "CEO" alongside the HQ team badge (the CEO lives in HQ). Scope
+	// to the chat panel: with no project created the HQ project menu now also
+	// renders on /home (its italic "HQ" name), so a document-wide query is ambiguous.
+	expect(within(panel).getByText('CEO')).toBeTruthy();
+	expect(within(panel).getByText('HQ')).toBeTruthy();
 	// The placeholder reflects the global, every-project scope of the chat.
 	const input = getByTestId('chat-input') as HTMLTextAreaElement;
 	expect(input.placeholder).toBe('Ask the CEO anything, across every project…');

--- a/packages/web/test/hq-menu-no-projects.test.tsx
+++ b/packages/web/test/hq-menu-no-projects.test.tsx
@@ -1,0 +1,63 @@
+// Before the first project is created, the app lands on /home, which has no
+// project-scoped route. The persistent project menu (ProjectSidebar) used to be
+// gated purely on a route-active project, so it never rendered on /home and the
+// operator could not view or expand the HQ menu — the one place to reach HQ's
+// Container page and diagnose a failed provision. The shell now falls back to HQ
+// as the menu's project while there are zero visible projects.
+//
+// Component tier: the menu's presence is conditional-rendering logic (does the
+// panel mount), not a real-layout/viewport assertion — happy-dom mounts the
+// `hidden lg:block` panel into the DOM so its testids are queryable. Only HQ
+// exists here (created by createTestApp; no seedWorkspace), which is exactly the
+// "no project created" state.
+
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedWorkspace } from './helpers/seed';
+
+test('the HQ menu is viewable on /home when no project has been created', async () => {
+	const { findByTestId, findAllByRole } = await renderApp({ initialPath: '/home' });
+
+	// The persistent menu panel renders (previously absent on /home), showing the
+	// HQ project's own menu: its name link, the coordination info tooltip that
+	// marks the internal HQ shape, and the Container link the user needs.
+	await findByTestId('project-menu', undefined, { timeout: 15_000 });
+	await findByTestId('project-sidebar-name');
+	await findByTestId('project-sidebar-info');
+	const containerLinks = await findAllByRole('link', { name: 'Container' });
+	expect(containerLinks.length).toBeGreaterThan(0);
+});
+
+test('the HQ menu surfaces the container failure indicator on /home', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		// The reported scenario: HQ's container failed to provision. The default
+		// harness marks it running, so flip it to error before mount.
+		seed: async (ctx) => {
+			await ctx.db.query(`UPDATE projects SET container_status = 'error' WHERE is_internal = true`);
+		},
+	});
+
+	// The Container item in the HQ menu shows its failure marker, so the operator
+	// can click through to diagnose — the whole point of reaching the menu here.
+	await findByTestId('project-sidebar-container-error', undefined, { timeout: 15_000 });
+});
+
+test('/home shows no project menu once a project exists (menu follows the route)', async () => {
+	const { findByTestId, queryByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	// Home has loaded its project dashboard...
+	await findByTestId('home-projects', undefined, { timeout: 15_000 });
+	// ...and the fallback does NOT fire: with a visible project, /home stays
+	// menu-less (the menu only appears on a project-scoped route).
+	await waitFor(() => {
+		expect(queryByTestId('project-menu')).toBeNull();
+		expect(queryByTestId('project-sidebar-name')).toBeNull();
+	});
+});


### PR DESCRIPTION
## Problem

On a fresh instance with **no user projects created**, the operator lands on `/home` (the welcome screen). The persistent left "project menu" (`ProjectSidebar` - Inbox / Tasks / Documents / Assets / Container / Activity / Team) and its collapsed "expand" tab were gated entirely on there being a **route-scoped active project** (`useActiveProject()`, non-null only when the URL carries a `projectId`). `/home` has no `projectId`, and there was no fallback to HQ - the one project that always exists.

Result: when no project is created, the user cannot view or expand the HQ project menu from the home screen. This is especially painful when HQ's container fails to provision ("Provisioning failed: Docker..."), because the HQ menu's **Container** item (which even shows a failure indicator) is exactly where the user would go to diagnose and retry - yet the menu is unreachable as a persistent panel.

## Fix

Introduce a narrow fallback in `ShellChrome` (`packages/web/src/routes/__root.tsx`): when there is no route-active project **and** there are zero visible (non-internal) projects, use HQ as the menu's project. The gate now keys on a derived `menuProjectSlug` instead of `active`, and the resolved slug is threaded explicitly into `ProjectSidebar` (new optional `projectSlug` prop) so the fallback works on desktop, in the collapsed expand tab, and in the mobile drawer.

- On a project route, `menuProjectSlug === active.slug` - **unchanged**.
- On `/home` with zero visible projects and HQ present, it becomes HQ's slug and the menu renders HQ's existing `is_internal` shape (no Budget/Settings; Container + Activity top-level; italic name + info tooltip; Container failure indicator when the container errored).
- On `/home` with at least one visible project, no menu renders - **unchanged**.

`useActiveProject`'s meaning is left intact (still "the currently-navigated project"), so the rail's HQ active-ring and the mobile new-task default are unaffected. The fallback also keys on `!projectsLoading` so the menu doesn't flash in during the index load.

## Files

- `packages/web/src/routes/__root.tsx` - compute `menuProjectSlug`; gate the desktop menu panel, the collapsed expand tab, and the mobile drawer on it; pass the slug to `ProjectSidebar`.
- `packages/web/src/components/project-sidebar.tsx` - accept an optional `projectSlug` prop; resolve `projectId` from it first; guard on `projectId` instead of `active`.

## Tests

New component test `packages/web/test/hq-menu-no-projects.test.tsx`:

- The HQ menu is viewable on `/home` when no project has been created (asserts the menu panel, HQ name, coordination info tooltip, and Container link render).
- The HQ menu surfaces the container **failure** indicator on `/home` (the diagnostic path the user needs).
- `/home` shows **no** project menu once a project exists (guards against over-showing).

Verified green alongside the related suites: `internal-project`, `project-menu-collapse`, `hq-provisioning-signal`, `home-new-project`, `onboarding-home`, `project-rail`. `bun run typecheck` and biome pass.

## Docs

Web-only navigation fix; no CLI/MCP/REST/route/data-model surface changed. Confirmed no `docs/**` or `.dev/architecture.md` prose describes the menu gating, so nothing to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGtc6dx3W1FBFhtxqKJ3hA)_