### PR TITLE
fix(web): drop inline Model pricing blurb duplicated by the help dialog

### DIFF
--- a/packages/web/src/components/model-pricing-section.tsx
+++ b/packages/web/src/components/model-pricing-section.tsx
@@ -179,52 +179,43 @@ export function ModelPricingSection() {
 	return (
 		<section className="mt-10 pt-8 border-t border-border">
 			<div className="flex items-start justify-between gap-3 mb-4">
-				<div>
-					<div className="flex items-center gap-1.5">
-						<h2 className="text-base font-medium">Model pricing</h2>
-						<HelpDialog
-							title="How run costs are calculated"
-							triggerLabel="How run costs are calculated"
-							data-testid="model-pricing-help"
-						>
-							<div className="flex flex-col gap-3 text-sm text-text-2 leading-relaxed">
-								<p>
-									<span className="font-semibold text-text-1">
-										Every run is priced from this table.
-									</span>{' '}
-									Hezo multiplies the token counts each runtime reports by these per-model rates.
-									Dollar figures a runtime emits itself (e.g.{' '}
-									<span className="font-mono">total_cost_usd</span>) are ignored — they are
-									client-side estimates from the CLI's own rate card, which is wrong for third-party
-									endpoints.
-								</p>
-								<p>
-									Rates refresh from <span className="font-mono">pricepertoken.com</span> daily and
-									at startup; the Refresh button forces one now.
-								</p>
-								<p>
-									<span className="font-semibold text-text-1">
-										Costs are a conservative upper-bound estimate.
-									</span>{' '}
-									The catalog carries no cache pricing, so cached reads and writes are billed at the
-									full input rate. Providers charge cache reads at a steep discount, so real bills
-									are usually lower than the recorded figures — never higher.
-								</p>
-								<p>
-									A manual override wins over the catalog for its model and <em>can</em> set cache
-									rates — add one for exact billing, to correct a rate, or to price a model the
-									catalog lacks.
-								</p>
-							</div>
-						</HelpDialog>
-					</div>
-					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-						Every agent run is priced from this table: the run's token counts times these per-token
-						rates. Rates refresh daily from <span className="font-mono">pricepertoken.com</span>,
-						which carries no cache pricing — cached reads/writes are billed at the full input rate,
-						so recorded costs are a conservative upper-bound estimate. A manual override wins for
-						its model and can set cache rates for exact billing.
-					</p>
+				<div className="flex items-center gap-1.5">
+					<h2 className="text-base font-medium">Model pricing</h2>
+					<HelpDialog
+						title="How run costs are calculated"
+						triggerLabel="How run costs are calculated"
+						data-testid="model-pricing-help"
+					>
+						<div className="flex flex-col gap-3 text-sm text-text-2 leading-relaxed">
+							<p>
+								<span className="font-semibold text-text-1">
+									Every run is priced from this table.
+								</span>{' '}
+								Hezo multiplies the token counts each runtime reports by these per-model rates.
+								Dollar figures a runtime emits itself (e.g.{' '}
+								<span className="font-mono">total_cost_usd</span>) are ignored — they are
+								client-side estimates from the CLI's own rate card, which is wrong for third-party
+								endpoints.
+							</p>
+							<p>
+								Rates refresh from <span className="font-mono">pricepertoken.com</span> daily and at
+								startup; the Refresh button forces one now.
+							</p>
+							<p>
+								<span className="font-semibold text-text-1">
+									Costs are a conservative upper-bound estimate.
+								</span>{' '}
+								The catalog carries no cache pricing, so cached reads and writes are billed at the
+								full input rate. Providers charge cache reads at a steep discount, so real bills are
+								usually lower than the recorded figures — never higher.
+							</p>
+							<p>
+								A manual override wins over the catalog for its model and <em>can</em> set cache
+								rates — add one for exact billing, to correct a rate, or to price a model the
+								catalog lacks.
+							</p>
+						</div>
+					</HelpDialog>
 				</div>
 				<div className="flex items-center gap-2 shrink-0">
 					<Button

--- a/packages/web/test/model-pricing.test.tsx
+++ b/packages/web/test/model-pricing.test.tsx
@@ -53,9 +53,6 @@ test('model pricing lists the baked catalog plus overrides and creates an overri
 	await findByRole('heading', { name: 'AI providers' });
 	await findByRole('heading', { name: 'Model pricing' });
 
-	// The blurb states the single source and the conservative posture.
-	await findByText(/Rates refresh daily from/);
-
 	// The migration-baked catalog renders alongside the seeded manual row.
 	await findByText('claude-opus-4.8', undefined, { timeout: 10_000 });
 	await findByText('seeded-custom-model');
@@ -121,9 +118,11 @@ test('the Model pricing help dialog explains table-only pricing and the conserva
 		initialPath: '/settings/ai-providers',
 	});
 
-	// The explanation lives behind the help button, not inline.
+	// The explanation lives behind the help button, not inline — the old inline
+	// paragraph duplicating the dialog must not render under the heading.
 	const help = await findByTestId('model-pricing-help', undefined, { timeout: 10_000 });
 	expect(queryByText('How run costs are calculated')).toBeNull();
+	expect(queryByText(/Every agent run is priced from this table/)).toBeNull();
 
 	await user.click(help);
 


### PR DESCRIPTION
## What

Removes the inline explainer paragraph under the **Model pricing** heading on the AI providers settings page. The same explanation already lives behind the "?" help dialog right next to the heading, so the inline copy was pure duplication - and on mobile it pushed the pricing table a full screen down (see screenshot report).

## Changes

- `packages/web/src/components/model-pricing-section.tsx`: deleted the inline `<p>` blurb; the `HelpDialog` next to the heading remains the single home for the explanation. The now-redundant wrapper `<div>` around the heading row was flattened.
- `packages/web/test/model-pricing.test.tsx`: dropped the assertion on the removed inline text, and strengthened the help-dialog test to assert the inline paragraph no longer renders (`queryByText(/Every agent run is priced from this table/)` is null).

## Testing

- `bunx vitest run test/model-pricing.test.tsx` - 4/4 passing
- `tsc --noEmit` on `@hezo/web` - clean
- Docs checked: `docs/concepts/budgets-and-costs.md` describes pricing behaviour, not the removed inline blurb, so it stays accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjGVtZeqACD9jWL7yyevZh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjGVtZeqACD9jWL7yyevZh)_