### PR TITLE
Remove duplicate deploy badges from README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@
 </p>
 
 <p align="center">
-  <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/hezo-ai/hezo&cloudshell_workspace=deploy/gcp&cloudshell_tutorial=tutorial.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="28" /></a>
-  <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://hezo-deploy.s3.us-east-1.amazonaws.com/hezo.cfn.yaml&stackName=hezo"><img src="https://img.shields.io/badge/Deploy_on-AWS-FF9900?style=for-the-badge&logo=amazonwebservices&logoColor=white" alt="Deploy on AWS" height="28" /></a>
-  <a href="./docs/deployment/one-click.md"><img src="https://img.shields.io/badge/Deploy_on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white" alt="Deploy on DigitalOcean" height="28" /></a>
-</p>
-
-<p align="center">
   <strong>Your own team of AI agents. Built to deliver.</strong>
 </p>
 


### PR DESCRIPTION
Removes the three one-click deploy buttons (Google Cloud, AWS, DigitalOcean) from the top of `README.md`.

## Why

On mobile the buttons stack into three full-width rows and push the tagline, nav links, and hero screenshot well below the fold, so the header is mostly deploy chrome before a reader knows what Hezo is.

## Notes

No links are lost. The same three buttons already appear in the Quickstart deploy section (with the surrounding explanation of which providers are one-click today and a pointer to `docs/deployment/one-click.md`), which is where someone ready to deploy is looking. The CI, coverage, license, and languages badges are untouched.

Pure deletion of six lines, docs-only - no code or user-facing strings changed, so no `Docs-Checked:`/`Translations-Checked:` trailer applies. `docs-terminology.test.ts` could not be run in this container (dependencies are not installed), but the change adds no prose: verified the diff introduces zero added lines and no em/en dashes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCpiC71hHHGSVqvDZMt3Kx)_