### PR TITLE
fix(web): let users dismiss the reconnecting toast, with a 20s snooze

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2235,6 +2235,20 @@ transient state** (`creating` / `stopping` — deliberately not the `null` of a 
 project, which would poll forever). That bounds the damage of a missed transition to a few
 seconds of stale banner instead of "stuck until the operator reloads the page."
 
+**Connection indicator.** `useConnectionMonitor` (`hooks/use-connection-status.ts`) drives a
+module-level store from two signals - `navigator.onLine` (catches a dropped network an
+already-open half-open socket hasn't noticed) and the socket's own `connected` flag (catches a
+server that went away while the route is intact) - gated on "connected at least once" and
+debounced ~2s so a mobile radio blip doesn't flash. The store is a module singleton rather than
+a context because the writer lives inside `SocketProvider` while the reader, the global
+`<Toaster />`, mounts outside the provider and the router in `main.tsx`. The indicator renders
+as a persistent, non-auto-dismissing toast ("Connection lost / Reconnecting…" plus **Retry
+now**, wired to the socket client's `reconnect()`). It is **user-dismissable** - close button or
+right swipe, both through Radix's `onOpenChange` into `dismissConnectionOffline()` - which
+hides it for `DISMISS_SNOOZE_MS` (20s) and then re-surfaces it if the socket is still down;
+reconnect attempts continue untouched underneath, so the snooze only silences the notice. A heal
+discards the snooze, so a fresh drop always surfaces immediately.
+
 **Lazy comments feed.** A task's comment thread can be long, so the feed
 (`components/task-detail/comments-section.tsx`, virtualized with react-virtuoso) loads in
 two payloads off the one `GET …/tasks/:taskId/comments` route. On mount it fetches a

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -1,6 +1,6 @@
 import * as RadixToast from '@radix-ui/react-toast';
 import { Loader2, WifiOff, X } from 'lucide-react';
-import { useConnectionStatus } from '../../hooks/use-connection-status';
+import { dismissConnectionOffline, useConnectionStatus } from '../../hooks/use-connection-status';
 import { toast, useToasts } from '../../hooks/use-toast';
 
 const ERROR_DURATION_MS = 6000;
@@ -13,18 +13,22 @@ export function Toaster() {
 
 	return (
 		<RadixToast.Provider swipeDirection="right" duration={ERROR_DURATION_MS}>
-			{/* Persistent connection indicator, pinned above transient toasts. It is
-			    controlled (open + no onOpenChange) and never auto-dismisses
-			    (duration Infinity), so it stays until the socket heals; swipe is
-			    suppressed so it can't be shoved off while still offline. */}
+			{/* Persistent connection indicator, pinned above transient toasts. It never
+			    auto-dismisses (duration Infinity), so it stays until the socket heals
+			    or the user clears it — via the close button or a right swipe, both of
+			    which route through onOpenChange into a 20s snooze. Reconnect attempts
+			    continue underneath; if the socket is still down when the snooze
+			    expires the indicator comes back. */}
 			{offline && (
 				<RadixToast.Root
 					open
 					type="background"
 					duration={Number.POSITIVE_INFINITY}
-					onSwipeStart={(e) => e.preventDefault()}
+					onOpenChange={(open) => {
+						if (!open) dismissConnectionOffline();
+					}}
 					data-testid="connection-toast"
-					className="border border-danger bg-surface text-text-1 rounded-md shadow-md px-3 py-2.5 flex items-start gap-3 data-[state=open]:animate-in data-[state=open]:slide-in-from-right-2 data-[state=closed]:animate-out data-[state=closed]:fade-out"
+					className="border border-danger bg-surface text-text-1 rounded-md shadow-md px-3 py-2.5 flex items-start gap-3 data-[state=open]:animate-in data-[state=open]:slide-in-from-right-2 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-transform data-[swipe=end]:animate-out data-[swipe=end]:fade-out"
 				>
 					<WifiOff className="w-4 h-4 text-danger shrink-0 mt-0.5" aria-hidden="true" />
 					<div className="flex-1 min-w-0">
@@ -44,6 +48,15 @@ export function Toaster() {
 							Retry now
 						</button>
 					</div>
+					{/* Tap target is padded out to ~32px so it stays comfortable on mobile,
+					    where this indicator is most often in the way. */}
+					<RadixToast.Close
+						aria-label="Dismiss"
+						data-testid="connection-dismiss"
+						className="text-text-3 hover:text-text-1 shrink-0 -m-1.5 p-1.5"
+					>
+						<X className="w-3.5 h-3.5" />
+					</RadixToast.Close>
 				</RadixToast.Root>
 			)}
 			{toasts.map((t) => (

--- a/packages/web/src/hooks/use-connection-status.ts
+++ b/packages/web/src/hooks/use-connection-status.ts
@@ -13,13 +13,31 @@ import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
  * top-right toast stack without threading the socket through the whole tree.
  */
 export interface ConnectionState {
-	/** True once the socket has dropped (after connecting at least once). */
+	/**
+	 * True when the disconnect should be *surfaced*: the socket has dropped (after
+	 * connecting at least once) and the user has not snoozed the indicator.
+	 */
 	offline: boolean;
 	/** Force an immediate reconnect — wired to the socket client's `reconnect()`. */
 	retry: (() => void) | null;
 }
 
 const ONLINE: ConnectionState = { offline: false, retry: null };
+
+/**
+ * How long a user dismissal (close button or swipe) hides the indicator for. The
+ * connection itself is unaffected — reconnect attempts continue underneath — so
+ * this is purely "stop telling me for a bit". If the socket is still down when
+ * the snooze expires the indicator comes back.
+ */
+export const DISMISS_SNOOZE_MS = 20_000;
+
+/** Raw connection health, independent of whether it's currently being shown. */
+let disconnected = false;
+let retryAction: (() => void) | null = null;
+/** Set by `dismissConnectionOffline`, cleared by the timer below or by healing. */
+let snoozed = false;
+let snoozeTimer: ReturnType<typeof setTimeout> | null = null;
 
 let state: ConnectionState = ONLINE;
 const listeners = new Set<(s: ConnectionState) => void>();
@@ -28,18 +46,59 @@ function emit() {
 	for (const l of listeners) l(state);
 }
 
+function clearSnooze() {
+	snoozed = false;
+	if (snoozeTimer !== null) {
+		clearTimeout(snoozeTimer);
+		snoozeTimer = null;
+	}
+}
+
+/**
+ * Recompute the public snapshot from the raw flags. `useSyncExternalStore`
+ * compares snapshots by reference, so this must only mint a new object when the
+ * visible state actually changed — otherwise every call re-renders readers.
+ */
+function publish() {
+	const next: ConnectionState =
+		disconnected && !snoozed ? { offline: true, retry: retryAction } : ONLINE;
+	if (next.offline === state.offline && next.retry === state.retry) return;
+	state = next;
+	emit();
+}
+
 /** Mark the connection as lost, carrying the retry action for "Retry now". */
 export function setConnectionOffline(retry: () => void): void {
-	if (state.offline && state.retry === retry) return;
-	state = { offline: true, retry };
-	emit();
+	disconnected = true;
+	retryAction = retry;
+	publish();
 }
 
 /** Mark the connection as healthy again (also used to reset on provider unmount). */
 export function setConnectionOnline(): void {
-	if (!state.offline && state.retry === null) return;
-	state = ONLINE;
-	emit();
+	disconnected = false;
+	retryAction = null;
+	// A fresh drop after a heal is a new event, so it must surface immediately
+	// rather than inheriting the previous drop's snooze.
+	clearSnooze();
+	publish();
+}
+
+/**
+ * Hide the indicator for `DISMISS_SNOOZE_MS`, then re-surface it if the socket is
+ * still down. No-op while online, so a stray dismissal can't pre-snooze a future
+ * disconnect.
+ */
+export function dismissConnectionOffline(): void {
+	if (!disconnected) return;
+	clearSnooze();
+	snoozed = true;
+	snoozeTimer = setTimeout(() => {
+		snoozeTimer = null;
+		snoozed = false;
+		publish();
+	}, DISMISS_SNOOZE_MS);
+	publish();
 }
 
 export function useConnectionStatus(): ConnectionState {

--- a/packages/web/test/connection-status.test.tsx
+++ b/packages/web/test/connection-status.test.tsx
@@ -2,12 +2,14 @@
 // monitor that drives it (debounce + connected-once gate), and the persistent
 // toast the Toaster renders from it. The monitor consumes only a boolean + a
 // stable callback, so it's driven directly by a prop here (no real socket).
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { Toaster } from '../src/components/ui/toast';
 import {
 	type ConnectionState,
+	DISMISS_SNOOZE_MS,
+	dismissConnectionOffline,
 	OFFLINE_DEBOUNCE_MS,
 	setConnectionOffline,
 	setConnectionOnline,
@@ -41,6 +43,86 @@ describe('connection store', () => {
 		act(() => setConnectionOnline());
 		expect(latest.offline).toBe(false);
 		expect(latest.retry).toBeNull();
+	});
+});
+
+describe('dismiss snooze', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		setConnectionOnline();
+	});
+
+	test('hides the indicator for the snooze window, then re-surfaces it if still down', () => {
+		vi.useFakeTimers();
+		render(<Reader />);
+		const retry = () => {};
+		act(() => setConnectionOffline(retry));
+		expect(latest.offline).toBe(true);
+
+		act(() => dismissConnectionOffline());
+		expect(latest.offline).toBe(false);
+
+		act(() => vi.advanceTimersByTime(DISMISS_SNOOZE_MS - 1));
+		expect(latest.offline).toBe(false); // still snoozed
+
+		// The connection never healed, so the indicator comes back with its retry.
+		act(() => vi.advanceTimersByTime(1));
+		expect(latest.offline).toBe(true);
+		expect(latest.retry).toBe(retry);
+	});
+
+	test('a heal during the snooze leaves nothing to re-surface', () => {
+		vi.useFakeTimers();
+		render(<Reader />);
+		act(() => setConnectionOffline(() => {}));
+		act(() => dismissConnectionOffline());
+		act(() => setConnectionOnline());
+
+		act(() => vi.advanceTimersByTime(DISMISS_SNOOZE_MS * 2));
+		expect(latest.offline).toBe(false);
+	});
+
+	test('a drop after a heal surfaces immediately — it does not inherit the snooze', () => {
+		vi.useFakeTimers();
+		render(<Reader />);
+		act(() => setConnectionOffline(() => {}));
+		act(() => dismissConnectionOffline());
+		act(() => setConnectionOnline());
+
+		act(() => setConnectionOffline(() => {}));
+		expect(latest.offline).toBe(true);
+	});
+
+	test('dismissing while online is a no-op and cannot pre-snooze a later drop', () => {
+		vi.useFakeTimers();
+		render(<Reader />);
+		act(() => dismissConnectionOffline());
+		act(() => setConnectionOffline(() => {}));
+		expect(latest.offline).toBe(true);
+	});
+
+	test('the monitor does not re-surface a dismissed disconnect before the snooze expires', () => {
+		vi.useFakeTimers();
+		const reconnect = vi.fn();
+		const ui = (connected: boolean) => (
+			<>
+				<Monitor connected={connected} reconnect={reconnect} />
+				<Reader />
+			</>
+		);
+		const { rerender } = render(ui(true));
+		rerender(ui(false));
+		act(() => vi.advanceTimersByTime(OFFLINE_DEBOUNCE_MS));
+		expect(latest.offline).toBe(true);
+
+		act(() => dismissConnectionOffline());
+		// The socket stays down and the monitor keeps running throughout.
+		act(() => vi.advanceTimersByTime(DISMISS_SNOOZE_MS - 1));
+		rerender(ui(false));
+		expect(latest.offline).toBe(false);
+
+		act(() => vi.advanceTimersByTime(1));
+		expect(latest.offline).toBe(true);
 	});
 });
 
@@ -133,5 +215,28 @@ describe('connection toast (Toaster)', () => {
 
 		await user.click(screen.getByTestId('connection-retry'));
 		expect(retry).toHaveBeenCalledTimes(1);
+	});
+
+	test('the close button clears the banner and it returns after the snooze', () => {
+		// Fake timers must be installed before the dismissal so the snooze timeout is
+		// the fake one. That rules out userEvent (it awaits real-time delays between
+		// its synthesized events), so the click goes through fireEvent instead.
+		vi.useFakeTimers();
+		try {
+			render(<Toaster />);
+			act(() => setConnectionOffline(() => {}));
+			expect(screen.getByTestId('connection-toast')).toBeTruthy();
+
+			act(() => {
+				fireEvent.click(screen.getByTestId('connection-dismiss'));
+			});
+			expect(screen.queryByTestId('connection-toast')).toBeNull();
+
+			// Still offline when the snooze expires, so it comes back on its own.
+			act(() => vi.advanceTimersByTime(DISMISS_SNOOZE_MS));
+			expect(screen.getByTestId('connection-toast')).toBeTruthy();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/test/browser/connection-toast.spec.ts
+++ b/test/browser/connection-toast.spec.ts
@@ -1,4 +1,5 @@
-// Testing decision tree, points 1 (real CSS layout / boundingBox) and 5 (a real
+// Testing decision tree, points 1 (real CSS layout / boundingBox), 3 (a native
+// pointer drag with pointer capture — the swipe-to-dismiss gesture) and 5 (a real
 // WebSocket stream): the disconnect toast is driven by the live socket dropping
 // on a genuine `offline` transition, and the assertions read real positions
 // (top-right, below the header, clear of the bottom-right chat launcher) that
@@ -6,7 +7,11 @@
 
 import { expect, test } from './fixtures';
 
-test('shows a top-right reconnecting toast when the socket drops, and clears when it heals', async ({
+// Mirrors DISMISS_SNOOZE_MS in packages/web/src/hooks/use-connection-status.ts
+// (kept local: importing the hook module would pull React into the Node runner).
+const DISMISS_SNOOZE_MS = 20_000;
+
+test('shows a top-right reconnecting toast when the socket drops, clears when it heals, and can be dismissed by swipe or close', async ({
 	sharedPage,
 	sharedWorkspace,
 }) => {
@@ -58,4 +63,31 @@ test('shows a top-right reconnecting toast when the socket drops, and clears whe
 	// Restore the network → the socket reconnects → the toast clears.
 	await context.setOffline(false);
 	await expect(toast).toBeHidden({ timeout: 15000 });
+
+	// Drop it again to exercise dismissal: the toast is in the way of the app, so it
+	// must be clearable while still offline. Swipe right past Radix's swipe
+	// threshold — a real pointer drag with pointer capture, which happy-dom cannot
+	// model; the snooze *timing* is covered in packages/web/test/connection-status.
+	await context.setOffline(true);
+	await expect(toast).toBeVisible({ timeout: 10000 });
+	const swipeBox = await toast.boundingBox();
+	if (!swipeBox) throw new Error('missing toast box');
+	const midY = swipeBox.y + swipeBox.height / 2;
+	await page.mouse.move(swipeBox.x + swipeBox.width / 2, midY);
+	await page.mouse.down();
+	await page.mouse.move(swipeBox.x + swipeBox.width / 2 + 200, midY, { steps: 10 });
+	await page.mouse.up();
+	await expect(toast).toBeHidden();
+
+	// The snooze holds it down while the socket is still failing to reconnect, so a
+	// dismissal isn't undone by the next reconnect attempt a second later.
+	await page.waitForTimeout(5000);
+	await expect(toast).toBeHidden();
+
+	// And the close button is the non-gesture route to the same dismissal.
+	await expect(toast).toBeVisible({ timeout: DISMISS_SNOOZE_MS });
+	await page.getByTestId('connection-dismiss').click();
+	await expect(toast).toBeHidden();
+
+	await context.setOffline(false);
 });


### PR DESCRIPTION
The "Connection lost / Reconnecting..." indicator was deliberately undismissable: swipe was suppressed with an `onSwipeStart` preventDefault and there was no close button, so it stayed pinned top-right until the socket healed. On mobile that leaves it sitting over the app with no way to get it out of the way while the connection is still down.

## What changed

**Two ways to clear it** - a right swipe (the Provider's swipe direction, now with the Radix swipe-transform classes so the drag follows the finger) and an X close button in the top right with a ~32px tap target. Both route through Radix's `onOpenChange` into a new `dismissConnectionOffline()`.

**Dismissal is a snooze, not a mute.** `use-connection-status.ts` now separates raw connection health (`disconnected` + the retry action) from whether it is being surfaced. A dismissal hides the indicator for `DISMISS_SNOOZE_MS` (20s), then re-surfaces it if the socket is still down. Reconnect attempts continue untouched underneath - the snooze only silences the notice.

Edge cases handled:

- A heal discards the snooze, so a fresh drop always surfaces immediately rather than inheriting the previous drop's snooze.
- Dismissing while online is a no-op, so a stray dismissal can't pre-snooze a future disconnect.
- The socket monitor keeps running through the snooze and does not undo the dismissal.
- `publish()` only mints a new snapshot when the *visible* state changes, since `useSyncExternalStore` compares snapshots by reference.

## Tests

Six new component tests in `packages/web/test/connection-status.test.tsx` cover the snooze semantics: hide then re-surface at exactly the 20s boundary, heal during the snooze, drop after a heal, no-op while online, the monitor not undoing a dismissal, and the close button end to end through the `Toaster`.

`test/browser/connection-toast.spec.ts` adds a real right-swipe pointer drag past Radix's swipe threshold (pointer capture, which happy-dom cannot model - decision-tree point 3) plus the close button, and re-orders so the existing heal assertion stays meaningful.

Verified: `bunx vitest run test/connection-status.test.tsx` (13 passed) and the browser spec via `bun run test --browser --pattern connection-toast` (passed, 43s), plus `typecheck` and `check`.

## Docs

`.dev/architecture.md` (web frontend) now documents the connection indicator - the two signals driving it, why the store is a module singleton rather than a context, and the dismiss snooze. No user-facing `docs/` page describes the disconnect toast, so nothing changed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TskKRWpZz3x6YgwMSQbT5

---
_Generated by [Claude Code](https://claude.ai/code/session_019TskKRWpZz3x6YgwMSQbT5)_