### PR TITLE
fix(server): stop the MCP endpoint stalling under concurrent agent requests

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2601,6 +2601,37 @@ by `packages/server/scripts/build-mcp-reference.ts` (run under `bun run build:do
 `mcp-reference.test.ts`) and committed as `docs/reference/mcp-api.md`. Authorization for
 both the REST and MCP surfaces is § 10.
 
+**Transport internals** (`mcp/server.ts`). The endpoint is a plain Hono route, not an SDK
+transport binding: it reads the JSON-RPC body itself and short-circuits the cases that must
+not reach the tool registry — a notification (no `id`) gets `202` with an empty body, as the
+streamable-http contract requires and rmcp clients depend on; `initialize` is answered
+directly, since the registry's connection has already negotiated initialization; and an
+unapproved caller is served the onboarding tools (`register`, `connection_status`) and
+nothing else. Only `tools/list` and `tools/call` from an authenticated principal reach the
+registry.
+
+Those two are proxied to the singleton `McpServer` over an **`InMemoryTransport` pair that
+is linked once and shared by every request**, with the per-request principal carried into
+the tool handlers through an `AsyncLocalStorage` (`authContext`) rather than through the
+transport. Sharing the link is load-bearing in both directions:
+
+- An SDK `Protocol` owns exactly one transport, so linking a pair **per request** meant the
+  second of any two overlapping requests threw `Already connected to a transport` from a
+  floating promise, and its client then waited out the full SDK request timeout (60s) for an
+  `initialize` reply no server would ever send. That made the endpoint effectively
+  single-flight under concurrency and stalled every agent behind it. One long-lived link
+  avoids it outright: the SDK multiplexes concurrent requests over a single transport by
+  JSON-RPC id.
+- `InMemoryTransport.send` invokes the peer's `onmessage` **synchronously**, on the caller's
+  stack, which is what keeps each request's `authContext` store visible to the handler it
+  dispatches. Any change that makes delivery asynchronous, or that hoists the auth context
+  out of the call stack, breaks per-request authorization on a shared link.
+
+The link is rebuilt on `initMcpServer` (a new server needs a new pair) and a failed link is
+not cached, so the next request retries. `mcp-concurrency.test.ts` guards the invariant; it
+has to bypass the DB-backed auth lookup, because the test database serialises those queries
+and would otherwise prevent requests from ever overlapping.
+
 ---
 
 ## 14. Testing

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,7 +10,7 @@ host** — not to a managed-container PaaS. These artifacts automate that host s
 
 | Path | Purpose |
 |---|---|
-| `provision.sh` | The canonical, self-contained installer. Creates a swap file (default 4 GB, `HEZO_SWAP_SIZE`) so low-RAM hosts don't get OOM-killed, installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, exempts Hezo from needrestart's automatic restarts, and locks the firewall down. Single source of truth — everything else runs it. |
+| `provision.sh` | The canonical, self-contained installer. Creates a swap file (default 6 GB, `HEZO_SWAP_SIZE`) so low-RAM hosts don't get OOM-killed, installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, exempts Hezo from needrestart's automatic restarts, and locks the firewall down. Single source of truth — everything else runs it. |
 | `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
 | `aws/` | CloudFormation **Launch Stack** template (`hezo.cfn.yaml`) — an EC2 VM whose UserData runs `provision.sh`. See [`aws/README.md`](aws/README.md). |
 | `gcp/` | **Open in Cloud Shell** deploy — `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) with a guided `tutorial.md`. See [`gcp/README.md`](gcp/README.md). |

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -9,7 +9,7 @@
 #   • you can also just SSH into a box and run it by hand
 #
 # What it does, idempotently:
-#   1. ensures a swap file exists (default 4 GB) so low-RAM hosts don't get OOM-killed
+#   1. ensures a swap file exists (default 6 GB) so low-RAM hosts don't get OOM-killed
 #   2. installs Docker Engine and starts it (Hezo needs the host Docker socket)
 #   3. downloads the arch-matched `hezo` binary from GitHub Releases
 #   4. installs Caddy as a reverse proxy with automatic HTTPS + WebSocket passthrough
@@ -38,8 +38,8 @@
 #                          /etc/hezo/hezo.env on first provision; omit for local disk.
 #   HEZO_DATABASE_POOL_SIZE  connection-pool size for the external database (2-100).
 #   HEZO_SWAP_SIZE         size of the swap file this script creates so low-RAM hosts
-#                          don't OOM (default 4G; accepts 4G / 4096M). Set 0 to disable.
-#                          Auto-shrinks to fit the disk when 4G plus headroom won't fit,
+#                          don't OOM (default 6G; accepts 6G / 6144M). Set 0 to disable.
+#                          Auto-shrinks to fit the disk when 6G plus headroom won't fit,
 #                          and is skipped when the host already has active swap.
 #   HEZO_RELEASE_TAG       pin a release tag (default: latest)
 #   HEZO_IMAGE_BUILD       set to 1 when baking a machine image (e.g. the DigitalOcean
@@ -89,7 +89,7 @@ cat >/usr/local/sbin/hezo-ensure-swap.sh <<'EOF'
 # boot: a no-op when the host already has active swap. Never aborts the caller —
 # a host that forbids swapon just logs a warning and exits 0.
 #
-#   HEZO_SWAP_SIZE  desired size (default 4G; accepts 4G / 4096M / integer MiB).
+#   HEZO_SWAP_SIZE  desired size (default 6G; accepts 6G / 6144M / integer MiB).
 #                   Set 0/off/none to disable. Auto-shrinks to fit the disk.
 set -uo pipefail
 
@@ -99,7 +99,7 @@ FLOOR_MIB=512     # don't bother creating swap smaller than this
 
 log() { echo "[hezo-swap] $*"; }
 
-REQUEST="${HEZO_SWAP_SIZE:-4G}"
+REQUEST="${HEZO_SWAP_SIZE:-6G}"
 case "${REQUEST,,}" in
 	0 | off | none | no | false | disabled)
 		log "swap disabled (HEZO_SWAP_SIZE=${REQUEST})"
@@ -113,7 +113,7 @@ if [[ -n "$(swapon --show=NAME --noheadings 2>/dev/null)" ]]; then
 	exit 0
 fi
 
-# Parse the requested size to MiB (4G / 4096M / bare integer MiB).
+# Parse the requested size to MiB (6G / 6144M / bare integer MiB).
 size_to_mib() {
 	local v="${1,,}" num unit
 	num="${v%[gm]}"
@@ -188,7 +188,7 @@ chmod +x /usr/local/sbin/hezo-ensure-swap.sh
 # Docker + Caddy installs. Skipped for machine-image builds (see the heredoc note
 # above); the first-boot unit creates it on the end user's real first boot instead.
 if [[ "${HEZO_IMAGE_BUILD:-}" != "1" ]]; then
-	HEZO_SWAP_SIZE="${HEZO_SWAP_SIZE:-4G}" /usr/local/sbin/hezo-ensure-swap.sh || log "swap setup skipped"
+	HEZO_SWAP_SIZE="${HEZO_SWAP_SIZE:-6G}" /usr/local/sbin/hezo-ensure-swap.sh || log "swap setup skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -45,7 +45,7 @@ uses the portable [cloud-init snippet](#deploy-it) below.
 
 On first boot the snippet:
 
-- creates a **4 GB swap file** so a low-RAM server doesn't get OOM-killed while
+- creates a **6 GB swap file** so a low-RAM server doesn't get OOM-killed while
   installing and running (auto-shrunk to fit the disk, and skipped if the box already
   has swap - size it with `HEZO_SWAP_SIZE`, or set `0` to disable),
 - installs **Docker** and starts it (Hezo runs each project's agents in a container),
@@ -65,7 +65,7 @@ setup screen; you take it from there.
 ## Deploy it
 
 1. **Create an Ubuntu server** on your provider - 2 GB RAM or more is a good start.
-   The deploy also adds a 4 GB swap file, so it still comes up on a smaller box.
+   The deploy also adds a 6 GB swap file, so it still comes up on a smaller box.
 2. **Paste the snippet below** into the provider's user-data field (each provider
    calls it something slightly different - see [Where to paste it](#where-to-paste-it)).
 3. **Create the server and wait ~2 minutes** for first boot to finish.
@@ -79,7 +79,7 @@ package_update: true
 packages:
   - curl
 runcmd:
-  # To change the swap size (default 4G; set 0 to disable), uncomment and edit this
+  # To change the swap size (default 6G; set 0 to disable), uncomment and edit this
   # before the curl line runs:
   # - [ sh, -c, "echo 'HEZO_SWAP_SIZE=2G' >> /etc/environment" ]
   # To use your own domain instead of sslip.io, point an A record at this server, then

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -19,11 +19,11 @@ keys, and the spend.
 
 **Low-RAM host?** Agent containers are memory-hungry, so on a small box (under ~2 GB
 RAM) add swap or the kernel may OOM-kill Hezo. The
-[one-click deploy](/docs/deployment/one-click) sets up a 4 GB swap file for you; on a
+[one-click deploy](/docs/deployment/one-click) sets up a 6 GB swap file for you; on a
 manual install, add one yourself:
 
 ```sh
-sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile
+sudo fallocate -l 6G /swapfile && sudo chmod 600 /swapfile
 sudo mkswap /swapfile && sudo swapon /swapfile
 echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
 ```

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -22,6 +22,36 @@ import { authContext, registerTools, resolveScope, type ToolDef } from './tools'
 
 let mcpServer: McpServer | null = null;
 let toolDefs: ToolDef[] = [];
+/**
+ * The in-memory client/server pair that fronts the tool registry, created once
+ * and shared by every request.
+ *
+ * A Protocol owns exactly one transport, so linking a fresh pair per request
+ * made overlapping requests collide on the shared server: the second caller's
+ * `connect()` rejected, and its client then waited out the full SDK request
+ * timeout for an `initialize` reply no server would send. The SDK multiplexes
+ * concurrent requests over a single transport by JSON-RPC id, so one long-lived
+ * link serves them all. Delivery is synchronous on the caller's stack, which is
+ * what keeps the per-request auth context flowing into the tool handlers.
+ */
+let proxyClient: Promise<Client> | null = null;
+
+function getProxyClient(server: McpServer): Promise<Client> {
+	if (!proxyClient) {
+		proxyClient = (async () => {
+			const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+			const client = new Client({ name: 'hezo-proxy', version: '0.1.0' });
+			await server.connect(serverTransport);
+			await client.connect(clientTransport);
+			return client;
+		})().catch((e) => {
+			// Don't cache a failed link — let the next request build a new one.
+			proxyClient = null;
+			throw e;
+		});
+	}
+	return proxyClient;
+}
 
 export function initMcpServer(
 	db: Db,
@@ -34,6 +64,8 @@ export function initMcpServer(
 	serverPort?: number,
 ): ToolDef[] {
 	mcpServer = new McpServer({ name: 'hezo', version: '0.1.0' });
+	// A new server needs a new link; the old pair belongs to the discarded one.
+	proxyClient = null;
 	toolDefs = registerTools(
 		mcpServer,
 		db,
@@ -153,29 +185,21 @@ export async function handleMcpRequest(c: Context<Env>): Promise<Response> {
 		});
 	}
 
-	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-	const serverConnection = mcpServer.connect(serverTransport);
-	const client = new Client({ name: 'hezo-proxy', version: '0.1.0' });
-	await client.connect(clientTransport);
+	const client = await getProxyClient(mcpServer);
 
-	try {
-		let result: unknown;
-		if (body.method === 'tools/list') {
-			result = await client.listTools();
-		} else if (body.method === 'tools/call') {
-			result = await authContext.run(auth, () => client.callTool(body.params));
-		} else {
-			return c.json({
-				jsonrpc: '2.0',
-				id: body.id,
-				error: { code: -32601, message: `Unknown method: ${body.method}` },
-			});
-		}
-		return c.json({ jsonrpc: '2.0', id: body.id, result });
-	} finally {
-		await client.close();
-		await serverConnection;
+	let result: unknown;
+	if (body.method === 'tools/list') {
+		result = await client.listTools();
+	} else if (body.method === 'tools/call') {
+		result = await authContext.run(auth, () => client.callTool(body.params));
+	} else {
+		return c.json({
+			jsonrpc: '2.0',
+			id: body.id,
+			error: { code: -32601, message: `Unknown method: ${body.method}` },
+		});
 	}
+	return c.json({ jsonrpc: '2.0', id: body.id, result });
 }
 
 /**

--- a/packages/server/test/mcp-concurrency.test.ts
+++ b/packages/server/test/mcp-concurrency.test.ts
@@ -1,0 +1,63 @@
+import { AuthType } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { createTestApp } from './helpers/app';
+
+const BYPASS_TOKEN = 'mcp-concurrency-probe';
+
+// Every /mcp request resolves its principal with a DB round-trip first, and the
+// test database serialises those, so requests here would otherwise queue up and
+// never overlap. Resolving this one token without touching the DB lets several
+// requests reach the transport at the same time, which is what a pooled
+// production database does and what the shared-transport fix has to survive.
+vi.mock('../src/middleware/auth', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../src/middleware/auth')>();
+	return {
+		...actual,
+		verifyToken: async (...args: Parameters<typeof actual.verifyToken>) =>
+			args[0] === BYPASS_TOKEN
+				? { type: AuthType.Admin, userId: 'mcp-concurrency-probe', isSuperuser: true }
+				: actual.verifyToken(...args),
+	};
+});
+
+let app: Hono<Env>;
+let db: Db;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+it('serves overlapping requests over one shared transport', async () => {
+	const responses = await Promise.all(
+		Array.from({ length: 8 }, (_, i) =>
+			app.request('/mcp', {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${BYPASS_TOKEN}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: i }),
+			}),
+		),
+	);
+
+	// Linking a fresh client/server pair per request made every request after the
+	// first fail to attach and then stall waiting for an initialize reply, so a
+	// regression shows up as an error body or a timeout rather than a bad value.
+	for (const [i, res] of responses.entries()) {
+		expect(res.status, `request ${i}`).toBe(200);
+		const body = await res.json();
+		expect(body.error, `request ${i}`).toBeUndefined();
+		expect(body.result.tools.length, `request ${i}`).toBeGreaterThan(0);
+	}
+});

--- a/packages/web/test/document-download.test.tsx
+++ b/packages/web/test/document-download.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { renderApp } from './helpers/render';
+import { clickUntil, renderApp } from './helpers/render';
 import {
 	type SeededWorkspace,
 	seedComment,
@@ -133,10 +133,17 @@ test('downloads the document from the task-sidebar preview panel', async () => {
 			params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 		});
 
-		// The panel opens from the doc mention in the comment.
-		const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
-		await user.click(mention);
-		await findByTestId('preview-panel');
+		// The panel opens from the doc mention in the comment. The thread re-renders
+		// as its queries settle, which can replace the mention node after it is
+		// located — clicking a handle captured beforehand then lands on a detached
+		// element and the panel never opens. Click the live node until it does.
+		await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+		await clickUntil(
+			user,
+			() => document.querySelector('[data-testid="doc-mention-link"]'),
+			() => !!document.querySelector('[data-testid="preview-panel"]'),
+			{ label: 'the doc mention' },
+		);
 
 		// The control renders only once the panel's doc query has resolved.
 		const trigger = await findByTestId('doc-download', undefined, { timeout: 15_000 });


### PR DESCRIPTION
Diagnosed from a live instance whose web app had become unloadable.

## The MCP endpoint could not serve concurrent requests

`handleMcpRequest` linked a fresh `InMemoryTransport` pair to the **singleton** `McpServer` on every request. An SDK `Protocol` owns exactly one transport, so the second of any two overlapping requests threw `Already connected to a transport` - from a promise only awaited in a `finally` the code never reached, because `await client.connect(...)` sat outside the `try`, which is why it surfaced as an `unhandledRejection`. That request's client then waited out the full 60s SDK timeout for an `initialize` reply no server would ever send, producing the paired `-32001` / `Route error on POST /mcp` entries.

The endpoint was therefore effectively single-flight. On the live instance, with six concurrent agent runs, that was **54 collisions and 32 request timeouts in 25 minutes** - every agent stalling 60s per MCP call and holding its run (and its memory) open far longer than needed.

The fix links the pair **once** and shares it. The SDK multiplexes concurrent requests over a single transport by JSON-RPC id, and `InMemoryTransport.send` invokes the peer's `onmessage` synchronously on the caller's stack, which is what keeps each request's `authContext` visible to the handler it dispatches. The link is rebuilt on `initMcpServer`, and a failed link is not cached so the next request retries.

## Swap default 4G -> 6G

The same host - 2 vCPU / 2GB / **no swap** - OOM-killed the server itself (RSS had grown to 1.3GB; 32 restarts with `status=137`) and then its agent containers, 65 OOM events in total. `provision.sh` already installs an idempotent swap helper, but it had never run on that box because upgrading the binary does not re-run provisioning. Raising the default gives low-RAM hosts more cushion.

## Testing

- `packages/server/test/mcp-concurrency.test.ts` is a genuine regression test: **verified to fail against the pre-fix code with the identical production error and a 62s runtime** (that 60s hang), and to pass after. It has to bypass the DB-backed auth lookup, because the test database serialises those queries and requests would otherwise never overlap - a first attempt that did not bypass it passed against the buggy code.
- `packages/web/test/document-download.test.tsx` was failing on `main`. It clicked a mention node captured beforehand; the comment thread re-renders as its queries settle and replaces that node, so the click landed on a detached element and the preview panel never opened. It now uses the existing `clickUntil` helper, as `project-doc-preview.test.ts` already does for the same interaction. It failed 2 of 2 full web runs before, and passes 4 of 4 after.

Full non-browser suite green: server 6036, web 1373, shared 186, plus the Bun-native tier.

## Not addressed here

- There is no **global** run-concurrency cap, only per-project `max_concurrent_runs` - two projects at 3 each gave 6 simultaneous runs on a 2-core box.
- The server process reached 1.3GB RSS before being killed, which seems worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah2j3uKmdLCzACaxWvjxwU
