### PR TITLE
feat: run containers on demand with a global container limit and RAM caps

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -53,7 +53,7 @@ manager (agents bring their own models and runtimes).
 | Realtime | WebSocket row-change events → client invalidates React Query keys |
 | Agent interface | MCP (Streamable HTTP) at `POST /mcp` via `@modelcontextprotocol/sdk` |
 | Crypto | AES-256-GCM at rest; master key held in memory only |
-| Containers | Docker Engine API, one container per project |
+| Containers | Docker Engine API, one container per project — started on demand, stopped after an idle timeout |
 
 **Monorepo** — Bun workspaces + Turborepo. **Three** packages plus a root `agents/`
 tree:
@@ -259,7 +259,7 @@ status flip, and code worktree. They fire on the Captain's heartbeat when goals 
 the Goals page's **Run now** button (`POST /projects/:projectId/goals/run-now` →
 `JobManager.dispatchProgressUpdateNow`, which resolves the project's Captain and reuses the same
 due-goal logic). If **Run now** hits a *transient* conflict — the Captain is already running, the
-project is at its concurrency limit, the container is still coming up, or a launch race — the run is
+instance is at its active-container limit, or a launch race — the run is
 **queued** rather than erroring: a task-less `agent_wakeup_requests` row tagged
 `payload.trigger='progress_update_now'` (deduped per Captain by `createProgressUpdateWakeup`, so
 "Run now" is idempotent) that the 5s dispatcher retries until the Captain frees up. This trigger tag
@@ -1115,9 +1115,35 @@ one comment source that surfaced no reference to what triggered it). The Coach's
 review is the one path that instead embeds the **full** comment history (both share
 `loadCommentHistory`/`renderCommentHistory`).
 
-**Containers & worktrees.** One container per project; the project's
-`<dataDir>/teams/<slug>/projects/<slug>/workspace/` bind-mounts to `/workspace`, with one
-subdirectory per linked repo. For each task the runner creates a `git worktree` at
+**Containers & worktrees.** One container per project, **run on demand**: the container is
+not required to be up between runs. `runAgent` establishes it at the start of every run via
+`ensureProjectContainerRunning` (running → reuse; stopped → start in place; missing/stale row →
+provision), chat sessions do the same, and the `container-idle-stop` cron (1/min) stops any
+container idle past the operator's timeout (`container_idle_timeout_min` in `system_meta`,
+default 15 minutes, `0` = always-on) — so a quiet instance runs zero containers. "Idle" means:
+no active (queued/running) run, no run finished inside the window, no queued wakeup that could
+dispatch (capacity-skipped wakeups deliberately don't pin containers), and no chat session with
+recent `last_activity_at` or an in-flight turn; `projects.container_last_started_at` floors the
+check so a fresh start always gets one full window. Every lifecycle *decision* — ensure-running
+and the cron's check-then-stop (which re-verifies the predicate plus the scheduler's in-memory
+run/pending refcounts under the lock) — serializes per project through
+`withContainerLifecycleLock` (`services/containers.ts`), so a start and a stop can never
+interleave: worst case is a wasted stop/start cycle, never a failed run. Concurrency is bounded
+by one **global active-container limit** (`max_active_containers` in `system_meta`; when unset,
+the default is computed from host memory as `(RAM + swap) / default_ram_cap_per_container_gb`,
+clamped to [1,100]): dispatch passes a run whose project container is already active (no new
+container needed) and queues one that would need another container past the cap
+(`WakeupSkipReason.InstanceAtCapacity`, retried by the 5s dispatcher; an in-memory
+`pendingContainerStarts` refcount covers the window before the DB row reads Running). Dispatch
+drains FIFO by `created_at` with no per-project fair-share — a deep backlog in one project
+consumes freed slots first; that scheduler is the hook if this ever needs fairness. The chat
+path is *not* gated: its container counts toward the limit once running, but starting a chat is
+never refused — busy agents must not lock the operator out of the control surface. All three
+knobs (limit, per-container RAM cap, idle timeout) live on the global Settings → Concurrency
+page (`GET/PATCH /api/instance-settings`; `PATCH {max_active_containers: null}` resets to the
+computed default). The project's
+`<dataDir>/teams/<teamId>/projects/<projectId>/workspace/` (id-keyed, never slugs) bind-mounts
+to `/workspace`, with one subdirectory per linked repo. For each task the runner creates a `git worktree` at
 `/worktrees/<task-identifier>/<repo-name>` on branch `hezo/<task-identifier>`, persisted
 across runs and torn down when the task reaches a terminal status (`done`/`cancelled`). That
 teardown (`removeTaskWorktrees`, a host-side `rmSync`) fires from `triggerStatusAutomations`,
@@ -1164,8 +1190,10 @@ its abort handler on the *response* stream's end, never on the `ClientRequest`'s
 that had already been detached.
 
 **Container hardening.** Each project container is created with a hardened `HostConfig`
-(`provisionContainer`): a cgroup memory cap (`Memory`=`MemorySwap`= the project's
-`memory_limit_gib` + 512 MiB headroom, so no swap escape valve) as a hard backstop *behind*
+(`provisionContainer`): a cgroup memory cap (`Memory`=`MemorySwap`= the effective RAM cap +
+512 MiB headroom, so no swap escape valve — the per-project `memory_limit_gib` override when
+set, else the instance-wide `default_ram_cap_per_container_gb`, default 2 GB) as a hard
+backstop *behind*
 the sync-loop stats poller that stays the graceful early-stop at the configured ceiling;
 `PidsLimit` (4096) as a fork-bomb guard; `Init: true` so a real init reaps zombies under the
 `sleep infinity` PID 1; and `CapDrop: ['ALL']` with a minimal add-back

--- a/.dev/hosted-architecture.md
+++ b/.dev/hosted-architecture.md
@@ -48,7 +48,8 @@ Hezo is single-tenant by design at three independent layers:
    across all teams.
 2. **The runtime assumes it owns the host**
    (`services/docker.ts`, `services/containers.ts`, `services/egress/*`):
-   exclusive `/var/run/docker.sock`, one long-lived container per project,
+   exclusive `/var/run/docker.sock`, one container per project (started on
+   demand, idle-stopped),
    in-memory per-process egress port allocators (front 20000–29999, host MITM
    30000–39999, dev 10000–19999), `/tmp/hezo-<hash>/` run sockets.
 3. **Security boundary — decisive for untrusted signup.** Agents execute
@@ -440,8 +441,8 @@ hypervisor — the provisioner interface keeps that door open.
 > doing background agent work, **LLM API token spend likely dwarfs compute**.
 > The credential/billing model (bring-your-own-key vs. a pooled platform key
 > with metering) deserves at least as much design effort as the substrate;
-> Hezo's per-project/per-agent budget caps and
-> `projects.max_concurrent_runs` are the existing levers.
+> Hezo's per-project/per-agent budget caps and the instance-wide
+> `max_active_containers` cap are the existing levers.
 
 ## Quotas, rate limiting, abuse
 

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -15,6 +15,10 @@ project. You don't manage teams separately; you reach a team through its project
 This keeps things clean: a project's agents, tasks, budget, container, and connections
 all belong to that project and nothing leaks between them.
 
+A project's container runs only while there is work: it starts automatically when an
+agent run or the assistant needs it and stops again after sitting idle, so projects you
+aren't actively using cost nothing.
+
 ## Project icon
 
 By default a project shows its initials wherever it is listed. To give it a distinct look,

--- a/docs/security/container-isolation.md
+++ b/docs/security/container-isolation.md
@@ -16,6 +16,29 @@ Each project's container is a private workspace holding that project's code and 
 Because the sandbox is per project, one project's agents can't see or touch another's
 work - the blast radius of anything going wrong is contained to a single project.
 
+## Containers run only when there is work
+
+A container starts automatically the moment an agent run or an assistant chat needs it,
+and stops again after sitting idle (15 minutes by default). A quiet instance runs zero
+containers. Two global limits in **Settings > Concurrency** bound what a burst of agent
+activity can consume:
+
+- **Maximum active containers** - how many project containers may run at the same time
+  (including the assistant chat's container). When unset, Hezo sizes it automatically
+  from the machine's memory: (RAM + swap) divided by the RAM cap below. Runs that would
+  need another container past the limit wait in the queue and start as containers go
+  idle; the assistant chat always starts.
+- **RAM cap per container** - the memory limit applied to every container (2 GB by
+  default; projects that need more can override it in their own settings). A container
+  over its cap is stopped, or has its biggest process killed by the kernel, instead of
+  taking down the whole server.
+
+As a sizing rule of thumb, one working agent (its coding CLI plus the helper tools it
+spawns) typically uses 300-350 MB of memory, and the container cap bounds the total
+regardless of how many agents share it. The idle timeout is configurable on the same
+page; note that stopping an idle container also stops any dev or preview servers running
+inside it, and setting the timeout to 0 keeps containers always on.
+
 From inside the container, agents **cannot** reach:
 
 - your **host filesystem** (only the project's own workspace is available), or
@@ -40,7 +63,8 @@ turned away - it never gets a secret substituted, so the guarantee holds even th
 ## Resource and privilege limits
 
 Each container also runs with guardrails so a runaway or misbehaving agent can't exhaust the
-host: a **memory cap** (per project, with the running total shown while an agent works), a
+host: a **memory cap** (the global RAM cap per container, overridable per project, with
+the running total shown while an agent works), a
 **process limit** that stops fork bombs, and a **reduced set of Linux capabilities** (the
 container starts with all capabilities dropped and only the few the workload needs added
 back). A proper init process runs as PID 1 so exited helper processes are always cleaned up.

--- a/packages/server/migrations/048_global_concurrency_and_container_idle_stop.sql
+++ b/packages/server/migrations/048_global_concurrency_and_container_idle_stop.sql
@@ -1,0 +1,35 @@
+-- The concurrency cap becomes one global, instance-wide limit on ACTIVE
+-- CONTAINERS (system_meta key 'max_active_containers'; an absent key means a
+-- default computed from host memory), replacing the per-project run column. A
+-- per-project cap cannot bound what the host actually experiences: N projects
+-- x M runs each all land on the same box.
+ALTER TABLE projects DROP COLUMN max_concurrent_runs;
+
+-- Memory cap: NULL now means "inherit the instance-wide default"
+-- (system_meta 'default_ram_cap_per_container_gb', default 2). Rows on the old
+-- hardcoded 16GiB default move to inherit -- on a small host that cap is a
+-- no-op (the prod OOM incident: a runaway in-container process triggered a
+-- GLOBAL OOM kill instead of a contained cgroup one). Explicitly customized
+-- values are preserved as per-project overrides.
+ALTER TABLE projects ALTER COLUMN memory_limit_gib DROP NOT NULL;
+ALTER TABLE projects ALTER COLUMN memory_limit_gib DROP DEFAULT;
+UPDATE projects SET memory_limit_gib = NULL WHERE memory_limit_gib = 16;
+
+-- Idle-stop floor: when this project's container last entered 'running'. The
+-- idle-stop cron never stops a container younger than the idle timeout, so a
+-- manual start or fresh provision always gets one full idle window. Backfilled
+-- to now() for currently-running containers so an upgrade grants the same grace
+-- instead of stopping everything on the first tick.
+ALTER TABLE projects ADD COLUMN container_last_started_at TIMESTAMPTZ;
+UPDATE projects SET container_last_started_at = now() WHERE container_status = 'running';
+
+-- Idle-stop cron: "projects with a run finished inside the idle window" is a
+-- bare recency range scan on finished_at. The existing idx_runs_member_finished
+-- (047) leads on member_id and cannot serve a recency-only predicate.
+CREATE INDEX idx_runs_finished ON heartbeat_runs (finished_at DESC);
+
+-- Idle-stop cron: in-flight chat turns hold a container up. Partial on the two
+-- live states so the index carries only the working set, same shape as
+-- idx_wakeups_pending (047).
+CREATE INDEX idx_chat_messages_inflight ON chat_messages (session_id)
+    WHERE status IN ('pending', 'streaming');

--- a/packages/server/src/lib/git-lock.ts
+++ b/packages/server/src/lib/git-lock.ts
@@ -4,15 +4,10 @@
 // brief setup/recovery steps must not overlap or they race on git's index/ref
 // locks. Keyed by project id, so different projects never block one another.
 // In-process only (single-server assumption), same as the rest of the runtime.
+import { withKeyedLock } from './keyed-lock';
+
 const projectGitLocks = new Map<string, Promise<unknown>>();
 
 export function withProjectGitLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
-	const prev = projectGitLocks.get(projectId) ?? Promise.resolve();
-	const run = prev.then(() => fn());
-	const tail = run.catch(() => {});
-	projectGitLocks.set(projectId, tail);
-	void tail.then(() => {
-		if (projectGitLocks.get(projectId) === tail) projectGitLocks.delete(projectId);
-	});
-	return run;
+	return withKeyedLock(projectGitLocks, projectId, fn);
 }

--- a/packages/server/src/lib/host-memory.ts
+++ b/packages/server/src/lib/host-memory.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { totalmem } from 'node:os';
+
+/**
+ * Total host memory, used to compute the automatic max-active-containers
+ * default ((RAM + swap) / per-container ram cap). RAM comes from
+ * `os.totalmem()`; swap from `/proc/meminfo` `SwapTotal` on Linux (production
+ * runs on Linux; on other platforms — e.g. macOS dev — swap reads as 0, which
+ * only makes the computed default more conservative). Memoized per process:
+ * host memory doesn't change while the server runs.
+ */
+export interface HostMemory {
+	totalRamBytes: number;
+	totalSwapBytes: number;
+}
+
+let cached: HostMemory | null = null;
+
+export function getHostMemory(): HostMemory {
+	if (cached) return cached;
+	cached = { totalRamBytes: totalmem(), totalSwapBytes: readSwapTotalBytes() };
+	return cached;
+}
+
+/** Test seam: override the probe (pass null to restore the real one). */
+export function setHostMemoryForTest(value: HostMemory | null): void {
+	cached = value;
+}
+
+function readSwapTotalBytes(): number {
+	try {
+		const meminfo = readFileSync('/proc/meminfo', 'utf8');
+		// Format: "SwapTotal:       6291452 kB"
+		const match = meminfo.match(/^SwapTotal:\s+(\d+)\s*kB/m);
+		return match ? Number.parseInt(match[1], 10) * 1024 : 0;
+	} catch {
+		return 0;
+	}
+}

--- a/packages/server/src/lib/keyed-lock.ts
+++ b/packages/server/src/lib/keyed-lock.ts
@@ -1,0 +1,20 @@
+/**
+ * Promise-chain keyed mutex: serializes async work per key while different keys
+ * proceed independently. In-process only (single-server assumption). Callers own
+ * their Map so each lock family (git ops, container lifecycle, ...) has its own
+ * key space and its own documented scope.
+ */
+export function withKeyedLock<T>(
+	locks: Map<string, Promise<unknown>>,
+	key: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const prev = locks.get(key) ?? Promise.resolve();
+	const run = prev.then(() => fn());
+	const tail = run.catch(() => {});
+	locks.set(key, tail);
+	void tail.then(() => {
+		if (locks.get(key) === tail) locks.delete(key);
+	});
+	return run;
+}

--- a/packages/server/src/lib/system-meta.ts
+++ b/packages/server/src/lib/system-meta.ts
@@ -1,12 +1,23 @@
 import {
+	CONTAINER_IDLE_TIMEOUT_MIN_MAX,
+	CONTAINER_IDLE_TIMEOUT_MIN_MIN,
 	coerceLocaleSettings,
+	computeDefaultMaxActiveContainers,
+	DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN,
+	DEFAULT_MAX_ACTIVE_CONTAINERS,
 	DEFAULT_MAX_CHAT_HISTORY_SIZE,
+	DEFAULT_RAM_CAP_PER_CONTAINER_GB,
 	type LocaleSettings,
 	type LocaleSettingsPatch,
+	MAX_ACTIVE_CONTAINERS_MAX,
+	MAX_ACTIVE_CONTAINERS_MIN,
 	MAX_CHAT_HISTORY_SIZE_MAX,
 	MAX_CHAT_HISTORY_SIZE_MIN,
+	RAM_CAP_PER_CONTAINER_GB_MAX,
+	RAM_CAP_PER_CONTAINER_GB_MIN,
 } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { getHostMemory } from './host-memory';
 
 /**
  * Instance-wide key-value settings stored in the `system_meta` table (the same
@@ -15,6 +26,9 @@ import type { Db } from '../db/database';
 
 export const INSTANCE_BASE_URL_KEY = 'instance_base_url';
 export const MAX_CHAT_HISTORY_SIZE_KEY = 'max_chat_history_size';
+export const MAX_ACTIVE_CONTAINERS_KEY = 'max_active_containers';
+export const RAM_CAP_PER_CONTAINER_KEY = 'default_ram_cap_per_container_gb';
+export const CONTAINER_IDLE_TIMEOUT_KEY = 'container_idle_timeout_min';
 
 /**
  * Locale keys. One key per axis rather than a single JSON blob, so a partial
@@ -77,6 +91,127 @@ export async function getMaxChatHistorySize(db: Db): Promise<number> {
 export async function setMaxChatHistorySize(db: Db, value: number): Promise<number> {
 	const clamped = clampMaxChatHistorySize(value);
 	await setSystemMeta(db, MAX_CHAT_HISTORY_SIZE_KEY, String(clamped));
+	return clamped;
+}
+
+/**
+ * Clamp to the allowed max-active-containers range. Exported so the settings
+ * route validates with the same bounds the reader enforces.
+ */
+export function clampMaxActiveContainers(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_MAX_ACTIVE_CONTAINERS;
+	return Math.min(
+		MAX_ACTIVE_CONTAINERS_MAX,
+		Math.max(MAX_ACTIVE_CONTAINERS_MIN, Math.round(value)),
+	);
+}
+
+/**
+ * The automatic max-active-containers value for this host: how many
+ * ram-cap-sized containers fit in total virtual memory (RAM + swap). Used
+ * whenever the operator has not explicitly set `max_active_containers`.
+ */
+export async function computeAutoMaxActiveContainers(db: Db): Promise<number> {
+	const ramCapGb = await getDefaultRamCapPerContainerGb(db);
+	const { totalRamBytes, totalSwapBytes } = getHostMemory();
+	return computeDefaultMaxActiveContainers(totalRamBytes, totalSwapBytes, ramCapGb);
+}
+
+/**
+ * The explicitly stored max-active-containers value, or null when the operator
+ * has never set one (→ the computed default applies).
+ */
+export async function getMaxActiveContainersSetting(db: Db): Promise<number | null> {
+	const raw = await getSystemMeta(db, MAX_ACTIVE_CONTAINERS_KEY);
+	if (raw === null) return null;
+	const parsed = Number.parseInt(raw, 10);
+	if (Number.isNaN(parsed)) return null;
+	return clampMaxActiveContainers(parsed);
+}
+
+/**
+ * The effective instance-wide cap on simultaneously active (running) project
+ * containers — the operator's main bound on memory, since every container is
+ * memory-capped and total demand never exceeds `N × cap`. An explicitly stored
+ * value wins; otherwise the default is computed from host memory and the
+ * per-container ram cap. Malformed stored values degrade to the computed
+ * default so a stale row can never wedge dispatch.
+ */
+export async function getMaxActiveContainers(db: Db): Promise<number> {
+	return (await getMaxActiveContainersSetting(db)) ?? computeAutoMaxActiveContainers(db);
+}
+
+export async function setMaxActiveContainers(db: Db, value: number): Promise<number> {
+	const clamped = clampMaxActiveContainers(value);
+	await setSystemMeta(db, MAX_ACTIVE_CONTAINERS_KEY, String(clamped));
+	return clamped;
+}
+
+/** Clear the explicit value — the computed (auto) default applies again. */
+export async function clearMaxActiveContainers(db: Db): Promise<void> {
+	await deleteSystemMeta(db, MAX_ACTIVE_CONTAINERS_KEY);
+}
+
+/**
+ * Clamp to the allowed per-container ram-cap range (GB). Exported so the
+ * settings route validates with the same bounds the reader enforces.
+ */
+export function clampRamCapPerContainerGb(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_RAM_CAP_PER_CONTAINER_GB;
+	return Math.min(
+		RAM_CAP_PER_CONTAINER_GB_MAX,
+		Math.max(RAM_CAP_PER_CONTAINER_GB_MIN, Math.round(value)),
+	);
+}
+
+/**
+ * The instance-wide default memory cap per project container, in GB. Applied
+ * as the Docker cgroup limit to every container without a per-project
+ * override, and used as the divisor of the automatic max-active-containers
+ * default. Falls back to 2 when unset or malformed.
+ */
+export async function getDefaultRamCapPerContainerGb(db: Db): Promise<number> {
+	const raw = await getSystemMeta(db, RAM_CAP_PER_CONTAINER_KEY);
+	if (raw === null) return DEFAULT_RAM_CAP_PER_CONTAINER_GB;
+	const parsed = Number.parseInt(raw, 10);
+	if (Number.isNaN(parsed)) return DEFAULT_RAM_CAP_PER_CONTAINER_GB;
+	return clampRamCapPerContainerGb(parsed);
+}
+
+export async function setDefaultRamCapPerContainerGb(db: Db, value: number): Promise<number> {
+	const clamped = clampRamCapPerContainerGb(value);
+	await setSystemMeta(db, RAM_CAP_PER_CONTAINER_KEY, String(clamped));
+	return clamped;
+}
+
+/**
+ * Clamp to the allowed container idle-timeout range (minutes). 0 is a valid
+ * value meaning "never stop" (always-on containers).
+ */
+export function clampContainerIdleTimeoutMin(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN;
+	return Math.min(
+		CONTAINER_IDLE_TIMEOUT_MIN_MAX,
+		Math.max(CONTAINER_IDLE_TIMEOUT_MIN_MIN, Math.round(value)),
+	);
+}
+
+/**
+ * Minutes a project's container may sit without activity (agent runs, assistant
+ * chat) before the idle-stop cron stops it; containers restart on demand.
+ * 0 = never stop. Falls back to the default when unset or malformed.
+ */
+export async function getContainerIdleTimeoutMin(db: Db): Promise<number> {
+	const raw = await getSystemMeta(db, CONTAINER_IDLE_TIMEOUT_KEY);
+	if (raw === null) return DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN;
+	const parsed = Number.parseInt(raw, 10);
+	if (Number.isNaN(parsed)) return DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN;
+	return clampContainerIdleTimeoutMin(parsed);
+}
+
+export async function setContainerIdleTimeoutMin(db: Db, value: number): Promise<number> {
+	const clamped = clampContainerIdleTimeoutMin(value);
+	await setSystemMeta(db, CONTAINER_IDLE_TIMEOUT_KEY, String(clamped));
 	return clamped;
 }
 

--- a/packages/server/src/routes/goals.ts
+++ b/packages/server/src/routes/goals.ts
@@ -101,8 +101,8 @@ const PROGRESS_UPDATE_MESSAGES: Record<ProgressUpdateDispatchReason, string> = {
 	captain_disabled: 'The Captain is currently disabled.',
 	no_due_goals: 'No goals are due for a progress update right now.',
 	agent_busy: 'The Captain is already running in this project.',
-	project_at_capacity: 'This project is at its concurrent-run limit.',
-	container_down: 'The project container is not running yet.',
+	instance_at_capacity:
+		'Hezo is at its active-container limit; the run will start when a container goes idle.',
 	over_budget: 'The Captain or project is over its budget.',
 	launch_conflict: 'A progress-update run is already starting.',
 };

--- a/packages/server/src/routes/instance-settings.ts
+++ b/packages/server/src/routes/instance-settings.ts
@@ -1,19 +1,36 @@
 import {
+	CONTAINER_IDLE_TIMEOUT_MIN_MAX,
+	CONTAINER_IDLE_TIMEOUT_MIN_MIN,
+	MAX_ACTIVE_CONTAINERS_MAX,
+	MAX_ACTIVE_CONTAINERS_MIN,
 	MAX_CHAT_HISTORY_SIZE_MAX,
 	MAX_CHAT_HISTORY_SIZE_MIN,
 	parseLocaleSettingsPatch,
+	RAM_CAP_PER_CONTAINER_GB_MAX,
+	RAM_CAP_PER_CONTAINER_GB_MIN,
 } from '@hezo/shared';
 import { Hono } from 'hono';
+import type { Db } from '../db/database';
+import { getHostMemory } from '../lib/host-memory';
 import { err, ok } from '../lib/response';
 import {
+	clearMaxActiveContainers,
+	computeAutoMaxActiveContainers,
 	deleteSystemMeta,
+	getContainerIdleTimeoutMin,
+	getDefaultRamCapPerContainerGb,
 	getInstanceBaseUrl,
 	getInstanceLocale,
+	getMaxActiveContainers,
+	getMaxActiveContainersSetting,
 	getMaxChatHistorySize,
 	INSTANCE_BASE_URL_KEY,
 	instanceLocaleIsConfigured,
 	normalizeBaseUrl,
+	setContainerIdleTimeoutMin,
+	setDefaultRamCapPerContainerGb,
 	setInstanceLocale,
+	setMaxActiveContainers,
 	setMaxChatHistorySize,
 	setSystemMeta,
 } from '../lib/system-meta';
@@ -23,14 +40,33 @@ import { adminPasswordIsSet } from '../services/password';
 
 export const instanceSettingsRoutes = new Hono<Env>();
 
+/**
+ * The settings payload GET and PATCH both return. `max_active_containers` is
+ * the effective value; `_is_set` distinguishes an explicit choice from the
+ * computed default, and the host memory figures let the settings page render
+ * the formula behind the automatic value ("8 GB / 2 GB = 4").
+ */
+async function instanceSettingsPayload(db: Db) {
+	const explicitMaxActive = await getMaxActiveContainersSetting(db);
+	const { totalRamBytes, totalSwapBytes } = getHostMemory();
+	return {
+		base_url: await getInstanceBaseUrl(db),
+		max_chat_history_size: await getMaxChatHistorySize(db),
+		max_active_containers: await getMaxActiveContainers(db),
+		max_active_containers_is_set: explicitMaxActive !== null,
+		max_active_containers_computed_default: await computeAutoMaxActiveContainers(db),
+		default_ram_cap_per_container_gb: await getDefaultRamCapPerContainerGb(db),
+		container_idle_timeout_min: await getContainerIdleTimeoutMin(db),
+		host_total_ram_bytes: totalRamBytes,
+		host_total_swap_bytes: totalSwapBytes,
+		locale: await getInstanceLocale(db),
+	};
+}
+
 // Instance-wide settings. Readable by any authenticated principal (the same
 // openness as GET /api/ai-providers); writes are superuser-only.
 instanceSettingsRoutes.get('/instance-settings', async (c) => {
-	const db = c.get('db');
-	const base_url = await getInstanceBaseUrl(db);
-	const max_chat_history_size = await getMaxChatHistorySize(db);
-	const locale = await getInstanceLocale(db);
-	return ok(c, { base_url, max_chat_history_size, locale });
+	return ok(c, await instanceSettingsPayload(c.get('db')));
 });
 
 /**
@@ -68,33 +104,92 @@ instanceSettingsRoutes.patch('/instance-settings/locale', async (c) => {
 	return ok(c, { locale, configured: await instanceLocaleIsConfigured(db) });
 });
 
+/**
+ * Validate an integer-range setting from the PATCH body: returns an error
+ * message when invalid, or null when `value` is an in-range integer.
+ */
+function integerRangeError(field: string, value: unknown, min: number, max: number): string | null {
+	if (typeof value !== 'number' || !Number.isInteger(value)) {
+		return `${field} must be an integer`;
+	}
+	if (value < min || value > max) {
+		return `${field} must be between ${min} and ${max}`;
+	}
+	return null;
+}
+
 instanceSettingsRoutes.patch('/instance-settings', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 
 	const db = c.get('db');
-	const body = await c.req
-		.json<{ base_url?: unknown; max_chat_history_size?: unknown }>()
-		.catch(() => ({}) as { base_url?: unknown; max_chat_history_size?: unknown });
+	type PatchBody = {
+		base_url?: unknown;
+		max_chat_history_size?: unknown;
+		max_active_containers?: unknown;
+		default_ram_cap_per_container_gb?: unknown;
+		container_idle_timeout_min?: unknown;
+	};
+	const body = await c.req.json<PatchBody>().catch(() => ({}) as PatchBody);
 
-	if (!('base_url' in body) && !('max_chat_history_size' in body)) {
-		return err(c, 'INVALID_REQUEST', 'base_url or max_chat_history_size is required', 400);
+	const knownFields = [
+		'base_url',
+		'max_chat_history_size',
+		'max_active_containers',
+		'default_ram_cap_per_container_gb',
+		'container_idle_timeout_min',
+	] as const;
+	if (!knownFields.some((f) => f in body)) {
+		return err(c, 'INVALID_REQUEST', `one of ${knownFields.join(', ')} is required`, 400);
 	}
 
 	if ('max_chat_history_size' in body) {
-		const value = body.max_chat_history_size;
-		if (typeof value !== 'number' || !Number.isInteger(value)) {
-			return err(c, 'INVALID_REQUEST', 'max_chat_history_size must be an integer', 400);
-		}
-		if (value < MAX_CHAT_HISTORY_SIZE_MIN || value > MAX_CHAT_HISTORY_SIZE_MAX) {
-			return err(
-				c,
-				'INVALID_REQUEST',
-				`max_chat_history_size must be between ${MAX_CHAT_HISTORY_SIZE_MIN} and ${MAX_CHAT_HISTORY_SIZE_MAX}`,
-				400,
+		const invalid = integerRangeError(
+			'max_chat_history_size',
+			body.max_chat_history_size,
+			MAX_CHAT_HISTORY_SIZE_MIN,
+			MAX_CHAT_HISTORY_SIZE_MAX,
+		);
+		if (invalid) return err(c, 'INVALID_REQUEST', invalid, 400);
+		await setMaxChatHistorySize(db, body.max_chat_history_size as number);
+	}
+
+	if ('max_active_containers' in body) {
+		// null resets to the automatic (host-memory-computed) default.
+		if (body.max_active_containers === null) {
+			await clearMaxActiveContainers(db);
+		} else {
+			const invalid = integerRangeError(
+				'max_active_containers',
+				body.max_active_containers,
+				MAX_ACTIVE_CONTAINERS_MIN,
+				MAX_ACTIVE_CONTAINERS_MAX,
 			);
+			if (invalid) return err(c, 'INVALID_REQUEST', invalid, 400);
+			await setMaxActiveContainers(db, body.max_active_containers as number);
 		}
-		await setMaxChatHistorySize(db, value);
+	}
+
+	if ('default_ram_cap_per_container_gb' in body) {
+		const invalid = integerRangeError(
+			'default_ram_cap_per_container_gb',
+			body.default_ram_cap_per_container_gb,
+			RAM_CAP_PER_CONTAINER_GB_MIN,
+			RAM_CAP_PER_CONTAINER_GB_MAX,
+		);
+		if (invalid) return err(c, 'INVALID_REQUEST', invalid, 400);
+		await setDefaultRamCapPerContainerGb(db, body.default_ram_cap_per_container_gb as number);
+	}
+
+	if ('container_idle_timeout_min' in body) {
+		const invalid = integerRangeError(
+			'container_idle_timeout_min',
+			body.container_idle_timeout_min,
+			CONTAINER_IDLE_TIMEOUT_MIN_MIN,
+			CONTAINER_IDLE_TIMEOUT_MIN_MAX,
+		);
+		if (invalid) return err(c, 'INVALID_REQUEST', invalid, 400);
+		await setContainerIdleTimeoutMin(db, body.container_idle_timeout_min as number);
 	}
 
 	if ('base_url' in body) {
@@ -118,8 +213,5 @@ instanceSettingsRoutes.patch('/instance-settings', async (c) => {
 
 	// Locale is echoed so GET and PATCH return the same shape, but it is not
 	// writable here — PATCH /instance-settings/locale is its single write path.
-	const base_url = await getInstanceBaseUrl(db);
-	const max_chat_history_size = await getMaxChatHistorySize(db);
-	const locale = await getInstanceLocale(db);
-	return ok(c, { base_url, max_chat_history_size, locale });
+	return ok(c, await instanceSettingsPayload(c.get('db')));
 });

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -546,8 +546,7 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 	const body = await c.req.json<{
 		name?: string;
 		description?: string;
-		max_concurrent_runs?: number;
-		memory_limit_gib?: number;
+		memory_limit_gib?: number | null;
 		daily_budget_cents?: number;
 		weekly_budget_cents?: number;
 		monthly_budget_cents?: number;
@@ -577,17 +576,14 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		params.push(body.description);
 		idx++;
 	}
-	if (body.max_concurrent_runs !== undefined) {
-		if (!Number.isInteger(body.max_concurrent_runs) || body.max_concurrent_runs < 1) {
-			return err(c, 'INVALID_REQUEST', 'max_concurrent_runs must be an integer ≥ 1', 400);
-		}
-		sets.push(`max_concurrent_runs = $${idx}`);
-		params.push(body.max_concurrent_runs);
-		idx++;
-	}
 	if (body.memory_limit_gib !== undefined) {
-		if (!Number.isInteger(body.memory_limit_gib) || body.memory_limit_gib < 1) {
-			return err(c, 'INVALID_REQUEST', 'memory_limit_gib must be an integer ≥ 1', 400);
+		// null clears the per-project override — the container inherits the
+		// instance-wide default ram cap.
+		if (
+			body.memory_limit_gib !== null &&
+			(!Number.isInteger(body.memory_limit_gib) || body.memory_limit_gib < 1)
+		) {
+			return err(c, 'INVALID_REQUEST', 'memory_limit_gib must be an integer ≥ 1 or null', 400);
 		}
 		sets.push(`memory_limit_gib = $${idx}`);
 		params.push(body.memory_limit_gib);
@@ -898,10 +894,12 @@ projectsRoutes.post('/projects/:projectId/container/start', async (c) => {
 	const containerId = result.rows[0].container_id;
 	try {
 		await docker.startContainer(containerId);
-		await db.query('UPDATE projects SET container_status = $1::container_status WHERE id = $2', [
-			ContainerStatus.Running,
-			projectId,
-		]);
+		await db.query(
+			`UPDATE projects
+			 SET container_status = $1::container_status, container_last_started_at = now()
+			 WHERE id = $2`,
+			[ContainerStatus.Running, projectId],
+		);
 		c.get('containerLogStreamer').subscribe(projectId, containerId, c.get('logs'), docker);
 		await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
 		await wakeAgentsWithPendingWork(db, projectId, teamId);

--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -8,7 +8,7 @@ import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import {
 	getBusyAgentIdsInProject,
-	isProjectAtCapacityInDb,
+	isContainerCapacityBlockedInDb,
 	isTaskBusyInDb,
 } from '../services/run-concurrency';
 import { recordWakeupCancelled, resolveActorName } from '../services/task-events';
@@ -46,10 +46,10 @@ queuedWakeupsRoutes.get('/projects/:projectId/tasks/:taskId/queued-wakeups', asy
 		[teamId, WakeupStatus.Queued, taskId],
 	);
 
-	// Live run-now gating. Task busy state and project capacity are shared by
-	// every wakeup on this task, so compute them once; dependency-blocker state
-	// is per-wakeup because shouldDeferWakeupForBlockers only gates certain
-	// wakeup sources.
+	// Live run-now gating. Task busy state and the global run capacity are
+	// shared by every wakeup on this task, so compute them once;
+	// dependency-blocker state is per-wakeup because shouldDeferWakeupForBlockers
+	// only gates certain wakeup sources.
 	const projRow = await db.query<{ project_id: string }>(
 		'SELECT project_id FROM tasks WHERE id = $1',
 		[taskId],
@@ -57,11 +57,11 @@ queuedWakeupsRoutes.get('/projects/:projectId/tasks/:taskId/queued-wakeups', asy
 	const projectId = projRow.rows[0]?.project_id ?? null;
 
 	let taskBusy = false;
-	let projectAtCapacity = false;
+	let instanceAtCapacity = false;
 	if (await isTaskBusyInDb(db, taskId)) {
 		taskBusy = true;
-	} else if (projectId && (await isProjectAtCapacityInDb(db, projectId))) {
-		projectAtCapacity = true;
+	} else if (projectId && (await isContainerCapacityBlockedInDb(db, projectId))) {
+		instanceAtCapacity = true;
 	}
 
 	// agent_busy is per-agent (each wakeup has its own member), so it lives on
@@ -85,10 +85,20 @@ queuedWakeupsRoutes.get('/projects/:projectId/tasks/:taskId/queued-wakeups', asy
 		wakeups,
 		dispatch: {
 			task_busy: taskBusy,
-			project_at_capacity: projectAtCapacity,
+			instance_at_capacity: instanceAtCapacity,
 		},
 	});
 });
+
+// Shared by both manual-dispatch handlers below; keys mirror DispatchNowResult.
+const DISPATCH_CONFLICT_MESSAGES: Record<string, string> = {
+	task_busy: 'This ticket already has a run in progress',
+	instance_at_capacity:
+		'Hezo is at its active-container limit; the run will start when a container goes idle',
+	agent_busy: 'This agent is currently running on another task in this project',
+	blocked: 'This ticket is blocked by an open dependency',
+	not_queued: 'Wakeup is no longer queued and cannot be run',
+};
 
 queuedWakeupsRoutes.post(
 	'/projects/:projectId/tasks/:taskId/queued-wakeups/:wakeupId/cancel',
@@ -206,14 +216,12 @@ queuedWakeupsRoutes.post(
 			if (result.reason === 'not_found') {
 				return err(c, 'NOT_FOUND', 'Queued wakeup not found', 404);
 			}
-			const messages: Record<string, string> = {
-				task_busy: 'This ticket already has a run in progress',
-				project_at_capacity: 'This project is at its concurrent-run limit',
-				agent_busy: 'This agent is currently running on another task in this project',
-				blocked: 'This ticket is blocked by an open dependency',
-				not_queued: 'Wakeup is no longer queued and cannot be run',
-			};
-			return err(c, 'CONFLICT', messages[result.reason] ?? 'Unable to start queued run', 409);
+			return err(
+				c,
+				'CONFLICT',
+				DISPATCH_CONFLICT_MESSAGES[result.reason] ?? 'Unable to start queued run',
+				409,
+			);
 		}
 
 		return ok(c, { dispatched: true });
@@ -258,14 +266,12 @@ queuedWakeupsRoutes.post('/projects/:projectId/tasks/:taskId/runs/:runId/retry',
 		if (result.reason === 'not_found') {
 			return err(c, 'NOT_FOUND', 'Queued wakeup not found', 404);
 		}
-		const messages: Record<string, string> = {
-			task_busy: 'This ticket already has a run in progress',
-			project_at_capacity: 'This project is at its concurrent-run limit',
-			agent_busy: 'This agent is currently running on another task in this project',
-			blocked: 'This ticket is blocked by an open dependency',
-			not_queued: 'Wakeup is no longer queued and cannot be run',
-		};
-		return err(c, 'CONFLICT', messages[result.reason] ?? 'Unable to start retry run', 409);
+		return err(
+			c,
+			'CONFLICT',
+			DISPATCH_CONFLICT_MESSAGES[result.reason] ?? 'Unable to start retry run',
+			409,
+		);
 	}
 
 	return ok(c, { dispatched: true });

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -33,7 +33,7 @@ import { getConnection } from '../services/oauth/connection-store';
 import { performRepoSetup } from '../services/repo-provisioning';
 import { refreshRepoPushAccess } from '../services/repo-push-access';
 import { removeRepoFromWorkspace } from '../services/repo-sync';
-import { getProjectConcurrency } from '../services/run-concurrency';
+import { countActiveRunsInProject } from '../services/run-concurrency';
 import { type BridgeRunnerArgs, withProvisionBridge } from '../services/ssh-agent';
 import {
 	CONTAINER_WORKSPACE_ROOT,
@@ -405,7 +405,7 @@ reposRoutes.get('/projects/:projectId/repos/:repoId/git-state', async (c) => {
 
 	// Reset actions are blocked while any run is active on the project; surface the
 	// count so the panel can gate its buttons instead of failing the reset reactively.
-	const { active } = await getProjectConcurrency(db, projectId);
+	const active = await countActiveRunsInProject(db, projectId);
 
 	return ok(c, {
 		container_running: true,
@@ -453,7 +453,7 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 	if (!repo) return err(c, 'NOT_FOUND', 'Repo not found', 404);
 
 	// Never reset while a run may hold a worktree in this project's shared .git.
-	const { active } = await getProjectConcurrency(db, projectId);
+	const active = await countActiveRunsInProject(db, projectId);
 	if (active > 0) {
 		return err(
 			c,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -63,13 +63,14 @@ import {
 	type ProbeResult,
 	shouldAbortForConnectivity,
 } from './container-connectivity-status';
+import type { ContainerLogStreamer } from './container-logs';
 import {
 	type ContainerRunUser,
 	chownToRunUser,
 	ensureContainerDirReady,
 	resolveContainerRunUser,
 } from './container-user';
-import { syncContainerStatus } from './containers';
+import { ensureProjectContainerRunning } from './containers';
 import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
@@ -152,11 +153,18 @@ interface ProjectInfo {
 	slug: string;
 	team_id: string;
 	team_slug: string;
-	container_id: string;
-	container_status: string;
+	container_id: string | null;
+	container_status: string | null;
 	designated_repo_id: string | null;
 	is_internal: boolean;
 }
+
+/**
+ * ProjectInfo once the runner has ensured the project container is running —
+ * containers start on demand at run start, so callers may hand runAgent a
+ * project whose container is stopped or was never provisioned.
+ */
+type RunningProjectInfo = ProjectInfo & { container_id: string };
 
 export interface RunResult {
 	success: boolean;
@@ -184,6 +192,8 @@ export interface RunnerDeps {
 	sshAgentServer?: SshAgentServer;
 	egressProxy?: EgressProxy | null;
 	egressCAPath?: string | null;
+	/** When present, a container the runner lazy-starts resubscribes its log stream. */
+	containerLogStreamer?: ContainerLogStreamer;
 	/** Latest container→host connectivity outcome. When present and the egress
 	 * proxy is unreachable from containers, the run aborts instead of silently
 	 * falling through to direct egress. Absent → fail open (back-compat). */
@@ -662,7 +672,7 @@ async function buildRunContext(
 	deps: RunnerDeps,
 	agent: AgentInfo,
 	task: TaskInfo | null,
-	project: ProjectInfo,
+	project: RunningProjectInfo,
 	wakeupPayload: Record<string, unknown> | undefined,
 	credential: AiProviderCredential,
 	provider: AiProvider,
@@ -1009,32 +1019,44 @@ export async function runAgent(
 		};
 	};
 
-	if (!project.container_id || project.container_status !== ContainerStatus.Running) {
-		return finalizeFailure(
-			'Project container is not running. Start the container from the Project page and retry.',
-		);
+	// Containers run on demand: start (or provision) the project's container for
+	// this run rather than requiring it to already be up. ensureProjectContainerRunning
+	// inspects Docker live — a stale `running` row whose container is gone is
+	// repaired by re-provisioning — and serializes per project, so concurrent runs
+	// dispatching into the same stopped project start exactly one container.
+	if (project.container_status !== ContainerStatus.Running) {
+		emit('stdout', '[runner] Starting the project container…\n');
 	}
-
-	// The cached container_status can lag reality — Docker may have been restarted
-	// or the container pruned externally, leaving the row marked "running" while
-	// execCreate would 404 mid-run. Verify liveness against Docker and reconcile the
-	// DB (syncContainerStatus nulls the id + flips status on a 404 or exit) before we
-	// commit to the run, then broadcast so the banner / sidebar / Container page
-	// correct at once.
-	const liveStatus = await syncContainerStatus(
-		deps.db,
-		deps.docker,
-		project.id,
-		project.slug,
-		project.container_id,
-		project.container_status,
-	);
-	if (liveStatus !== ContainerStatus.Running) {
+	let containerId: string;
+	try {
+		containerId = await ensureProjectContainerRunning(
+			{
+				db: deps.db,
+				docker: deps.docker,
+				dataDir: deps.dataDir,
+				wsManager: deps.wsManager,
+				masterKeyManager: deps.masterKeyManager,
+				logs: deps.logs,
+				containerLogStreamer: deps.containerLogStreamer,
+				sshAgentServer: deps.sshAgentServer,
+				egressCAPath: deps.egressCAPath,
+			},
+			project.id,
+		);
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
 		await broadcastProjectUpdate(deps.db, deps.wsManager, project.team_id, project.id);
 		return finalizeFailure(
-			'Project container is not running. Start the container from the Project page and retry.',
+			`Could not start the project container: ${message}. See the Container page for logs.`,
 		);
 	}
+	// The run may have been aborted (e.g. timed out) while a slow provision ran.
+	if (signal?.aborted) return finalizeAbort();
+	const runningProject: RunningProjectInfo = {
+		...project,
+		container_id: containerId,
+		container_status: ContainerStatus.Running,
+	};
 
 	let provider: AiProvider;
 	let runtimeType: AgentRuntime;
@@ -1100,7 +1122,7 @@ export async function runAgent(
 		// ssh socket owner, and the chowns that give the run-user ownership of the
 		// host-written config/worktree dirs. Defaults to root for an image with no
 		// `node` user, which makes those chowns a harmless no-op.
-		const runUser = await resolveContainerRunUser(deps.docker, project.container_id);
+		const runUser = await resolveContainerRunUser(deps.docker, containerId);
 
 		let sshSocketContainerPath: string | null = null;
 		let sshSocketHostPath: string | null = null;
@@ -1179,7 +1201,7 @@ export async function runAgent(
 			deps,
 			agent,
 			task,
-			project,
+			runningProject,
 			wakeupPayload,
 			credential,
 			provider,
@@ -1282,7 +1304,16 @@ export async function runAgent(
 
 			// Progress-update runs only call MCP tools; they need no code worktree.
 			const prep = task
-				? await prepareWorktrees(deps, project, task, heartbeatRunId, bridge, runUser, emit, signal)
+				? await prepareWorktrees(
+						deps,
+						runningProject,
+						task,
+						heartbeatRunId,
+						bridge,
+						runUser,
+						emit,
+						signal,
+					)
 				: {
 						workingDir: '/workspace',
 						designatedRepo: null as RepoRow | null,
@@ -1309,7 +1340,7 @@ export async function runAgent(
 
 			emit('stdout', `${invocationCommand}\n`);
 
-			const execId = await deps.docker.execCreate(project.container_id, {
+			const execId = await deps.docker.execCreate(containerId, {
 				Cmd: context.execCmd,
 				Env: context.env,
 				WorkingDir: prep.workingDir,
@@ -1594,7 +1625,7 @@ export async function runAgent(
 			// it — and best-effort so a kill failure never masks the run result.
 			if (isAbort && reason !== 'container_stopped' && reason !== 'container_error') {
 				try {
-					await deps.docker.killRunProcesses(project.container_id, heartbeatRunId);
+					await deps.docker.killRunProcesses(containerId, heartbeatRunId);
 				} catch (killError) {
 					log.error(
 						`Run ${heartbeatRunId}: failed to kill container processes on abort:`,
@@ -1668,7 +1699,7 @@ async function anyWorktreeChanged(
 
 async function prepareWorktrees(
 	deps: RunnerDeps,
-	project: ProjectInfo,
+	project: RunningProjectInfo,
 	task: TaskInfo,
 	heartbeatRunId: string,
 	bridge: BridgeRunnerArgs | null,

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -17,8 +17,10 @@ import type { Db } from '../db/database';
 import { trackBackground } from '../lib/background';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
 import { forEachConcurrent } from '../lib/concurrency';
+import { withKeyedLock } from '../lib/keyed-lock';
 import { ref } from '../lib/log-ref';
 import { stripNulBytes, terminalStatusParams } from '../lib/sql';
+import { getDefaultRamCapPerContainerGb } from '../lib/system-meta';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
 import type { ContainerLogStreamer } from './container-logs';
@@ -54,6 +56,21 @@ export interface ContainerTransition {
 }
 
 const log = logger.child('containers');
+
+/**
+ * Serializes container lifecycle *decisions* per project: ensure-running
+ * (start/provision at run or chat start) and the idle-stop cron's
+ * check-then-stop. Without it, two runs dispatching into the same stopped
+ * project could both provision (two containers, one orphaned), and idle-stop
+ * could stop a container between a dispatch's capacity check and its exec.
+ * Never held across an agent exec — only across the brief inspect/start/
+ * provision/stop step — so it is not a throughput ceiling on runs themselves.
+ * Keyed by project id; in-process only (single-server assumption).
+ */
+const containerLifecycleLocks = new Map<string, Promise<unknown>>();
+export function withContainerLifecycleLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+	return withKeyedLock(containerLifecycleLocks, projectId, fn);
+}
 
 export interface ProjectRow {
 	id: string;
@@ -164,13 +181,12 @@ export function shouldKeepOldContainers(): boolean {
 	return keepOldContainersFlag;
 }
 
-/**
- * Default per-container working-set ceiling, used when a project has not set
- * its own `projects.memory_limit_gib`. The sync loop stops the container when
- * working-set memory crosses this threshold and records an explanation in
- * `container_error`. Override per project from the Settings page.
- */
-export const DEFAULT_MEMORY_LIMIT_GIB = 16;
+// The per-container working-set ceiling is the instance-wide
+// `default_ram_cap_per_container_gb` setting (system_meta, default 2GB),
+// overridable per project via `projects.memory_limit_gib` (NULL = inherit).
+// The old hardcoded 16GiB default was a no-op on small hosts — 8x physical
+// RAM on a 2GB VPS — so a runaway in-container process triggered a *global*
+// OOM kill instead of a contained cgroup one.
 
 const memoryLimitBytes = (gib: number) => gib * 1024 ** 3;
 
@@ -398,11 +414,12 @@ export async function provisionContainer(
 		// cgroup hard cap = the project's working-set ceiling + headroom; the
 		// sync-loop stats poller remains the graceful early-stop at the ceiling
 		// itself (see MEMORY_HARD_CAP_HEADROOM_BYTES).
-		const limitRow = await db.query<{ memory_limit_gib: number }>(
+		const limitRow = await db.query<{ memory_limit_gib: number | null }>(
 			'SELECT memory_limit_gib FROM projects WHERE id = $1',
 			[project.id],
 		);
-		const memoryLimitGib = limitRow.rows[0]?.memory_limit_gib ?? DEFAULT_MEMORY_LIMIT_GIB;
+		const memoryLimitGib =
+			limitRow.rows[0]?.memory_limit_gib ?? (await getDefaultRamCapPerContainerGb(db));
 		const memoryHardCapBytes = memoryLimitBytes(memoryLimitGib) + MEMORY_HARD_CAP_HEADROOM_BYTES;
 
 		const { Id } = await docker.createContainer(containerName, {
@@ -450,7 +467,10 @@ export async function provisionContainer(
 		);
 
 		await db.query(
-			'UPDATE projects SET container_id = $1, container_status = $2::container_status, container_error = NULL WHERE id = $3',
+			`UPDATE projects
+			 SET container_id = $1, container_status = $2::container_status,
+			     container_error = NULL, container_last_started_at = now()
+			 WHERE id = $3`,
 			[Id, ContainerStatus.Running, project.id],
 		);
 
@@ -581,37 +601,64 @@ export async function ensureProjectContainerRunning(
 	deps: ContainerDeps,
 	projectId: string,
 ): Promise<string> {
-	const { db, docker } = deps;
-	const res = await db.query<ProjectRow & { team_slug: string }>(
-		`SELECT p.id, p.team_id, p.slug, p.docker_base_image, p.container_id, p.container_status,
-		        p.dev_ports, c.slug AS team_slug
-		 FROM projects p JOIN teams c ON c.id = p.team_id
-		 WHERE p.id = $1`,
-		[projectId],
-	);
-	const proj = res.rows[0];
-	if (!proj) throw new Error('Project not found');
+	// The whole inspect→start/provision step runs under the per-project lifecycle
+	// lock so every caller (agent runner, chat session, repo provisioning) is
+	// covered without call-site changes: concurrent ensures serialize, and the
+	// second caller sees a running container instead of double-provisioning.
+	return withContainerLifecycleLock(projectId, async () => {
+		const { db, docker } = deps;
+		const res = await db.query<ProjectRow & { team_slug: string }>(
+			`SELECT p.id, p.team_id, p.slug, p.docker_base_image, p.container_id, p.container_status,
+			        p.dev_ports, c.slug AS team_slug
+			 FROM projects p JOIN teams c ON c.id = p.team_id
+			 WHERE p.id = $1`,
+			[projectId],
+		);
+		const proj = res.rows[0];
+		if (!proj) throw new Error('Project not found');
 
-	if (proj.container_id) {
-		const info = await docker.inspectContainer(proj.container_id);
-		if (info?.State.Running) return proj.container_id;
-		if (info) {
-			// Container exists but is stopped — start it in place.
-			await docker.startContainer(proj.container_id);
-			await db.query(
-				'UPDATE projects SET container_status = $1::container_status, container_error = NULL WHERE id = $2',
-				[ContainerStatus.Running, proj.id],
-			);
-			if (deps.containerLogStreamer && deps.logs) {
-				deps.containerLogStreamer.subscribe(proj.id, proj.container_id, deps.logs, docker);
+		if (proj.container_id) {
+			const info = await docker.inspectContainer(proj.container_id);
+			if (info?.State.Running) {
+				// Docker is the truth; if the row lags (e.g. an out-of-band start),
+				// reconcile it and stamp the start floor so the idle-stop cron can
+				// see — and eventually reclaim — this container.
+				if (proj.container_status !== ContainerStatus.Running) {
+					await db.query(
+						`UPDATE projects
+						 SET container_status = $1::container_status, container_error = NULL,
+						     container_last_started_at = now()
+						 WHERE id = $2`,
+						[ContainerStatus.Running, proj.id],
+					);
+					await broadcastProjectUpdate(db, deps.wsManager, proj.team_id, proj.id);
+				}
+				return proj.container_id;
 			}
-			await broadcastProjectUpdate(db, deps.wsManager, proj.team_id, proj.id);
-			return proj.container_id;
+			if (info) {
+				// Container exists but is stopped — start it in place.
+				await docker.startContainer(proj.container_id);
+				await db.query(
+					`UPDATE projects
+					 SET container_status = $1::container_status, container_error = NULL,
+					     container_last_started_at = now()
+					 WHERE id = $2`,
+					[ContainerStatus.Running, proj.id],
+				);
+				if (deps.containerLogStreamer && deps.logs) {
+					deps.containerLogStreamer.subscribe(proj.id, proj.container_id, deps.logs, docker);
+				}
+				await broadcastProjectUpdate(db, deps.wsManager, proj.team_id, proj.id);
+				log.info(
+					`project ${ref(proj.slug, proj.id)} container ${ref(proj.slug, proj.container_id.slice(0, 12))} started on demand`,
+				);
+				return proj.container_id;
+			}
 		}
-	}
 
-	// No container id, or the stored id no longer exists in Docker — provision.
-	return provisionContainer(deps, proj, proj.team_slug);
+		// No container id, or the stored id no longer exists in Docker — provision.
+		return provisionContainer(deps, proj, proj.team_slug);
+	});
 }
 
 export async function teardownContainer(
@@ -705,6 +752,105 @@ export async function stopContainerGracefully(
 	);
 
 	await broadcastProjectUpdate(db, wsManager, teamId, projectId);
+}
+
+/**
+ * Activity that holds a project's container up, shared by the idle-stop cron's
+ * candidate scan and its under-lock recheck. Evaluated activity-side so an idle
+ * instance's cost tracks activity inside the window, not table history. A
+ * project is busy when it has: an active (queued/running) run; a run finished
+ * inside the idle window (idx_runs_finished); a queued wakeup that could
+ * actually dispatch — capacity-skipped wakeups deliberately do NOT hold a
+ * container, else a backlog waiting on the container cap would pin containers
+ * warm forever ('project_at_capacity' is the pre-rename legacy value, re-stamped
+ * within seconds of an upgrade); or a live chat session with recent activity or
+ * an in-flight (pending/streaming) turn (idx_chat_messages_inflight).
+ * `$1` is the idle window in minutes everywhere.
+ */
+const UUID_RE = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+const BUSY_PROJECTS_SQL = `
+	SELECT DISTINCT t.project_id FROM heartbeat_runs hr
+	 JOIN tasks t ON t.id = hr.task_id
+	 WHERE hr.status IN ('queued', 'running')
+	UNION
+	SELECT DISTINCT t.project_id FROM heartbeat_runs hr
+	 JOIN tasks t ON t.id = hr.task_id
+	 WHERE hr.finished_at > now() - ($1 * interval '1 minute')
+	UNION
+	SELECT DISTINCT t.project_id FROM agent_wakeup_requests w
+	 JOIN tasks t ON t.id = (w.payload->>'task_id')::uuid
+	 WHERE w.status = 'queued'
+	   AND w.payload->>'task_id' ~ '${UUID_RE}'
+	   AND (w.last_skipped_reason IS NULL
+	     OR w.last_skipped_reason NOT IN ('instance_at_capacity', 'project_at_capacity'))
+	UNION
+	SELECT DISTINCT (w.payload->>'project_id')::uuid AS project_id FROM agent_wakeup_requests w
+	 WHERE w.status = 'queued'
+	   AND w.payload->>'project_id' ~ '${UUID_RE}'
+	   AND (w.last_skipped_reason IS NULL
+	     OR w.last_skipped_reason NOT IN ('instance_at_capacity', 'project_at_capacity'))
+	UNION
+	SELECT cs.project_id FROM chat_sessions cs
+	 WHERE cs.status IN ('starting', 'running')
+	   AND (cs.last_activity_at > now() - ($1 * interval '1 minute')
+	     OR EXISTS (SELECT 1 FROM chat_messages cm
+	                WHERE cm.session_id = cs.id AND cm.status IN ('pending', 'streaming')))
+`;
+
+/**
+ * The per-candidate predicate the idle-stop cron applies: container running,
+ * up for at least one full idle window (the start-time floor — a manual start
+ * or fresh provision is never stopped early; NULL-started rows never match, so
+ * they are never idle-stopped), and no busy signal. `extraSql` narrows to one
+ * project for the under-lock recheck.
+ */
+const IDLE_CANDIDATE_SQL = (extraSql: string, limitSql: string) => `
+	WITH busy AS (${BUSY_PROJECTS_SQL})
+	SELECT p.id, p.slug, p.team_id, p.container_id
+	FROM projects p
+	WHERE p.container_status = 'running'::container_status
+	  AND p.container_id IS NOT NULL
+	  AND p.container_last_started_at IS NOT NULL
+	  AND p.container_last_started_at < now() - ($1 * interval '1 minute')
+	  AND p.id NOT IN (SELECT project_id FROM busy)
+	  ${extraSql}
+	${limitSql}
+`;
+
+export interface IdleContainerCandidate {
+	id: string;
+	slug: string;
+	team_id: string;
+	container_id: string;
+}
+
+/** Projects whose running container has been idle past the timeout. */
+export async function findIdleContainerCandidates(
+	db: Db,
+	timeoutMin: number,
+	limit: number,
+): Promise<IdleContainerCandidate[]> {
+	const res = await db.query<IdleContainerCandidate>(IDLE_CANDIDATE_SQL('', 'LIMIT $2'), [
+		timeoutMin,
+		limit,
+	]);
+	return res.rows;
+}
+
+/**
+ * Re-verify one candidate immediately before stopping it (run under the
+ * project's lifecycle lock, after the caller's in-memory checks).
+ */
+export async function isProjectIdleForContainerStop(
+	db: Db,
+	projectId: string,
+	timeoutMin: number,
+): Promise<boolean> {
+	const res = await db.query(IDLE_CANDIDATE_SQL('AND p.id = $2', 'LIMIT 1'), [
+		timeoutMin,
+		projectId,
+	]);
+	return res.rows.length > 0;
 }
 
 /**
@@ -861,8 +1007,8 @@ export async function syncContainerStatus(
 }
 
 /**
- * If the container's working-set memory crosses the per-project memory ceiling
- * (`projects.memory_limit_gib`, default {@link DEFAULT_MEMORY_LIMIT_GIB}), stop
+ * If the container's working-set memory crosses its effective memory ceiling
+ * (`projects.memory_limit_gib` override, else the instance-wide ram cap), stop
  * it and record an explanatory message in `container_error`. The banner and
  * container page both surface that field. Returns the synthesised status when the
  * container was stopped, or null when it was within budget or stats were unavailable.
@@ -961,10 +1107,14 @@ export async function syncAllContainerStatuses(
 		team_id: string;
 		container_id: string;
 		container_status: string | null;
-		memory_limit_gib: number;
+		memory_limit_gib: number | null;
 	}>(
 		'SELECT id, slug, team_id, container_id, container_status, memory_limit_gib FROM projects WHERE container_id IS NOT NULL',
 	);
+
+	// Effective per-container ceiling: the project override, else the
+	// instance-wide default — read once per pass, not once per project.
+	const defaultRamCapGib = await getDefaultRamCapPerContainerGb(db);
 
 	const transitions: ContainerTransition[] = [];
 	const now = Date.now();
@@ -996,7 +1146,7 @@ export async function syncAllContainerStatuses(
 				project.slug,
 				project.team_id,
 				project.container_id,
-				project.memory_limit_gib,
+				project.memory_limit_gib ?? defaultRamCapGib,
 			);
 			if (overrideStatus !== null) {
 				newStatus = overrideStatus;

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -28,6 +28,7 @@ import { broadcastRowChange } from '../lib/broadcast';
 import type { StorageBackend } from '../lib/db-info';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
 import { ref } from '../lib/log-ref';
+import { getContainerIdleTimeoutMin } from '../lib/system-meta';
 import { logger } from '../logger';
 import { getLatestInfo } from '../routes/updates';
 import { exitToApplyUpdate } from '../runtime-control';
@@ -52,11 +53,15 @@ import {
 	type ContainerTransition,
 	ensureProjectContainerRunning,
 	failProjectRuns,
+	findIdleContainerCandidates,
+	isProjectIdleForContainerStop,
 	provisionContainer,
 	rebuildContainer,
+	stopContainerGracefully,
 	syncAllContainerStatuses,
 	verifyContainerWorkspace,
 	wakeAgentsWithPendingWork,
+	withContainerLifecycleLock,
 } from './containers';
 import type { ContainerProcessInfo, DockerClient } from './docker';
 import type { EgressProxy } from './egress';
@@ -67,7 +72,7 @@ import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './o
 import type { PricingService } from './pricing';
 import { collectCandidateRunIds, decideSweepKills } from './process-sweeper';
 import { ensureRepoSetupAction } from './repo-setup';
-import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
+import { getActiveContainers, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { reportTelemetry } from './telemetry';
 import { ensureUpdateStaged, isSupervisedWorker, readUpdateState } from './updater';
@@ -105,6 +110,9 @@ interface RunDispatchContext {
 	memberId: string;
 	taskId: string;
 	projectId: string;
+	/** This dispatch will lazy-start the project's container — it holds a
+	 * pending-container-start slot until the run settles. */
+	pendingContainerStart?: boolean;
 }
 
 interface RunningTask {
@@ -135,7 +143,7 @@ export type DispatchNowResult =
 			dispatched: false;
 			reason:
 				| 'task_busy'
-				| 'project_at_capacity'
+				| 'instance_at_capacity'
 				| 'agent_busy'
 				| 'blocked'
 				| 'not_queued'
@@ -151,8 +159,7 @@ export type ProgressUpdateDispatchReason =
 	| 'captain_disabled'
 	| 'no_due_goals'
 	| 'agent_busy'
-	| 'project_at_capacity'
-	| 'container_down'
+	| 'instance_at_capacity'
 	| 'over_budget'
 	| 'launch_conflict';
 
@@ -236,6 +243,18 @@ const BUDGET_RESUME_CRON = process.env.HEZO_BUDGET_RESUME_CRON ?? '*/30 * * * * 
 // slows page loads enough to time out browser/component specs. Both are env-
 // configurable so the E2E server can dial them down — see playwright.config.ts.
 const CONTAINER_SYNC_CRON = process.env.HEZO_CONTAINER_SYNC_CRON ?? '* * * * * *';
+
+/**
+ * Idle-container reaper cadence: once a minute (offset to :15 to avoid the
+ * top-of-minute pile-up with other jobs). The state it watches — "did the idle
+ * window elapse" — changes on minute granularity, so a faster tick would only
+ * burn queries. Env-overridable so E2E can dial it down.
+ */
+const CONTAINER_IDLE_STOP_CRON = process.env.HEZO_CONTAINER_IDLE_STOP_CRON ?? '15 * * * * *';
+
+/** Containers stopped per idle-stop tick — a bound, not a target; the next
+ * tick continues where this one stopped. */
+const IDLE_STOP_BATCH_LIMIT = 10;
 const ORPHAN_DETECTION_CRON = process.env.HEZO_ORPHAN_DETECTION_CRON ?? '*/30 * * * * *';
 // The reactive budget pauses, which the heartbeat scheduler must not wake (the
 // budget-resume sweep lifts them back to `idle` once the window rolls over).
@@ -285,6 +304,9 @@ export class JobManager {
 	// would be wrong here: with several runs in flight, the first to finish would
 	// free the guard for the rest.
 	private activeProjectRuns = new Map<string, number>();
+	/** Projects whose container is being lazy-started by an in-flight dispatch —
+	 * counted against the active-container cap before the DB row reads Running. */
+	private pendingContainerStarts = new Map<string, number>();
 	private deps: JobManagerDeps;
 	private started = false;
 
@@ -369,15 +391,15 @@ export class JobManager {
 				return { dispatched: false, reason: 'task_busy' };
 			}
 			const project = await this.resolveProjectForTask(wakeupTaskId);
-			if (project && (await this.isProjectAtCapacity(project.id))) {
+			if (await this.isContainerCapacityBlocked(project?.id ?? null)) {
 				await this.markWakeupSkipped(
 					wakeup.id,
-					WakeupSkipReason.ProjectAtCapacity,
+					WakeupSkipReason.InstanceAtCapacity,
 					wakeupTaskId,
 					wakeup.team_id,
 					null,
 				);
-				return { dispatched: false, reason: 'project_at_capacity' };
+				return { dispatched: false, reason: 'instance_at_capacity' };
 			}
 			if (project && (await this.isAgentBusyInProject(wakeup.member_id, project.id))) {
 				await this.markWakeupSkipped(
@@ -490,6 +512,11 @@ export class JobManager {
 			log: cronLog,
 			onTick: () => this.guarded('container-sync', () => this.syncContainerStatuses()),
 		});
+		this.cron.createJob('container-idle-stop', {
+			cron: CONTAINER_IDLE_STOP_CRON,
+			log: cronLog,
+			onTick: () => this.guarded('container-idle-stop', () => this.stopIdleContainers()),
+		});
 		this.cron.createJob('inbox-archive', {
 			cron: INBOX_ARCHIVE_CRON,
 			log: cronLog,
@@ -582,6 +609,7 @@ export class JobManager {
 	private releaseRunDispatch(ctx: RunDispatchContext): void {
 		this.activeTaskRuns.delete(ctx.taskId);
 		this.releaseProjectRun(ctx.projectId);
+		if (ctx.pendingContainerStart) this.releasePendingContainerStart(ctx.projectId);
 	}
 
 	cancelTask(key: string, reason?: unknown): boolean {
@@ -816,8 +844,14 @@ export class JobManager {
 			log.warn('Docker not reachable at startup; skipping HQ container warm-up');
 			return;
 		}
+		// First-boot only: warm HQ when it has never been provisioned, so the first
+		// CEO chat / onboarding message isn't stuck behind a minutes-long image
+		// pull. Once a container exists (running or idle-stopped), lazy start covers
+		// every later use in under a second — eagerly starting it here would just
+		// wake a container the idle-stop cron reclaims minutes later.
 		const hq = await this.deps.db.query<{ id: string }>(
-			`SELECT id FROM projects WHERE team_id = $1 AND is_internal = true`,
+			`SELECT id FROM projects
+			 WHERE team_id = $1 AND is_internal = true AND container_id IS NULL`,
 			[DEFAULT_TEAM_ID],
 		);
 		const hqProjectId = hq.rows[0]?.id;
@@ -830,7 +864,8 @@ export class JobManager {
 	 * running. Covers the host-reboot / Docker-restart case where the server
 	 * never got to mark the container as stopped. Missing containers are
 	 * re-provisioned from scratch; stopped ones are started in place. Projects
-	 * the user explicitly stopped (container_status = stopped) are left alone.
+	 * stopped deliberately — by the operator or by the idle-stop cron (both write
+	 * container_status = stopped) — are left alone to lazy-start on demand.
 	 */
 	private async restartStoppedRunningContainers(docker: DockerClient): Promise<void> {
 		const { db, wsManager, containerLogStreamer, logs } = this.deps;
@@ -890,7 +925,10 @@ export class JobManager {
 				if (info.State.Running) continue;
 
 				await docker.startContainer(row.container_id);
-				await db.query('UPDATE projects SET container_error = NULL WHERE id = $1', [row.id]);
+				await db.query(
+					'UPDATE projects SET container_error = NULL, container_last_started_at = now() WHERE id = $1',
+					[row.id],
+				);
 				containerLogStreamer.subscribe(row.id, row.container_id, logs, docker);
 				broadcastRowChange(wsManager, wsRoom.team(row.team_id), 'projects', 'UPDATE', {
 					id: row.id,
@@ -1086,7 +1124,10 @@ export class JobManager {
 			if (info === null || !info.State.Running) continue;
 
 			await db.query(
-				`UPDATE projects SET container_id = $1, container_status = $2::container_status WHERE id = $3`,
+				`UPDATE projects
+				 SET container_id = $1, container_status = $2::container_status,
+				     container_last_started_at = now()
+				 WHERE id = $3`,
 				[info.Id, ContainerStatus.Running, project.id],
 			);
 			containerLogStreamer.subscribe(project.id, info.Id, logs, docker);
@@ -1145,14 +1186,42 @@ export class JobManager {
 		return isTaskBusyInDb(this.deps.db, taskId);
 	}
 
-	private async isProjectAtCapacity(projectId: string): Promise<boolean> {
-		const { limit, active } = await getProjectConcurrency(this.deps.db, projectId);
-		// The in-memory refcount leads the DB during the dispatch window; once a
-		// run's row lands both refer to the same run, so `max` dedupes rather than
-		// double-counting. Using the larger of the two never under-counts, so the
-		// ceiling is never exceeded.
-		const inFlight = Math.max(this.activeProjectRuns.get(projectId) ?? 0, active);
-		return inFlight >= limit;
+	/**
+	 * Would running in `projectId` need a container start that exceeds the
+	 * instance's active-container cap? A project whose container is already
+	 * running — or already being lazy-started by a concurrent dispatch — is
+	 * never blocked: its run consumes no new container slot. Task-less callers
+	 * pass null and are gated on the total alone (activateAgent re-checks with
+	 * the chosen task's project). The in-memory pending-start refcounts lead
+	 * the DB while a lazy start is in flight and are deduped against projects
+	 * whose container already reads Running, so the ceiling is never exceeded.
+	 */
+	private async isContainerCapacityBlocked(projectId: string | null): Promise<boolean> {
+		const { limit, runningProjectIds } = await getActiveContainers(this.deps.db);
+		if (
+			projectId &&
+			(runningProjectIds.has(projectId) || this.pendingContainerStarts.has(projectId))
+		) {
+			return false;
+		}
+		let pendingExtra = 0;
+		for (const id of this.pendingContainerStarts.keys()) {
+			if (!runningProjectIds.has(id)) pendingExtra++;
+		}
+		return runningProjectIds.size + pendingExtra >= limit;
+	}
+
+	private acquirePendingContainerStart(projectId: string): void {
+		this.pendingContainerStarts.set(
+			projectId,
+			(this.pendingContainerStarts.get(projectId) ?? 0) + 1,
+		);
+	}
+
+	private releasePendingContainerStart(projectId: string): void {
+		const next = (this.pendingContainerStarts.get(projectId) ?? 0) - 1;
+		if (next > 0) this.pendingContainerStarts.set(projectId, next);
+		else this.pendingContainerStarts.delete(projectId);
 	}
 
 	private acquireProjectRun(projectId: string): void {
@@ -1278,13 +1347,11 @@ export class JobManager {
 					continue;
 				}
 				const project = await this.resolveProjectForTask(wakeupTaskId);
-				if (project && (await this.isProjectAtCapacity(project.id))) {
-					log.debug(
-						`Skipping wakeup ${wakeup.id} — project ${ref(project.slug, project.id)} is at run capacity`,
-					);
+				if (await this.isContainerCapacityBlocked(project?.id ?? null)) {
+					log.debug(`Skipping wakeup ${wakeup.id} — instance is at its active-container limit`);
 					await this.markWakeupSkipped(
 						wakeup.id,
-						WakeupSkipReason.ProjectAtCapacity,
+						WakeupSkipReason.InstanceAtCapacity,
 						wakeupTaskId,
 						wakeup.team_id,
 						null,
@@ -1306,8 +1373,10 @@ export class JobManager {
 				}
 			} else if (this.isMemberRunning(wakeup.member_id)) {
 				// Task-less wakeup (e.g. queued heartbeat) — picks a task inside
-				// activateAgent, so we can't pre-check a project lock. Fall back to
-				// per-agent dedup to avoid stacking idle pings.
+				// activateAgent, so we can't pre-check a task lock or a project's
+				// container here (activateAgent re-checks the container cap once the
+				// task is chosen). Fall back to per-agent dedup to avoid stacking
+				// idle pings.
 				log.debug(`Skipping wakeup ${wakeup.id} — agent ${wakeup.member_id} already running`);
 				await this.markWakeupSkipped(
 					wakeup.id,
@@ -1627,19 +1696,13 @@ export class JobManager {
 				// already claimed by the dispatcher, so the transient branch must re-queue it,
 				// not just stamp a skip reason — otherwise it would stick in `claimed`.)
 				if (wakeupPayload?.trigger === 'progress_update_now' && wakeupId) {
-					if (
-						result.reason === 'agent_busy' ||
-						result.reason === 'project_at_capacity' ||
-						result.reason === 'container_down'
-					) {
+					if (result.reason === 'agent_busy' || result.reason === 'instance_at_capacity') {
 						// Still transient — re-queue so a later cron tick retries once the
-						// Captain frees / the container comes up / capacity clears.
+						// Captain frees / capacity clears.
 						const skipReason =
-							result.reason === 'project_at_capacity'
-								? WakeupSkipReason.ProjectAtCapacity
-								: result.reason === 'container_down'
-									? WakeupSkipReason.ContainerDown
-									: WakeupSkipReason.AgentRunning;
+							result.reason === 'instance_at_capacity'
+								? WakeupSkipReason.InstanceAtCapacity
+								: WakeupSkipReason.AgentRunning;
 						await db.query(
 							`UPDATE agent_wakeup_requests
 							 SET status = $1::wakeup_status, claimed_at = NULL,
@@ -1727,9 +1790,9 @@ export class JobManager {
 			await this.requeueWakeup(wakeupId);
 			return;
 		}
-		if (await this.isProjectAtCapacity(task.project_id)) {
+		if (await this.isContainerCapacityBlocked(task.project_id)) {
 			log.debug(
-				`Project ${task.project_id} is at run capacity — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
+				`Instance is at its active-container limit — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
 			await this.requeueWakeup(wakeupId);
 			return;
@@ -1851,28 +1914,17 @@ export class JobManager {
 			return;
 		}
 
-		if (!projectRow.container_id) {
-			// container_id stays NULL until the container reaches running, so a
-			// 'creating' status here means provisioning is in flight (often minutes
-			// on a first image build). Re-queue and retry once it's up rather than
-			// burning the wakeup — otherwise a task assigned at project-creation time
-			// (e.g. the CEO's coherence pass) would never start.
-			if (projectRow.container_status === ContainerStatus.Creating) {
-				log.debug(
-					`Container for project ${ref(projectRow.slug, task.project_id)} still provisioning — re-queuing wakeup`,
-				);
-				await this.requeueWakeup(wakeupId);
-				return;
-			}
+		// container_id stays NULL until the container reaches running, so a
+		// 'creating' status here means another actor's provisioning is in flight
+		// (often minutes on a first image build). Re-queue and retry once it's up
+		// rather than holding a global run slot for the wait. Every other
+		// no-container state (never provisioned, stopped, errored) falls through —
+		// the runner starts or provisions the container on demand at run start.
+		if (!projectRow.container_id && projectRow.container_status === ContainerStatus.Creating) {
 			log.debug(
-				`No container for project ${ref(projectRow.slug, task.project_id)} — wakeup failed`,
+				`Container for project ${ref(projectRow.slug, task.project_id)} still provisioning — re-queuing wakeup`,
 			);
-			if (wakeupId) {
-				await db.query(
-					'UPDATE agent_wakeup_requests SET status = $1::wakeup_status WHERE id = $2',
-					[WakeupStatus.Failed, wakeupId],
-				);
-			}
+			await this.requeueWakeup(wakeupId);
 			return;
 		}
 
@@ -1928,6 +1980,7 @@ export class JobManager {
 			sshAgentServer: this.deps.sshAgentServer,
 			egressProxy: this.deps.egressProxy ?? null,
 			egressCAPath: this.deps.egressCAPath ?? null,
+			containerLogStreamer: this.deps.containerLogStreamer,
 			pricing: this.deps.pricing,
 		};
 		const timeoutMs = agent.rows[0].run_timeout_min * 60 * 1000;
@@ -1937,6 +1990,12 @@ export class JobManager {
 		const lockedTaskId = task.id;
 		this.activeTaskRuns.add(lockedTaskId);
 		this.acquireProjectRun(projectId);
+		// Launching into a project whose container isn't running will lazy-start
+		// one — hold a pending-start slot so the container cap counts it during
+		// the window before the DB row reads Running. Released with the dispatch
+		// guards when the run settles.
+		const pendingContainerStart = projectRow.container_status !== ContainerStatus.Running;
+		if (pendingContainerStart) this.acquirePendingContainerStart(projectId);
 
 		const launched = this.launchTask(
 			taskKey,
@@ -2028,7 +2087,7 @@ export class JobManager {
 				}
 			},
 			timeoutMs,
-			{ memberId, taskId: lockedTaskId, projectId },
+			{ memberId, taskId: lockedTaskId, projectId, pendingContainerStart },
 		);
 
 		if (!launched) {
@@ -2037,6 +2096,7 @@ export class JobManager {
 			// task badge doesn't stick, and re-queue for a later slot.
 			this.activeTaskRuns.delete(lockedTaskId);
 			this.releaseProjectRun(projectId);
+			if (pendingContainerStart) this.releasePendingContainerStart(projectId);
 			await db.query(
 				'UPDATE execution_locks SET released_at = now() WHERE task_id = $1 AND member_id = $2 AND released_at IS NULL',
 				[lockedTaskId, memberId],
@@ -2228,17 +2288,16 @@ export class JobManager {
 		const dueGoals = await getDueGoals(db, projectRow.id);
 		if (dueGoals.length === 0) return { dispatched: false, reason: 'no_due_goals' };
 
-		// Don't start a progress update while the Captain is already running in this project, the
-		// project is at capacity, the container isn't up, or the Captain/project is over budget.
-		// The scheduled caller falls through — the goals remain due for the next heartbeat.
+		// Don't start a progress update while the Captain is already running in this
+		// project, the instance is at its global run capacity, or the Captain/project
+		// is over budget. The scheduled caller falls through — the goals remain due
+		// for the next heartbeat. A stopped container is no blocker: the runner
+		// lazy-starts it.
 		if (await this.isAgentBusyInProject(memberId, projectRow.id)) {
 			return { dispatched: false, reason: 'agent_busy' };
 		}
-		if (await this.isProjectAtCapacity(projectRow.id)) {
-			return { dispatched: false, reason: 'project_at_capacity' };
-		}
-		if (!projectRow.container_id || projectRow.container_status !== ContainerStatus.Running) {
-			return { dispatched: false, reason: 'container_down' };
+		if (await this.isContainerCapacityBlocked(projectRow.id)) {
+			return { dispatched: false, reason: 'instance_at_capacity' };
 		}
 		if (await checkOverBudget(db, memberId, projectRow.id)) {
 			return { dispatched: false, reason: 'over_budget' };
@@ -2281,11 +2340,16 @@ export class JobManager {
 			sshAgentServer: this.deps.sshAgentServer,
 			egressProxy: this.deps.egressProxy ?? null,
 			egressCAPath: this.deps.egressCAPath ?? null,
+			containerLogStreamer: this.deps.containerLogStreamer,
 			pricing: this.deps.pricing,
 		};
 		const timeoutMs = agentRow.run_timeout_min * 60 * 1000;
 		const key = `progressupdate:${memberId}:${projectRow.id}`;
 		this.acquireProjectRun(projectRow.id);
+		// Same pending-start accounting as activateAgent: a progress-update run
+		// into a stopped project lazy-starts its container.
+		const pendingContainerStart = projectRow.container_status !== ContainerStatus.Running;
+		if (pendingContainerStart) this.acquirePendingContainerStart(projectRow.id);
 
 		const launched = this.launchTask(
 			key,
@@ -2340,6 +2404,7 @@ export class JobManager {
 					return null;
 				} finally {
 					this.releaseProjectRun(projectRow.id);
+					if (pendingContainerStart) this.releasePendingContainerStart(projectRow.id);
 					void trackBackground(this.guarded('wakeups', () => this.processWakeups()));
 				}
 			},
@@ -2351,6 +2416,7 @@ export class JobManager {
 			// scheduled path the requeued wakeup retries; on the manual path wakeupId is undefined
 			// so requeueWakeup no-ops and the caller surfaces the conflict.
 			this.releaseProjectRun(projectRow.id);
+			if (pendingContainerStart) this.releasePendingContainerStart(projectRow.id);
 			await setAgentIdleIfNoActiveRuns(db, memberId, teamId, undefined, this.deps.wsManager);
 			await this.requeueWakeup(wakeupId);
 			return { dispatched: false, reason: 'launch_conflict' };
@@ -2447,16 +2513,15 @@ export class JobManager {
 			},
 		);
 
-		// A transient conflict (Captain already running, project at capacity,
-		// container still coming up, or a launch race) is queued rather than
-		// surfaced as an error: the 5s dispatcher retries the wakeup and the run
-		// fires once the Captain frees up. Terminal reasons (no project/captain,
-		// disabled, over budget, nothing due) fall through unchanged.
+		// A transient conflict (Captain already running, the instance at its global
+		// run capacity, or a launch race) is queued rather than surfaced as an
+		// error: the 5s dispatcher retries the wakeup and the run fires once the
+		// Captain frees up. Terminal reasons (no project/captain, disabled, over
+		// budget, nothing due) fall through unchanged.
 		if (
 			!result.dispatched &&
 			(result.reason === 'agent_busy' ||
-				result.reason === 'project_at_capacity' ||
-				result.reason === 'container_down' ||
+				result.reason === 'instance_at_capacity' ||
 				result.reason === 'launch_conflict')
 		) {
 			const projRow = await db.query<{ id: string }>(
@@ -2727,6 +2792,54 @@ export class JobManager {
 
 		for (const transition of transitions) {
 			await this.handleContainerTransition(transition);
+		}
+	}
+
+	/**
+	 * Stop containers idle past the operator-configured timeout, so an instance
+	 * with no work runs zero containers. Bounded per tick; each stop re-verifies
+	 * the busy predicate under the project's lifecycle lock, so a concurrent
+	 * dispatch's lazy start and this stop can never interleave — the in-memory
+	 * checks close the window before a dispatched run has any DB row, and
+	 * `isProjectIdleForContainerStop` re-runs the DB predicate last. A timeout
+	 * of 0 disables the reaper entirely (always-on containers).
+	 */
+	private async stopIdleContainers(): Promise<void> {
+		const { db, docker } = this.deps;
+		const timeoutMin = await getContainerIdleTimeoutMin(db);
+		if (timeoutMin === 0) return;
+		if (!(await docker.ping())) {
+			log.debug('Docker not reachable; skipping idle-container pass');
+			return;
+		}
+
+		const candidates = await findIdleContainerCandidates(db, timeoutMin, IDLE_STOP_BATCH_LIMIT);
+		let stopped = 0;
+		for (const candidate of candidates) {
+			try {
+				await withContainerLifecycleLock(candidate.id, async () => {
+					if ((this.activeProjectRuns.get(candidate.id) ?? 0) > 0) return;
+					if (this.pendingContainerStarts.has(candidate.id)) return;
+					if (this.getLiveRunsForProject(candidate.id).length > 0) return;
+					if (!(await isProjectIdleForContainerStop(db, candidate.id, timeoutMin))) return;
+					log.info(
+						`project ${ref(candidate.slug, candidate.id)} idle for ${timeoutMin}min — stopping container ${ref(candidate.slug, candidate.container_id.slice(0, 12))}`,
+					);
+					await stopContainerGracefully(
+						this.buildContainerDeps(),
+						candidate.id,
+						candidate.slug,
+						candidate.team_id,
+						candidate.container_id,
+					);
+					stopped++;
+				});
+			} catch (err) {
+				log.error(`Idle-stop failed for project ${ref(candidate.slug, candidate.id)}:`, err);
+			}
+		}
+		if (candidates.length > 0) {
+			log.debug(`Idle-container pass: ${stopped}/${candidates.length} candidate(s) stopped`);
 		}
 	}
 

--- a/packages/server/src/services/run-concurrency.ts
+++ b/packages/server/src/services/run-concurrency.ts
@@ -1,12 +1,16 @@
-import { HeartbeatRunStatus } from '@hezo/shared';
+import { ContainerStatus, HeartbeatRunStatus } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { getMaxActiveContainers } from '../lib/system-meta';
 
 /**
  * DB-backed concurrency checks — the single source of truth for the two run
  * rules: at most one active (queued/running) agent run per task, and at most
- * `projects.max_concurrent_runs` per project. Shared by the scheduler
- * (`JobManager`, which layers its in-memory dispatch guards on top) and the
- * stateless run-now route.
+ * `max_active_containers` (system_meta; default computed from host memory)
+ * simultaneously RUNNING project containers across the instance. The container
+ * cap is the memory guarantee: every container is memory-capped, so total
+ * demand never exceeds `N × cap` no matter how many runs share a container.
+ * Shared by the scheduler (`JobManager`, which layers its in-memory dispatch
+ * guards on top) and the stateless run-now route.
  *
  * `lib/active-run.ts` and the `has_active_run` flag in `routes/tasks.ts` run
  * similar task-scoped checks for assignee-lock / badge purposes; they have
@@ -24,39 +28,58 @@ export async function isTaskBusyInDb(db: Db, taskId: string): Promise<boolean> {
 	return active.rows.length > 0;
 }
 
-export interface ProjectConcurrency {
-	/** Configured ceiling on simultaneous agent runs for the project. */
+export interface ActiveContainers {
+	/** Configured (or host-memory-computed) ceiling on running containers. */
 	limit: number;
-	/** Active (queued/running) runs currently counted against that ceiling. */
-	active: number;
+	/** Project ids whose container currently reads Running in the DB. */
+	runningProjectIds: Set<string>;
 }
 
 /**
- * Read a project's concurrency ceiling alongside its current active-run count
- * in a single query. The scheduler reconciles `active` against its in-memory
- * dispatch refcount (taking the larger of the two) before comparing to `limit`.
+ * Read the instance-wide container ceiling alongside the set of projects with
+ * a running container. Returning the id set (not just a count) lets callers
+ * both dedupe their in-memory pending-start guards against it and pass a run
+ * whose target container is already up. The projects table is tiny, so this is
+ * a cheap scan.
  */
-export async function getProjectConcurrency(
-	db: Db,
-	projectId: string,
-): Promise<ProjectConcurrency> {
-	const row = await db.query<{ limit: number; active: number }>(
-		`SELECT p.max_concurrent_runs AS limit,
-		        (SELECT count(*)::int FROM heartbeat_runs r
-		           JOIN tasks t ON t.id = r.task_id
-		          WHERE t.project_id = p.id
-		            AND r.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)) AS active
-		 FROM projects p
-		 WHERE p.id = $1`,
-		[projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
-	);
-	const r = row.rows[0];
-	return { limit: r?.limit ?? 1, active: r?.active ?? 0 };
+export async function getActiveContainers(db: Db): Promise<ActiveContainers> {
+	const [limit, rows] = await Promise.all([
+		getMaxActiveContainers(db),
+		db.query<{ id: string }>(
+			`SELECT id FROM projects WHERE container_status = $1::container_status`,
+			[ContainerStatus.Running],
+		),
+	]);
+	return { limit, runningProjectIds: new Set(rows.rows.map((r) => r.id)) };
 }
 
-export async function isProjectAtCapacityInDb(db: Db, projectId: string): Promise<boolean> {
-	const { limit, active } = await getProjectConcurrency(db, projectId);
-	return active >= limit;
+/**
+ * Stateless container-capacity gate (route-side mirror of the scheduler's
+ * in-memory-guarded check): would running in `projectId` need a container
+ * start that exceeds the cap? A project whose container is already running is
+ * never blocked — its run consumes no new container slot.
+ */
+export async function isContainerCapacityBlockedInDb(db: Db, projectId: string): Promise<boolean> {
+	const { limit, runningProjectIds } = await getActiveContainers(db);
+	if (runningProjectIds.has(projectId)) return false;
+	return runningProjectIds.size >= limit;
+}
+
+/**
+ * Active (queued/running) runs inside one project. Not a capacity input — the
+ * cap is instance-wide — but the repo routes gate destructive git operations
+ * (reset, re-clone) on the project being quiet, and the idle-stop recheck uses
+ * the same figure.
+ */
+export async function countActiveRunsInProject(db: Db, projectId: string): Promise<number> {
+	const row = await db.query<{ active: number }>(
+		`SELECT count(*)::int AS active FROM heartbeat_runs r
+		 JOIN tasks t ON t.id = r.task_id
+		 WHERE t.project_id = $1
+		   AND r.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+		[projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+	);
+	return row.rows[0]?.active ?? 0;
 }
 
 /**

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -33,6 +33,7 @@ import {
 	ContainerConnectivityStatus,
 	type ProbeResult,
 } from '../src/services/container-connectivity-status';
+import { ensureProjectContainerRunning } from '../src/services/containers';
 import type { DockerClient } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { PricingService, upsertManualRate } from '../src/services/pricing';
@@ -430,47 +431,109 @@ describe('runAgent lifecycle — full success bookkeeping', () => {
 		expect(result.stderr).toContain('No deepseek credential configured');
 	});
 
-	it('fails fast when the project container is not running', async () => {
+	it('lazy-starts a stopped container and the run proceeds', async () => {
+		// Runs never assume a running container: a stopped one is started in
+		// place before the exec, and the start is stamped on the project row.
+		await db.query(
+			`UPDATE projects SET container_status = $1::container_status, container_id = $2,
+			     container_error = NULL, container_last_started_at = NULL WHERE id = $3`,
+			[ContainerStatus.Stopped, 'lazy-lc', projectId],
+		);
+		const startCalls: string[] = [];
+		let started = false;
+		const docker = makeDocker({
+			inspectContainer: async (id: string) => ({
+				Id: id,
+				State: started
+					? { Status: 'running', Running: true, Pid: 1, ExitCode: 0 }
+					: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+				Config: { Image: 'test' },
+			}),
+			startContainer: async (id: string) => {
+				startCalls.push(id);
+				started = true;
+			},
+		});
 		const result = await runAgent(
-			baseDeps(makeDocker()),
+			baseDeps(docker),
 			makeAgent(),
 			makeTask(),
-			makeProject({ container_status: ContainerStatus.Stopped }),
+			makeProject({ container_id: 'lazy-lc', container_status: ContainerStatus.Stopped }),
 		);
-		expect(result.success).toBe(false);
-		expect(result.stderr).toContain('not running');
-		const run = await db.query<{ status: string; log_text: string | null }>(
-			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
-			[result.heartbeatRunId],
-		);
-		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-		expect(run.rows[0].log_text).toContain('not running');
+		expect(result.success).toBe(true);
+		expect(startCalls).toEqual(['lazy-lc']);
+
+		const proj = await db.query<{
+			container_status: string;
+			container_last_started_at: string | null;
+		}>('SELECT container_status, container_last_started_at FROM projects WHERE id = $1', [
+			projectId,
+		]);
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Running);
+		expect(proj.rows[0].container_last_started_at).not.toBeNull();
 	});
 
-	it('reconciles a cached-running container that vanished from Docker and fails the run', async () => {
+	it('concurrent ensures serialize on the lifecycle lock — exactly one container is provisioned', async () => {
+		await db.query(
+			`UPDATE projects SET container_status = NULL, container_id = NULL,
+			     container_error = NULL WHERE id = $1`,
+			[projectId],
+		);
+		let createCalls = 0;
+		const docker = makeDocker({
+			inspectContainer: async (id: string) => ({
+				Id: id,
+				State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+				Config: { Image: 'test' },
+			}),
+			createContainer: async () => {
+				createCalls++;
+				return { Id: `once-lc-${createCalls}`, Warnings: [] };
+			},
+		});
+		const containerDeps = { db, docker, dataDir };
+		const [a, b] = await Promise.all([
+			ensureProjectContainerRunning(containerDeps, projectId),
+			ensureProjectContainerRunning(containerDeps, projectId),
+		]);
+		// The second ensure waited on the lock, re-read the row the first wrote,
+		// found the container running, and reused it.
+		expect(createCalls).toBe(1);
+		expect(a).toBe('once-lc-1');
+		expect(b).toBe('once-lc-1');
+	});
+
+	it('re-provisions a cached-running container that vanished from Docker and the run proceeds', async () => {
 		await db.query(
 			`UPDATE projects SET container_status = $1::container_status, container_id = $2,
 			     container_error = NULL WHERE id = $3`,
 			[ContainerStatus.Running, 'gone-lc', projectId],
 		);
-		const { broadcasts, wsManager } = recordingWs();
-		const docker = makeDocker({ inspectContainer: async () => null });
+		const created: string[] = [];
+		const docker = makeDocker({
+			inspectContainer: async () => null,
+			createContainer: async () => {
+				created.push('reborn-lc');
+				return { Id: 'reborn-lc', Warnings: [] };
+			},
+		});
 		const result = await runAgent(
-			baseDeps(docker, { wsManager }),
+			baseDeps(docker),
 			makeAgent(),
 			makeTask(),
 			makeProject({ container_id: 'gone-lc' }),
 		);
-		expect(result.success).toBe(false);
-		expect(result.stderr).toContain('not running');
+		// The stale row is repaired by provisioning a fresh container — the run
+		// rides it instead of failing.
+		expect(result.success).toBe(true);
+		expect(created).toEqual(['reborn-lc']);
 
 		const proj = await db.query<{ container_status: string; container_id: string | null }>(
 			'SELECT container_status, container_id FROM projects WHERE id = $1',
 			[projectId],
 		);
-		expect(proj.rows[0].container_status).toBe(ContainerStatus.Error);
-		expect(proj.rows[0].container_id).toBeNull();
-		expect(broadcasts.some((b) => b.event?.table === 'projects')).toBe(true);
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Running);
+		expect(proj.rows[0].container_id).toBe('reborn-lc');
 	});
 
 	it('stamps triggered_by actor details on the run comment and skips the prompt directive at minimal effort', async () => {

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -5,7 +5,6 @@ import {
 	AiProvider,
 	ContainerStatus,
 	HeartbeatRunStatus,
-	WsMessageType,
 } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -112,6 +111,14 @@ beforeAll(async () => {
 		}),
 	});
 	taskId = (await taskRes.json()).data.id;
+
+	// The lazy-start ensure resolves the container from the DB row, so pin it to
+	// the id the docker mocks assume (running under the default inspect).
+	await db.query(
+		`UPDATE projects SET container_id = 'container-123', container_status = 'running'::container_status
+		 WHERE id = $1`,
+		[projectId],
+	);
 });
 
 afterAll(async () => {
@@ -239,29 +246,34 @@ function makeProject(overrides: Record<string, unknown> = {}) {
 }
 
 describe('runAgent', () => {
-	it('returns failure when container is not running and records it in the run log', async () => {
-		const broadcasts: Array<{ room: string; event: any }> = [];
-		const wsManager = {
-			broadcast: (room: string, event: any) => {
-				broadcasts.push({ room, event });
+	it('lazy-starts a stopped container, narrates it in the run log, and proceeds', async () => {
+		await db.query(
+			`UPDATE projects SET container_status = 'stopped'::container_status, container_id = 'c-1',
+			     container_error = NULL WHERE id = $1`,
+			[projectId],
+		);
+		const startCalls: string[] = [];
+		let started = false;
+		const docker = createMockDocker({
+			inspectContainer: async (id: string) => ({
+				Id: id,
+				State: started
+					? { Status: 'running', Running: true, Pid: 1, ExitCode: 0 }
+					: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+				Config: { Image: 'test' },
+			}),
+			startContainer: async (id: string) => {
+				startCalls.push(id);
+				started = true;
 			},
-			subscribe: () => {},
-			unsubscribe: () => {},
-			unsubscribeAll: () => {},
-			getRoomSize: () => 0,
-			getTotalConnections: () => 0,
-		} as any;
-
-		const logs = new LogStreamBroker();
-		logs.setWsManager(wsManager);
+		});
 		const deps: RunnerDeps = {
 			db,
-			docker: createMockDocker(),
+			docker,
 			masterKeyManager,
 			serverPort: 3000,
 			dataDir: '/tmp/test-data',
-			wsManager,
-			logs,
+			logs: new LogStreamBroker(),
 		};
 
 		const result = await runAgent(
@@ -271,56 +283,50 @@ describe('runAgent', () => {
 			makeProject({ container_status: ContainerStatus.Stopped, container_id: 'c-1' }),
 		);
 
-		expect(result.success).toBe(false);
-		expect(result.exitCode).toBe(-1);
-		expect(result.stderr).toContain('not running');
-		expect(result.heartbeatRunId).toBeDefined();
+		expect(result.success).toBe(true);
+		expect(startCalls).toEqual(['c-1']);
 
-		const run = await db.query<{ status: string; log_text: string; error: string | null }>(
-			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text, error FROM heartbeat_runs WHERE id = $1`,
+		const run = await db.query<{ log_text: string }>(
+			`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
 			[result.heartbeatRunId],
 		);
-		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-		expect(run.rows[0].log_text).toContain('[runner]');
-		expect(run.rows[0].log_text).toContain('not running');
-		expect(run.rows[0].error).toContain('not running');
+		expect(run.rows[0].log_text).toContain('Starting the project container');
 
-		const logBroadcasts = broadcasts.filter((b) => b.event.type === 'run_log');
-		expect(logBroadcasts.some((b) => b.event.text.includes('not running'))).toBe(true);
+		const proj = await db.query<{ container_status: string }>(
+			'SELECT container_status FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Running);
+
+		await db.query(
+			`UPDATE projects SET container_id = 'container-123', container_status = 'running'::container_status WHERE id = $1`,
+			[projectId],
+		);
 	});
 
-	it('reconciles and fails the run when a cached-running container has vanished from Docker', async () => {
+	it('re-provisions when a cached-running container has vanished from Docker and proceeds', async () => {
 		// The DB still says running, but Docker 404s on inspect — the exact stale
-		// state after an external `docker rm` or a Docker daemon restart. The runner
-		// must catch this before execCreate, flip the row to error, null the id, and
-		// broadcast so the UI corrects — rather than trip over a raw 404 mid-run.
-		const broadcasts: Array<{ room: string; event: any }> = [];
-		const wsManager = {
-			broadcast: (room: string, event: any) => {
-				broadcasts.push({ room, event });
-			},
-			subscribe: () => {},
-			unsubscribe: () => {},
-			unsubscribeAll: () => {},
-			getRoomSize: () => 0,
-			getTotalConnections: () => 0,
-		} as any;
-
-		// The cached state the runner reads: running, with a container id Docker no
-		// longer knows about.
+		// state after an external `docker rm` or a Docker daemon restart. The
+		// runner repairs the row by provisioning a fresh container and rides it.
 		await db.query(
 			`UPDATE projects SET container_status = $1::container_status, container_id = $2,
 			     container_error = NULL WHERE id = $3`,
 			[ContainerStatus.Running, 'gone-1', projectId],
 		);
 
+		const created: string[] = [];
 		const deps: RunnerDeps = {
 			db,
-			docker: createMockDocker({ inspectContainer: async () => null }),
+			docker: createMockDocker({
+				inspectContainer: async () => null,
+				createContainer: async () => {
+					created.push('reborn-1');
+					return { Id: 'reborn-1', Warnings: [] };
+				},
+			}),
 			masterKeyManager,
 			serverPort: 3000,
 			dataDir: '/tmp/test-data',
-			wsManager,
 			logs: new LogStreamBroker(),
 		};
 
@@ -331,36 +337,38 @@ describe('runAgent', () => {
 			makeProject({ container_status: ContainerStatus.Running, container_id: 'gone-1' }),
 		);
 
-		expect(result.success).toBe(false);
-		expect(result.stderr).toContain('not running');
-
-		const run = await db.query<{ status: string; log_text: string }>(
-			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
-			[result.heartbeatRunId],
-		);
-		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-		expect(run.rows[0].log_text).toContain('not running');
+		expect(result.success).toBe(true);
+		expect(created).toEqual(['reborn-1']);
 
 		// The stale row was reconciled against Docker reality.
 		const proj = await db.query<{ container_status: string; container_id: string | null }>(
 			'SELECT container_status, container_id FROM projects WHERE id = $1',
 			[projectId],
 		);
-		expect(proj.rows[0].container_status).toBe(ContainerStatus.Error);
-		expect(proj.rows[0].container_id).toBeNull();
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Running);
+		expect(proj.rows[0].container_id).toBe('reborn-1');
 
-		// And the correction was broadcast so the banner/sidebar/Container page update.
-		expect(
-			broadcasts.some(
-				(b) => b.event.type === WsMessageType.RowChange && b.event.table === 'projects',
-			),
-		).toBe(true);
+		await db.query(
+			`UPDATE projects SET container_id = 'container-123', container_status = 'running'::container_status WHERE id = $1`,
+			[projectId],
+		);
 	});
 
-	it('returns failure when container_id is null and records it in the run log', async () => {
+	it('provisions from scratch when the project has no container and proceeds', async () => {
+		await db.query(
+			`UPDATE projects SET container_status = NULL, container_id = NULL,
+			     container_error = NULL WHERE id = $1`,
+			[projectId],
+		);
+		const created: string[] = [];
 		const deps: RunnerDeps = {
 			db,
-			docker: createMockDocker(),
+			docker: createMockDocker({
+				createContainer: async () => {
+					created.push('fresh-1');
+					return { Id: 'fresh-1', Warnings: [] };
+				},
+			}),
 			masterKeyManager,
 			serverPort: 3000,
 			dataDir: '/tmp/test-data',
@@ -371,19 +379,24 @@ describe('runAgent', () => {
 			deps,
 			makeAgent(),
 			makeTask(),
-			makeProject({ container_id: null }),
+			makeProject({ container_id: null, container_status: null }),
 		);
 
-		expect(result.success).toBe(false);
-		expect(result.stderr).toContain('not running');
+		expect(result.success).toBe(true);
+		expect(created).toEqual(['fresh-1']);
 		expect(result.heartbeatRunId).toBeDefined();
 
-		const run = await db.query<{ status: string; log_text: string }>(
-			`SELECT status, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
-			[result.heartbeatRunId],
+		const proj = await db.query<{ container_status: string; container_id: string | null }>(
+			'SELECT container_status, container_id FROM projects WHERE id = $1',
+			[projectId],
 		);
-		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-		expect(run.rows[0].log_text).toContain('not running');
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Running);
+		expect(proj.rows[0].container_id).toBe('fresh-1');
+
+		await db.query(
+			`UPDATE projects SET container_id = 'container-123', container_status = 'running'::container_status WHERE id = $1`,
+			[projectId],
+		);
 	});
 
 	it('runs successfully and creates a heartbeat run', async () => {

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -357,7 +357,8 @@ describe('syncAllContainerStatuses', () => {
 		);
 		expect(result.rows[0].container_status).toBe('error');
 		expect(result.rows[0].container_error).toContain('17.00 GiB');
-		expect(result.rows[0].container_error).toContain('16 GiB');
+		// Fresh projects inherit the instance-wide ram cap (default 2 GB).
+		expect(result.rows[0].container_error).toContain('2 GiB');
 		expect(result.rows[0].container_error).toMatch(/restart/i);
 
 		expect(mockWsManager.broadcast).toHaveBeenCalled();

--- a/packages/server/test/containers-lifecycle-branches.test.ts
+++ b/packages/server/test/containers-lifecycle-branches.test.ts
@@ -710,7 +710,8 @@ describe('memory-limit enforcement edge cases', () => {
 		);
 		expect(row.rows[0].container_status).toBe('error');
 		expect(row.rows[0].container_error).toContain('20.00 GiB');
-		expect(row.rows[0].container_error).toContain('16 GiB');
+		// No per-project override → the instance-wide default cap (2 GB) applies.
+		expect(row.rows[0].container_error).toContain('2 GiB');
 		expect(transitions).toEqual([
 			expect.objectContaining({ projectId, oldStatus: 'running', newStatus: 'error' }),
 		]);

--- a/packages/server/test/containers-provision-branches.test.ts
+++ b/packages/server/test/containers-provision-branches.test.ts
@@ -392,23 +392,24 @@ describe('provisionContainer', () => {
 		expect(hc.Init).toBe(true);
 		expect(hc.CapDrop).toEqual(['ALL']);
 		expect(hc.PidsLimit).toBe(4096);
-		// Hard cap = project ceiling (default 16 GiB) + 512 MiB headroom, no swap
-		// escape valve — the stats poller stops the container at the ceiling
-		// itself; the cgroup is the between-ticks backstop.
-		const expectedCap = 16 * 1024 ** 3 + 512 * 1024 ** 2;
+		// Hard cap = the instance-wide ram cap (default 2 GB, no per-project
+		// override set) + 512 MiB headroom, no swap escape valve — the stats
+		// poller stops the container at the ceiling itself; the cgroup is the
+		// between-ticks backstop.
+		const expectedCap = 2 * 1024 ** 3 + 512 * 1024 ** 2;
 		expect(hc.Memory).toBe(expectedCap);
 		expect(hc.MemorySwap).toBe(expectedCap);
 	});
 
 	it('derives the cgroup cap from a project-specific memory_limit_gib', async () => {
 		await resetContainerRow();
-		await db.query('UPDATE projects SET memory_limit_gib = 2 WHERE id = $1', [projectId]);
+		await db.query('UPDATE projects SET memory_limit_gib = 8 WHERE id = $1', [projectId]);
 		try {
 			const { docker, created } = recordingDocker();
 
 			await provisionContainer(baseDeps(docker), await projectRow(), teamSlug);
 
-			const expectedCap = 2 * 1024 ** 3 + 512 * 1024 ** 2;
+			const expectedCap = 8 * 1024 ** 3 + 512 * 1024 ** 2;
 			expect(created[0].config.HostConfig.Memory).toBe(expectedCap);
 			expect(created[0].config.HostConfig.MemorySwap).toBe(expectedCap);
 		} finally {

--- a/packages/server/test/goals-coverage-more.test.ts
+++ b/packages/server/test/goals-coverage-more.test.ts
@@ -21,6 +21,12 @@ import {
 	updateGoal,
 } from '../src/services/goals';
 import { authHeader, createTestProject, createTestTeam } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
 
 let ctx: ServerTestContext;
@@ -779,9 +785,13 @@ describe('run-now dispatch and queued-run lifecycle', () => {
 		}
 	});
 
-	it('queues when a goal is due but the container is down, then supports cancel', async () => {
+	it('queues when a goal is due but the container limit is reached, then supports cancel', async () => {
 		// The project's due goals already exist from the cadence tests, so run-now
-		// passes the "nothing due" gate and hits the container-down conflict → queued.
+		// passes the "nothing due" gate. A down container no longer conflicts (the
+		// runner lazy-starts it), so the transient conflict is the container
+		// limit: cap 1, held by a filler project's running container.
+		await setMaxActiveContainersForTest(ctx.db, 1);
+		await seedRunningContainerProject(ctx.db, 'cap-goals-more');
 		const res = await ctx.app.request(`/api/projects/${projectSlug}/goals/run-now`, {
 			method: 'POST',
 			headers: jsonHeaders(),
@@ -827,6 +837,9 @@ describe('run-now dispatch and queued-run lifecycle', () => {
 			{ method: 'POST', headers: jsonHeaders(), body: '{}' },
 		);
 		expect(again.status).toBe(409);
+
+		await removeSeededContainerProject(ctx.db, 'cap-goals-more');
+		await clearMaxActiveContainersForTest(ctx.db);
 	});
 
 	it('reports no_due_goals as a valid 200 no-op once nothing is due', async () => {

--- a/packages/server/test/goals-queued-run.test.ts
+++ b/packages/server/test/goals-queued-run.test.ts
@@ -15,6 +15,12 @@ import {
 	createTestProject,
 	createTestTeam,
 } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 
 // The queued manual progress-update run ("Run now" while the Captain is busy). Covers the queue
 // dedup that must NOT cross-coalesce with the Captain's scheduled task-less heartbeat wakeup, the
@@ -116,6 +122,11 @@ async function wakeupRow(id: string) {
 describe('queued manual progress-update run', () => {
 	it('does not cross-coalesce with the Captain scheduled heartbeat wakeup', async () => {
 		await createDueGoal('Coalesce guard goal');
+		// Block dispatch on the container limit so run-now takes the queued path
+		// (the pre-lazy-start code got the same outcome from the container being
+		// down; that is no longer a blocker).
+		await setMaxActiveContainersForTest(db, 1);
+		await seedRunningContainerProject(db, 'cap-goals-coalesce');
 
 		// A pre-existing task-less scheduled heartbeat wakeup for the same Captain.
 		const heartbeat = await db.query<{ id: string }>(
@@ -160,6 +171,8 @@ describe('queued manual progress-update run', () => {
 		await db.query(`DELETE FROM agent_wakeup_requests WHERE id = ANY($1)`, [
 			[heartbeatId, body.wakeup_id],
 		]);
+		await removeSeededContainerProject(db, 'cap-goals-coalesce');
+		await clearMaxActiveContainersForTest(db);
 	});
 
 	it('cancel returns 404 for an unknown wakeup id', async () => {
@@ -170,21 +183,27 @@ describe('queued manual progress-update run', () => {
 		expect(res.status).toBe(404);
 	});
 
-	it('re-queues (not falls through to task work) when the container is down at dispatch', async () => {
-		// Due goal + no running container ⇒ tryDispatchProgressUpdate returns container_down.
+	it('re-queues (not falls through to task work) when the container limit is reached at dispatch', async () => {
+		// A container that is down is no longer a blocker (the runner lazy-starts
+		// it); the transient re-queue case is now the container LIMIT. This
+		// project's container is down, the limit is 1, and a filler project's
+		// running container holds the only slot.
+		await createDueGoal('Capacity re-queue goal');
 		const wakeupId = await insertProgressWakeup();
 		const manager = createJobManager();
+		await setMaxActiveContainersForTest(db, 1);
+		await seedRunningContainerProject(db, 'cap-goals-filler');
 
 		// Drive activateAgent through the public run-now dispatch (task-less path).
 		await manager.dispatchWakeupNow(wakeupId);
 
-		// The guard re-queued the wakeup with a container_down skip reason instead of letting
-		// the Captain fall through to picking up a task.
+		// The guard re-queued the wakeup with an instance_at_capacity skip reason
+		// instead of letting the Captain fall through to picking up a task.
 		const ws = await wakeupRow(wakeupId);
 		expect(ws.status).toBe(WakeupStatus.Queued);
-		expect(ws.last_skipped_reason).toBe(WakeupSkipReason.ContainerDown);
+		expect(ws.last_skipped_reason).toBe(WakeupSkipReason.InstanceAtCapacity);
 
-		// No progress-update run was started (still no container).
+		// No progress-update run was started.
 		const runs = await db.query<{ c: number }>(
 			`SELECT COUNT(*)::int AS c FROM heartbeat_runs WHERE member_id = $1`,
 			[captainId],
@@ -192,6 +211,8 @@ describe('queued manual progress-update run', () => {
 		expect(runs.rows[0].c).toBe(0);
 
 		manager.shutdown();
+		await removeSeededContainerProject(db, 'cap-goals-filler');
+		await clearMaxActiveContainersForTest(db);
 		await db.query(`DELETE FROM agent_wakeup_requests WHERE id = $1`, [wakeupId]);
 	});
 

--- a/packages/server/test/goals-run-now.test.ts
+++ b/packages/server/test/goals-run-now.test.ts
@@ -4,6 +4,7 @@ import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { seedRunningContainerProject, setMaxActiveContainersForTest } from './helpers/capacity';
 
 // The manual "Run now" endpoint reuses the scheduled progress-update logic
 // (`dispatchProgressUpdateNow` → `tryDispatchProgressUpdate`). These cover the deterministic
@@ -51,7 +52,7 @@ describe('POST /projects/:projectId/goals/run-now', () => {
 		expect(body.reason).toBe('no_due_goals');
 	});
 
-	it('queues the run (200, queued) when a goal is due but the container is down', async () => {
+	it('queues the run (200, queued) when a goal is due but the container limit is reached', async () => {
 		// A freshly created goal has never been checked, so it is immediately due.
 		const create = await app.request(`/api/projects/${projectSlug}/goals`, {
 			method: 'POST',
@@ -64,14 +65,21 @@ describe('POST /projects/:projectId/goals/run-now', () => {
 		});
 		expect(create.status).toBe(201);
 
+		// A container that is down is no longer a transient conflict (the runner
+		// lazy-starts it); the queued path now comes from the container limit:
+		// cap 1, consumed by a filler project's running container.
+		await setMaxActiveContainersForTest(db, 1);
+		await seedRunningContainerProject(db, 'cap-goals-runnow');
+
 		const res = await app.request(`/api/projects/${projectSlug}/goals/run-now`, {
 			method: 'POST',
 			headers: jsonHeaders(),
 			body: '{}',
 		});
-		// Past the "nothing due" check it hits run-gating — the test project has no running
-		// container (a transient conflict) — so instead of a 409 the run is queued to fire once
-		// the Captain is free. Proves the Captain and the due goal were both resolved.
+		// Past the "nothing due" check it hits run-gating — starting this project's
+		// container would exceed the cap (a transient conflict) — so instead of a
+		// 409 the run is queued to fire once a slot frees. Proves the Captain and
+		// the due goal were both resolved.
 		expect(res.status).toBe(200);
 		const body = (await res.json()).data;
 		expect(body.queued).toBe(true);

--- a/packages/server/test/helpers/capacity.ts
+++ b/packages/server/test/helpers/capacity.ts
@@ -1,0 +1,40 @@
+import type { Db } from '../../src/db/database';
+import {
+	deleteSystemMeta,
+	MAX_ACTIVE_CONTAINERS_KEY,
+	setSystemMeta,
+} from '../../src/lib/system-meta';
+
+/**
+ * Capacity-test seeding for the container-count concurrency model. A project
+ * whose own container is running is never capacity-blocked, so "at capacity"
+ * scenarios need the limit consumed by OTHER projects' running containers:
+ * this creates a filler team+project pair whose container reads Running.
+ */
+export async function seedRunningContainerProject(db: Db, slug: string): Promise<string> {
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ($1, $1) RETURNING id`,
+		[slug],
+	);
+	const project = await db.query<{ id: string }>(
+		`INSERT INTO projects (team_id, name, slug, task_prefix, container_id, container_status, container_last_started_at)
+		 VALUES ($1, $2, $2, upper(left($2, 3)), 'cid-' || $2, 'running', now()) RETURNING id`,
+		[team.rows[0].id, slug],
+	);
+	return project.rows[0].id;
+}
+
+/** Set the instance-wide active-container limit (system_meta). */
+export async function setMaxActiveContainersForTest(db: Db, limit: number): Promise<void> {
+	await setSystemMeta(db, MAX_ACTIVE_CONTAINERS_KEY, String(limit));
+}
+
+/** Remove the explicit limit — the host-memory-computed default applies again. */
+export async function clearMaxActiveContainersForTest(db: Db): Promise<void> {
+	await deleteSystemMeta(db, MAX_ACTIVE_CONTAINERS_KEY);
+}
+
+/** Delete a filler project seeded by {@link seedRunningContainerProject}. */
+export async function removeSeededContainerProject(db: Db, slug: string): Promise<void> {
+	await db.query(`DELETE FROM teams WHERE slug = $1`, [slug]);
+}

--- a/packages/server/test/instance-settings.test.ts
+++ b/packages/server/test/instance-settings.test.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { setHostMemoryForTest } from '../src/lib/host-memory';
 import { getSystemMeta, INSTANCE_BASE_URL_KEY } from '../src/lib/system-meta';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
@@ -135,5 +136,105 @@ describe('PATCH /api/instance-settings', () => {
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.base_url).toBeNull();
 		expect(await getBaseUrl()).toBeNull();
+	});
+});
+
+describe('concurrency settings', () => {
+	const GIB = 1024 ** 3;
+
+	beforeAll(() => {
+		// Pin the host-memory probe to the incident's reference host: a "2GB"
+		// droplet (1.92GiB MemTotal) with 6GiB swap → auto default 8 / 2 = 4.
+		setHostMemoryForTest({ totalRamBytes: 1.92 * GIB, totalSwapBytes: 6 * GIB });
+	});
+	afterAll(() => setHostMemoryForTest(null));
+
+	function patchSettings(body: Record<string, unknown>, authToken = token) {
+		return app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(authToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+	}
+
+	async function getSettings(): Promise<{
+		max_active_containers: number;
+		max_active_containers_is_set: boolean;
+		max_active_containers_computed_default: number;
+		default_ram_cap_per_container_gb: number;
+		container_idle_timeout_min: number;
+		host_total_ram_bytes: number;
+		host_total_swap_bytes: number;
+	}> {
+		const res = await app.request('/api/instance-settings', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		return (await res.json()).data;
+	}
+
+	it('computes the default max_active_containers from host memory when unset', async () => {
+		const data = await getSettings();
+		expect(data.max_active_containers).toBe(4); // round(1.92 + 6) = 8 GiB / 2 GB
+		expect(data.max_active_containers_is_set).toBe(false);
+		expect(data.max_active_containers_computed_default).toBe(4);
+		expect(data.default_ram_cap_per_container_gb).toBe(2);
+		expect(data.container_idle_timeout_min).toBe(15);
+		expect(data.host_total_swap_bytes).toBe(6 * GIB);
+	});
+
+	it('raising the ram cap lowers the computed default', async () => {
+		const res = await patchSettings({ default_ram_cap_per_container_gb: 4 });
+		expect(res.status).toBe(200);
+		const data = await getSettings();
+		expect(data.default_ram_cap_per_container_gb).toBe(4);
+		expect(data.max_active_containers).toBe(2); // 8 GiB / 4 GB
+		expect(data.max_active_containers_is_set).toBe(false);
+		await patchSettings({ default_ram_cap_per_container_gb: 2 });
+	});
+
+	it('an explicitly set value wins over the computed default', async () => {
+		const res = await patchSettings({ max_active_containers: 7 });
+		expect(res.status).toBe(200);
+		const data = await getSettings();
+		expect(data.max_active_containers).toBe(7);
+		expect(data.max_active_containers_is_set).toBe(true);
+		expect(data.max_active_containers_computed_default).toBe(4);
+	});
+
+	it('null resets max_active_containers back to the computed default', async () => {
+		const res = await patchSettings({ max_active_containers: null });
+		expect(res.status).toBe(200);
+		const data = await getSettings();
+		expect(data.max_active_containers).toBe(4);
+		expect(data.max_active_containers_is_set).toBe(false);
+	});
+
+	it('updates and persists the idle timeout, including 0 (never stop)', async () => {
+		expect((await patchSettings({ container_idle_timeout_min: 45 })).status).toBe(200);
+		expect((await getSettings()).container_idle_timeout_min).toBe(45);
+		expect((await patchSettings({ container_idle_timeout_min: 0 })).status).toBe(200);
+		expect((await getSettings()).container_idle_timeout_min).toBe(0);
+	});
+
+	it.each([
+		['a zero container cap', { max_active_containers: 0 }],
+		['a negative container cap', { max_active_containers: -1 }],
+		['an over-max container cap', { max_active_containers: 101 }],
+		['a non-integer container cap', { max_active_containers: 2.5 }],
+		['a string container cap', { max_active_containers: '3' }],
+		['a zero ram cap', { default_ram_cap_per_container_gb: 0 }],
+		['an over-max ram cap', { default_ram_cap_per_container_gb: 513 }],
+		['a non-integer ram cap', { default_ram_cap_per_container_gb: 1.5 }],
+		['a negative idle timeout', { container_idle_timeout_min: -1 }],
+		['an over-max idle timeout', { container_idle_timeout_min: 10081 }],
+		['a non-integer idle timeout', { container_idle_timeout_min: 1.5 }],
+	])('rejects %s', async (_name, body) => {
+		const res = await patchSettings(body);
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('rejects non-superusers', async () => {
+		const res = await patchSettings({ max_active_containers: 5 }, nonSuperuserToken);
+		expect(res.status).toBe(403);
 	});
 });

--- a/packages/server/test/job-manager-extended.test.ts
+++ b/packages/server/test/job-manager-extended.test.ts
@@ -25,6 +25,12 @@ import {
 	createTestProject,
 	createTestTeam,
 } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 
 // This suite drives the run-scheduling, task-selection, dispatch, and budget /
 // container-transition branches of JobManager that the existing
@@ -287,37 +293,29 @@ describe('JobManager — extended coverage', () => {
 			manager.shutdown();
 		});
 
-		it('returns project_at_capacity and records the skip when the project is at its run limit', async () => {
+		it('returns instance_at_capacity when starting a container would exceed the limit', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-
-			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), ...json },
-				body: JSON.stringify({ project_id: projectId, title: 'Sib busy', assignee_id: agentId }),
-			});
-			const sibId = (await sibRes.json()).data.id as string;
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[agentId, teamId, sibId, HeartbeatRunStatus.Running],
-			);
+			// Container semantics: this project's container is stopped, the limit is
+			// 1, and a filler project's running container consumes the only slot.
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			await seedRunningContainerProject(db, 'cap-filler-dispatch');
 			const wakeupId = await insertQueuedWakeup(agentId);
 
 			const result = await manager.dispatchWakeupNow(wakeupId);
-			expect(result).toEqual({ dispatched: false, reason: 'project_at_capacity' });
+			expect(result).toEqual({ dispatched: false, reason: 'instance_at_capacity' });
 			const ws = await wakeupStatus(wakeupId);
 			expect(ws.status).toBe(WakeupStatus.Queued);
-			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.ProjectAtCapacity);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.InstanceAtCapacity);
 
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await removeSeededContainerProject(db, 'cap-filler-dispatch');
+			await clearMaxActiveContainersForTest(db);
 			manager.shutdown();
 		});
 
 		it('returns agent_busy when the same agent already runs in the project', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 
 			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
 				method: 'POST',
@@ -386,7 +384,7 @@ describe('JobManager — extended coverage', () => {
 			// tasks broadcast.
 			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
 			await db.query(
-				`UPDATE projects SET container_id = 'test-container', container_status = 'running', max_concurrent_runs = 3 WHERE id = $1`,
+				`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
 				[projectId],
 			);
 			const throwingWs = {
@@ -421,7 +419,6 @@ describe('JobManager — extended coverage', () => {
 	describe('processWakeups gating branches', () => {
 		it('skips a task wakeup with agent_running when the agent already runs in the project', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 
 			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
 				method: 'POST',
@@ -514,7 +511,7 @@ describe('JobManager — extended coverage', () => {
 			await db.query(
 				`UPDATE projects
 				 SET container_id = 'test-container', container_status = 'running',
-				     max_concurrent_runs = 3, designated_repo_id = $2
+				     designated_repo_id = $2
 				 WHERE id = $1`,
 				[projectId, repo.rows[0].id],
 			);
@@ -529,21 +526,13 @@ describe('JobManager — extended coverage', () => {
 			);
 		});
 
-		it('re-queues the wakeup when the project is at capacity at activation time', async () => {
+		it('re-queues the wakeup when the container limit is reached at activation time', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-
-			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), ...json },
-				body: JSON.stringify({ project_id: projectId, title: 'Cap sib', assignee_id: agentId }),
-			});
-			const sibId = (await sibRes.json()).data.id as string;
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[secondAgentId, teamId, sibId, HeartbeatRunStatus.Running],
-			);
+			// The project's container is stopped and a filler project's running
+			// container consumes the single slot, so activation must re-queue.
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			await seedRunningContainerProject(db, 'cap-filler-activate');
 			const wakeupId = await insertQueuedWakeup(agentId, 'mention');
 			await db.query("UPDATE agent_wakeup_requests SET status = 'claimed' WHERE id = $1", [
 				wakeupId,
@@ -568,8 +557,9 @@ describe('JobManager — extended coverage', () => {
 			expect(r.rows[0].status).toBe(WakeupStatus.Queued);
 			expect(r.rows[0].claimed_at).toBeNull();
 
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await removeSeededContainerProject(db, 'cap-filler-activate');
+			await clearMaxActiveContainersForTest(db);
 			manager.shutdown();
 		});
 

--- a/packages/server/test/job-manager-idle-stop.test.ts
+++ b/packages/server/test/job-manager-idle-stop.test.ts
@@ -1,0 +1,249 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import { CONTAINER_IDLE_TIMEOUT_KEY, setSystemMeta } from '../src/lib/system-meta';
+import type { Env } from '../src/lib/types';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
+
+let db: Db;
+let app: Hono<Env>;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+let teamId: string;
+let projectId: string;
+let agentId: string;
+let taskId: string;
+
+const CONTAINER_ID = 'idle-box';
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	app = ctx.app;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'App Team',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Idle Stop Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+	const projectRes = await createTestProject(db, teamId, { name: 'Idle Stop Project' });
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+
+	const agent = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 LIMIT 1`,
+		[teamId],
+	);
+	agentId = agent.rows[0].id;
+
+	const taskRes = await app.request(`/api/projects/${project.slug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'content-type': 'application/json' },
+		body: JSON.stringify({
+			project_id: projectId,
+			title: 'Idle-stop probe task',
+			assignee_id: agentId,
+		}),
+	});
+	const taskBody = await taskRes.json();
+	if (!taskRes.ok) throw new Error(`task create failed: ${JSON.stringify(taskBody)}`);
+	taskId = taskBody.data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+function createManager(stops: string[]): JobManager {
+	return new JobManager({
+		db,
+		docker: createStubDocker({
+			ping: async () => true,
+			stopContainer: async (id: string) => {
+				stops.push(id);
+			},
+		}),
+		masterKeyManager,
+		serverPort: 3100,
+		dataDir,
+		wsManager: { broadcast: () => {} } as unknown as JobManagerDeps['wsManager'],
+		logs: new LogStreamBroker(),
+		containerLogStreamer: new ContainerLogStreamer(),
+	});
+}
+
+async function runIdlePass(): Promise<{ stops: string[]; manager: JobManager }> {
+	const stops: string[] = [];
+	const manager = createManager(stops);
+	await (manager as unknown as { stopIdleContainers(): Promise<void> }).stopIdleContainers();
+	manager.shutdown();
+	return { stops, manager };
+}
+
+async function containerStatus(): Promise<string | null> {
+	const r = await db.query<{ container_status: string | null }>(
+		'SELECT container_status FROM projects WHERE id = $1',
+		[projectId],
+	);
+	return r.rows[0].container_status;
+}
+
+beforeEach(async () => {
+	// Reset to "running and idle for an hour" with a 15-minute timeout; each
+	// test then adds exactly one busy signal (or changes the timeout).
+	await setSystemMeta(db, CONTAINER_IDLE_TIMEOUT_KEY, '15');
+	await db.query(
+		`UPDATE projects
+		 SET container_id = $2, container_status = 'running', container_error = NULL,
+		     container_last_started_at = now() - interval '60 minutes'
+		 WHERE id = $1`,
+		[projectId, CONTAINER_ID],
+	);
+	await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+	await db.query('DELETE FROM agent_wakeup_requests WHERE team_id = $1', [teamId]);
+	await db.query(
+		'DELETE FROM chat_messages WHERE session_id IN (SELECT id FROM chat_sessions WHERE team_id = $1)',
+		[teamId],
+	);
+	await db.query('DELETE FROM chat_sessions WHERE team_id = $1', [teamId]);
+	await db.query('DELETE FROM chat_conversations WHERE team_id = $1', [teamId]);
+});
+
+describe('container-idle-stop', () => {
+	it('stops a container idle past the timeout and marks the project stopped', async () => {
+		const { stops } = await runIdlePass();
+		expect(stops).toContain(CONTAINER_ID);
+		expect(await containerStatus()).toBe('stopped');
+	});
+
+	it('a timeout of 0 disables the reaper entirely', async () => {
+		await setSystemMeta(db, CONTAINER_IDLE_TIMEOUT_KEY, '0');
+		const { stops } = await runIdlePass();
+		expect(stops).toEqual([]);
+		expect(await containerStatus()).toBe('running');
+	});
+
+	it('never stops a container inside its first idle window (start-time floor)', async () => {
+		await db.query(
+			`UPDATE projects SET container_last_started_at = now() - interval '5 minutes' WHERE id = $1`,
+			[projectId],
+		);
+		const { stops } = await runIdlePass();
+		expect(stops).toEqual([]);
+		expect(await containerStatus()).toBe('running');
+	});
+
+	it('an active (queued/running) run holds the container up', async () => {
+		await db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+			[agentId, teamId, taskId],
+		);
+		const { stops } = await runIdlePass();
+		expect(stops).toEqual([]);
+		expect(await containerStatus()).toBe('running');
+	});
+
+	it('a run finished inside the idle window holds the container up; an old one does not', async () => {
+		await db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+			 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, now(), now() - interval '5 minutes')`,
+			[agentId, teamId, taskId],
+		);
+		expect((await runIdlePass()).stops).toEqual([]);
+
+		await db.query(
+			`UPDATE heartbeat_runs SET finished_at = now() - interval '60 minutes' WHERE team_id = $1`,
+			[teamId],
+		);
+		expect((await runIdlePass()).stops).toContain(CONTAINER_ID);
+	});
+
+	it('a queued wakeup that could dispatch holds the container up', async () => {
+		await db.query(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+			 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+			         jsonb_build_object('task_id', $3::text))`,
+			[agentId, teamId, taskId],
+		);
+		const { stops } = await runIdlePass();
+		expect(stops).toEqual([]);
+	});
+
+	it('a capacity-skipped wakeup does NOT hold the container (its backlog is what the cap waits on)', async () => {
+		await db.query(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, last_skipped_at, last_skipped_reason)
+			 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+			         jsonb_build_object('task_id', $3::text), now(), 'instance_at_capacity')`,
+			[agentId, teamId, taskId],
+		);
+		const { stops } = await runIdlePass();
+		expect(stops).toContain(CONTAINER_ID);
+	});
+
+	it('a chat session with recent activity holds the container; a stale one does not', async () => {
+		const conversation = await db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, title)
+			 VALUES ($1, $2, $3, 'Idle chat') RETURNING id`,
+			[agentId, teamId, projectId],
+		);
+		await db.query(
+			`INSERT INTO chat_sessions (member_id, team_id, project_id, runtime_type, status, last_activity_at)
+			 VALUES ($1, $2, $3, 'claude_code', 'running', now())`,
+			[agentId, teamId, projectId],
+		);
+		expect((await runIdlePass()).stops).toEqual([]);
+
+		// The session alone doesn't pin the container once its activity is stale.
+		await db.query(
+			`UPDATE chat_sessions SET last_activity_at = now() - interval '60 minutes' WHERE team_id = $1`,
+			[teamId],
+		);
+		expect((await runIdlePass()).stops).toContain(CONTAINER_ID);
+
+		// …unless a turn is still in flight (pending/streaming message).
+		await db.query(
+			`UPDATE projects SET container_status = 'running', container_last_started_at = now() - interval '60 minutes' WHERE id = $1`,
+			[projectId],
+		);
+		const session = await db.query<{ id: string }>(
+			`SELECT id FROM chat_sessions WHERE team_id = $1 LIMIT 1`,
+			[teamId],
+		);
+		await db.query(
+			`INSERT INTO chat_messages (conversation_id, role, status, content, session_id)
+			 VALUES ($1, 'assistant', 'streaming', '', $2)`,
+			[conversation.rows[0].id, session.rows[0].id],
+		);
+		expect((await runIdlePass()).stops).toEqual([]);
+	});
+
+	it('the in-memory dispatch recheck blocks a stop even before any run row exists', async () => {
+		const stops: string[] = [];
+		const manager = createManager(stops);
+		// Simulate a dispatch that has acquired its slot but not yet created the
+		// heartbeat_runs row — the exact window the under-lock recheck closes.
+		(manager as unknown as { acquireProjectRun(id: string): void }).acquireProjectRun(projectId);
+		await (manager as unknown as { stopIdleContainers(): Promise<void> }).stopIdleContainers();
+		expect(stops).toEqual([]);
+		expect(await containerStatus()).toBe('running');
+		manager.shutdown();
+	});
+});

--- a/packages/server/test/job-manager-progress.test.ts
+++ b/packages/server/test/job-manager-progress.test.ts
@@ -15,6 +15,12 @@ import { ContainerLogStreamer } from '../src/services/container-logs';
 import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { authHeader, createStubDocker, createTestProject, createTestTeam } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
 
 // The Captain's progress-update ("Run now" / scheduled goal-check) flows:
@@ -102,8 +108,7 @@ beforeAll(async () => {
 	captainId = captain.rows[0].id;
 
 	await db.query(
-		`UPDATE projects SET container_id = 'progress-box', container_status = 'running',
-		        max_concurrent_runs = 3
+		`UPDATE projects SET container_id = 'progress-box', container_status = 'running'
 		 WHERE id = $1`,
 		[projectId],
 	);
@@ -125,8 +130,7 @@ afterEach(async () => {
 		[AgentRuntimeStatus.Idle, captainId],
 	);
 	await ctx.db.query(
-		`UPDATE projects SET container_id = 'progress-box', container_status = 'running',
-		        max_concurrent_runs = 3
+		`UPDATE projects SET container_id = 'progress-box', container_status = 'running'
 		 WHERE id = $1`,
 		[projectId],
 	);
@@ -237,20 +241,16 @@ describe('JobManager progress-update flows', () => {
 			manager.shutdown();
 		});
 
-		it('returns project_at_capacity when the project run limit is reached', async () => {
+		it('returns instance_at_capacity when starting the container would exceed the limit', async () => {
 			const manager = createJobManager();
 			await insertDueGoal('Capacity goal');
-			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-			const other = await ctx.db.query<{ id: string }>(
-				`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
-				 WHERE m.team_id = $1 AND ma.slug <> 'captain' LIMIT 1`,
-				[teamId],
-			);
-			await ctx.db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[other.rows[0].id, teamId, planningTaskId, HeartbeatRunStatus.Running],
-			);
+			// Container semantics: the Captain's project container is stopped and a
+			// filler project's running container holds the single slot.
+			await setMaxActiveContainersForTest(ctx.db, 1);
+			await ctx.db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [
+				projectId,
+			]);
+			await seedRunningContainerProject(ctx.db, 'cap-filler-progress');
 			const result = await internals(manager).tryDispatchProgressUpdate(
 				captainId,
 				teamId,
@@ -258,18 +258,29 @@ describe('JobManager progress-update flows', () => {
 				undefined,
 				{},
 			);
-			expect(result).toEqual({ dispatched: false, reason: 'project_at_capacity' });
-			await ctx.db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [other.rows[0].id]);
+			expect(result).toEqual({ dispatched: false, reason: 'instance_at_capacity' });
+			await removeSeededContainerProject(ctx.db, 'cap-filler-progress');
+			await clearMaxActiveContainersForTest(ctx.db);
 			manager.shutdown();
 		});
 
-		it('returns container_down when the container is not running', async () => {
+		it('a missing container no longer blocks dispatch — the budget gate is reached', async () => {
 			const manager = createJobManager();
 			await insertDueGoal('Container-down goal');
+			// The old code returned container_down here before ever checking the
+			// budget; with lazy-start there is no container gate, so the (later)
+			// budget gate must be what fires.
 			await ctx.db.query(
 				'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
 				[projectId],
 			);
+			await ctx.db.query('UPDATE member_agents SET daily_budget_cents = 100 WHERE id = $1', [
+				captainId,
+			]);
+			await ctx.db.query(
+				'INSERT INTO cost_entries (member_id, project_id, amount_cents) VALUES ($1, $2, 500)',
+				[captainId, projectId],
+			);
 			const result = await internals(manager).tryDispatchProgressUpdate(
 				captainId,
 				teamId,
@@ -277,7 +288,7 @@ describe('JobManager progress-update flows', () => {
 				undefined,
 				{},
 			);
-			expect(result).toEqual({ dispatched: false, reason: 'container_down' });
+			expect(result).toEqual({ dispatched: false, reason: 'over_budget' });
 			manager.shutdown();
 		});
 
@@ -518,20 +529,14 @@ describe('JobManager progress-update flows', () => {
 			manager.shutdown();
 		});
 
-		it('re-queues a manual progress_update_now wakeup while the project is at capacity', async () => {
+		it('re-queues a manual progress_update_now wakeup while the container limit is reached', async () => {
 			const manager = createJobManager();
 			await insertDueGoal('Manual capacity goal');
-			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-			const other = await ctx.db.query<{ id: string }>(
-				`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
-				 WHERE m.team_id = $1 AND ma.slug <> 'captain' LIMIT 1`,
-				[teamId],
-			);
-			await ctx.db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[other.rows[0].id, teamId, planningTaskId, HeartbeatRunStatus.Running],
-			);
+			await setMaxActiveContainersForTest(ctx.db, 1);
+			await ctx.db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [
+				projectId,
+			]);
+			await seedRunningContainerProject(ctx.db, 'cap-filler-manual');
 			const wakeupId = await insertClaimedWakeup({ trigger: 'progress_update_now' });
 
 			await internals(manager).activateAgent(
@@ -544,18 +549,35 @@ describe('JobManager progress-update flows', () => {
 
 			const w = await wakeupRow(wakeupId);
 			expect(w.status).toBe(WakeupStatus.Queued);
-			expect(w.last_skipped_reason).toBe(WakeupSkipReason.ProjectAtCapacity);
-			await ctx.db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [other.rows[0].id]);
+			expect(w.last_skipped_reason).toBe(WakeupSkipReason.InstanceAtCapacity);
+			// It must NOT have fallen through to task selection.
+			const runs = await ctx.db.query('SELECT 1 FROM heartbeat_runs WHERE member_id = $1', [
+				captainId,
+			]);
+			expect(runs.rows.length).toBe(0);
+			await removeSeededContainerProject(ctx.db, 'cap-filler-manual');
+			await clearMaxActiveContainersForTest(ctx.db);
 			manager.shutdown();
 		});
 
-		it('re-queues a manual progress_update_now wakeup while the container is down', async () => {
+		it('completes a container-down manual progress_update_now via the budget gate, never task selection', async () => {
 			const manager = createJobManager();
 			await insertDueGoal('Manual transient goal');
+			// Container down is no longer a transient requeue reason — the runner
+			// lazy-starts containers. Prove the gate is gone with a terminal budget
+			// outcome (which completes the wakeup as a no-op), and that a manual
+			// progress wakeup still never falls through to task selection.
 			await ctx.db.query(
 				'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
 				[projectId],
 			);
+			await ctx.db.query('UPDATE member_agents SET daily_budget_cents = 100 WHERE id = $1', [
+				captainId,
+			]);
+			await ctx.db.query(
+				'INSERT INTO cost_entries (member_id, project_id, amount_cents) VALUES ($1, $2, 500)',
+				[captainId, projectId],
+			);
 			const wakeupId = await insertClaimedWakeup({ trigger: 'progress_update_now' });
 
 			await internals(manager).activateAgent(
@@ -567,9 +589,7 @@ describe('JobManager progress-update flows', () => {
 			);
 
 			const w = await wakeupRow(wakeupId);
-			expect(w.status).toBe(WakeupStatus.Queued);
-			expect(w.claimed_at).toBeNull();
-			expect(w.last_skipped_reason).toBe(WakeupSkipReason.ContainerDown);
+			expect(w.status).toBe(WakeupStatus.Completed);
 			// It must NOT have fallen through to task selection.
 			const runs = await ctx.db.query('SELECT 1 FROM heartbeat_runs WHERE member_id = $1', [
 				captainId,

--- a/packages/server/test/job-manager-recovery.test.ts
+++ b/packages/server/test/job-manager-recovery.test.ts
@@ -581,12 +581,15 @@ describe('JobManager recovery & maintenance', () => {
 			stopped.shutdown();
 		});
 
-		it('ensureHqContainerRunning starts the stopped HQ container and no-ops without an HQ project', async () => {
+		it('ensureHqContainerRunning is first-boot-only: it skips a stopped HQ container and no-ops without an HQ project', async () => {
 			const { db } = ctx;
 			const hq = await db.query<{ id: string }>(
 				'SELECT id FROM projects WHERE is_internal = true LIMIT 1',
 			);
 			const hqId = hq.rows[0].id;
+			// An idle-stopped (already-provisioned) HQ container is left alone —
+			// lazy start covers the next use in under a second; eagerly waking it
+			// would just hand the idle-stop cron a container to reclaim.
 			await db.query(
 				`UPDATE projects SET container_status = 'stopped'::container_status, container_id = 'hq-box'
 				 WHERE id = $1`,
@@ -609,12 +612,12 @@ describe('JobManager recovery & maintenance', () => {
 			});
 
 			await manager.ensureHqContainerRunning();
-			expect(startCalls).toEqual(['hq-box']);
+			expect(startCalls).toEqual([]);
 			const row = await db.query<{ container_status: string }>(
 				'SELECT container_status::text AS container_status FROM projects WHERE id = $1',
 				[hqId],
 			);
-			expect(row.rows[0].container_status).toBe(ContainerStatus.Running);
+			expect(row.rows[0].container_status).toBe(ContainerStatus.Stopped);
 
 			// Hide the HQ project: the warm-up returns without touching Docker.
 			await db.query('UPDATE projects SET is_internal = false WHERE id = $1', [hqId]);

--- a/packages/server/test/job-manager-scheduling.test.ts
+++ b/packages/server/test/job-manager-scheduling.test.ts
@@ -133,7 +133,7 @@ beforeAll(async () => {
 	await db.query(
 		`UPDATE projects
 		 SET designated_repo_id = $1, container_id = 'sched-container',
-		     container_status = 'running', max_concurrent_runs = 3
+		     container_status = 'running'
 		 WHERE id = $2`,
 		[repoRes.rows[0].id, projectId],
 	);
@@ -164,8 +164,7 @@ afterEach(async () => {
 		[agentId, secondAgentId],
 	]);
 	await ctx.db.query(
-		`UPDATE projects SET container_id = 'sched-container', container_status = 'running',
-		        max_concurrent_runs = 3
+		`UPDATE projects SET container_id = 'sched-container', container_status = 'running'
 		 WHERE id = $1`,
 		[projectId],
 	);

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -17,6 +17,12 @@ import {
 	createTestProject,
 	createTestTeam,
 } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 
 let app: Hono<Env>;
 let db: Db;
@@ -193,26 +199,13 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		});
 
-		it('records project_at_capacity on a task wakeup when the project is at its run limit', async () => {
+		it('records instance_at_capacity on a task wakeup when the container limit is reached', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-
-			const otherTaskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					project_id: projectId,
-					title: 'Sibling busy task',
-					assignee_id: agentId,
-				}),
-			});
-			const otherTask = (await otherTaskRes.json()).data as { id: string; identifier: string };
-
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[agentId, teamId, otherTask.id, HeartbeatRunStatus.Running],
-			);
+			// Container semantics: the wakeup's project container is stopped and a
+			// filler project's running container consumes the single slot.
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			await seedRunningContainerProject(db, 'cap-filler-wakeups');
 
 			const wakeupRes = await db.query<{ id: string }>(
 				`INSERT INTO agent_wakeup_requests
@@ -235,7 +228,7 @@ describe('JobManager workflow methods', () => {
 				[wakeupId],
 			);
 			expect(wakeup.rows[0].status).toBe(WakeupStatus.Queued);
-			expect(wakeup.rows[0].last_skipped_reason).toBe('project_at_capacity');
+			expect(wakeup.rows[0].last_skipped_reason).toBe('instance_at_capacity');
 			expect(wakeup.rows[0].last_skipped_blocker_task_id).toBeNull();
 
 			const taskRes = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
@@ -248,12 +241,18 @@ describe('JobManager workflow methods', () => {
 				} | null;
 			};
 			expect(task.queued_wakeup).not.toBeNull();
-			expect(task.queued_wakeup?.reason).toBe('project_at_capacity');
+			expect(task.queued_wakeup?.reason).toBe('instance_at_capacity');
 
 			manager.shutdown();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
-			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [otherTask.id]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await removeSeededContainerProject(db, 'cap-filler-wakeups');
+			await clearMaxActiveContainersForTest(db);
+			// Drain everything still queued: the capacity block skipped not just our
+			// wakeup but any background ones (task-assignment pings), which earlier
+			// tests used to leave settled — later tests assume none are pending.
+			await db.query(`DELETE FROM agent_wakeup_requests WHERE team_id = $1 AND status = 'queued'`, [
+				teamId,
+			]);
 		});
 
 		it('clears last_skipped_* state when a wakeup is finally claimed', async () => {
@@ -301,6 +300,11 @@ describe('JobManager workflow methods', () => {
 			);
 			const wakeupId = wakeupRes.rows[0].id;
 
+			const runsBefore = await db.query<{ count: string }>(
+				'SELECT count(*)::text AS count FROM heartbeat_runs WHERE task_id = $1',
+				[taskId],
+			);
+
 			await (manager as any).processWakeups();
 
 			// The wakeup is returned to the queue (not failed) so it retries once the
@@ -316,7 +320,7 @@ describe('JobManager workflow methods', () => {
 				'SELECT count(*)::text AS count FROM heartbeat_runs WHERE task_id = $1',
 				[taskId],
 			);
-			expect(runs.rows[0].count).toBe('0');
+			expect(runs.rows[0].count).toBe(runsBefore.rows[0].count);
 
 			manager.shutdown();
 			await db.query(
@@ -454,14 +458,24 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		});
 
-		it('marks wakeup as failed when project has no container', async () => {
+		it('launches (lazy-starting the container) when the project has no container', async () => {
 			const manager = createJobManager();
 
 			// Assign the task to the agent (project has no container_id yet)
 			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
 
-			// Ensure project has no container_id
-			await db.query('UPDATE projects SET container_id = NULL WHERE id = $1', [projectId]);
+			// No container at all: the old code failed the wakeup here; with
+			// lazy-start the activation falls through and launches — the runner
+			// provisions the container as part of the run.
+			await db.query(
+				'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
+				[projectId],
+			);
+
+			const runsBefore = await db.query<{ count: string }>(
+				'SELECT count(*)::text AS count FROM heartbeat_runs WHERE task_id = $1',
+				[taskId],
+			);
 
 			const wakeupRes = await db.query<{ id: string }>(
 				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, created_at)
@@ -472,15 +486,27 @@ describe('JobManager workflow methods', () => {
 			const wakeupId = wakeupRes.rows[0].id;
 
 			await (manager as any).activateAgent(agentId, teamId, wakeupId);
+			await waitForBackground();
 
-			const result = await db.query<{ status: string }>(
-				'SELECT status FROM agent_wakeup_requests WHERE id = $1',
-				[wakeupId],
+			// The old fast-path failed the wakeup WITHOUT ever creating a run. The
+			// proof of lazy-start is that a real run row exists — under the stub
+			// docker its provision then fails, which is the run's own outcome (and
+			// what a real deployment would surface on the task), not a dispatch
+			// refusal.
+			const runsAfter = await db.query<{ count: string }>(
+				'SELECT count(*)::text AS count FROM heartbeat_runs WHERE task_id = $1',
+				[taskId],
 			);
-			expect(result.rows[0].status).toBe(WakeupStatus.Failed);
+			expect(Number(runsAfter.rows[0].count)).toBeGreaterThan(Number(runsBefore.rows[0].count));
 
 			manager.shutdown();
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [taskId]);
+			await db.query(
+				`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
+				[projectId],
+			);
+			await db.query('UPDATE execution_locks SET released_at = now() WHERE released_at IS NULL');
 		});
 
 		it('creates an execution lock and launches a task when project has container', async () => {
@@ -2110,7 +2136,10 @@ describe('JobManager workflow methods', () => {
 			);
 		});
 
-		it('starts the stopped HQ container in place and marks it running', async () => {
+		it('leaves an idle-stopped HQ container alone — lazy start covers later use', async () => {
+			// The warm-up is first-boot-only: once a container exists (running or
+			// stopped), eagerly starting it would just wake a container the
+			// idle-stop cron reclaims minutes later.
 			const hq = await hqProject();
 			await db.query(
 				`UPDATE projects SET container_status = 'stopped'::container_status, container_id = 'hq-box'
@@ -2134,12 +2163,12 @@ describe('JobManager workflow methods', () => {
 
 			await manager.ensureHqContainerRunning();
 
-			expect(startCalls).toEqual(['hq-box']);
+			expect(startCalls).toEqual([]);
 			const row = await db.query<{ container_status: string }>(
 				'SELECT container_status FROM projects WHERE id = $1',
 				[hq.id],
 			);
-			expect(row.rows[0].container_status).toBe('running');
+			expect(row.rows[0].container_status).toBe('stopped');
 
 			manager.shutdown();
 		});
@@ -2317,99 +2346,69 @@ describe('JobManager workflow methods', () => {
 		});
 	});
 
-	describe('per-project serialisation and cross-project parallelism', () => {
-		it('isProjectAtCapacity returns true once running runs reach the limit', async () => {
+	describe('container-capacity gating and cross-project parallelism', () => {
+		it('isContainerCapacityBlocked trips when a new container would exceed the limit', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			await seedRunningContainerProject(db, 'cap-check-a');
 
-			const otherTaskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					project_id: projectId,
-					title: 'Sibling task in same project',
-					assignee_id: agentId,
-				}),
-			});
-			const otherTaskId = (await otherTaskRes.json()).data.id;
+			expect(await (manager as any).isContainerCapacityBlocked(projectId)).toBe(true);
 
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[agentId, teamId, otherTaskId, HeartbeatRunStatus.Running],
-			);
-
-			const busy = await (manager as any).isProjectAtCapacity(projectId);
-			expect(busy).toBe(true);
-
-			await db.query(
-				"UPDATE heartbeat_runs SET status = 'succeeded', finished_at = now() WHERE task_id = $1",
-				[otherTaskId],
-			);
-			const busyAfter = await (manager as any).isProjectAtCapacity(projectId);
-			expect(busyAfter).toBe(false);
+			// The filler's container stops — the slot frees and the block lifts.
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE slug = 'cap-check-a'`);
+			expect(await (manager as any).isContainerCapacityBlocked(projectId)).toBe(false);
 
 			manager.shutdown();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [otherTaskId]);
-			await db.query('DELETE FROM tasks WHERE id = $1', [otherTaskId]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await removeSeededContainerProject(db, 'cap-check-a');
+			await clearMaxActiveContainersForTest(db);
 		});
 
-		it('isProjectAtCapacity stays false while running runs are below the limit', async () => {
+		it('a project whose container is already running is never capacity-blocked', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+			// The project's own running container fills the single slot — but a run
+			// into it needs no NEW container, so it must pass.
+			await setMaxActiveContainersForTest(db, 1);
+			expect(await (manager as any).isContainerCapacityBlocked(projectId)).toBe(false);
+			manager.shutdown();
+			await clearMaxActiveContainersForTest(db);
+		});
 
-			const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					project_id: projectId,
-					title: 'One of three slots',
-					assignee_id: agentId,
-				}),
-			});
-			const oneOfThree = (await taskRes.json()).data.id;
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[agentId, teamId, oneOfThree, HeartbeatRunStatus.Running],
-			);
+		it('pending lazy-starts hold a slot and let same-project dispatches piggyback', async () => {
+			const manager = createJobManager();
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			(manager as any).acquirePendingContainerStart(projectId);
 
-			expect(await (manager as any).isProjectAtCapacity(projectId)).toBe(false);
+			// The same project piggybacks on the in-flight start…
+			expect(await (manager as any).isContainerCapacityBlocked(projectId)).toBe(false);
+			// …while a different project is blocked by the slot it holds.
+			expect(
+				await (manager as any).isContainerCapacityBlocked('00000000-0000-0000-0000-0000000000aa'),
+			).toBe(true);
+
+			(manager as any).releasePendingContainerStart(projectId);
+			expect(
+				await (manager as any).isContainerCapacityBlocked('00000000-0000-0000-0000-0000000000aa'),
+			).toBe(false);
 
 			manager.shutdown();
-			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [oneOfThree]);
-			await db.query('DELETE FROM tasks WHERE id = $1', [oneOfThree]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await clearMaxActiveContainersForTest(db);
 		});
 
-		it('re-queues a wakeup when its project is already at its run limit', async () => {
+		it('re-queues a wakeup when the container limit is reached', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-
-			// An active run in project A at the limit blocks a wakeup targeting
-			// another task in project A.
-			const sibTaskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
-				method: 'POST',
-				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					project_id: projectId,
-					title: 'Second task in project A',
-					assignee_id: agentId,
-				}),
-			});
-			const sibTaskId = (await sibTaskRes.json()).data.id;
-
-			await db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
-				[agentId, teamId, taskId, HeartbeatRunStatus.Running],
-			);
+			await setMaxActiveContainersForTest(db, 1);
+			await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+			await seedRunningContainerProject(db, 'cap-filler-requeue');
 
 			const wakeupRes = await db.query<{ id: string }>(
 				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, created_at, payload)
 				 VALUES ($1, $2, 'mention', 'queued', now() - interval '30 seconds', $3::jsonb)
 				 RETURNING id`,
-				[agentId, teamId, JSON.stringify({ task_id: sibTaskId })],
+				[agentId, teamId, JSON.stringify({ task_id: taskId })],
 			);
 			const wakeupId = wakeupRes.rows[0].id;
 
@@ -2422,15 +2421,14 @@ describe('JobManager workflow methods', () => {
 			expect(status.rows[0].status).toBe(WakeupStatus.Queued);
 
 			manager.shutdown();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+			await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+			await removeSeededContainerProject(db, 'cap-filler-requeue');
+			await clearMaxActiveContainersForTest(db);
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
-			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [taskId]);
-			await db.query('DELETE FROM tasks WHERE id = $1', [sibTaskId]);
 		});
 
 		it('the per-agent lock is gone: agent busy in project A does not block a wakeup for project B', async () => {
 			const manager = createJobManager();
-			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 
 			// Project B lives in a SECOND team (a team owns exactly one project), so
 			// it is genuinely distinct from project A. We never dispatch on it — we just
@@ -2478,13 +2476,15 @@ describe('JobManager workflow methods', () => {
 			});
 
 			// The legacy per-agent check would have skipped this wakeup. The
-			// per-project capacity check should not: project B has no active run.
+			// container-capacity check doesn't consider per-agent business at all:
+			// with a free container slot, project B is not blocked by the agent's
+			// activity in project A.
 			expect(manager.isMemberRunning(agentId)).toBe(true);
-			expect(await (manager as any).isProjectAtCapacity(projectId)).toBe(true);
-			expect(await (manager as any).isProjectAtCapacity(projectBId)).toBe(false);
+			await setMaxActiveContainersForTest(db, 2);
+			expect(await (manager as any).isContainerCapacityBlocked(projectBId)).toBe(false);
+			await clearMaxActiveContainersForTest(db);
 
 			manager.shutdown();
-			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 			// Project B lives in its own team, so it cannot interfere with project A's
 			// tests; the whole context is torn down in afterAll. Leave its rows in place
 			// rather than untangle the team/agent/planning-task FK chain.

--- a/packages/server/test/migrate-048-global-concurrency-and-container-idle-stop.test.ts
+++ b/packages/server/test/migrate-048-global-concurrency-and-container-idle-stop.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '048_global_concurrency_and_container_idle_stop.sql';
+
+describe('048_global_concurrency_and_container_idle_stop migration', () => {
+	let h: DataPreservationHarness;
+	let runningProjectId: string;
+	let stoppedProjectId: string;
+	let runId: string;
+	let sessionId: string;
+	let messageId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// projects.team_id is UNIQUE (1:1 team↔project), so each project needs its own team.
+		const newTeam = async (slug: string): Promise<string> => {
+			const t = await h.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ($1, $1) RETURNING id`,
+				[slug],
+			);
+			return t.rows[0].id;
+		};
+
+		// A project with a running container, a custom concurrency value, and the
+		// old memory default (16) — the dropped column must not take the rest of
+		// the row with it, and the 16 must convert to NULL (inherit).
+		const runningTeamId = await newTeam('team-running');
+		const running = await h.db.query<{ id: string; memory_limit_gib: number }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, max_concurrent_runs, container_id, container_status)
+			 VALUES ($1, 'Running', 'running', 'RUN', 5, 'cid-running', 'running')
+			 RETURNING id, memory_limit_gib`,
+			[runningTeamId],
+		);
+		runningProjectId = running.rows[0].id;
+		// Guard the premise: the pre-migration memory default really is 16.
+		expect(running.rows[0].memory_limit_gib).toBe(16);
+
+		// A project whose container is stopped (023 concurrency default of 10) and
+		// whose memory cap an operator explicitly customized — must be preserved.
+		const stopped = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, container_id, container_status, memory_limit_gib)
+			 VALUES ($1, 'Stopped', 'stopped', 'STO', 'cid-stopped', 'stopped', 8) RETURNING id`,
+			[await newTeam('team-stopped')],
+		);
+		stoppedProjectId = stopped.rows[0].id;
+
+		// A finished run — the new idx_runs_finished must not disturb existing rows.
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Agent') RETURNING id`,
+			[runningTeamId],
+		);
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+			 VALUES ($1, $2, 1, 'RUN-1', 'Task') RETURNING id`,
+			[runningTeamId, runningProjectId],
+		);
+		const run = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, finished_at)
+			 VALUES ($1, $2, $3, 'succeeded', now() - interval '1 hour') RETURNING id`,
+			[runningTeamId, member.rows[0].id, task.rows[0].id],
+		);
+		runId = run.rows[0].id;
+
+		// A chat session with an in-flight message — the new partial index on
+		// chat_messages must not disturb existing rows.
+		const conversation = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, title)
+			 VALUES ($1, $2, $3, 'Chat') RETURNING id`,
+			[member.rows[0].id, runningTeamId, runningProjectId],
+		);
+		const session = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_sessions (member_id, team_id, project_id, runtime_type, status)
+			 VALUES ($1, $2, $3, 'claude_code', 'running') RETURNING id`,
+			[member.rows[0].id, runningTeamId, runningProjectId],
+		);
+		sessionId = session.rows[0].id;
+		const message = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_messages (conversation_id, role, status, content, session_id)
+			 VALUES ($1, 'assistant', 'streaming', '', $2) RETURNING id`,
+			[conversation.rows[0].id, sessionId],
+		);
+		messageId = message.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('drops the max_concurrent_runs column', async () => {
+		const c = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM information_schema.columns
+			 WHERE table_name = 'projects' AND column_name = 'max_concurrent_runs'`,
+		);
+		expect(c.rows[0].c).toBe(0);
+	});
+
+	it('makes memory_limit_gib nullable with no default, converting old-default rows to inherit', async () => {
+		const col = await h.db.query<{ is_nullable: string; column_default: string | null }>(
+			`SELECT is_nullable, column_default FROM information_schema.columns
+			 WHERE table_name = 'projects' AND column_name = 'memory_limit_gib'`,
+		);
+		expect(col.rows[0]).toMatchObject({ is_nullable: 'YES', column_default: null });
+
+		const rows = await h.db.query<{ id: string; memory_limit_gib: number | null }>(
+			`SELECT id, memory_limit_gib FROM projects WHERE id = ANY($1::uuid[])`,
+			[[runningProjectId, stoppedProjectId]],
+		);
+		const byId = new Map(rows.rows.map((r) => [r.id, r.memory_limit_gib]));
+		expect(byId.get(runningProjectId)).toBeNull(); // was on the old default 16
+		expect(byId.get(stoppedProjectId)).toBe(8); // explicit override preserved
+	});
+
+	it('adds container_last_started_at, backfilled only for running containers', async () => {
+		const rows = await h.db.query<{ id: string; container_last_started_at: string | null }>(
+			`SELECT id, container_last_started_at FROM projects WHERE id = ANY($1::uuid[])`,
+			[[runningProjectId, stoppedProjectId]],
+		);
+		const byId = new Map(rows.rows.map((r) => [r.id, r.container_last_started_at]));
+		expect(byId.get(runningProjectId)).not.toBeNull();
+		expect(byId.get(stoppedProjectId)).toBeNull();
+	});
+
+	it('creates the two idle-stop indexes', async () => {
+		const idx = await h.db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes
+			 WHERE indexname IN ('idx_runs_finished', 'idx_chat_messages_inflight')`,
+		);
+		expect(idx.rows.map((r) => r.indexname).sort()).toEqual([
+			'idx_chat_messages_inflight',
+			'idx_runs_finished',
+		]);
+	});
+
+	it('preserves pre-existing projects, runs, and chat rows', async () => {
+		const projects = await h.db.query<{ id: string; container_id: string; slug: string }>(
+			`SELECT id, container_id, slug FROM projects WHERE id = ANY($1::uuid[]) ORDER BY slug`,
+			[[runningProjectId, stoppedProjectId]],
+		);
+		expect(projects.rows).toHaveLength(2);
+		expect(projects.rows[0]).toMatchObject({ slug: 'running', container_id: 'cid-running' });
+		expect(projects.rows[1]).toMatchObject({ slug: 'stopped', container_id: 'cid-stopped' });
+
+		const run = await h.db.query<{ status: string }>(
+			`SELECT status FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0]?.status).toBe('succeeded');
+
+		const msg = await h.db.query<{ status: string; session_id: string }>(
+			`SELECT status, session_id FROM chat_messages WHERE id = $1`,
+			[messageId],
+		);
+		expect(msg.rows[0]).toMatchObject({ status: 'streaming', session_id: sessionId });
+	});
+});

--- a/packages/server/test/projects-routes-cov-fill.test.ts
+++ b/packages/server/test/projects-routes-cov-fill.test.ts
@@ -351,22 +351,14 @@ describe('PATCH /api/projects/:projectId', () => {
 		expect((await res.json()).data.description).toBe('Refreshed description.');
 	});
 
-	it('rejects a non-integer max_concurrent_runs and accepts a valid one', async () => {
-		const bad = await ctx.app.request(`/api/projects/${projectSlug}`, {
-			method: 'PATCH',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ max_concurrent_runs: 0 }),
-		});
-		expect(bad.status).toBe(400);
-		expect((await bad.json()).error.message).toContain('max_concurrent_runs');
-
-		const good = await ctx.app.request(`/api/projects/${projectSlug}`, {
+	it('ignores the removed max_concurrent_runs field (concurrency is instance-level now)', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ max_concurrent_runs: 3 }),
 		});
-		expect(good.status).toBe(200);
-		expect((await good.json()).data.max_concurrent_runs).toBe(3);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.max_concurrent_runs).toBeUndefined();
 	});
 
 	it('rejects an invalid memory_limit_gib and accepts a valid one', async () => {

--- a/packages/server/test/projects-routes-extended.test.ts
+++ b/packages/server/test/projects-routes-extended.test.ts
@@ -83,16 +83,9 @@ describe('PATCH /projects/:projectId — validation + reshaping', () => {
 		projectSlug = data.slug; // keep the handle current for later tests
 	});
 
-	it('rejects a non-integer max_concurrent_runs', async () => {
-		const { status, body } = await patch({ max_concurrent_runs: 0 });
-		expect(status).toBe(400);
-		expect((body.error as { message: string }).message).toMatch(/max_concurrent_runs/);
-	});
-
-	it('accepts a valid max_concurrent_runs', async () => {
-		const { status, body } = await patch({ max_concurrent_runs: 4 });
+	it('ignores the removed max_concurrent_runs field (concurrency is instance-level)', async () => {
+		const { status } = await patch({ max_concurrent_runs: 4 });
 		expect(status).toBe(200);
-		expect((body.data as { max_concurrent_runs: number }).max_concurrent_runs).toBe(4);
 	});
 
 	it('rejects a memory_limit_gib below 1', async () => {
@@ -100,10 +93,16 @@ describe('PATCH /projects/:projectId — validation + reshaping', () => {
 		expect(status).toBe(400);
 	});
 
-	it('accepts a valid memory_limit_gib', async () => {
+	it('accepts a valid memory_limit_gib override', async () => {
 		const { status, body } = await patch({ memory_limit_gib: 8 });
 		expect(status).toBe(200);
 		expect((body.data as { memory_limit_gib: number }).memory_limit_gib).toBe(8);
+	});
+
+	it('clears the memory override with null — back to the instance default', async () => {
+		const { status, body } = await patch({ memory_limit_gib: null });
+		expect(status).toBe(200);
+		expect((body.data as { memory_limit_gib: number | null }).memory_limit_gib).toBeNull();
 	});
 
 	it('updates budget windows when consistent', async () => {

--- a/packages/server/test/queued-wakeups-covfill.test.ts
+++ b/packages/server/test/queued-wakeups-covfill.test.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import {
@@ -77,6 +78,19 @@ async function clearWakeups(forTaskId: string): Promise<void> {
 		forTaskId,
 	]);
 }
+
+afterEach(async () => {
+	// Same drain as queued-wakeups.test.ts: dispatched tests now launch real
+	// background runs (lazy-start); settle them and sweep their leftovers so
+	// later assertions see only their own rows.
+	await waitForBackground();
+	await db.query(
+		`DELETE FROM agent_wakeup_requests WHERE team_id = $1 AND status = 'queued'::wakeup_status`,
+		[teamId],
+	);
+	await db.query('UPDATE execution_locks SET released_at = now() WHERE released_at IS NULL');
+	await clearRuns();
+});
 
 async function insertRunningRun(memberId: string, forTaskId: string): Promise<string> {
 	const r = await db.query<{ id: string }>(
@@ -437,13 +451,18 @@ describe('POST runs/:runId/retry', () => {
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.dispatched).toBe(true);
 
+		// The dispatch launches a background run (lazy-start); settle it so its
+		// failure-chain wakeups can't race the assertions, then pin them to the
+		// retry's own on_demand wakeup.
+		await waitForBackground();
 		const wakeup = await db.query<{
 			member_id: string;
 			source: string;
 			status: string;
 			payload: { source_run_id?: string; triggered_by?: { name: string } };
 		}>(
-			"SELECT member_id, source, status, payload FROM agent_wakeup_requests WHERE payload->>'task_id' = $1",
+			`SELECT member_id, source, status, payload FROM agent_wakeup_requests
+			 WHERE payload->>'task_id' = $1 AND source = 'on_demand'`,
 			[taskId],
 		);
 		expect(wakeup.rows).toHaveLength(1);

--- a/packages/server/test/queued-wakeups-covfill.test.ts
+++ b/packages/server/test/queued-wakeups-covfill.test.ts
@@ -10,6 +10,12 @@ import {
 	createTestTeam,
 	projectSlugFor,
 } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 
 let app: Hono<Env>;
 let db: Db;
@@ -114,7 +120,7 @@ async function listQueued(forTaskId: string) {
 					agent_busy: boolean;
 					run_now_blocked: string | null;
 				}>;
-				dispatch: { task_busy: boolean; project_at_capacity: boolean };
+				dispatch: { task_busy: boolean; instance_at_capacity: boolean };
 			};
 		},
 	};
@@ -190,7 +196,7 @@ describe('GET queued-wakeups', () => {
 		expect(alpha.last_skipped_reason).toBe('task_busy');
 		expect(wakeups[1].coalesced_count).toBe(3);
 		expect(dispatch.task_busy).toBe(false);
-		expect(dispatch.project_at_capacity).toBe(false);
+		expect(dispatch.instance_at_capacity).toBe(false);
 		expect(alpha.agent_busy).toBe(false);
 		expect(alpha.run_now_blocked).toBeNull();
 	});
@@ -203,14 +209,19 @@ describe('GET queued-wakeups', () => {
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(true);
-		expect(body.data.dispatch.project_at_capacity).toBe(false);
+		expect(body.data.dispatch.instance_at_capacity).toBe(false);
 		await clearRuns();
 	});
 
-	it('reports project_at_capacity and per-agent busy state', async () => {
+	it('reports instance_at_capacity and per-agent busy state', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
+		// Container semantics: this project's container is stopped and a filler
+		// project's running container consumes the single slot. Per-agent busy
+		// state is independent of the container gate.
+		await setMaxActiveContainersForTest(db, 1);
+		await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+		await seedRunningContainerProject(db, 'cap-covfill-get');
 		const sibling = await createTask('Covfill Busy Sibling');
 		await insertRunningRun(agentA, sibling);
 		const busy = await insertQueuedWakeup(agentA, taskId);
@@ -218,12 +229,14 @@ describe('GET queued-wakeups', () => {
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_at_capacity).toBe(true);
+		expect(body.data.dispatch.instance_at_capacity).toBe(true);
 		const byId = Object.fromEntries(body.data.wakeups.map((w) => [w.id, w]));
 		expect(byId[busy].agent_busy).toBe(true);
 		expect(byId[free].agent_busy).toBe(false);
 
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+		await removeSeededContainerProject(db, 'cap-covfill-get');
+		await clearMaxActiveContainersForTest(db);
 		await clearRuns();
 	});
 
@@ -337,19 +350,21 @@ describe('POST run-now', () => {
 		await clearRuns();
 	});
 
-	it('409s when the project is at capacity', async () => {
+	it('409s when the container limit is reached', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-		const sibling = await createTask('Covfill Capacity Sibling');
-		await insertRunningRun(agentA, sibling);
+		await setMaxActiveContainersForTest(db, 1);
+		await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+		await seedRunningContainerProject(db, 'cap-covfill-runnow');
 		const wakeupId = await insertQueuedWakeup(agentB, taskId);
 
 		const res = await runNow(taskId, wakeupId);
 		expect(res.status).toBe(409);
 		const body = (await res.json()) as { error: { message: string } };
-		expect(body.error.message).toContain('concurrent-run limit');
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		expect(body.error.message).toContain('active-container limit');
+		await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+		await removeSeededContainerProject(db, 'cap-covfill-runnow');
+		await clearMaxActiveContainersForTest(db);
 		await clearRuns();
 	});
 

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -10,6 +10,12 @@ import {
 	createTestTeam,
 	projectSlugFor,
 } from './helpers/app';
+import {
+	clearMaxActiveContainersForTest,
+	removeSeededContainerProject,
+	seedRunningContainerProject,
+	setMaxActiveContainersForTest,
+} from './helpers/capacity';
 
 let app: Hono<Env>;
 let db: Db;
@@ -130,7 +136,7 @@ interface WakeupRow {
 
 interface DispatchState {
 	task_busy: boolean;
-	project_at_capacity: boolean;
+	instance_at_capacity: boolean;
 }
 
 beforeAll(async () => {
@@ -195,7 +201,7 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_at_capacity).toBe(false);
+		expect(body.data.dispatch.instance_at_capacity).toBe(false);
 		expect(body.data.wakeups[0].run_now_blocked).toBeNull();
 	});
 
@@ -210,32 +216,35 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 		await clearRuns();
 	});
 
-	it('reports project_at_capacity when the project is at its run limit', async () => {
+	it('reports instance_at_capacity when starting the container would exceed the limit', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-		const sibling = await createTask('Busy Sibling');
-		await insertRunningRun(agentA, sibling);
+		// Container semantics: this project's container is stopped and a filler
+		// project's running container consumes the single slot.
+		await setMaxActiveContainersForTest(db, 1);
+		await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+		await seedRunningContainerProject(db, 'cap-filler-get');
 		await insertQueuedWakeup(agentB, taskId);
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_at_capacity).toBe(true);
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-		await clearRuns();
+		expect(body.data.dispatch.instance_at_capacity).toBe(true);
+		await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+		await removeSeededContainerProject(db, 'cap-filler-get');
+		await clearMaxActiveContainersForTest(db);
 	});
 
-	it('still has capacity while running runs stay below the limit', async () => {
+	it('a project whose container is already running is never at capacity', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
-		const sibling = await createTask('One Of Three');
-		await insertRunningRun(agentA, sibling);
+		// Even with the limit fully consumed by this project's own container, a
+		// run into it needs no new container slot.
+		await setMaxActiveContainersForTest(db, 1);
 		await insertQueuedWakeup(agentB, taskId);
 
 		const { body } = await listQueued(taskId);
-		expect(body.data.dispatch.project_at_capacity).toBe(false);
-		await clearRuns();
+		expect(body.data.dispatch.instance_at_capacity).toBe(false);
+		await clearMaxActiveContainersForTest(db);
 	});
 
 	it('flags run_now_blocked per source when the task has an open dependency', async () => {
@@ -256,7 +265,6 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 	it('flags agent_busy per agent when that agent runs on another task in the project', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 		// Agent Alpha is running on a sibling task, so its dispatch slot is taken
 		// even though the project still has capacity. Agent Beta is free.
 		const sibling = await createTask('Agent-busy GET Sibling');
@@ -269,7 +277,7 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 		expect(byId[busy].agent_busy).toBe(true);
 		expect(byId[free].agent_busy).toBe(false);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_at_capacity).toBe(false);
+		expect(body.data.dispatch.instance_at_capacity).toBe(false);
 		await clearRuns();
 	});
 });
@@ -323,12 +331,12 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 		await clearRuns();
 	});
 
-	it('returns 409 and records project_at_capacity when the project is at its run limit', async () => {
+	it('returns 409 and records instance_at_capacity when the container limit is reached', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
-		const sibling = await createTask('Run-now Busy Sibling');
-		await insertRunningRun(agentA, sibling);
+		await setMaxActiveContainersForTest(db, 1);
+		await db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [projectId]);
+		await seedRunningContainerProject(db, 'cap-filler-runnow');
 		const wakeupId = await insertQueuedWakeup(agentB, taskId);
 
 		const res = await runNow(taskId, wakeupId);
@@ -339,15 +347,16 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 			[wakeupId],
 		);
 		expect(row.rows[0].status).toBe('queued');
-		expect(row.rows[0].last_skipped_reason).toBe('project_at_capacity');
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		expect(row.rows[0].last_skipped_reason).toBe('instance_at_capacity');
+		await db.query(`UPDATE projects SET container_status = 'running' WHERE id = $1`, [projectId]);
+		await removeSeededContainerProject(db, 'cap-filler-runnow');
+		await clearMaxActiveContainersForTest(db);
 		await clearRuns();
 	});
 
 	it('returns 409 and leaks no lock when the agent already runs in the project', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
-		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 		// The same agent is already running on a sibling task in this project, so
 		// its per agent+project dispatch slot is taken even though capacity remains.
 		const sibling = await createTask('Agent-busy Sibling');

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -1,6 +1,7 @@
 import type { Hono } from 'hono';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import {
@@ -70,6 +71,20 @@ async function clearWakeups(forTaskId: string): Promise<void> {
 		forTaskId,
 	]);
 }
+
+afterEach(async () => {
+	// Lazy-start means the dispatch tests launch real background runs against
+	// the fake docker. Drain them — and the failure-chain wakeups/locks they
+	// leave — before the next test asserts on run or wakeup state; on slow CI
+	// runners the async run otherwise bleeds across tests.
+	await waitForBackground();
+	await db.query(
+		`DELETE FROM agent_wakeup_requests WHERE team_id = $1 AND status = 'queued'::wakeup_status`,
+		[teamId],
+	);
+	await db.query('UPDATE execution_locks SET released_at = now() WHERE released_at IS NULL');
+	await clearRuns();
+});
 
 async function insertRunningRun(memberId: string, forTaskId: string): Promise<string> {
 	const r = await db.query<{ id: string }>(

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -59,6 +59,58 @@ export const MAX_CHAT_HISTORY_SIZE_MIN = 8 * 1024;
 export const MAX_CHAT_HISTORY_SIZE_MAX = 256 * 1024;
 
 /**
+ * Instance-wide cap on simultaneously ACTIVE (running) project containers,
+ * including the assistant chat's container. Combined with the per-container RAM
+ * cap, this bounds total memory demand at `N × cap` no matter how many runs
+ * share a container. Stored in system_meta; when the key is absent the
+ * effective default is COMPUTED from host memory via
+ * {@link computeDefaultMaxActiveContainers} — the constant below is only the
+ * last-resort fallback when host memory is unreadable. Clamped to [MIN, MAX].
+ */
+export const DEFAULT_MAX_ACTIVE_CONTAINERS = 3;
+export const MAX_ACTIVE_CONTAINERS_MIN = 1;
+export const MAX_ACTIVE_CONTAINERS_MAX = 100;
+
+/**
+ * Instance-wide default memory cap per project container, in GB. Dual role:
+ * the Docker cgroup memory limit applied to every container that doesn't carry
+ * a per-project override, and the divisor in the automatic max-active-container
+ * default ((RAM + swap) / cap). Stored in system_meta; absent key = default.
+ */
+export const DEFAULT_RAM_CAP_PER_CONTAINER_GB = 2;
+export const RAM_CAP_PER_CONTAINER_GB_MIN = 1;
+export const RAM_CAP_PER_CONTAINER_GB_MAX = 512;
+
+/**
+ * The automatic max-active-containers default: how many ram-cap-sized
+ * containers fit in the host's total virtual memory (RAM + swap), so total
+ * container demand can never exceed what the host actually has. The reference
+ * 1.92GiB-RAM + 6GiB-swap host rounds to 8GiB and yields 8 / 2 = 4. Pure math
+ * (shared so the web settings page can render the same formula); byte inputs
+ * come from the server's host-memory probe.
+ */
+export function computeDefaultMaxActiveContainers(
+	totalRamBytes: number,
+	totalSwapBytes: number,
+	ramCapGb: number,
+): number {
+	const gib = 1024 ** 3;
+	const totalGib = Math.round((totalRamBytes + totalSwapBytes) / gib);
+	const computed = Math.floor(totalGib / Math.max(1, ramCapGb));
+	return Math.min(MAX_ACTIVE_CONTAINERS_MAX, Math.max(MAX_ACTIVE_CONTAINERS_MIN, computed));
+}
+
+/**
+ * Minutes a project's container keeps running after its last activity (agent
+ * runs, assistant chat) before the idle-stop cron stops it. Containers restart
+ * on demand when a run or chat needs them. 0 = never stop (always-on).
+ * Stored in system_meta; absent key = default. Clamped to [MIN, MAX].
+ */
+export const DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN = 15;
+export const CONTAINER_IDLE_TIMEOUT_MIN_MIN = 0;
+export const CONTAINER_IDLE_TIMEOUT_MIN_MAX = 10080;
+
+/**
  * The "latest few" messages kept in the active window after a compaction flush.
  * Internal constant (not an operator setting): everything older than this tail
  * is summarized into long-term memory and dropped from the chatbox.

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -787,10 +787,9 @@ export const TERMINAL_WAKEUP_STATUSES: readonly WakeupStatus[] = [
 
 export const WakeupSkipReason = {
 	TaskBusy: 'task_busy',
-	ProjectAtCapacity: 'project_at_capacity',
+	InstanceAtCapacity: 'instance_at_capacity',
 	AgentRunning: 'agent_running',
 	OverBudget: 'over_budget',
-	ContainerDown: 'container_down',
 } as const;
 export type WakeupSkipReason = (typeof WakeupSkipReason)[keyof typeof WakeupSkipReason];
 

--- a/packages/shared/test/max-active-containers.test.ts
+++ b/packages/shared/test/max-active-containers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { computeDefaultMaxActiveContainers } from '../src/constants';
+
+const GIB = 1024 ** 3;
+
+describe('computeDefaultMaxActiveContainers', () => {
+	it('divides total virtual memory by the ram cap (8GB / 2GB = 4)', () => {
+		expect(computeDefaultMaxActiveContainers(2 * GIB, 6 * GIB, 2)).toBe(4);
+	});
+
+	it('rounds the total before dividing — the 1.92GiB + 6GiB reference host yields 4', () => {
+		// A "2GB" droplet reports ~1.92GiB MemTotal; 1.92 + 6 = 7.92 rounds to 8.
+		expect(computeDefaultMaxActiveContainers(1.92 * GIB, 6 * GIB, 2)).toBe(4);
+	});
+
+	it('scales with the cap — the same host with a 4GB cap yields 2', () => {
+		expect(computeDefaultMaxActiveContainers(2 * GIB, 6 * GIB, 4)).toBe(2);
+	});
+
+	it('never returns below the minimum, even when the cap exceeds host memory', () => {
+		expect(computeDefaultMaxActiveContainers(1 * GIB, 0, 2)).toBe(1);
+		expect(computeDefaultMaxActiveContainers(0.5 * GIB, 0, 8)).toBe(1);
+	});
+
+	it('clamps to the maximum on huge hosts', () => {
+		expect(computeDefaultMaxActiveContainers(512 * GIB, 0, 1)).toBe(100);
+	});
+
+	it('treats swap as zero when absent', () => {
+		expect(computeDefaultMaxActiveContainers(16 * GIB, 0, 2)).toBe(8);
+	});
+
+	it('guards a zero/invalid cap by treating it as 1', () => {
+		expect(computeDefaultMaxActiveContainers(8 * GIB, 0, 0)).toBe(8);
+	});
+});

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -119,9 +119,11 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 	}, []);
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
-	// The CEO can only act while the HQ container is up. When it isn't, the chat
-	// stays openable but swaps its body for the container state + a link to fix it.
-	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
+	// A stopped HQ container is no blocker — sending a message lazy-starts it.
+	// Only genuine errors and in-flight transitions (provisioning/rebuilding)
+	// swap the chat body for the container state + a link to fix it.
+	const blockedHealth =
+		hqHealth && hqHealth.kind !== 'healthy' && hqHealth.kind !== 'stopped' ? hqHealth : null;
 	const [draft, setDraft] = useState('');
 	const [copied, setCopied] = useState(false);
 	// Files staged for the next message; the reusable attachment kit owns the

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -81,8 +81,9 @@ function containerNotReadyReason(health: ContainerHealth | null): string {
 		case 'provisioning':
 			return 'Container is starting up — retry will be available once it is running';
 		default:
-			// stopped, error, or the project index has not loaded yet.
-			return 'Container is not running — start it from the Container page to retry';
+			// error, or the project index has not loaded yet (stopped never blocks —
+			// the retry lazy-starts the container).
+			return 'Container hit an error — fix it from the Container page to retry';
 	}
 }
 
@@ -98,10 +99,10 @@ function RunRetryButton({
 	const retry = useRetryFailedRun({ projectId, taskId });
 	const project = useProjectMeta(projectId);
 	const health = useContainerHealth(project);
-	// A run can only be dispatched into a healthy container (running, and not mid
-	// base-image rebuild). Mirror the runtime gate so a click can't queue a retry
-	// that would immediately fail on a missing/stopped container.
-	const containerReady = health?.kind === 'healthy';
+	// A stopped container is fine — the runner lazy-starts it. Only block while
+	// an error needs fixing or a provision/rebuild is in flight, mirroring the
+	// runtime gate.
+	const containerReady = health?.kind === 'healthy' || health?.kind === 'stopped';
 	return (
 		<Tooltip content={containerReady ? 'Retry this run' : containerNotReadyReason(health)}>
 			<button

--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -30,7 +30,10 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		};
 	}, []);
 
-	if (!project || !health || health.kind === 'healthy') return null;
+	// `stopped` is the normal resting state — containers start on demand when a
+	// run or chat needs them — so it gets no banner at all; only genuine errors
+	// and in-flight transitions are surfaced.
+	if (!project || !health || health.kind === 'healthy' || health.kind === 'stopped') return null;
 
 	// The shared base image is (re)building. Surface the rebuilding status with a
 	// determinate progress bar — the build gates every container that needs the
@@ -84,10 +87,9 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		);
 	}
 
-	// Stopped or errored — the container needs a rebuild. The banner body links to
-	// the container page; the Restart button rebuilds in place without navigating.
-	const hasError = health.kind === 'error';
-	const message = `${project.name} container is not running`;
+	// Errored — the container needs attention. The banner body links to the
+	// container page; the Restart button rebuilds in place without navigating.
+	const message = `${project.name} container hit an error`;
 
 	const rebuild = async (e: React.MouseEvent) => {
 		e.preventDefault();
@@ -102,9 +104,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		}
 	};
 
-	const tone = hasError
-		? 'bg-danger/10 text-danger hover:bg-danger/20'
-		: 'bg-warning/10 text-warning hover:bg-warning/20';
+	const tone = 'bg-danger/10 text-danger hover:bg-danger/20';
 
 	return (
 		<div ref={bannerRef} className={BANNER_OUTER}>

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -294,9 +294,11 @@ export function CreateProjectWithTeamDialog({
 	const navigate = useNavigate();
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
-	// Project intake/creation is driven by the CEO in HQ, so it can't proceed
-	// until the HQ container is running. Block the form until then.
-	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
+	// Project intake/creation is CEO-driven, but a stopped HQ container is no
+	// blocker — the intake run lazy-starts it. Block the form only on errors and
+	// in-flight transitions.
+	const blockedHealth =
+		hqHealth && hqHealth.kind !== 'healthy' && hqHealth.kind !== 'stopped' ? hqHealth : null;
 
 	// The unified option list across the three sources. HQ (the internal team) is
 	// already excluded from `projects` by useAllVisibleProjects.

--- a/packages/web/src/components/hq-container-notice.tsx
+++ b/packages/web/src/components/hq-container-notice.tsx
@@ -56,7 +56,7 @@ function noticeTitle(health: Exclude<ContainerHealth, { kind: 'healthy' }>): str
 				? 'Stopping the HQ container…'
 				: 'Starting the HQ container…';
 		case 'stopped':
-			return 'The HQ container isn’t running';
+			return 'The HQ container is asleep — it starts automatically when needed';
 		case 'error':
 			return 'The HQ container has an error';
 	}

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -47,7 +47,8 @@ export function ProjectSidebar({
 
 	const isInternal = project?.is_internal ?? false;
 	const projectParams = { projectId };
-	const containerFailed = health?.kind === 'stopped' || health?.kind === 'error';
+	// `stopped` is the normal on-demand resting state — only genuine errors flag.
+	const containerFailed = health?.kind === 'error';
 	const containerProvisioning = health?.kind === 'provisioning' || health?.kind === 'rebuilding';
 
 	const enabledAgents = (agents ?? []).filter((a) => a.admin_status !== AgentAdminStatus.Disabled);

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -24,6 +24,7 @@ const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/admin-password', labelKey: 'settings.adminPassword' },
 	{ to: '/settings/users', labelKey: 'settings.users' },
 	{ to: '/settings/chatbox', labelKey: 'settings.chatbox' },
+	{ to: '/settings/concurrency', labelKey: 'settings.concurrency' },
 	{ to: '/settings/skills', labelKey: 'settings.skills' },
 	{ to: '/settings/connectors', labelKey: 'settings.connectors' },
 	{ to: '/settings/chat-channels', labelKey: 'settings.chatChannels' },

--- a/packages/web/src/components/task-detail/agent-queue-section.tsx
+++ b/packages/web/src/components/task-detail/agent-queue-section.tsx
@@ -182,7 +182,7 @@ function RunningAgentRow({
  */
 function runNowBlockReason(wakeup: QueuedWakeup, dispatch: QueuedDispatchState): string | null {
 	if (dispatch.task_busy) return 'This ticket already has a run in progress';
-	if (dispatch.project_at_capacity) return 'Project is at its concurrent-run limit';
+	if (dispatch.instance_at_capacity) return 'Hezo is at its active-container limit';
 	if (wakeup.agent_busy) return 'This agent is currently running on another task in this project';
 	if (wakeup.run_now_blocked === 'blocked_by_dependency') return 'Blocked by an open dependency';
 	return null;

--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -90,8 +90,9 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 				{!task.has_active_run && task.queued_wakeup && (
 					<Badge color="blue" className="gap-1" testId="task-queued-badge">
 						<span className="inline-block w-1.5 h-1.5 rounded-full bg-info-soft-fg" />
-						{task.queued_wakeup.reason === 'project_at_capacity'
-							? 'Queued — project at capacity'
+						{task.queued_wakeup.reason === 'instance_at_capacity' ||
+						task.queued_wakeup.reason === 'project_at_capacity'
+							? 'Queued — at the container limit'
 							: 'Run queued'}
 					</Badge>
 				)}

--- a/packages/web/src/components/task-run-dot.tsx
+++ b/packages/web/src/components/task-run-dot.tsx
@@ -30,8 +30,9 @@ export function TaskRunDot({ hasActiveRun, queuedWakeup }: TaskRunDotProps) {
 	}
 	if (queuedWakeup) {
 		const label =
+			queuedWakeup.reason === 'instance_at_capacity' ||
 			queuedWakeup.reason === 'project_at_capacity'
-				? 'Run queued — project at capacity'
+				? 'Run queued — at the container limit'
 				: 'Run queued — waiting';
 		return (
 			<Tooltip content={label}>

--- a/packages/web/src/hooks/use-container-health.ts
+++ b/packages/web/src/hooks/use-container-health.ts
@@ -8,9 +8,12 @@ import type { Project } from './use-projects';
  * container status banner, the CEO chat, and the create-project gate so they
  * never disagree about whether a container is usable.
  *
- * `provisioning` covers the transient setup/teardown states (creating, stopping)
- * and the not-yet-provisioned `null` status — anything that should resolve to
- * running on its own. Only `running` (and not mid-rebuild) is `healthy`.
+ * `stopped` is a NORMAL resting state, not a fault: containers start on demand
+ * (agent runs and chats lazy-start them) and the idle-stop cron parks them
+ * again. It covers the never-provisioned `null` status too — the first use
+ * provisions. `provisioning` covers the transient in-flight states (creating,
+ * stopping). Only `running` (and not mid-rebuild) is `healthy`; only `error`
+ * deserves error styling.
  */
 export type ContainerHealth =
 	| { kind: 'healthy' }
@@ -27,15 +30,15 @@ export function useContainerHealth(project: Project | undefined): ContainerHealt
 	const status = project.container_status;
 
 	// A base-image rebuild gates every container that needs the fresh image,
-	// unless the operator deliberately stopped this one.
-	if (imageBuild?.building && status !== ContainerStatus.Stopped) {
+	// unless this one is asleep anyway (it picks the fresh image up on wake).
+	if (imageBuild?.building && status !== ContainerStatus.Stopped && status !== null) {
 		return { kind: 'rebuilding', percent: imageBuild.percent };
 	}
 	if (status === ContainerStatus.Error) return { kind: 'error' };
-	if (status === ContainerStatus.Stopped) return { kind: 'stopped' };
+	if (status === ContainerStatus.Stopped || status === null) return { kind: 'stopped' };
 	if (status === ContainerStatus.Running) return { kind: 'healthy' };
 
-	// creating, stopping, or null (never provisioned / warming up at boot).
+	// creating or stopping — in-flight, resolves on its own.
 	return {
 		kind: 'provisioning',
 		transient: status === ContainerStatus.Stopping ? 'stopping' : 'creating',

--- a/packages/web/src/hooks/use-instance-settings.ts
+++ b/packages/web/src/hooks/use-instance-settings.ts
@@ -6,11 +6,25 @@ import { queryKeys } from '../lib/query-keys';
 export interface InstanceSettings {
 	base_url: string | null;
 	max_chat_history_size: number;
+	/** Effective active-container cap: the explicit setting, else the computed default. */
+	max_active_containers: number;
+	/** True when the operator explicitly set a value (vs the automatic default). */
+	max_active_containers_is_set: boolean;
+	/** The host-memory-computed default: (RAM + swap) / ram cap per container. */
+	max_active_containers_computed_default: number;
+	default_ram_cap_per_container_gb: number;
+	container_idle_timeout_min: number;
+	host_total_ram_bytes: number;
+	host_total_swap_bytes: number;
 }
 
 export type InstanceSettingsUpdate = Partial<{
 	base_url: string | null;
 	max_chat_history_size: number;
+	/** null resets to the automatic (host-memory-computed) default. */
+	max_active_containers: number | null;
+	default_ram_cap_per_container_gb: number;
+	container_idle_timeout_min: number;
 }>;
 
 export function useInstanceSettings() {

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -16,8 +16,8 @@ export interface Project {
 	task_prefix: string;
 	description: string;
 	is_internal?: boolean;
-	max_concurrent_runs: number;
-	memory_limit_gib: number;
+	/** Per-project container memory override in GiB; null = inherit the instance-wide ram cap. */
+	memory_limit_gib: number | null;
 	daily_budget_cents: number;
 	weekly_budget_cents: number;
 	monthly_budget_cents: number;
@@ -238,8 +238,8 @@ export function useCreateProjectWithTeam() {
 interface UpdateProjectVars {
 	name?: string;
 	description?: string;
-	max_concurrent_runs?: number;
-	memory_limit_gib?: number;
+	/** null clears the override back to the instance-wide default ram cap. */
+	memory_limit_gib?: number | null;
 	daily_budget_cents?: number;
 	weekly_budget_cents?: number;
 	monthly_budget_cents?: number;

--- a/packages/web/src/hooks/use-queued-wakeups.ts
+++ b/packages/web/src/hooks/use-queued-wakeups.ts
@@ -19,7 +19,7 @@ export interface QueuedWakeup {
 /** Live "can this task accept a run now" state, shared by every queued wakeup on the task. */
 export interface QueuedDispatchState {
 	task_busy: boolean;
-	project_at_capacity: boolean;
+	instance_at_capacity: boolean;
 }
 
 export interface QueuedWakeupsState {

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -8,7 +8,8 @@ import { useSimpleOptimisticUpdate } from './use-optimistic-mutation';
 import { toast } from './use-toast';
 
 export interface QueuedWakeup {
-	reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
+	/** `project_at_capacity` is the pre-rename legacy value, kept for the upgrade window. */
+	reason: 'task_busy' | 'instance_at_capacity' | 'project_at_capacity' | 'agent_running';
 	since: string;
 	blocker_task_id: string | null;
 	blocker_identifier: string | null;

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Aktivitätsprotokoll",
 	"settings.adminPassword": "Admin-Passwort",
 	"settings.chatbox": "Chatbox",
+	"settings.concurrency": "Parallelität",
 	"settings.archivedProjects": "Archivierte Projekte",
 	"settings.logOut": "Abmelden",
 	"theme.label": "Design",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Activity log",
 	"settings.adminPassword": "Admin password",
 	"settings.chatbox": "Chatbox",
+	"settings.concurrency": "Concurrency",
 	"settings.archivedProjects": "Archived projects",
 	"settings.logOut": "Log out",
 	"theme.label": "Theme",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Registro de actividad",
 	"settings.adminPassword": "Contraseña de administrador",
 	"settings.chatbox": "Chat",
+	"settings.concurrency": "Ejecución simultánea",
 	"settings.archivedProjects": "Proyectos archivados",
 	"settings.logOut": "Cerrar sesión",
 	"theme.label": "Tema",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Journal d'activité",
 	"settings.adminPassword": "Mot de passe administrateur",
 	"settings.chatbox": "Messagerie",
+	"settings.concurrency": "Exécution simultanée",
 	"settings.archivedProjects": "Projets archivés",
 	"settings.logOut": "Se déconnecter",
 	"theme.label": "Thème",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Registro attività",
 	"settings.adminPassword": "Password amministratore",
 	"settings.chatbox": "Chat",
+	"settings.concurrency": "Esecuzione simultanea",
 	"settings.archivedProjects": "Progetti archiviati",
 	"settings.logOut": "Esci",
 	"theme.label": "Tema",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "アクティビティログ",
 	"settings.adminPassword": "管理者パスワード",
 	"settings.chatbox": "チャット",
+	"settings.concurrency": "同時実行",
 	"settings.archivedProjects": "アーカイブ済みプロジェクト",
 	"settings.logOut": "ログアウト",
 	"theme.label": "テーマ",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "활동 로그",
 	"settings.adminPassword": "관리자 비밀번호",
 	"settings.chatbox": "채팅",
+	"settings.concurrency": "동시 실행",
 	"settings.archivedProjects": "보관된 프로젝트",
 	"settings.logOut": "로그아웃",
 	"theme.label": "테마",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Activiteitenlog",
 	"settings.adminPassword": "Beheerderswachtwoord",
 	"settings.chatbox": "Chat",
+	"settings.concurrency": "Gelijktijdige uitvoering",
 	"settings.archivedProjects": "Gearchiveerde projecten",
 	"settings.logOut": "Uitloggen",
 	"theme.label": "Thema",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Dziennik aktywności",
 	"settings.adminPassword": "Hasło administratora",
 	"settings.chatbox": "Czat",
+	"settings.concurrency": "Współbieżność",
 	"settings.archivedProjects": "Zarchiwizowane projekty",
 	"settings.logOut": "Wyloguj się",
 	"theme.label": "Motyw",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Registro de atividades",
 	"settings.adminPassword": "Senha de administrador",
 	"settings.chatbox": "Chat",
+	"settings.concurrency": "Execução simultânea",
 	"settings.archivedProjects": "Projetos arquivados",
 	"settings.logOut": "Sair",
 	"theme.label": "Tema",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "Aktivitetslogg",
 	"settings.adminPassword": "Administratörslösenord",
 	"settings.chatbox": "Chatt",
+	"settings.concurrency": "Samtidig körning",
 	"settings.archivedProjects": "Arkiverade projekt",
 	"settings.logOut": "Logga ut",
 	"theme.label": "Tema",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -57,6 +57,7 @@
 	"settings.auditLog": "活动日志",
 	"settings.adminPassword": "管理员密码",
 	"settings.chatbox": "聊天",
+	"settings.concurrency": "并发",
 	"settings.archivedProjects": "已归档项目",
 	"settings.logOut": "退出登录",
 	"theme.label": "主题",

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -9,64 +9,74 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsRouteRouteImport } from './routes/settings/route'
-import { Route as HomeIndexRouteImport } from './routes/home/index'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
+import { Route as HomeIndexRouteImport } from './routes/home/index'
+import { Route as SettingsUsersRouteImport } from './routes/settings/users'
+import { Route as SettingsStorageRouteImport } from './routes/settings/storage'
+import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
+import { Route as SettingsLocaleRouteImport } from './routes/settings/locale'
+import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
+import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
+import { Route as SettingsConcurrencyRouteImport } from './routes/settings/concurrency'
+import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
+import { Route as SettingsChatChannelsRouteImport } from './routes/settings/chat-channels'
+import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
+import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
+import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
+import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
+import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
 import { Route as MarketplaceSlugRouteImport } from './routes/marketplace/$slug'
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
-import { Route as SettingsIndexRouteImport } from './routes/settings/index'
-import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
-import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
-import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
-import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
-import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
-import { Route as SettingsChatChannelsRouteImport } from './routes/settings/chat-channels'
-import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
-import { Route as SettingsConcurrencyRouteImport } from './routes/settings/concurrency'
-import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
-import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
-import { Route as SettingsLocaleRouteImport } from './routes/settings/locale'
-import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
-import { Route as SettingsStorageRouteImport } from './routes/settings/storage'
-import { Route as SettingsUsersRouteImport } from './routes/settings/users'
-import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
-import { Route as PreviewProjectIdFilenameRouteImport } from './routes/preview/$projectId/$filename'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
-import { Route as ProjectsProjectIdAssetsRouteImport } from './routes/projects/$projectId/assets'
-import { Route as ProjectsProjectIdAuditLogRouteImport } from './routes/projects/$projectId/audit-log'
-import { Route as ProjectsProjectIdBudgetRouteImport } from './routes/projects/$projectId/budget'
-import { Route as ProjectsProjectIdConnectorsRouteImport } from './routes/projects/$projectId/connectors'
-import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
-import { Route as ProjectsProjectIdCustomPromptRouteImport } from './routes/projects/$projectId/custom-prompt'
-import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
-import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
+import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
 import { Route as ProjectsProjectIdSkillsRouteImport } from './routes/projects/$projectId/skills'
-import { Route as ProjectsProjectIdAgentsIndexRouteImport } from './routes/projects/$projectId/agents/index'
-import { Route as ProjectsProjectIdAgentsAgentIdRouteRouteImport } from './routes/projects/$projectId/agents/$agentId/route'
-import { Route as ProjectsProjectIdAgentsHireRouteImport } from './routes/projects/$projectId/agents/hire'
-import { Route as ProjectsProjectIdAssetsViewRouteImport } from './routes/projects/$projectId/assets_.view'
-import { Route as ProjectsProjectIdGoalsIndexRouteImport } from './routes/projects/$projectId/goals/index'
-import { Route as ProjectsProjectIdGoalsGoalIdRouteImport } from './routes/projects/$projectId/goals/$goalId'
-import { Route as ProjectsProjectIdInboxIndexRouteImport } from './routes/projects/$projectId/inbox/index'
-import { Route as ProjectsProjectIdSettingsIndexRouteImport } from './routes/projects/$projectId/settings/index'
+import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
+import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
+import { Route as ProjectsProjectIdCustomPromptRouteImport } from './routes/projects/$projectId/custom-prompt'
+import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
+import { Route as ProjectsProjectIdConnectorsRouteImport } from './routes/projects/$projectId/connectors'
+import { Route as ProjectsProjectIdBudgetRouteImport } from './routes/projects/$projectId/budget'
+import { Route as ProjectsProjectIdAuditLogRouteImport } from './routes/projects/$projectId/audit-log'
+import { Route as ProjectsProjectIdAssetsRouteImport } from './routes/projects/$projectId/assets'
+import { Route as PreviewProjectIdFilenameRouteImport } from './routes/preview/$projectId/$filename'
 import { Route as ProjectsProjectIdTasksIndexRouteImport } from './routes/projects/$projectId/tasks/index'
-import { Route as ProjectsProjectIdTasksTaskIdRouteImport } from './routes/projects/$projectId/tasks/$taskId'
+import { Route as ProjectsProjectIdSettingsIndexRouteImport } from './routes/projects/$projectId/settings/index'
+import { Route as ProjectsProjectIdInboxIndexRouteImport } from './routes/projects/$projectId/inbox/index'
+import { Route as ProjectsProjectIdGoalsIndexRouteImport } from './routes/projects/$projectId/goals/index'
+import { Route as ProjectsProjectIdAgentsIndexRouteImport } from './routes/projects/$projectId/agents/index'
 import { Route as ProjectsProjectIdTeamSettingsGeneralRouteImport } from './routes/projects/$projectId/team-settings/general'
+import { Route as ProjectsProjectIdTasksTaskIdRouteImport } from './routes/projects/$projectId/tasks/$taskId'
+import { Route as ProjectsProjectIdGoalsGoalIdRouteImport } from './routes/projects/$projectId/goals/$goalId'
+import { Route as ProjectsProjectIdAssetsViewRouteImport } from './routes/projects/$projectId/assets_.view'
+import { Route as ProjectsProjectIdAgentsHireRouteImport } from './routes/projects/$projectId/agents/hire'
+import { Route as ProjectsProjectIdAgentsAgentIdRouteRouteImport } from './routes/projects/$projectId/agents/$agentId/route'
 import { Route as ProjectsProjectIdAgentsAgentIdIndexRouteImport } from './routes/projects/$projectId/agents/$agentId/index'
-import { Route as ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport } from './routes/projects/$projectId/agents/$agentId/chat-history'
 import { Route as ProjectsProjectIdAgentsAgentIdSettingsRouteImport } from './routes/projects/$projectId/agents/$agentId/settings'
+import { Route as ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport } from './routes/projects/$projectId/agents/$agentId/chat-history'
 import { Route as ProjectsProjectIdAgentsAgentIdExecutionsIndexRouteImport } from './routes/projects/$projectId/agents/$agentId/executions/index'
 import { Route as ProjectsProjectIdAgentsAgentIdExecutionsRunIdRouteImport } from './routes/projects/$projectId/agents/$agentId/executions/$runId'
 
+const SettingsRouteRoute = SettingsRouteRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsRouteRoute = SettingsRouteRouteImport.update({
-  id: '/settings',
-  path: '/settings',
+const SettingsIndexRoute = SettingsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const MarketplaceIndexRoute = MarketplaceIndexRouteImport.update({
+  id: '/marketplace/',
+  path: '/marketplace/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HomeIndexRoute = HomeIndexRouteImport.update({
@@ -74,10 +84,76 @@ const HomeIndexRoute = HomeIndexRouteImport.update({
   path: '/home/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MarketplaceIndexRoute = MarketplaceIndexRouteImport.update({
-  id: '/marketplace/',
-  path: '/marketplace/',
-  getParentRoute: () => rootRouteImport,
+const SettingsUsersRoute = SettingsUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsStorageRoute = SettingsStorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsLocaleRoute = SettingsLocaleRouteImport.update({
+  id: '/locale',
+  path: '/locale',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
+  id: '/credentials',
+  path: '/credentials',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
+  id: '/connectors',
+  path: '/connectors',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsConcurrencyRoute = SettingsConcurrencyRouteImport.update({
+  id: '/concurrency',
+  path: '/concurrency',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
+  id: '/chatbox',
+  path: '/chatbox',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsChatChannelsRoute = SettingsChatChannelsRouteImport.update({
+  id: '/chat-channels',
+  path: '/chat-channels',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
+  id: '/audit-log',
+  path: '/audit-log',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsArchivedProjectsRoute =
+  SettingsArchivedProjectsRouteImport.update({
+    id: '/archived-projects',
+    path: '/archived-projects',
+    getParentRoute: () => SettingsRouteRoute,
+  } as any)
+const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
+  id: '/ai-providers',
+  path: '/ai-providers',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAdminPasswordRoute = SettingsAdminPasswordRouteImport.update({
+  id: '/admin-password',
+  path: '/admin-password',
+  getParentRoute: () => SettingsRouteRoute,
 } as any)
 const MarketplaceSlugRoute = MarketplaceSlugRouteImport.update({
   id: '/marketplace/$slug',
@@ -89,124 +165,30 @@ const ProjectsProjectIdRouteRoute = ProjectsProjectIdRouteRouteImport.update({
   path: '/projects/$projectId',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsIndexRoute = SettingsIndexRouteImport.update({
+const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsAdminPasswordRoute = SettingsAdminPasswordRouteImport.update({
-  id: '/admin-password',
-  path: '/admin-password',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
-  id: '/ai-providers',
-  path: '/ai-providers',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
-  id: '/api-keys',
-  path: '/api-keys',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsArchivedProjectsRoute =
-  SettingsArchivedProjectsRouteImport.update({
-    id: '/archived-projects',
-    path: '/archived-projects',
-    getParentRoute: () => SettingsRouteRoute,
-  } as any)
-const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
-  id: '/audit-log',
-  path: '/audit-log',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsChatChannelsRoute = SettingsChatChannelsRouteImport.update({
-  id: '/chat-channels',
-  path: '/chat-channels',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
-  id: '/chatbox',
-  path: '/chatbox',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsConcurrencyRoute = SettingsConcurrencyRouteImport.update({
-  id: '/concurrency',
-  path: '/concurrency',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
-  id: '/connectors',
-  path: '/connectors',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
-  id: '/credentials',
-  path: '/credentials',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsLocaleRoute = SettingsLocaleRouteImport.update({
-  id: '/locale',
-  path: '/locale',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsStorageRoute = SettingsStorageRouteImport.update({
-  id: '/storage',
-  path: '/storage',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsUsersRoute = SettingsUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => SettingsRouteRoute,
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
 const HomeInboxIndexRoute = HomeInboxIndexRouteImport.update({
   id: '/home/inbox/',
   path: '/home/inbox/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const PreviewProjectIdFilenameRoute =
-  PreviewProjectIdFilenameRouteImport.update({
-    id: '/preview/$projectId/$filename',
-    path: '/preview/$projectId/$filename',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
-  id: '/',
-  path: '/',
+const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const ProjectsProjectIdAssetsRoute = ProjectsProjectIdAssetsRouteImport.update({
-  id: '/assets',
-  path: '/assets',
+const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
+  id: '/git',
+  path: '/git',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const ProjectsProjectIdAuditLogRoute =
-  ProjectsProjectIdAuditLogRouteImport.update({
-    id: '/audit-log',
-    path: '/audit-log',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdBudgetRoute = ProjectsProjectIdBudgetRouteImport.update({
-  id: '/budget',
-  path: '/budget',
-  getParentRoute: () => ProjectsProjectIdRouteRoute,
-} as any)
-const ProjectsProjectIdConnectorsRoute =
-  ProjectsProjectIdConnectorsRouteImport.update({
-    id: '/connectors',
-    path: '/connectors',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdContainerRoute =
-  ProjectsProjectIdContainerRouteImport.update({
-    id: '/container',
-    path: '/container',
+const ProjectsProjectIdDocumentsRoute =
+  ProjectsProjectIdDocumentsRouteImport.update({
+    id: '/documents',
+    path: '/documents',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
 const ProjectsProjectIdCustomPromptRoute =
@@ -215,62 +197,44 @@ const ProjectsProjectIdCustomPromptRoute =
     path: '/custom-prompt',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdDocumentsRoute =
-  ProjectsProjectIdDocumentsRouteImport.update({
-    id: '/documents',
-    path: '/documents',
+const ProjectsProjectIdContainerRoute =
+  ProjectsProjectIdContainerRouteImport.update({
+    id: '/container',
+    path: '/container',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
-  id: '/git',
-  path: '/git',
+const ProjectsProjectIdConnectorsRoute =
+  ProjectsProjectIdConnectorsRouteImport.update({
+    id: '/connectors',
+    path: '/connectors',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdBudgetRoute = ProjectsProjectIdBudgetRouteImport.update({
+  id: '/budget',
+  path: '/budget',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
+const ProjectsProjectIdAuditLogRoute =
+  ProjectsProjectIdAuditLogRouteImport.update({
+    id: '/audit-log',
+    path: '/audit-log',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAssetsRoute = ProjectsProjectIdAssetsRouteImport.update({
+  id: '/assets',
+  path: '/assets',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const ProjectsProjectIdAgentsIndexRoute =
-  ProjectsProjectIdAgentsIndexRouteImport.update({
-    id: '/agents/',
-    path: '/agents/',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
+const PreviewProjectIdFilenameRoute =
+  PreviewProjectIdFilenameRouteImport.update({
+    id: '/preview/$projectId/$filename',
+    path: '/preview/$projectId/$filename',
+    getParentRoute: () => rootRouteImport,
   } as any)
-const ProjectsProjectIdAgentsAgentIdRouteRoute =
-  ProjectsProjectIdAgentsAgentIdRouteRouteImport.update({
-    id: '/agents/$agentId',
-    path: '/agents/$agentId',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdAgentsHireRoute =
-  ProjectsProjectIdAgentsHireRouteImport.update({
-    id: '/agents/hire',
-    path: '/agents/hire',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdAssetsViewRoute =
-  ProjectsProjectIdAssetsViewRouteImport.update({
-    id: '/assets_/view',
-    path: '/assets/view',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdGoalsIndexRoute =
-  ProjectsProjectIdGoalsIndexRouteImport.update({
-    id: '/goals/',
-    path: '/goals/',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdGoalsGoalIdRoute =
-  ProjectsProjectIdGoalsGoalIdRouteImport.update({
-    id: '/goals/$goalId',
-    path: '/goals/$goalId',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdInboxIndexRoute =
-  ProjectsProjectIdInboxIndexRouteImport.update({
-    id: '/inbox/',
-    path: '/inbox/',
+const ProjectsProjectIdTasksIndexRoute =
+  ProjectsProjectIdTasksIndexRouteImport.update({
+    id: '/tasks/',
+    path: '/tasks/',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
 const ProjectsProjectIdSettingsIndexRoute =
@@ -279,16 +243,22 @@ const ProjectsProjectIdSettingsIndexRoute =
     path: '/settings/',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdTasksIndexRoute =
-  ProjectsProjectIdTasksIndexRouteImport.update({
-    id: '/tasks/',
-    path: '/tasks/',
+const ProjectsProjectIdInboxIndexRoute =
+  ProjectsProjectIdInboxIndexRouteImport.update({
+    id: '/inbox/',
+    path: '/inbox/',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdTasksTaskIdRoute =
-  ProjectsProjectIdTasksTaskIdRouteImport.update({
-    id: '/tasks/$taskId',
-    path: '/tasks/$taskId',
+const ProjectsProjectIdGoalsIndexRoute =
+  ProjectsProjectIdGoalsIndexRouteImport.update({
+    id: '/goals/',
+    path: '/goals/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAgentsIndexRoute =
+  ProjectsProjectIdAgentsIndexRouteImport.update({
+    id: '/agents/',
+    path: '/agents/',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
 const ProjectsProjectIdTeamSettingsGeneralRoute =
@@ -297,22 +267,52 @@ const ProjectsProjectIdTeamSettingsGeneralRoute =
     path: '/team-settings/general',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
+const ProjectsProjectIdTasksTaskIdRoute =
+  ProjectsProjectIdTasksTaskIdRouteImport.update({
+    id: '/tasks/$taskId',
+    path: '/tasks/$taskId',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdGoalsGoalIdRoute =
+  ProjectsProjectIdGoalsGoalIdRouteImport.update({
+    id: '/goals/$goalId',
+    path: '/goals/$goalId',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAssetsViewRoute =
+  ProjectsProjectIdAssetsViewRouteImport.update({
+    id: '/assets_/view',
+    path: '/assets/view',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAgentsHireRoute =
+  ProjectsProjectIdAgentsHireRouteImport.update({
+    id: '/agents/hire',
+    path: '/agents/hire',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAgentsAgentIdRouteRoute =
+  ProjectsProjectIdAgentsAgentIdRouteRouteImport.update({
+    id: '/agents/$agentId',
+    path: '/agents/$agentId',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
 const ProjectsProjectIdAgentsAgentIdIndexRoute =
   ProjectsProjectIdAgentsAgentIdIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
   } as any)
-const ProjectsProjectIdAgentsAgentIdChatHistoryRoute =
-  ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport.update({
-    id: '/chat-history',
-    path: '/chat-history',
-    getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
-  } as any)
 const ProjectsProjectIdAgentsAgentIdSettingsRoute =
   ProjectsProjectIdAgentsAgentIdSettingsRouteImport.update({
     id: '/settings',
     path: '/settings',
+    getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAgentsAgentIdChatHistoryRoute =
+  ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport.update({
+    id: '/chat-history',
+    path: '/chat-history',
     getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
   } as any)
 const ProjectsProjectIdAgentsAgentIdExecutionsIndexRoute =
@@ -645,6 +645,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -652,11 +659,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteRouteImport
+    '/settings/': {
+      id: '/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/marketplace/': {
+      id: '/marketplace/'
+      path: '/marketplace'
+      fullPath: '/marketplace/'
+      preLoaderRoute: typeof MarketplaceIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/home/': {
@@ -666,12 +680,103 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HomeIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/marketplace/': {
-      id: '/marketplace/'
-      path: '/marketplace'
-      fullPath: '/marketplace/'
-      preLoaderRoute: typeof MarketplaceIndexRouteImport
-      parentRoute: typeof rootRouteImport
+    '/settings/users': {
+      id: '/settings/users'
+      path: '/users'
+      fullPath: '/settings/users'
+      preLoaderRoute: typeof SettingsUsersRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/storage': {
+      id: '/settings/storage'
+      path: '/storage'
+      fullPath: '/settings/storage'
+      preLoaderRoute: typeof SettingsStorageRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/skills': {
+      id: '/settings/skills'
+      path: '/skills'
+      fullPath: '/settings/skills'
+      preLoaderRoute: typeof SettingsSkillsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/locale': {
+      id: '/settings/locale'
+      path: '/locale'
+      fullPath: '/settings/locale'
+      preLoaderRoute: typeof SettingsLocaleRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/credentials': {
+      id: '/settings/credentials'
+      path: '/credentials'
+      fullPath: '/settings/credentials'
+      preLoaderRoute: typeof SettingsCredentialsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/connectors': {
+      id: '/settings/connectors'
+      path: '/connectors'
+      fullPath: '/settings/connectors'
+      preLoaderRoute: typeof SettingsConnectorsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/concurrency': {
+      id: '/settings/concurrency'
+      path: '/concurrency'
+      fullPath: '/settings/concurrency'
+      preLoaderRoute: typeof SettingsConcurrencyRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/chatbox': {
+      id: '/settings/chatbox'
+      path: '/chatbox'
+      fullPath: '/settings/chatbox'
+      preLoaderRoute: typeof SettingsChatboxRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/chat-channels': {
+      id: '/settings/chat-channels'
+      path: '/chat-channels'
+      fullPath: '/settings/chat-channels'
+      preLoaderRoute: typeof SettingsChatChannelsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/audit-log': {
+      id: '/settings/audit-log'
+      path: '/audit-log'
+      fullPath: '/settings/audit-log'
+      preLoaderRoute: typeof SettingsAuditLogRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/archived-projects': {
+      id: '/settings/archived-projects'
+      path: '/archived-projects'
+      fullPath: '/settings/archived-projects'
+      preLoaderRoute: typeof SettingsArchivedProjectsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/api-keys': {
+      id: '/settings/api-keys'
+      path: '/api-keys'
+      fullPath: '/settings/api-keys'
+      preLoaderRoute: typeof SettingsApiKeysRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/ai-providers': {
+      id: '/settings/ai-providers'
+      path: '/ai-providers'
+      fullPath: '/settings/ai-providers'
+      preLoaderRoute: typeof SettingsAiProvidersRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/admin-password': {
+      id: '/settings/admin-password'
+      path: '/admin-password'
+      fullPath: '/settings/admin-password'
+      preLoaderRoute: typeof SettingsAdminPasswordRouteImport
+      parentRoute: typeof SettingsRouteRoute
     }
     '/marketplace/$slug': {
       id: '/marketplace/$slug'
@@ -687,110 +792,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings/': {
-      id: '/settings/'
+    '/projects/$projectId/': {
+      id: '/projects/$projectId/'
       path: '/'
-      fullPath: '/settings/'
-      preLoaderRoute: typeof SettingsIndexRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/admin-password': {
-      id: '/settings/admin-password'
-      path: '/admin-password'
-      fullPath: '/settings/admin-password'
-      preLoaderRoute: typeof SettingsAdminPasswordRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/ai-providers': {
-      id: '/settings/ai-providers'
-      path: '/ai-providers'
-      fullPath: '/settings/ai-providers'
-      preLoaderRoute: typeof SettingsAiProvidersRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/api-keys': {
-      id: '/settings/api-keys'
-      path: '/api-keys'
-      fullPath: '/settings/api-keys'
-      preLoaderRoute: typeof SettingsApiKeysRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/archived-projects': {
-      id: '/settings/archived-projects'
-      path: '/archived-projects'
-      fullPath: '/settings/archived-projects'
-      preLoaderRoute: typeof SettingsArchivedProjectsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/audit-log': {
-      id: '/settings/audit-log'
-      path: '/audit-log'
-      fullPath: '/settings/audit-log'
-      preLoaderRoute: typeof SettingsAuditLogRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/chat-channels': {
-      id: '/settings/chat-channels'
-      path: '/chat-channels'
-      fullPath: '/settings/chat-channels'
-      preLoaderRoute: typeof SettingsChatChannelsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/chatbox': {
-      id: '/settings/chatbox'
-      path: '/chatbox'
-      fullPath: '/settings/chatbox'
-      preLoaderRoute: typeof SettingsChatboxRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/concurrency': {
-      id: '/settings/concurrency'
-      path: '/concurrency'
-      fullPath: '/settings/concurrency'
-      preLoaderRoute: typeof SettingsConcurrencyRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/connectors': {
-      id: '/settings/connectors'
-      path: '/connectors'
-      fullPath: '/settings/connectors'
-      preLoaderRoute: typeof SettingsConnectorsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/credentials': {
-      id: '/settings/credentials'
-      path: '/credentials'
-      fullPath: '/settings/credentials'
-      preLoaderRoute: typeof SettingsCredentialsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/locale': {
-      id: '/settings/locale'
-      path: '/locale'
-      fullPath: '/settings/locale'
-      preLoaderRoute: typeof SettingsLocaleRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/skills': {
-      id: '/settings/skills'
-      path: '/skills'
-      fullPath: '/settings/skills'
-      preLoaderRoute: typeof SettingsSkillsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/storage': {
-      id: '/settings/storage'
-      path: '/storage'
-      fullPath: '/settings/storage'
-      preLoaderRoute: typeof SettingsStorageRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/users': {
-      id: '/settings/users'
-      path: '/users'
-      fullPath: '/settings/users'
-      preLoaderRoute: typeof SettingsUsersRouteImport
-      parentRoute: typeof SettingsRouteRoute
+      fullPath: '/projects/$projectId/'
+      preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/home/inbox/': {
       id: '/home/inbox/'
@@ -799,67 +806,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HomeInboxIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/preview/$projectId/$filename': {
-      id: '/preview/$projectId/$filename'
-      path: '/preview/$projectId/$filename'
-      fullPath: '/preview/$projectId/$filename'
-      preLoaderRoute: typeof PreviewProjectIdFilenameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/projects/$projectId/': {
-      id: '/projects/$projectId/'
-      path: '/'
-      fullPath: '/projects/$projectId/'
-      preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/assets': {
-      id: '/projects/$projectId/assets'
-      path: '/assets'
-      fullPath: '/projects/$projectId/assets'
-      preLoaderRoute: typeof ProjectsProjectIdAssetsRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/audit-log': {
-      id: '/projects/$projectId/audit-log'
-      path: '/audit-log'
-      fullPath: '/projects/$projectId/audit-log'
-      preLoaderRoute: typeof ProjectsProjectIdAuditLogRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/budget': {
-      id: '/projects/$projectId/budget'
-      path: '/budget'
-      fullPath: '/projects/$projectId/budget'
-      preLoaderRoute: typeof ProjectsProjectIdBudgetRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/connectors': {
-      id: '/projects/$projectId/connectors'
-      path: '/connectors'
-      fullPath: '/projects/$projectId/connectors'
-      preLoaderRoute: typeof ProjectsProjectIdConnectorsRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/container': {
-      id: '/projects/$projectId/container'
-      path: '/container'
-      fullPath: '/projects/$projectId/container'
-      preLoaderRoute: typeof ProjectsProjectIdContainerRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/custom-prompt': {
-      id: '/projects/$projectId/custom-prompt'
-      path: '/custom-prompt'
-      fullPath: '/projects/$projectId/custom-prompt'
-      preLoaderRoute: typeof ProjectsProjectIdCustomPromptRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/documents': {
-      id: '/projects/$projectId/documents'
-      path: '/documents'
-      fullPath: '/projects/$projectId/documents'
-      preLoaderRoute: typeof ProjectsProjectIdDocumentsRouteImport
+    '/projects/$projectId/skills': {
+      id: '/projects/$projectId/skills'
+      path: '/skills'
+      fullPath: '/projects/$projectId/skills'
+      preLoaderRoute: typeof ProjectsProjectIdSkillsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/git': {
@@ -869,60 +820,67 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdGitRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/skills': {
-      id: '/projects/$projectId/skills'
-      path: '/skills'
-      fullPath: '/projects/$projectId/skills'
-      preLoaderRoute: typeof ProjectsProjectIdSkillsRouteImport
+    '/projects/$projectId/documents': {
+      id: '/projects/$projectId/documents'
+      path: '/documents'
+      fullPath: '/projects/$projectId/documents'
+      preLoaderRoute: typeof ProjectsProjectIdDocumentsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/agents/': {
-      id: '/projects/$projectId/agents/'
-      path: '/agents'
-      fullPath: '/projects/$projectId/agents/'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsIndexRouteImport
+    '/projects/$projectId/custom-prompt': {
+      id: '/projects/$projectId/custom-prompt'
+      path: '/custom-prompt'
+      fullPath: '/projects/$projectId/custom-prompt'
+      preLoaderRoute: typeof ProjectsProjectIdCustomPromptRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/agents/$agentId': {
-      id: '/projects/$projectId/agents/$agentId'
-      path: '/agents/$agentId'
-      fullPath: '/projects/$projectId/agents/$agentId'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteImport
+    '/projects/$projectId/container': {
+      id: '/projects/$projectId/container'
+      path: '/container'
+      fullPath: '/projects/$projectId/container'
+      preLoaderRoute: typeof ProjectsProjectIdContainerRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/agents/hire': {
-      id: '/projects/$projectId/agents/hire'
-      path: '/agents/hire'
-      fullPath: '/projects/$projectId/agents/hire'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsHireRouteImport
+    '/projects/$projectId/connectors': {
+      id: '/projects/$projectId/connectors'
+      path: '/connectors'
+      fullPath: '/projects/$projectId/connectors'
+      preLoaderRoute: typeof ProjectsProjectIdConnectorsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/assets_/view': {
-      id: '/projects/$projectId/assets_/view'
-      path: '/assets/view'
-      fullPath: '/projects/$projectId/assets/view'
-      preLoaderRoute: typeof ProjectsProjectIdAssetsViewRouteImport
+    '/projects/$projectId/budget': {
+      id: '/projects/$projectId/budget'
+      path: '/budget'
+      fullPath: '/projects/$projectId/budget'
+      preLoaderRoute: typeof ProjectsProjectIdBudgetRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/goals/': {
-      id: '/projects/$projectId/goals/'
-      path: '/goals'
-      fullPath: '/projects/$projectId/goals/'
-      preLoaderRoute: typeof ProjectsProjectIdGoalsIndexRouteImport
+    '/projects/$projectId/audit-log': {
+      id: '/projects/$projectId/audit-log'
+      path: '/audit-log'
+      fullPath: '/projects/$projectId/audit-log'
+      preLoaderRoute: typeof ProjectsProjectIdAuditLogRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/goals/$goalId': {
-      id: '/projects/$projectId/goals/$goalId'
-      path: '/goals/$goalId'
-      fullPath: '/projects/$projectId/goals/$goalId'
-      preLoaderRoute: typeof ProjectsProjectIdGoalsGoalIdRouteImport
+    '/projects/$projectId/assets': {
+      id: '/projects/$projectId/assets'
+      path: '/assets'
+      fullPath: '/projects/$projectId/assets'
+      preLoaderRoute: typeof ProjectsProjectIdAssetsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/inbox/': {
-      id: '/projects/$projectId/inbox/'
-      path: '/inbox'
-      fullPath: '/projects/$projectId/inbox/'
-      preLoaderRoute: typeof ProjectsProjectIdInboxIndexRouteImport
+    '/preview/$projectId/$filename': {
+      id: '/preview/$projectId/$filename'
+      path: '/preview/$projectId/$filename'
+      fullPath: '/preview/$projectId/$filename'
+      preLoaderRoute: typeof PreviewProjectIdFilenameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId/tasks/': {
+      id: '/projects/$projectId/tasks/'
+      path: '/tasks'
+      fullPath: '/projects/$projectId/tasks/'
+      preLoaderRoute: typeof ProjectsProjectIdTasksIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/settings/': {
@@ -932,18 +890,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdSettingsIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/tasks/': {
-      id: '/projects/$projectId/tasks/'
-      path: '/tasks'
-      fullPath: '/projects/$projectId/tasks/'
-      preLoaderRoute: typeof ProjectsProjectIdTasksIndexRouteImport
+    '/projects/$projectId/inbox/': {
+      id: '/projects/$projectId/inbox/'
+      path: '/inbox'
+      fullPath: '/projects/$projectId/inbox/'
+      preLoaderRoute: typeof ProjectsProjectIdInboxIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/tasks/$taskId': {
-      id: '/projects/$projectId/tasks/$taskId'
-      path: '/tasks/$taskId'
-      fullPath: '/projects/$projectId/tasks/$taskId'
-      preLoaderRoute: typeof ProjectsProjectIdTasksTaskIdRouteImport
+    '/projects/$projectId/goals/': {
+      id: '/projects/$projectId/goals/'
+      path: '/goals'
+      fullPath: '/projects/$projectId/goals/'
+      preLoaderRoute: typeof ProjectsProjectIdGoalsIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/agents/': {
+      id: '/projects/$projectId/agents/'
+      path: '/agents'
+      fullPath: '/projects/$projectId/agents/'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/team-settings/general': {
@@ -953,6 +918,41 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdTeamSettingsGeneralRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
+    '/projects/$projectId/tasks/$taskId': {
+      id: '/projects/$projectId/tasks/$taskId'
+      path: '/tasks/$taskId'
+      fullPath: '/projects/$projectId/tasks/$taskId'
+      preLoaderRoute: typeof ProjectsProjectIdTasksTaskIdRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/goals/$goalId': {
+      id: '/projects/$projectId/goals/$goalId'
+      path: '/goals/$goalId'
+      fullPath: '/projects/$projectId/goals/$goalId'
+      preLoaderRoute: typeof ProjectsProjectIdGoalsGoalIdRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/assets_/view': {
+      id: '/projects/$projectId/assets_/view'
+      path: '/assets/view'
+      fullPath: '/projects/$projectId/assets/view'
+      preLoaderRoute: typeof ProjectsProjectIdAssetsViewRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/agents/hire': {
+      id: '/projects/$projectId/agents/hire'
+      path: '/agents/hire'
+      fullPath: '/projects/$projectId/agents/hire'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsHireRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/agents/$agentId': {
+      id: '/projects/$projectId/agents/$agentId'
+      path: '/agents/$agentId'
+      fullPath: '/projects/$projectId/agents/$agentId'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
     '/projects/$projectId/agents/$agentId/': {
       id: '/projects/$projectId/agents/$agentId/'
       path: '/'
@@ -960,18 +960,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdIndexRouteImport
       parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
     }
-    '/projects/$projectId/agents/$agentId/chat-history': {
-      id: '/projects/$projectId/agents/$agentId/chat-history'
-      path: '/chat-history'
-      fullPath: '/projects/$projectId/agents/$agentId/chat-history'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport
-      parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
-    }
     '/projects/$projectId/agents/$agentId/settings': {
       id: '/projects/$projectId/agents/$agentId/settings'
       path: '/settings'
       fullPath: '/projects/$projectId/agents/$agentId/settings'
       preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdSettingsRouteImport
+      parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
+    }
+    '/projects/$projectId/agents/$agentId/chat-history': {
+      id: '/projects/$projectId/agents/$agentId/chat-history'
+      path: '/chat-history'
+      fullPath: '/projects/$projectId/agents/$agentId/chat-history'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport
       parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
     }
     '/projects/$projectId/agents/$agentId/executions/': {

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -9,73 +9,64 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as SettingsRouteRouteImport } from './routes/settings/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as SettingsIndexRouteImport } from './routes/settings/index'
-import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
+import { Route as SettingsRouteRouteImport } from './routes/settings/route'
 import { Route as HomeIndexRouteImport } from './routes/home/index'
-import { Route as SettingsUsersRouteImport } from './routes/settings/users'
-import { Route as SettingsStorageRouteImport } from './routes/settings/storage'
-import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
-import { Route as SettingsLocaleRouteImport } from './routes/settings/locale'
-import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
-import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
-import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
-import { Route as SettingsChatChannelsRouteImport } from './routes/settings/chat-channels'
-import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
-import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
-import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
-import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
-import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
+import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
 import { Route as MarketplaceSlugRouteImport } from './routes/marketplace/$slug'
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
-import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
+import { Route as SettingsIndexRouteImport } from './routes/settings/index'
+import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
+import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
+import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
+import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
+import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
+import { Route as SettingsChatChannelsRouteImport } from './routes/settings/chat-channels'
+import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
+import { Route as SettingsConcurrencyRouteImport } from './routes/settings/concurrency'
+import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
+import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
+import { Route as SettingsLocaleRouteImport } from './routes/settings/locale'
+import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
+import { Route as SettingsStorageRouteImport } from './routes/settings/storage'
+import { Route as SettingsUsersRouteImport } from './routes/settings/users'
 import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
-import { Route as ProjectsProjectIdSkillsRouteImport } from './routes/projects/$projectId/skills'
-import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
-import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
-import { Route as ProjectsProjectIdCustomPromptRouteImport } from './routes/projects/$projectId/custom-prompt'
-import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
-import { Route as ProjectsProjectIdConnectorsRouteImport } from './routes/projects/$projectId/connectors'
-import { Route as ProjectsProjectIdBudgetRouteImport } from './routes/projects/$projectId/budget'
-import { Route as ProjectsProjectIdAuditLogRouteImport } from './routes/projects/$projectId/audit-log'
-import { Route as ProjectsProjectIdAssetsRouteImport } from './routes/projects/$projectId/assets'
 import { Route as PreviewProjectIdFilenameRouteImport } from './routes/preview/$projectId/$filename'
-import { Route as ProjectsProjectIdTasksIndexRouteImport } from './routes/projects/$projectId/tasks/index'
-import { Route as ProjectsProjectIdSettingsIndexRouteImport } from './routes/projects/$projectId/settings/index'
-import { Route as ProjectsProjectIdInboxIndexRouteImport } from './routes/projects/$projectId/inbox/index'
-import { Route as ProjectsProjectIdGoalsIndexRouteImport } from './routes/projects/$projectId/goals/index'
+import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
+import { Route as ProjectsProjectIdAssetsRouteImport } from './routes/projects/$projectId/assets'
+import { Route as ProjectsProjectIdAuditLogRouteImport } from './routes/projects/$projectId/audit-log'
+import { Route as ProjectsProjectIdBudgetRouteImport } from './routes/projects/$projectId/budget'
+import { Route as ProjectsProjectIdConnectorsRouteImport } from './routes/projects/$projectId/connectors'
+import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
+import { Route as ProjectsProjectIdCustomPromptRouteImport } from './routes/projects/$projectId/custom-prompt'
+import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
+import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
+import { Route as ProjectsProjectIdSkillsRouteImport } from './routes/projects/$projectId/skills'
 import { Route as ProjectsProjectIdAgentsIndexRouteImport } from './routes/projects/$projectId/agents/index'
-import { Route as ProjectsProjectIdTeamSettingsGeneralRouteImport } from './routes/projects/$projectId/team-settings/general'
-import { Route as ProjectsProjectIdTasksTaskIdRouteImport } from './routes/projects/$projectId/tasks/$taskId'
-import { Route as ProjectsProjectIdGoalsGoalIdRouteImport } from './routes/projects/$projectId/goals/$goalId'
-import { Route as ProjectsProjectIdAssetsViewRouteImport } from './routes/projects/$projectId/assets_.view'
-import { Route as ProjectsProjectIdAgentsHireRouteImport } from './routes/projects/$projectId/agents/hire'
 import { Route as ProjectsProjectIdAgentsAgentIdRouteRouteImport } from './routes/projects/$projectId/agents/$agentId/route'
+import { Route as ProjectsProjectIdAgentsHireRouteImport } from './routes/projects/$projectId/agents/hire'
+import { Route as ProjectsProjectIdAssetsViewRouteImport } from './routes/projects/$projectId/assets_.view'
+import { Route as ProjectsProjectIdGoalsIndexRouteImport } from './routes/projects/$projectId/goals/index'
+import { Route as ProjectsProjectIdGoalsGoalIdRouteImport } from './routes/projects/$projectId/goals/$goalId'
+import { Route as ProjectsProjectIdInboxIndexRouteImport } from './routes/projects/$projectId/inbox/index'
+import { Route as ProjectsProjectIdSettingsIndexRouteImport } from './routes/projects/$projectId/settings/index'
+import { Route as ProjectsProjectIdTasksIndexRouteImport } from './routes/projects/$projectId/tasks/index'
+import { Route as ProjectsProjectIdTasksTaskIdRouteImport } from './routes/projects/$projectId/tasks/$taskId'
+import { Route as ProjectsProjectIdTeamSettingsGeneralRouteImport } from './routes/projects/$projectId/team-settings/general'
 import { Route as ProjectsProjectIdAgentsAgentIdIndexRouteImport } from './routes/projects/$projectId/agents/$agentId/index'
-import { Route as ProjectsProjectIdAgentsAgentIdSettingsRouteImport } from './routes/projects/$projectId/agents/$agentId/settings'
 import { Route as ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport } from './routes/projects/$projectId/agents/$agentId/chat-history'
+import { Route as ProjectsProjectIdAgentsAgentIdSettingsRouteImport } from './routes/projects/$projectId/agents/$agentId/settings'
 import { Route as ProjectsProjectIdAgentsAgentIdExecutionsIndexRouteImport } from './routes/projects/$projectId/agents/$agentId/executions/index'
 import { Route as ProjectsProjectIdAgentsAgentIdExecutionsRunIdRouteImport } from './routes/projects/$projectId/agents/$agentId/executions/$runId'
 
-const SettingsRouteRoute = SettingsRouteRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsIndexRoute = SettingsIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const MarketplaceIndexRoute = MarketplaceIndexRouteImport.update({
-  id: '/marketplace/',
-  path: '/marketplace/',
+const SettingsRouteRoute = SettingsRouteRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HomeIndexRoute = HomeIndexRouteImport.update({
@@ -83,71 +74,10 @@ const HomeIndexRoute = HomeIndexRouteImport.update({
   path: '/home/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsUsersRoute = SettingsUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsStorageRoute = SettingsStorageRouteImport.update({
-  id: '/storage',
-  path: '/storage',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsLocaleRoute = SettingsLocaleRouteImport.update({
-  id: '/locale',
-  path: '/locale',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
-  id: '/credentials',
-  path: '/credentials',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
-  id: '/connectors',
-  path: '/connectors',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
-  id: '/chatbox',
-  path: '/chatbox',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsChatChannelsRoute = SettingsChatChannelsRouteImport.update({
-  id: '/chat-channels',
-  path: '/chat-channels',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
-  id: '/audit-log',
-  path: '/audit-log',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsArchivedProjectsRoute =
-  SettingsArchivedProjectsRouteImport.update({
-    id: '/archived-projects',
-    path: '/archived-projects',
-    getParentRoute: () => SettingsRouteRoute,
-  } as any)
-const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
-  id: '/api-keys',
-  path: '/api-keys',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
-  id: '/ai-providers',
-  path: '/ai-providers',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsAdminPasswordRoute = SettingsAdminPasswordRouteImport.update({
-  id: '/admin-password',
-  path: '/admin-password',
-  getParentRoute: () => SettingsRouteRoute,
+const MarketplaceIndexRoute = MarketplaceIndexRouteImport.update({
+  id: '/marketplace/',
+  path: '/marketplace/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const MarketplaceSlugRoute = MarketplaceSlugRouteImport.update({
   id: '/marketplace/$slug',
@@ -159,53 +89,101 @@ const ProjectsProjectIdRouteRoute = ProjectsProjectIdRouteRouteImport.update({
   path: '/projects/$projectId',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
+const SettingsIndexRoute = SettingsIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => ProjectsProjectIdRouteRoute,
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAdminPasswordRoute = SettingsAdminPasswordRouteImport.update({
+  id: '/admin-password',
+  path: '/admin-password',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
+  id: '/ai-providers',
+  path: '/ai-providers',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsArchivedProjectsRoute =
+  SettingsArchivedProjectsRouteImport.update({
+    id: '/archived-projects',
+    path: '/archived-projects',
+    getParentRoute: () => SettingsRouteRoute,
+  } as any)
+const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
+  id: '/audit-log',
+  path: '/audit-log',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsChatChannelsRoute = SettingsChatChannelsRouteImport.update({
+  id: '/chat-channels',
+  path: '/chat-channels',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
+  id: '/chatbox',
+  path: '/chatbox',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsConcurrencyRoute = SettingsConcurrencyRouteImport.update({
+  id: '/concurrency',
+  path: '/concurrency',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
+  id: '/connectors',
+  path: '/connectors',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
+  id: '/credentials',
+  path: '/credentials',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsLocaleRoute = SettingsLocaleRouteImport.update({
+  id: '/locale',
+  path: '/locale',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsStorageRoute = SettingsStorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsUsersRoute = SettingsUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => SettingsRouteRoute,
 } as any)
 const HomeInboxIndexRoute = HomeInboxIndexRouteImport.update({
   id: '/home/inbox/',
   path: '/home/inbox/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
-  id: '/skills',
-  path: '/skills',
+const PreviewProjectIdFilenameRoute =
+  PreviewProjectIdFilenameRouteImport.update({
+    id: '/preview/$projectId/$filename',
+    path: '/preview/$projectId/$filename',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
-  id: '/git',
-  path: '/git',
-  getParentRoute: () => ProjectsProjectIdRouteRoute,
-} as any)
-const ProjectsProjectIdDocumentsRoute =
-  ProjectsProjectIdDocumentsRouteImport.update({
-    id: '/documents',
-    path: '/documents',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdCustomPromptRoute =
-  ProjectsProjectIdCustomPromptRouteImport.update({
-    id: '/custom-prompt',
-    path: '/custom-prompt',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdContainerRoute =
-  ProjectsProjectIdContainerRouteImport.update({
-    id: '/container',
-    path: '/container',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdConnectorsRoute =
-  ProjectsProjectIdConnectorsRouteImport.update({
-    id: '/connectors',
-    path: '/connectors',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdBudgetRoute = ProjectsProjectIdBudgetRouteImport.update({
-  id: '/budget',
-  path: '/budget',
+const ProjectsProjectIdAssetsRoute = ProjectsProjectIdAssetsRouteImport.update({
+  id: '/assets',
+  path: '/assets',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
 const ProjectsProjectIdAuditLogRoute =
@@ -214,75 +192,49 @@ const ProjectsProjectIdAuditLogRoute =
     path: '/audit-log',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdAssetsRoute = ProjectsProjectIdAssetsRouteImport.update({
-  id: '/assets',
-  path: '/assets',
+const ProjectsProjectIdBudgetRoute = ProjectsProjectIdBudgetRouteImport.update({
+  id: '/budget',
+  path: '/budget',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
-const PreviewProjectIdFilenameRoute =
-  PreviewProjectIdFilenameRouteImport.update({
-    id: '/preview/$projectId/$filename',
-    path: '/preview/$projectId/$filename',
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const ProjectsProjectIdTasksIndexRoute =
-  ProjectsProjectIdTasksIndexRouteImport.update({
-    id: '/tasks/',
-    path: '/tasks/',
+const ProjectsProjectIdConnectorsRoute =
+  ProjectsProjectIdConnectorsRouteImport.update({
+    id: '/connectors',
+    path: '/connectors',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdSettingsIndexRoute =
-  ProjectsProjectIdSettingsIndexRouteImport.update({
-    id: '/settings/',
-    path: '/settings/',
+const ProjectsProjectIdContainerRoute =
+  ProjectsProjectIdContainerRouteImport.update({
+    id: '/container',
+    path: '/container',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdInboxIndexRoute =
-  ProjectsProjectIdInboxIndexRouteImport.update({
-    id: '/inbox/',
-    path: '/inbox/',
+const ProjectsProjectIdCustomPromptRoute =
+  ProjectsProjectIdCustomPromptRouteImport.update({
+    id: '/custom-prompt',
+    path: '/custom-prompt',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
-const ProjectsProjectIdGoalsIndexRoute =
-  ProjectsProjectIdGoalsIndexRouteImport.update({
-    id: '/goals/',
-    path: '/goals/',
+const ProjectsProjectIdDocumentsRoute =
+  ProjectsProjectIdDocumentsRouteImport.update({
+    id: '/documents',
+    path: '/documents',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
+const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
+  id: '/git',
+  path: '/git',
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
+} as any)
+const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
+} as any)
 const ProjectsProjectIdAgentsIndexRoute =
   ProjectsProjectIdAgentsIndexRouteImport.update({
     id: '/agents/',
     path: '/agents/',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdTeamSettingsGeneralRoute =
-  ProjectsProjectIdTeamSettingsGeneralRouteImport.update({
-    id: '/team-settings/general',
-    path: '/team-settings/general',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdTasksTaskIdRoute =
-  ProjectsProjectIdTasksTaskIdRouteImport.update({
-    id: '/tasks/$taskId',
-    path: '/tasks/$taskId',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdGoalsGoalIdRoute =
-  ProjectsProjectIdGoalsGoalIdRouteImport.update({
-    id: '/goals/$goalId',
-    path: '/goals/$goalId',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdAssetsViewRoute =
-  ProjectsProjectIdAssetsViewRouteImport.update({
-    id: '/assets_/view',
-    path: '/assets/view',
-    getParentRoute: () => ProjectsProjectIdRouteRoute,
-  } as any)
-const ProjectsProjectIdAgentsHireRoute =
-  ProjectsProjectIdAgentsHireRouteImport.update({
-    id: '/agents/hire',
-    path: '/agents/hire',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
 const ProjectsProjectIdAgentsAgentIdRouteRoute =
@@ -291,22 +243,76 @@ const ProjectsProjectIdAgentsAgentIdRouteRoute =
     path: '/agents/$agentId',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
+const ProjectsProjectIdAgentsHireRoute =
+  ProjectsProjectIdAgentsHireRouteImport.update({
+    id: '/agents/hire',
+    path: '/agents/hire',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAssetsViewRoute =
+  ProjectsProjectIdAssetsViewRouteImport.update({
+    id: '/assets_/view',
+    path: '/assets/view',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdGoalsIndexRoute =
+  ProjectsProjectIdGoalsIndexRouteImport.update({
+    id: '/goals/',
+    path: '/goals/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdGoalsGoalIdRoute =
+  ProjectsProjectIdGoalsGoalIdRouteImport.update({
+    id: '/goals/$goalId',
+    path: '/goals/$goalId',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdInboxIndexRoute =
+  ProjectsProjectIdInboxIndexRouteImport.update({
+    id: '/inbox/',
+    path: '/inbox/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdSettingsIndexRoute =
+  ProjectsProjectIdSettingsIndexRouteImport.update({
+    id: '/settings/',
+    path: '/settings/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdTasksIndexRoute =
+  ProjectsProjectIdTasksIndexRouteImport.update({
+    id: '/tasks/',
+    path: '/tasks/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdTasksTaskIdRoute =
+  ProjectsProjectIdTasksTaskIdRouteImport.update({
+    id: '/tasks/$taskId',
+    path: '/tasks/$taskId',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
+const ProjectsProjectIdTeamSettingsGeneralRoute =
+  ProjectsProjectIdTeamSettingsGeneralRouteImport.update({
+    id: '/team-settings/general',
+    path: '/team-settings/general',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
 const ProjectsProjectIdAgentsAgentIdIndexRoute =
   ProjectsProjectIdAgentsAgentIdIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
   } as any)
-const ProjectsProjectIdAgentsAgentIdSettingsRoute =
-  ProjectsProjectIdAgentsAgentIdSettingsRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
-  } as any)
 const ProjectsProjectIdAgentsAgentIdChatHistoryRoute =
   ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport.update({
     id: '/chat-history',
     path: '/chat-history',
+    getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
+  } as any)
+const ProjectsProjectIdAgentsAgentIdSettingsRoute =
+  ProjectsProjectIdAgentsAgentIdSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
     getParentRoute: () => ProjectsProjectIdAgentsAgentIdRouteRoute,
   } as any)
 const ProjectsProjectIdAgentsAgentIdExecutionsIndexRoute =
@@ -334,6 +340,7 @@ export interface FileRoutesByFullPath {
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
+  '/settings/concurrency': typeof SettingsConcurrencyRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/locale': typeof SettingsLocaleRoute
@@ -382,6 +389,7 @@ export interface FileRoutesByTo {
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
+  '/settings/concurrency': typeof SettingsConcurrencyRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/locale': typeof SettingsLocaleRoute
@@ -432,6 +440,7 @@ export interface FileRoutesById {
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
+  '/settings/concurrency': typeof SettingsConcurrencyRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/locale': typeof SettingsLocaleRoute
@@ -484,6 +493,7 @@ export interface FileRouteTypes {
     | '/settings/audit-log'
     | '/settings/chat-channels'
     | '/settings/chatbox'
+    | '/settings/concurrency'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/locale'
@@ -532,6 +542,7 @@ export interface FileRouteTypes {
     | '/settings/audit-log'
     | '/settings/chat-channels'
     | '/settings/chatbox'
+    | '/settings/concurrency'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/locale'
@@ -581,6 +592,7 @@ export interface FileRouteTypes {
     | '/settings/audit-log'
     | '/settings/chat-channels'
     | '/settings/chatbox'
+    | '/settings/concurrency'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/locale'
@@ -633,13 +645,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
@@ -647,18 +652,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings/': {
-      id: '/settings/'
-      path: '/'
-      fullPath: '/settings/'
-      preLoaderRoute: typeof SettingsIndexRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/marketplace/': {
-      id: '/marketplace/'
-      path: '/marketplace'
-      fullPath: '/marketplace/'
-      preLoaderRoute: typeof MarketplaceIndexRouteImport
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/home/': {
@@ -668,96 +666,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HomeIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings/users': {
-      id: '/settings/users'
-      path: '/users'
-      fullPath: '/settings/users'
-      preLoaderRoute: typeof SettingsUsersRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/storage': {
-      id: '/settings/storage'
-      path: '/storage'
-      fullPath: '/settings/storage'
-      preLoaderRoute: typeof SettingsStorageRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/skills': {
-      id: '/settings/skills'
-      path: '/skills'
-      fullPath: '/settings/skills'
-      preLoaderRoute: typeof SettingsSkillsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/locale': {
-      id: '/settings/locale'
-      path: '/locale'
-      fullPath: '/settings/locale'
-      preLoaderRoute: typeof SettingsLocaleRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/credentials': {
-      id: '/settings/credentials'
-      path: '/credentials'
-      fullPath: '/settings/credentials'
-      preLoaderRoute: typeof SettingsCredentialsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/connectors': {
-      id: '/settings/connectors'
-      path: '/connectors'
-      fullPath: '/settings/connectors'
-      preLoaderRoute: typeof SettingsConnectorsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/chatbox': {
-      id: '/settings/chatbox'
-      path: '/chatbox'
-      fullPath: '/settings/chatbox'
-      preLoaderRoute: typeof SettingsChatboxRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/chat-channels': {
-      id: '/settings/chat-channels'
-      path: '/chat-channels'
-      fullPath: '/settings/chat-channels'
-      preLoaderRoute: typeof SettingsChatChannelsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/audit-log': {
-      id: '/settings/audit-log'
-      path: '/audit-log'
-      fullPath: '/settings/audit-log'
-      preLoaderRoute: typeof SettingsAuditLogRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/archived-projects': {
-      id: '/settings/archived-projects'
-      path: '/archived-projects'
-      fullPath: '/settings/archived-projects'
-      preLoaderRoute: typeof SettingsArchivedProjectsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/api-keys': {
-      id: '/settings/api-keys'
-      path: '/api-keys'
-      fullPath: '/settings/api-keys'
-      preLoaderRoute: typeof SettingsApiKeysRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/ai-providers': {
-      id: '/settings/ai-providers'
-      path: '/ai-providers'
-      fullPath: '/settings/ai-providers'
-      preLoaderRoute: typeof SettingsAiProvidersRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/admin-password': {
-      id: '/settings/admin-password'
-      path: '/admin-password'
-      fullPath: '/settings/admin-password'
-      preLoaderRoute: typeof SettingsAdminPasswordRouteImport
-      parentRoute: typeof SettingsRouteRoute
+    '/marketplace/': {
+      id: '/marketplace/'
+      path: '/marketplace'
+      fullPath: '/marketplace/'
+      preLoaderRoute: typeof MarketplaceIndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/marketplace/$slug': {
       id: '/marketplace/$slug'
@@ -773,12 +687,110 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/projects/$projectId/': {
-      id: '/projects/$projectId/'
+    '/settings/': {
+      id: '/settings/'
       path: '/'
-      fullPath: '/projects/$projectId/'
-      preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
+      fullPath: '/settings/'
+      preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/admin-password': {
+      id: '/settings/admin-password'
+      path: '/admin-password'
+      fullPath: '/settings/admin-password'
+      preLoaderRoute: typeof SettingsAdminPasswordRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/ai-providers': {
+      id: '/settings/ai-providers'
+      path: '/ai-providers'
+      fullPath: '/settings/ai-providers'
+      preLoaderRoute: typeof SettingsAiProvidersRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/api-keys': {
+      id: '/settings/api-keys'
+      path: '/api-keys'
+      fullPath: '/settings/api-keys'
+      preLoaderRoute: typeof SettingsApiKeysRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/archived-projects': {
+      id: '/settings/archived-projects'
+      path: '/archived-projects'
+      fullPath: '/settings/archived-projects'
+      preLoaderRoute: typeof SettingsArchivedProjectsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/audit-log': {
+      id: '/settings/audit-log'
+      path: '/audit-log'
+      fullPath: '/settings/audit-log'
+      preLoaderRoute: typeof SettingsAuditLogRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/chat-channels': {
+      id: '/settings/chat-channels'
+      path: '/chat-channels'
+      fullPath: '/settings/chat-channels'
+      preLoaderRoute: typeof SettingsChatChannelsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/chatbox': {
+      id: '/settings/chatbox'
+      path: '/chatbox'
+      fullPath: '/settings/chatbox'
+      preLoaderRoute: typeof SettingsChatboxRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/concurrency': {
+      id: '/settings/concurrency'
+      path: '/concurrency'
+      fullPath: '/settings/concurrency'
+      preLoaderRoute: typeof SettingsConcurrencyRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/connectors': {
+      id: '/settings/connectors'
+      path: '/connectors'
+      fullPath: '/settings/connectors'
+      preLoaderRoute: typeof SettingsConnectorsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/credentials': {
+      id: '/settings/credentials'
+      path: '/credentials'
+      fullPath: '/settings/credentials'
+      preLoaderRoute: typeof SettingsCredentialsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/locale': {
+      id: '/settings/locale'
+      path: '/locale'
+      fullPath: '/settings/locale'
+      preLoaderRoute: typeof SettingsLocaleRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/skills': {
+      id: '/settings/skills'
+      path: '/skills'
+      fullPath: '/settings/skills'
+      preLoaderRoute: typeof SettingsSkillsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/storage': {
+      id: '/settings/storage'
+      path: '/storage'
+      fullPath: '/settings/storage'
+      preLoaderRoute: typeof SettingsStorageRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/users': {
+      id: '/settings/users'
+      path: '/users'
+      fullPath: '/settings/users'
+      preLoaderRoute: typeof SettingsUsersRouteImport
+      parentRoute: typeof SettingsRouteRoute
     }
     '/home/inbox/': {
       id: '/home/inbox/'
@@ -787,60 +799,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HomeInboxIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/projects/$projectId/skills': {
-      id: '/projects/$projectId/skills'
-      path: '/skills'
-      fullPath: '/projects/$projectId/skills'
-      preLoaderRoute: typeof ProjectsProjectIdSkillsRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
+    '/preview/$projectId/$filename': {
+      id: '/preview/$projectId/$filename'
+      path: '/preview/$projectId/$filename'
+      fullPath: '/preview/$projectId/$filename'
+      preLoaderRoute: typeof PreviewProjectIdFilenameRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/projects/$projectId/git': {
-      id: '/projects/$projectId/git'
-      path: '/git'
-      fullPath: '/projects/$projectId/git'
-      preLoaderRoute: typeof ProjectsProjectIdGitRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/documents': {
-      id: '/projects/$projectId/documents'
-      path: '/documents'
-      fullPath: '/projects/$projectId/documents'
-      preLoaderRoute: typeof ProjectsProjectIdDocumentsRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/custom-prompt': {
-      id: '/projects/$projectId/custom-prompt'
-      path: '/custom-prompt'
-      fullPath: '/projects/$projectId/custom-prompt'
-      preLoaderRoute: typeof ProjectsProjectIdCustomPromptRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/container': {
-      id: '/projects/$projectId/container'
-      path: '/container'
-      fullPath: '/projects/$projectId/container'
-      preLoaderRoute: typeof ProjectsProjectIdContainerRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/connectors': {
-      id: '/projects/$projectId/connectors'
-      path: '/connectors'
-      fullPath: '/projects/$projectId/connectors'
-      preLoaderRoute: typeof ProjectsProjectIdConnectorsRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/budget': {
-      id: '/projects/$projectId/budget'
-      path: '/budget'
-      fullPath: '/projects/$projectId/budget'
-      preLoaderRoute: typeof ProjectsProjectIdBudgetRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/audit-log': {
-      id: '/projects/$projectId/audit-log'
-      path: '/audit-log'
-      fullPath: '/projects/$projectId/audit-log'
-      preLoaderRoute: typeof ProjectsProjectIdAuditLogRouteImport
+    '/projects/$projectId/': {
+      id: '/projects/$projectId/'
+      path: '/'
+      fullPath: '/projects/$projectId/'
+      preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/assets': {
@@ -850,39 +820,60 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdAssetsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/preview/$projectId/$filename': {
-      id: '/preview/$projectId/$filename'
-      path: '/preview/$projectId/$filename'
-      fullPath: '/preview/$projectId/$filename'
-      preLoaderRoute: typeof PreviewProjectIdFilenameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/projects/$projectId/tasks/': {
-      id: '/projects/$projectId/tasks/'
-      path: '/tasks'
-      fullPath: '/projects/$projectId/tasks/'
-      preLoaderRoute: typeof ProjectsProjectIdTasksIndexRouteImport
+    '/projects/$projectId/audit-log': {
+      id: '/projects/$projectId/audit-log'
+      path: '/audit-log'
+      fullPath: '/projects/$projectId/audit-log'
+      preLoaderRoute: typeof ProjectsProjectIdAuditLogRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/settings/': {
-      id: '/projects/$projectId/settings/'
-      path: '/settings'
-      fullPath: '/projects/$projectId/settings/'
-      preLoaderRoute: typeof ProjectsProjectIdSettingsIndexRouteImport
+    '/projects/$projectId/budget': {
+      id: '/projects/$projectId/budget'
+      path: '/budget'
+      fullPath: '/projects/$projectId/budget'
+      preLoaderRoute: typeof ProjectsProjectIdBudgetRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/inbox/': {
-      id: '/projects/$projectId/inbox/'
-      path: '/inbox'
-      fullPath: '/projects/$projectId/inbox/'
-      preLoaderRoute: typeof ProjectsProjectIdInboxIndexRouteImport
+    '/projects/$projectId/connectors': {
+      id: '/projects/$projectId/connectors'
+      path: '/connectors'
+      fullPath: '/projects/$projectId/connectors'
+      preLoaderRoute: typeof ProjectsProjectIdConnectorsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/goals/': {
-      id: '/projects/$projectId/goals/'
-      path: '/goals'
-      fullPath: '/projects/$projectId/goals/'
-      preLoaderRoute: typeof ProjectsProjectIdGoalsIndexRouteImport
+    '/projects/$projectId/container': {
+      id: '/projects/$projectId/container'
+      path: '/container'
+      fullPath: '/projects/$projectId/container'
+      preLoaderRoute: typeof ProjectsProjectIdContainerRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/custom-prompt': {
+      id: '/projects/$projectId/custom-prompt'
+      path: '/custom-prompt'
+      fullPath: '/projects/$projectId/custom-prompt'
+      preLoaderRoute: typeof ProjectsProjectIdCustomPromptRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/documents': {
+      id: '/projects/$projectId/documents'
+      path: '/documents'
+      fullPath: '/projects/$projectId/documents'
+      preLoaderRoute: typeof ProjectsProjectIdDocumentsRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/git': {
+      id: '/projects/$projectId/git'
+      path: '/git'
+      fullPath: '/projects/$projectId/git'
+      preLoaderRoute: typeof ProjectsProjectIdGitRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/skills': {
+      id: '/projects/$projectId/skills'
+      path: '/skills'
+      fullPath: '/projects/$projectId/skills'
+      preLoaderRoute: typeof ProjectsProjectIdSkillsRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/agents/': {
@@ -892,32 +883,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdAgentsIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/team-settings/general': {
-      id: '/projects/$projectId/team-settings/general'
-      path: '/team-settings/general'
-      fullPath: '/projects/$projectId/team-settings/general'
-      preLoaderRoute: typeof ProjectsProjectIdTeamSettingsGeneralRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/tasks/$taskId': {
-      id: '/projects/$projectId/tasks/$taskId'
-      path: '/tasks/$taskId'
-      fullPath: '/projects/$projectId/tasks/$taskId'
-      preLoaderRoute: typeof ProjectsProjectIdTasksTaskIdRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/goals/$goalId': {
-      id: '/projects/$projectId/goals/$goalId'
-      path: '/goals/$goalId'
-      fullPath: '/projects/$projectId/goals/$goalId'
-      preLoaderRoute: typeof ProjectsProjectIdGoalsGoalIdRouteImport
-      parentRoute: typeof ProjectsProjectIdRouteRoute
-    }
-    '/projects/$projectId/assets_/view': {
-      id: '/projects/$projectId/assets_/view'
-      path: '/assets/view'
-      fullPath: '/projects/$projectId/assets/view'
-      preLoaderRoute: typeof ProjectsProjectIdAssetsViewRouteImport
+    '/projects/$projectId/agents/$agentId': {
+      id: '/projects/$projectId/agents/$agentId'
+      path: '/agents/$agentId'
+      fullPath: '/projects/$projectId/agents/$agentId'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/agents/hire': {
@@ -927,11 +897,60 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdAgentsHireRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
-    '/projects/$projectId/agents/$agentId': {
-      id: '/projects/$projectId/agents/$agentId'
-      path: '/agents/$agentId'
-      fullPath: '/projects/$projectId/agents/$agentId'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteImport
+    '/projects/$projectId/assets_/view': {
+      id: '/projects/$projectId/assets_/view'
+      path: '/assets/view'
+      fullPath: '/projects/$projectId/assets/view'
+      preLoaderRoute: typeof ProjectsProjectIdAssetsViewRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/goals/': {
+      id: '/projects/$projectId/goals/'
+      path: '/goals'
+      fullPath: '/projects/$projectId/goals/'
+      preLoaderRoute: typeof ProjectsProjectIdGoalsIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/goals/$goalId': {
+      id: '/projects/$projectId/goals/$goalId'
+      path: '/goals/$goalId'
+      fullPath: '/projects/$projectId/goals/$goalId'
+      preLoaderRoute: typeof ProjectsProjectIdGoalsGoalIdRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/inbox/': {
+      id: '/projects/$projectId/inbox/'
+      path: '/inbox'
+      fullPath: '/projects/$projectId/inbox/'
+      preLoaderRoute: typeof ProjectsProjectIdInboxIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/settings/': {
+      id: '/projects/$projectId/settings/'
+      path: '/settings'
+      fullPath: '/projects/$projectId/settings/'
+      preLoaderRoute: typeof ProjectsProjectIdSettingsIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/tasks/': {
+      id: '/projects/$projectId/tasks/'
+      path: '/tasks'
+      fullPath: '/projects/$projectId/tasks/'
+      preLoaderRoute: typeof ProjectsProjectIdTasksIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/tasks/$taskId': {
+      id: '/projects/$projectId/tasks/$taskId'
+      path: '/tasks/$taskId'
+      fullPath: '/projects/$projectId/tasks/$taskId'
+      preLoaderRoute: typeof ProjectsProjectIdTasksTaskIdRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
+    '/projects/$projectId/team-settings/general': {
+      id: '/projects/$projectId/team-settings/general'
+      path: '/team-settings/general'
+      fullPath: '/projects/$projectId/team-settings/general'
+      preLoaderRoute: typeof ProjectsProjectIdTeamSettingsGeneralRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/agents/$agentId/': {
@@ -941,18 +960,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdIndexRouteImport
       parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
     }
-    '/projects/$projectId/agents/$agentId/settings': {
-      id: '/projects/$projectId/agents/$agentId/settings'
-      path: '/settings'
-      fullPath: '/projects/$projectId/agents/$agentId/settings'
-      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdSettingsRouteImport
-      parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
-    }
     '/projects/$projectId/agents/$agentId/chat-history': {
       id: '/projects/$projectId/agents/$agentId/chat-history'
       path: '/chat-history'
       fullPath: '/projects/$projectId/agents/$agentId/chat-history'
       preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdChatHistoryRouteImport
+      parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
+    }
+    '/projects/$projectId/agents/$agentId/settings': {
+      id: '/projects/$projectId/agents/$agentId/settings'
+      path: '/settings'
+      fullPath: '/projects/$projectId/agents/$agentId/settings'
+      preLoaderRoute: typeof ProjectsProjectIdAgentsAgentIdSettingsRouteImport
       parentRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRoute
     }
     '/projects/$projectId/agents/$agentId/executions/': {
@@ -980,6 +999,7 @@ interface SettingsRouteRouteChildren {
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
   SettingsChatChannelsRoute: typeof SettingsChatChannelsRoute
   SettingsChatboxRoute: typeof SettingsChatboxRoute
+  SettingsConcurrencyRoute: typeof SettingsConcurrencyRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
   SettingsLocaleRoute: typeof SettingsLocaleRoute
@@ -997,6 +1017,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsAuditLogRoute: SettingsAuditLogRoute,
   SettingsChatChannelsRoute: SettingsChatChannelsRoute,
   SettingsChatboxRoute: SettingsChatboxRoute,
+  SettingsConcurrencyRoute: SettingsConcurrencyRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
   SettingsLocaleRoute: SettingsLocaleRoute,

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -226,9 +226,11 @@ function NeedsYouMention({ mention }: { mention: AdminMentionItem }) {
 function WelcomeCard({ onCreate }: { onCreate: () => void }) {
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
-	// A project is scoped by the CEO in HQ, so the first project can't be created
-	// until the HQ container is up — surface that wait here rather than at click.
-	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
+	// Project scoping is CEO-driven, but a stopped (or never-provisioned) HQ
+	// container is no blocker — the first use lazy-starts it. Only errors and
+	// in-flight transitions surface a wait here.
+	const blockedHealth =
+		hqHealth && hqHealth.kind !== 'healthy' && hqHealth.kind !== 'stopped' ? hqHealth : null;
 
 	return (
 		<Card className="mb-6 p-0 overflow-hidden" data-testid="home-welcome-card">

--- a/packages/web/src/routes/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/projects/$projectId/container.tsx
@@ -89,6 +89,15 @@ function ContainerPage() {
 
 	return (
 		<div className="flex flex-col gap-5">
+			{/* Containers run on demand: agent runs and chats start this container
+			    automatically, and it stops again after the global idle timeout
+			    (Settings → Concurrency). The controls below are manual overrides. */}
+			<p className="text-[13px] text-text-2 max-w-[680px]">
+				This container starts automatically whenever an agent run or the assistant needs it, and
+				stops after sitting idle (configurable in Settings → Concurrency). Starting or stopping it
+				here is a manual override.
+			</p>
+
 			{/* Controls */}
 			<div className="flex flex-col gap-3 rounded-lg border border-border-subtle bg-surface px-4 py-3 sm:flex-row sm:items-center">
 				<div className="flex items-center gap-3">
@@ -294,12 +303,14 @@ function ContainerPage() {
 }
 
 function ContainerStatusBadge({ status }: { status: string | null }) {
-	if (!status) return <Badge color="gray">No container</Badge>;
+	// `null` (never provisioned) and `stopped` are both the normal resting
+	// state: the container starts on demand when a run or chat needs it.
+	if (!status) return <Badge color="neutral">Starts on demand</Badge>;
 	const config: Record<string, { color: string; label: string }> = {
 		creating: { color: 'warning', label: 'Provisioning' },
 		running: { color: 'success', label: 'Running' },
 		stopping: { color: 'warning', label: 'Stopping' },
-		stopped: { color: 'neutral', label: 'Stopped' },
+		stopped: { color: 'neutral', label: 'Stopped (starts on demand)' },
 		error: { color: 'danger', label: 'Error' },
 	};
 	const { color, label } = config[status] ?? { color: 'neutral', label: status };

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../../../components/ui/button';
 import { ConfirmDialog } from '../../../../components/ui/confirm-dialog';
 import { Input } from '../../../../components/ui/input';
 import { Textarea } from '../../../../components/ui/textarea';
+import { useInstanceSettings } from '../../../../hooks/use-instance-settings';
 import { useMe } from '../../../../hooks/use-me';
 import { useArchiveProject, useProject, useUpdateProject } from '../../../../hooks/use-projects';
 import { useScrollToHash } from '../../../../hooks/use-scroll-to-hash';
@@ -16,6 +17,8 @@ function ProjectSettingsPage() {
 	const { projectId } = Route.useParams();
 	const { data: project } = useProject(projectId);
 	const { data: me } = useMe();
+	const { data: instanceSettings } = useInstanceSettings();
+	const defaultRamCap = instanceSettings?.default_ram_cap_per_container_gb;
 	const updateProject = useUpdateProject(projectId);
 	const archiveProject = useArchiveProject(projectId);
 	const navigate = useNavigate();
@@ -24,8 +27,8 @@ function ProjectSettingsPage() {
 
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
-	const [maxRuns, setMaxRuns] = useState('1');
-	const [memoryLimit, setMemoryLimit] = useState('16');
+	// '' = no override: the container inherits the instance-wide ram cap.
+	const [memoryLimit, setMemoryLimit] = useState('');
 	const [editing, setEditing] = useState(false);
 	const [archiveOpen, setArchiveOpen] = useState(false);
 
@@ -35,24 +38,23 @@ function ProjectSettingsPage() {
 		if (!project) return;
 		setName(project.name);
 		setDescription(project.description ?? '');
-		setMaxRuns(String(project.max_concurrent_runs));
-		setMemoryLimit(String(project.memory_limit_gib));
+		setMemoryLimit(project.memory_limit_gib === null ? '' : String(project.memory_limit_gib));
 		setEditing(true);
 	}
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
-		const parsedMaxRuns = Number(maxRuns);
-		const parsedMemoryLimit = Number(memoryLimit);
+		const trimmedMemory = memoryLimit.trim();
+		const parsedMemoryLimit = Number(trimmedMemory);
 		await updateProject.mutateAsync({
 			name: name.trim() || undefined,
 			description: description.trim(),
-			max_concurrent_runs:
-				Number.isInteger(parsedMaxRuns) && parsedMaxRuns >= 1 ? parsedMaxRuns : undefined,
 			memory_limit_gib:
-				Number.isInteger(parsedMemoryLimit) && parsedMemoryLimit >= 1
-					? parsedMemoryLimit
-					: undefined,
+				trimmedMemory === ''
+					? null
+					: Number.isInteger(parsedMemoryLimit) && parsedMemoryLimit >= 1
+						? parsedMemoryLimit
+						: undefined,
 		});
 		setEditing(false);
 	}
@@ -73,30 +75,19 @@ function ProjectSettingsPage() {
 							rows={4}
 						/>
 						<Input
-							label="Max concurrent runs"
-							type="number"
-							min={1}
-							className="w-28"
-							value={maxRuns}
-							onChange={(e) => setMaxRuns(e.target.value)}
-							data-testid="max-concurrent-runs-input"
-						/>
-						<p className="text-xs text-text-3 -mt-1">
-							Agents that may run at once in this project. Different agents work different tickets
-							in parallel; one ticket still runs a single agent at a time.
-						</p>
-						<Input
 							label="Container memory limit (GiB)"
 							type="number"
 							min={1}
-							className="w-28"
+							className="w-40"
 							value={memoryLimit}
 							onChange={(e) => setMemoryLimit(e.target.value)}
+							placeholder={defaultRamCap ? `Default (${defaultRamCap} GB)` : 'Default'}
 							data-testid="memory-limit-gib-input"
 						/>
 						<p className="text-xs text-text-3 -mt-1">
-							The container is auto-stopped when it exceeds this RSS budget. Raise it on
-							memory-heavy projects; lower it to fail fast on runaway workloads.
+							Overrides the global RAM cap for this project's container. The container is
+							auto-stopped when it exceeds this budget. Leave empty to use the global default from
+							Settings → Concurrency.
 						</p>
 						<div className="flex gap-2">
 							<Button type="submit" size="sm" disabled={updateProject.isPending}>
@@ -117,14 +108,15 @@ function ProjectSettingsPage() {
 								<span className="text-text-2">Description:</span> {project.description}
 							</div>
 						)}
-						<div data-testid="max-concurrent-runs-value">
-							<span className="text-text-2">Max concurrent runs:</span>{' '}
-							{project.max_concurrent_runs}
-						</div>
 						<div data-testid="memory-limit-gib-value">
 							<span className="text-text-2">Container memory limit:</span>{' '}
-							{project.memory_limit_gib} GiB
+							{project.memory_limit_gib === null
+								? `Default${defaultRamCap ? ` (${defaultRamCap} GB)` : ''}`
+								: `${project.memory_limit_gib} GiB`}
 						</div>
+						<p className="text-xs text-text-3">
+							The concurrent-run limit is global - see Settings → Concurrency.
+						</p>
 						<Button variant="ghost" size="sm" onClick={startEditing} className="mt-2">
 							Edit
 						</Button>

--- a/packages/web/src/routes/settings/concurrency.tsx
+++ b/packages/web/src/routes/settings/concurrency.tsx
@@ -1,0 +1,320 @@
+import {
+	CONTAINER_IDLE_TIMEOUT_MIN_MAX,
+	CONTAINER_IDLE_TIMEOUT_MIN_MIN,
+	DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN,
+	DEFAULT_RAM_CAP_PER_CONTAINER_GB,
+	MAX_ACTIVE_CONTAINERS_MAX,
+	MAX_ACTIVE_CONTAINERS_MIN,
+	RAM_CAP_PER_CONTAINER_GB_MAX,
+	RAM_CAP_PER_CONTAINER_GB_MIN,
+} from '@hezo/shared';
+import { createFileRoute } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '../../components/ui/button';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
+import { Input } from '../../components/ui/input';
+import {
+	type InstanceSettings,
+	useInstanceSettings,
+	useUpdateInstanceSettings,
+} from '../../hooks/use-instance-settings';
+import { useMe } from '../../hooks/use-me';
+import type { ApiError } from '../../lib/api';
+
+const GIB = 1024 ** 3;
+
+function gb(bytes: number): number {
+	return Math.round((bytes / GIB) * 10) / 10;
+}
+
+function ConcurrencySettingsPage() {
+	const { data: me } = useMe();
+	const { data: settings } = useInstanceSettings();
+
+	const content =
+		me && !me.is_superuser ? (
+			<p className="text-[13px] text-text-2">
+				Concurrency settings are managed by the Admin. You don't have access to this page.
+			</p>
+		) : (
+			<>
+				<div className="mb-5">
+					<div className="flex items-center gap-1.5">
+						<h1 className="text-[22px] font-medium">Concurrency</h1>
+						<InfoTooltip
+							label="About concurrency"
+							content="How many project containers may run at once and how much memory each may use - together they bound the total resources Hezo takes on this machine."
+							data-testid="concurrency-info"
+						/>
+					</div>
+					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+						Project containers start on demand when an agent run or an assistant chat needs them,
+						and stop again after sitting idle. These settings bound how many can be active at once
+						and how much memory each may use, so a burst of agent activity can never take down the
+						machine.
+					</p>
+				</div>
+
+				<section className="border border-border rounded-md p-4 bg-surface mb-4">
+					<label
+						className="block text-[13px] font-medium mb-1"
+						htmlFor="max-active-containers-input"
+					>
+						Maximum active containers
+					</label>
+					<p className="text-[13px] text-text-2 mb-2.5 max-w-[680px]">
+						The maximum number of project containers that may be active at the same time, including
+						the assistant chat's container. Combined with the RAM cap below, this bounds how much
+						memory Hezo can use at once: total demand never exceeds this number times the cap. An
+						agent run whose project container is already active starts immediately; one that needs
+						another container waits in the queue until a container goes idle. The assistant chat
+						always starts, even at the limit. Must be between {MAX_ACTIVE_CONTAINERS_MIN} and{' '}
+						{MAX_ACTIVE_CONTAINERS_MAX}; leave on automatic to size it from this host's memory.
+					</p>
+					{settings === undefined ? null : <MaxActiveContainersForm settings={settings} />}
+				</section>
+
+				<section className="border border-border rounded-md p-4 bg-surface mb-4">
+					<label className="block text-[13px] font-medium mb-1" htmlFor="ram-cap-input">
+						RAM cap per container (GB)
+					</label>
+					<p className="text-[13px] text-text-2 mb-2.5 max-w-[680px]">
+						The memory limit applied to every project container. A container that grows past this
+						cap is stopped by Hezo (or has its biggest process killed by the kernel) instead of
+						taking down the whole server. It is also the divisor of the automatic container limit
+						above: raising the cap gives each container more headroom but lowers how many run at
+						once. Projects that need more memory can override it on their own Settings page. Must be
+						between {RAM_CAP_PER_CONTAINER_GB_MIN} and {RAM_CAP_PER_CONTAINER_GB_MAX}; defaults to{' '}
+						{DEFAULT_RAM_CAP_PER_CONTAINER_GB}.
+					</p>
+					{settings === undefined ? null : <RamCapForm settings={settings} />}
+				</section>
+
+				<section className="border border-border rounded-md p-4 bg-surface">
+					<label
+						className="block text-[13px] font-medium mb-1"
+						htmlFor="container-idle-timeout-input"
+					>
+						Container idle timeout (minutes)
+					</label>
+					<p className="text-[13px] text-text-2 mb-2.5 max-w-[680px]">
+						How long a project's container keeps running after its last activity (agent runs and
+						assistant chat) before it is stopped automatically. Containers start again on demand the
+						moment a run or a chat needs them. Stopping a container also stops any dev or preview
+						servers running inside it. Set 0 to keep containers always on. Must be between{' '}
+						{CONTAINER_IDLE_TIMEOUT_MIN_MIN} and {CONTAINER_IDLE_TIMEOUT_MIN_MAX}; defaults to{' '}
+						{DEFAULT_CONTAINER_IDLE_TIMEOUT_MIN}.
+					</p>
+					{settings === undefined ? null : <IdleTimeoutForm settings={settings} />}
+				</section>
+			</>
+		);
+
+	return <div className="max-w-[900px]">{content}</div>;
+}
+
+function MaxActiveContainersForm({ settings }: { settings: InstanceSettings }) {
+	const updateSettings = useUpdateInstanceSettings();
+	const [value, setValue] = useState(String(settings.max_active_containers));
+	const [error, setError] = useState<string | null>(null);
+
+	async function handleSave() {
+		setError(null);
+		const n = Number.parseInt(value, 10);
+		if (Number.isNaN(n) || n < MAX_ACTIVE_CONTAINERS_MIN || n > MAX_ACTIVE_CONTAINERS_MAX) {
+			setError(
+				`Enter a whole number between ${MAX_ACTIVE_CONTAINERS_MIN} and ${MAX_ACTIVE_CONTAINERS_MAX}.`,
+			);
+			return;
+		}
+		try {
+			const result = await updateSettings.mutateAsync({ max_active_containers: n });
+			setValue(String(result.max_active_containers));
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	async function handleReset() {
+		setError(null);
+		try {
+			const result = await updateSettings.mutateAsync({ max_active_containers: null });
+			setValue(String(result.max_active_containers));
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	const dirty = value.trim() !== String(settings.max_active_containers);
+	const ram = gb(settings.host_total_ram_bytes);
+	const swap = gb(settings.host_total_swap_bytes);
+	const total = Math.round((settings.host_total_ram_bytes + settings.host_total_swap_bytes) / GIB);
+
+	return (
+		<>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Input
+					id="max-active-containers-input"
+					data-testid="max-active-containers-input"
+					type="number"
+					inputMode="numeric"
+					min={MAX_ACTIVE_CONTAINERS_MIN}
+					max={MAX_ACTIVE_CONTAINERS_MAX}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					className="sm:w-40"
+				/>
+				<Button
+					size="sm"
+					data-testid="max-active-containers-save"
+					onClick={handleSave}
+					disabled={!dirty || updateSettings.isPending}
+				>
+					{updateSettings.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+				{settings.max_active_containers_is_set && (
+					<Button
+						size="sm"
+						variant="outline"
+						data-testid="max-active-containers-reset"
+						onClick={handleReset}
+						disabled={updateSettings.isPending}
+					>
+						Reset to automatic
+					</Button>
+				)}
+			</div>
+			<p className="text-[13px] text-text-2 mt-1.5" data-testid="max-active-containers-formula">
+				{settings.max_active_containers_is_set
+					? `Set explicitly - the automatic value for this host would be ${settings.max_active_containers_computed_default}.`
+					: `Automatic: this host has ${ram} GB RAM + ${swap} GB swap (~${total} GB) / ${settings.default_ram_cap_per_container_gb} GB per container = ${settings.max_active_containers_computed_default}.`}
+			</p>
+			{error && (
+				<p className="text-[13px] text-danger mt-1.5" data-testid="max-active-containers-error">
+					{error}
+				</p>
+			)}
+		</>
+	);
+}
+
+function RamCapForm({ settings }: { settings: InstanceSettings }) {
+	const updateSettings = useUpdateInstanceSettings();
+	const [value, setValue] = useState(String(settings.default_ram_cap_per_container_gb));
+	const [error, setError] = useState<string | null>(null);
+
+	async function handleSave() {
+		setError(null);
+		const n = Number.parseInt(value, 10);
+		if (Number.isNaN(n) || n < RAM_CAP_PER_CONTAINER_GB_MIN || n > RAM_CAP_PER_CONTAINER_GB_MAX) {
+			setError(
+				`Enter a whole number between ${RAM_CAP_PER_CONTAINER_GB_MIN} and ${RAM_CAP_PER_CONTAINER_GB_MAX}.`,
+			);
+			return;
+		}
+		try {
+			const result = await updateSettings.mutateAsync({ default_ram_cap_per_container_gb: n });
+			setValue(String(result.default_ram_cap_per_container_gb));
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	const dirty = value.trim() !== String(settings.default_ram_cap_per_container_gb);
+
+	return (
+		<>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Input
+					id="ram-cap-input"
+					data-testid="ram-cap-input"
+					type="number"
+					inputMode="numeric"
+					min={RAM_CAP_PER_CONTAINER_GB_MIN}
+					max={RAM_CAP_PER_CONTAINER_GB_MAX}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					className="sm:w-40"
+				/>
+				<Button
+					size="sm"
+					data-testid="ram-cap-save"
+					onClick={handleSave}
+					disabled={!dirty || updateSettings.isPending}
+				>
+					{updateSettings.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+			</div>
+			{error && (
+				<p className="text-[13px] text-danger mt-1.5" data-testid="ram-cap-error">
+					{error}
+				</p>
+			)}
+		</>
+	);
+}
+
+function IdleTimeoutForm({ settings }: { settings: InstanceSettings }) {
+	const updateSettings = useUpdateInstanceSettings();
+	const [value, setValue] = useState(String(settings.container_idle_timeout_min));
+	const [error, setError] = useState<string | null>(null);
+
+	async function handleSave() {
+		setError(null);
+		const n = Number.parseInt(value, 10);
+		if (
+			Number.isNaN(n) ||
+			n < CONTAINER_IDLE_TIMEOUT_MIN_MIN ||
+			n > CONTAINER_IDLE_TIMEOUT_MIN_MAX
+		) {
+			setError(
+				`Enter a whole number between ${CONTAINER_IDLE_TIMEOUT_MIN_MIN} and ${CONTAINER_IDLE_TIMEOUT_MIN_MAX}.`,
+			);
+			return;
+		}
+		try {
+			const result = await updateSettings.mutateAsync({ container_idle_timeout_min: n });
+			setValue(String(result.container_idle_timeout_min));
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	const dirty = value.trim() !== String(settings.container_idle_timeout_min);
+
+	return (
+		<>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Input
+					id="container-idle-timeout-input"
+					data-testid="container-idle-timeout-input"
+					type="number"
+					inputMode="numeric"
+					min={CONTAINER_IDLE_TIMEOUT_MIN_MIN}
+					max={CONTAINER_IDLE_TIMEOUT_MIN_MAX}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					className="sm:w-40"
+				/>
+				<Button
+					size="sm"
+					data-testid="container-idle-timeout-save"
+					onClick={handleSave}
+					disabled={!dirty || updateSettings.isPending}
+				>
+					{updateSettings.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+			</div>
+			{error && (
+				<p className="text-[13px] text-danger mt-1.5" data-testid="container-idle-timeout-error">
+					{error}
+				</p>
+			)}
+		</>
+	);
+}
+
+export const Route = createFileRoute('/settings/concurrency')({
+	component: ConcurrencySettingsPage,
+});

--- a/packages/web/test/container-states.test.tsx
+++ b/packages/web/test/container-states.test.tsx
@@ -38,8 +38,7 @@ function fakeProject(teamId: string, o: FakeProjectOpts) {
 		repo_count: 0,
 		open_task_count: 0,
 		is_internal: false,
-		max_concurrent_runs: 1,
-		memory_limit_gib: 16,
+		memory_limit_gib: null,
 		created_at: new Date().toISOString(),
 	};
 }
@@ -137,7 +136,7 @@ test('stopped container with no logs shows the "not running and no logs were cap
 		}),
 	);
 
-	await r.findByText('Stopped', undefined, { timeout: 20_000 });
+	await r.findByText('Stopped (starts on demand)', undefined, { timeout: 20_000 });
 	await r.findByText('Container is not running and no logs were captured.');
 });
 
@@ -151,7 +150,7 @@ test('a never-provisioned container (no container_id) shows the "No container pr
 		}),
 	);
 
-	await r.findByText('No container', undefined, { timeout: 20_000 });
+	await r.findByText('Starts on demand', undefined, { timeout: 20_000 });
 	await r.findByText('No container provisioned.');
 });
 

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -449,13 +449,30 @@ test('Run now queues when the Captain is busy, and the queued run can be cancell
 	let projectSlug = '';
 	const { findByTestId, findByText, queryByTestId, user, router } = await renderApp({
 		initialPath: '/',
-		seed: async () => {
+		seed: async (ctx) => {
 			const ws = await seedWorkspace();
 			const project = await seedProject(ws, { name: 'Queue Demo' });
 			projectSlug = project.slug;
-			// A freshly-seeded goal is immediately due; no running container in tests means the run
-			// is queued instead of started.
+			// A freshly-seeded goal is immediately due. A missing container no
+			// longer queues (the runner lazy-starts it), so block on the container
+			// limit instead: cap 1, this project's container stopped, a filler
+			// project's running container holding the only slot.
 			await seedGoal(ws, project, { title: 'Ship it', measurement: 'shipped' });
+			await ctx.db.query(
+				`INSERT INTO system_meta (key, value) VALUES ('max_active_containers', '1')
+				 ON CONFLICT (key) DO UPDATE SET value = '1'`,
+			);
+			await ctx.db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [
+				project.id,
+			]);
+			const filler = await ctx.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ('cap-goals-web', 'cap-goals-web') RETURNING id`,
+			);
+			await ctx.db.query(
+				`INSERT INTO projects (team_id, name, slug, task_prefix, container_id, container_status, container_last_started_at)
+				 VALUES ($1, 'cap-goals-web', 'cap-goals-web', 'CGW', 'cid-goals-web', 'running', now())`,
+				[filler.rows[0].id],
+			);
 		},
 	});
 

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -106,55 +106,6 @@ test('cancel button discards edits', async () => {
 	expect(queryByText('Should Not Save')).toBeNull();
 });
 
-test('edits the per-project concurrency cap and persists it', async () => {
-	const projectName = uniqueName('Concurrency Project');
-	let ws!: SeededWorkspace;
-	let projectSlug = '';
-	let projectId = '';
-
-	const { findByRole, findByTestId, getByRole, ctx, user, router } = await renderApp({
-		initialPath: '/',
-		seed: async () => {
-			ws = await seedWorkspace();
-			const project = await seedProject(ws, {
-				name: projectName,
-				description: 'Concurrency settings.',
-			});
-			projectSlug = project.slug;
-			projectId = project.id;
-		},
-	});
-
-	await router.navigate({
-		to: '/projects/$projectId/settings',
-		params: { projectId: projectSlug },
-	});
-
-	// Read view shows the seeded default of 10.
-	const readValue = await findByTestId('max-concurrent-runs-value', undefined, { timeout: 8_000 });
-	expect(readValue.textContent).toContain('10');
-
-	await user.click(await findByRole('button', { name: 'Edit' }));
-	const input = (await findByTestId('max-concurrent-runs-input', undefined, {
-		timeout: 8_000,
-	})) as HTMLInputElement;
-	await user.clear(input);
-	await user.type(input, '5');
-	await user.click(getByRole('button', { name: 'Save' }));
-
-	// The optimistic mutation hits the real backend; the project row reflects it.
-	await waitFor(
-		async () => {
-			const row = await ctx.db.query<{ max_concurrent_runs: number }>(
-				'SELECT max_concurrent_runs FROM projects WHERE id = $1',
-				[projectId],
-			);
-			expect(row.rows[0]?.max_concurrent_runs).toBe(5);
-		},
-		{ timeout: 8_000 },
-	);
-});
-
 test('edits the per-project memory limit and persists it', async () => {
 	const projectName = uniqueName('Memory Limit Project');
 	let ws!: SeededWorkspace;
@@ -179,9 +130,10 @@ test('edits the per-project memory limit and persists it', async () => {
 		params: { projectId: projectSlug },
 	});
 
-	// Read view shows the seeded default of 16 GiB.
+	// Read view shows the no-override state: the container inherits the
+	// instance-wide ram cap ("Default (2 GB)").
 	const readValue = await findByTestId('memory-limit-gib-value', undefined, { timeout: 8_000 });
-	expect(readValue.textContent).toContain('16');
+	expect(readValue.textContent).toContain('Default');
 
 	await user.click(await findByRole('button', { name: 'Edit' }));
 	const input = (await findByTestId('memory-limit-gib-input', undefined, {
@@ -193,11 +145,30 @@ test('edits the per-project memory limit and persists it', async () => {
 
 	await waitFor(
 		async () => {
-			const row = await ctx.db.query<{ memory_limit_gib: number }>(
+			const row = await ctx.db.query<{ memory_limit_gib: number | null }>(
 				'SELECT memory_limit_gib FROM projects WHERE id = $1',
 				[projectId],
 			);
 			expect(row.rows[0]?.memory_limit_gib).toBe(24);
+		},
+		{ timeout: 8_000 },
+	);
+
+	// Clearing the field removes the override — back to inherit (NULL).
+	await user.click(await findByRole('button', { name: 'Edit' }));
+	const input2 = (await findByTestId('memory-limit-gib-input', undefined, {
+		timeout: 8_000,
+	})) as HTMLInputElement;
+	await user.clear(input2);
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ memory_limit_gib: number | null }>(
+				'SELECT memory_limit_gib FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.memory_limit_gib).toBeNull();
 		},
 		{ timeout: 8_000 },
 	);

--- a/packages/web/test/queued-agents.test.tsx
+++ b/packages/web/test/queued-agents.test.tsx
@@ -121,15 +121,23 @@ test('disables run-now with a capacity reason when the project is at its run lim
 			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
 			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
 			const project = await seedProject(ws, { name: 'At Capacity Demo' });
-			// Cap the project at a single concurrent run.
-			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [project.id]);
-
-			// A sibling ticket is already running, so the project's one slot is taken.
-			const sibling = await seedTask(ws, project, { title: 'Occupying Slot' });
+			// Container semantics: cap the instance at one active container, park
+			// this project's container, and let a filler project's running
+			// container hold the only slot.
 			await ctx.db.query(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
-				[captain.id, ws.team.id, sibling.id],
+				`INSERT INTO system_meta (key, value) VALUES ('max_active_containers', '1')
+				 ON CONFLICT (key) DO UPDATE SET value = '1'`,
+			);
+			await ctx.db.query(`UPDATE projects SET container_status = 'stopped' WHERE id = $1`, [
+				project.id,
+			]);
+			const filler = await ctx.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ('cap-filler-web', 'cap-filler-web') RETURNING id`,
+			);
+			await ctx.db.query(
+				`INSERT INTO projects (team_id, name, slug, task_prefix, container_id, container_status, container_last_started_at)
+				 VALUES ($1, 'cap-filler-web', 'cap-filler-web', 'CFW', 'cid-filler', 'running', now())`,
+				[filler.rows[0].id],
 			);
 
 			const task = await seedTask(ws, project, { title: 'Waiting Task', assignee_id: captain.id });
@@ -158,7 +166,7 @@ test('disables run-now with a capacity reason when the project is at its run lim
 	await waitFor(() => {
 		expect(playBtn.getAttribute('aria-disabled')).toBe('true');
 	});
-	expect(playBtn.getAttribute('aria-label')).toMatch(/concurrent-run limit/i);
+	expect(playBtn.getAttribute('aria-label')).toMatch(/active-container limit/i);
 });
 
 test('disables run-now when the queued agent is already running on another task in the project', async () => {
@@ -171,8 +179,7 @@ test('disables run-now when the queued agent is already running on another task 
 			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
 			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
 			const project = await seedProject(ws, { name: 'Agent Busy Demo' });
-			// Plenty of capacity, so the only blocker is the agent's own slot.
-			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [project.id]);
+			// Plenty of container capacity, so the only blocker is the agent's own slot.
 
 			// The queued agent is already running on a sibling task in this project.
 			const sibling = await seedTask(ws, project, { title: 'Occupying Agent Slot' });

--- a/packages/web/test/run-comment-retry.test.tsx
+++ b/packages/web/test/run-comment-retry.test.tsx
@@ -289,16 +289,16 @@ test('succeeded run-entry comment shows no Retry button', async () => {
 	expect(queryByTestId('retry-failed-run')).toBeNull();
 });
 
-test('failed run-entry comment disables Retry while the container is not running', async () => {
+test('failed run-entry comment disables Retry while the container has an error', async () => {
 	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
 	const retryCalls: string[] = [];
 
 	const { findByTestId, user, router } = await setup({
 		seeded,
 		retryCalls,
-		// The exact stale state from the incident: the run failed and the container
-		// is gone, so a retry would only fail again.
-		containerStatus: 'stopped',
+		// An errored container needs fixing before a retry can succeed. (A merely
+		// stopped container no longer disables Retry — the runner lazy-starts it.)
+		containerStatus: 'error',
 		comments: ({ task, agent }) => [
 			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
 		],
@@ -312,7 +312,7 @@ test('failed run-entry comment disables Retry while the container is not running
 		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
 	});
 
-	// The button still renders (this is the latest failed run), but the not-running
+	// The button still renders (this is the latest failed run), but the errored
 	// container makes it inert so a click can't dispatch a doomed retry.
 	const retryButton = (await findByTestId('retry-failed-run', undefined, {
 		timeout: 20_000,

--- a/packages/web/test/settings-concurrency.test.tsx
+++ b/packages/web/test/settings-concurrency.test.tsx
@@ -1,0 +1,95 @@
+import { setHostMemoryForTest } from '@hezo/server/src/lib/host-memory';
+import { waitFor } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+const GIB = 1024 ** 3;
+
+afterEach(() => setHostMemoryForTest(null));
+
+test('concurrency settings page shows the computed default, saves, and resets to automatic', async () => {
+	// The incident's reference host: ~2GB RAM + 6GB swap → 8GB / 2GB cap = 4.
+	setHostMemoryForTest({ totalRamBytes: 1.92 * GIB, totalSwapBytes: 6 * GIB });
+
+	const { findByTestId, findByRole, queryByTestId, user } = await renderApp({
+		initialPath: '/settings/concurrency',
+	});
+
+	await findByRole('heading', { name: 'Concurrency' });
+
+	// Unset → the effective value is the host-memory-computed default.
+	const maxInput = (await findByTestId('max-active-containers-input')) as HTMLInputElement;
+	expect(maxInput.value).toBe('4');
+	const formula = await findByTestId('max-active-containers-formula');
+	expect(formula.textContent).toContain('= 4');
+	expect(queryByTestId('max-active-containers-reset')).toBeNull();
+
+	// An explicit value wins and offers a reset back to automatic.
+	await user.clear(maxInput);
+	await user.type(maxInput, '7');
+	await user.click(await findByTestId('max-active-containers-save'));
+	await waitFor(() => expect(maxInput.value).toBe('7'));
+	const reset = await findByTestId('max-active-containers-reset');
+
+	const { apiBase, token } = getTestContext();
+	const auth = { Authorization: `Bearer ${token}` };
+	let res = await apiBase('/api/instance-settings', { headers: auth });
+	let data = (await res.json()).data;
+	expect(data.max_active_containers).toBe(7);
+	expect(data.max_active_containers_is_set).toBe(true);
+
+	await user.click(reset);
+	await waitFor(() => expect(maxInput.value).toBe('4'));
+	res = await apiBase('/api/instance-settings', { headers: auth });
+	data = (await res.json()).data;
+	expect(data.max_active_containers).toBe(4);
+	expect(data.max_active_containers_is_set).toBe(false);
+});
+
+test('raising the ram cap lowers the automatic container limit and persists', async () => {
+	setHostMemoryForTest({ totalRamBytes: 1.92 * GIB, totalSwapBytes: 6 * GIB });
+
+	const { findByTestId, findByRole, user } = await renderApp({
+		initialPath: '/settings/concurrency',
+	});
+	await findByRole('heading', { name: 'Concurrency' });
+
+	const ramInput = (await findByTestId('ram-cap-input')) as HTMLInputElement;
+	expect(ramInput.value).toBe('2');
+	await user.clear(ramInput);
+	await user.type(ramInput, '4');
+	await user.click(await findByTestId('ram-cap-save'));
+	await waitFor(() => expect(ramInput.value).toBe('4'));
+
+	// The automatic limit follows the new divisor: 8GB / 4GB = 2.
+	const formula = await findByTestId('max-active-containers-formula');
+	await waitFor(() => expect(formula.textContent).toContain('= 2'));
+
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/instance-settings', {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	const data = (await res.json()).data;
+	expect(data.default_ram_cap_per_container_gb).toBe(4);
+	expect(data.max_active_containers).toBe(2);
+});
+
+test('saves the container idle timeout, including 0 for always-on', async () => {
+	const { findByTestId, findByRole, user } = await renderApp({
+		initialPath: '/settings/concurrency',
+	});
+	await findByRole('heading', { name: 'Concurrency' });
+
+	const input = (await findByTestId('container-idle-timeout-input')) as HTMLInputElement;
+	expect(input.value).toBe('15');
+	await user.clear(input);
+	await user.type(input, '0');
+	await user.click(await findByTestId('container-idle-timeout-save'));
+	await waitFor(() => expect(input.value).toBe('0'));
+
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/instance-settings', {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	expect((await res.json()).data.container_idle_timeout_min).toBe(0);
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
 			// `@hezo/server/test` entry must come first so it wins over the
 			// broader `@hezo/server` prefix.
 			'@hezo/server/test': resolve(ROOT, 'packages/server/test'),
+			// `@hezo/server/src/...` is the tsc-visible form (node resolution walks
+			// the workspace symlink into the real package dir), so alias it too —
+			// before the broader prefix — for tests importing server internals.
+			'@hezo/server/src': resolve(ROOT, 'packages/server/src'),
 			'@hezo/server': resolve(ROOT, 'packages/server/src'),
 			'@hezo/web': resolve(__dir, 'src'),
 			'@hezo/shared': resolve(ROOT, 'packages/shared/src/index.ts'),


### PR DESCRIPTION
# On-demand container lifecycle + instance-level resource caps

Motivated by a production incident: a 2 vCPU / 1.9GB box OOM-thrashed under 8 concurrent agent runs across three projects (~300MB each), with the kernel OOM killer taking out SSH sessions because the old per-container 16GiB cap was a no-op on a small host. Per-project run limits structurally cannot bound what the box experiences; these changes make the resource model instance-level and demand-driven.

## What changed

**Lazy-start + idle-stop (containers run only while there is work)**
- `runAgent` no longer refuses when a container isn't running: it establishes one via `ensureProjectContainerRunning` (running → reuse; stopped → start in place; missing/stale row → provision). The old "start the container from the Project page and retry" failure path is gone.
- New `container-idle-stop` cron (1/min, bounded LIMIT 10/tick, fully index-served) stops containers idle past a configurable timeout (default 15 min, `0` = always-on). The busy predicate covers active runs, runs finished inside the window, dispatchable queued wakeups (capacity-skipped ones deliberately don't pin containers), and chat sessions with recent activity or in-flight turns; `container_last_started_at` floors the check so a fresh start always gets one full window.
- Every lifecycle decision (ensure-running, check-then-stop) serializes per project through a new `withContainerLifecycleLock`, with an in-memory recheck inside the lock — a start and a stop can never interleave, and concurrent dispatches provision exactly one container.
- The HQ startup warm-up is now first-boot-only (never-provisioned HQ), so fresh-install onboarding isn't stuck behind an image pull while steady-state boots stay cold.

**One global concurrency limit, counted in containers**
- `projects.max_concurrent_runs` is dropped. The cap is now `max_active_containers` (system_meta): at most N project containers active at once, including the assistant chat's. A run whose project container is already active consumes no new slot; one that needs another container queues (`instance_at_capacity`) until a container goes idle. The chat path counts toward the limit but is never refused.
- When unset, the default is computed from host memory: `(RAM + swap) / RAM cap per container`, clamped to [1,100] — the incident's 1.92GB + 6GB swap host computes 8GB / 2GB = 4. `PATCH {max_active_containers: null}` resets to automatic.
- Per-task (1 run/task) and per-agent-per-project rules are unchanged.

**RAM cap per container**
- New instance setting `default_ram_cap_per_container_gb` (default 2). Dual role: the Docker cgroup memory cap (+512MiB headroom) for every container without an override, and the divisor of the automatic container limit — so total memory demand never exceeds `N × cap`, and a runaway process now hits a cgroup OOM instead of a global one.
- `projects.memory_limit_gib` becomes nullable = inherit; rows on the old 16GiB default migrate to inherit, explicit overrides are preserved and remain editable per project.

**Settings > Concurrency page** — all three knobs with honest resource copy (including the live formula behind the automatic value and a reset-to-automatic action); nav label translated in all 12 catalogs.

**"Stopped" is a normal state in the web UI** — no warning banner; chat, project creation, and run-retry no longer block on a stopped container; container health maps never-provisioned to the same on-demand state; only genuine `error` keeps error styling.

**Migration 048** (with a data-preservation test): drops `max_concurrent_runs`, reshapes `memory_limit_gib` (16 → NULL/inherit), adds `projects.container_last_started_at` (backfilled for running containers so the upgrade grants a full idle window) and the two idle-scan indexes.

## Operator notes

- Existing per-project run limits collapse into the global computed default — multi-project throughput may drop until the operator raises `max_active_containers`.
- The effective memory cap for most containers drops from a no-op 16GiB to a real 2GB; heavy workloads (big builds, browser automation) may need a per-project override or a higher instance cap. Containers created before the upgrade keep their baked-in cgroup cap until next rebuild, but the working-set enforcement applies the new cap immediately (graceful stop).
- Idle-stop ends dev/preview servers running in a container; timeout `0` restores always-on behavior.
- Dispatch drains FIFO with no per-project fair share under the global cap (documented in `.dev/architecture.md` as the hook for a future scheduler).

## Tests

- New: migration 048 data-preservation; idle-stop cron suite (9 cases incl. the capacity-skipped-wakeup and in-memory-recheck behaviors); lazy-start suite (stopped → started, vanished → re-provisioned, null → provisioned, concurrent ensures → one `createContainer`); instance-settings computed-default/reset coverage; Settings > Concurrency component tests; shared formula unit tests.
- Reworked: all capacity tests to container semantics via a shared `helpers/capacity.ts`; the old refusal/container-down contracts across job-manager, goals, queued-wakeups, agent-runner, and web suites.
- Full non-browser matrix (server + Bun-native + web + shared) run locally; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWKfBZK8tdomCvjyA82pBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWKfBZK8tdomCvjyA82pBu)_