### PR TITLE
fix(containers): make the tunnel work on a managed backend

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1139,11 +1139,36 @@ marker kill and teardown. Four findings are worth carrying:
 - **A digest-pinned `agent-base` is pullable anonymously**, so Daytona builds it with no
   registry credential - the `buildInfo` Dockerfile is `FROM …@sha256:…` and nothing else.
 
-The one part that cannot be exercised from a network that blocks WebSocket upgrades is the
-**tunnel**, whose Daytona transport is a PTY over WebSocket - and with it, anything that
-needs a container to reach Hezo (MCP, the egress proxy, the ssh-agent), so a full agent-CLI
-run included. That is a property of such a network, not of the adapter: every HTTP path
-(control plane, exec, streaming logs, files) works through the same one.
+**The tunnel has since been driven end to end**, from a network that permits WebSocket
+upgrades (the earlier pass could not reach it at all, which is why three defects lived in it -
+see the PTY section above and the readiness contract in § Container tunnel). A real agent run
+now completes on Daytona: DeepSeek through Claude Code, `tools=97` in the session line,
+`create_comment` and `update_task` landing over MCP, run `succeeded`, tokens priced from the
+table. Run logs stream over the WebSocket, suspend/resume preserves the filesystem, the pool
+serves concurrent runs one-per-container, the wall-clock kill leaves no marked process behind,
+and deleting the project destroys every sandbox it owned. On a network that blocks WebSocket
+upgrades none of that is reachable - a property of such a network, not of the adapter, since
+every HTTP path (control plane, exec, streaming logs, files) works through the same one.
+
+Two further quota facts were measured, and both bear on the pool:
+
+- **A *suspended* sandbox still holds its full memory and disk quota.** `planIdleShutdown`
+  keeps one suspended container per project on the reasoning that retention is nearly free.
+  It is not free here: stopping a sandbox releases nothing, so an idle project holds a whole
+  concurrency slot indefinitely, and on a tier allowing three sandboxes, three idle projects
+  consume the entire org quota and no run can start. Daytona's own refusal names the state
+  that *does* release it - **archive** - which Hezo never uses (`autoArchiveInterval` defaults
+  to 7 days and `archived` already maps to `exited`). **Known gap**: the suspend rung wants a
+  provider-side notion of "suspended" the adapter chooses, rather than one shape for both.
+- **Memory is a separate provider cap from disk, and binds first at this container size.** The
+  tier measured allowed 10 GiB total memory and 30 GiB total disk - three sandboxes either
+  way at 3 GiB/10 GiB each. Hezo's budget knows neither: it counts a container as its *cap*
+  (`memory_limit_gib`, 2 GB) while the provider allocates the **hard cap** - cap plus
+  `MEMORY_HARD_CAP_HEADROOM_BYTES`, rounded up - so the accounting understates real
+  consumption by 50% at that size, and a budget set to 24 GB admits twelve containers the
+  provider refuses on the fourth. The workaround noted above (size the budget against
+  `quota_disk_gb / 10`) therefore needs to be the *minimum* of the disk and memory
+  derivations, and computed against the hard cap rather than the cap.
 
 **Digest resolution** (`sandbox/image-ref.ts`) is the generic OCI registry manifest lookup
 that makes the pin possible: a HEAD on the manifest, exchanging a `WWW-Authenticate: Bearer`
@@ -1153,6 +1178,20 @@ tag** rather than failing when the registry cannot be reached - an offline insta
 private registry, or a locally-built tag that exists in no registry at all would otherwise
 be unable to start a container over a cache-freshness concern. The fallback logs what it
 costs, because the failure it re-admits is otherwise invisible.
+
+**`startRunTunnel` does not return until the endpoints work.** Opening the channel only
+*starts* the client; it is a process that still has to boot and bind three loopback ports, and
+on Daytona they appear ~1s later (the sandbox execs a shell, then `runuser`, then node). A run
+hands those endpoints straight to the coding CLI, which dials them immediately - and a CLI that
+gets `ECONNREFUSED` on the MCP endpoint marks that server failed **for the whole session**
+rather than retrying, so the agent runs to completion with no Hezo tools and the run reads as
+the agent having done nothing (`tools=25` instead of `tools=97` in the session line was the
+tell). So the tunnel polls the container until all three ports listen, reading `/proc/net/tcp`
+(always present, unlike `ss`/`netstat`, which a custom `docker_base_image` need not carry) and
+matching loopback specifically. It **fails the run** if they never do: without the tunnel the
+container cannot reach MCP, the egress proxy or the ssh-agent, so proceeding would produce
+exactly the silent no-op it exists to prevent. The wait lives in the shared tunnel code, not in
+either adapter - the race is Docker's too, just narrower.
 
 **The tunnel is the only way a container reaches Hezo**, on every backend, with no gate and
 no second path. `RunEndpoints` always names container loopback, where the in-container
@@ -1190,13 +1229,36 @@ an `input`/`stdin`/`stdinData` field entirely, and a command that reads stdin se
 EOF. What it has instead is a **PTY session over WebSocket** -
 `POST /process/pty {id}` then `wss://…/process/pty/{id}/connect` with the bearer token -
 verified end to end as a real bidirectional byte channel (writes reach the shell, output
-comes back). Two things follow for whoever builds the tunnel: the channel opens with a
-`{"status":"connected","type":"control"}` JSON frame that is not shell output, and it is a
-**PTY**, so line discipline is active (echo on, `\n` to `\r\n`, bracketed-paste sequences)
-and it must be put in raw mode before any framed protocol rides on it. The consequence for
-the seam is that the *transport* is per-backend while the framing and multiplexing above it
-stay shared - the plan's "one transport for both backends" holds for the protocol, not for
-the channel underneath it.
+comes back). The consequence for the seam is that the *transport* is per-backend while the
+framing and multiplexing above it stay shared - the plan's "one transport for both backends"
+holds for the protocol, not for the channel underneath it.
+
+**Four things on that channel would each desynchronise the framing on byte one**, and all four
+are absorbed in `openPty` (measured against the live API; the first was handled from the start
+and the rest were found by driving a real agent run over it):
+
+1. the opening `{"status":"connected","type":"control"}` JSON frame, which is not shell output;
+2. the PTY's **echo of `stty raw -echo`** - sent to turn echo off, and echoed back because echo
+   is still on. The decoder read `stty` as a type and stream id and `raw ` as a 1918990112-byte
+   length, and the mux closed the channel before any payload existed;
+3. bash's **bracketed-paste sequences** (`ESC[?2004h` / `ESC[?2004l`), emitted around every
+   command it accepts **even with echo off** - so raw mode does not remove them;
+4. the shell **prompt** printed when the launched command exits.
+
+So the launch is folded into `openPty` as one line - `stty raw -echo`, print a per-session
+sentinel, then **`exec`** the command - and nothing reaches the caller until that sentinel.
+`exec` replaces the shell, which removes (3) and (4) structurally rather than filtering them.
+The sentinel is emitted from **two halves** (`printf '%s%s' 'a' 'b'`) so the still-echoed command
+line does not contain it: printed whole, the sync fired on the echoed copy and forwarded the real
+one, moving the corruption one step later instead of removing it.
+
+**Closing the socket does not end the session or kill what runs on it** - measured: a process
+launched on a PTY was still listening after the WebSocket closed and the session still read
+`active`. Only `DELETE /process/pty/{id}` terminates it, so that is what `close()` does. On
+Docker the equivalent close kills the exec, so without it this leaks a process per channel on
+Daytona alone - and for the tunnel that is not cosmetic, since the client holds the run's three
+loopback ports and a pooled container serves many runs in sequence: the next run's client dies
+with `EADDRINUSE` and that run loses MCP, egress and the ssh-agent entirely.
 
 **Network isolation is the provider's, not ours - measured.** Daytona interposes an Envoy
 proxy in front of all sandbox egress: a raw TCP connect to `169.254.169.254`, to an RFC1918
@@ -1207,6 +1269,23 @@ the field is capped at **10 networks**, while "the public internet minus the pri
 is 51 CIDRs, so an attempt to send it fails the create outright - which would have broken
 every remote run rather than hardening it. What protects a secret remains that the secret
 only ever exists on the Hezo side.
+
+**Pool members are reconciled against the engine, because nothing else revisits them.** The
+acquire path repairs a stale member on two rungs - `reuse` verifies the container still runs,
+`resume` drops it if the start throws - but both only fire for a member the ladder actually
+*picks*, and it never picks a `busy` one. A run that died without releasing its row therefore
+left a member nothing ever looked at again, and since `getActiveContainers` counts
+`creating`/`idle`/`busy` towards the memory budget, each orphan permanently consumed capacity
+until every run in the project failed admission with "no container available". So
+`reconcilePoolMembers` runs from the `container-sync` job and drops members whose container the
+engine no longer knows. It drops **only on a definite answer**: `inspectContainer` returns null
+for a container the engine does not know and *throws* for anything else, and a throw means
+"could not determine" and changes nothing - deleting on an unanswerable check would lose the
+record of a live container and orphan it on the backend. A grace period keeps a just-created
+container from being judged early, and a per-pass bound keeps a large pool from turning one tick
+into a fan-out of round trips. This matters more on a managed backend than locally, because
+there a container disappearing is normal rather than anomalous - the provider stops, archives
+and reaps sandboxes on its own schedule, and enforces quota by refusing or removing them.
 
 **Capacity is a memory budget, and it reserves for the chat container up front.**
 `max_container_memory_gb` bounds the total memory *task run* containers may hold at once,
@@ -1809,7 +1888,12 @@ gone mid-op.
 **Timeout handling (graceful cut).** The `run_timeout_min` timer aborts the run's signal with a
 tagged `'run_timeout'` reason (`JobManager.launchTask`), so the runner finalizes it as `timed_out`
 — distinct from a bare abort (user cancel / shutdown → `cancelled`) and container death
-(`container_*` → `failed`); `runAgent`'s `abortedRunStatus` maps the reason. On a `timed_out` run
+(`container_*` → `failed`); `runAgent`'s `abortedRunStatus` maps the reason. **The signal
+decides the status, never the shape of the thrown error.** Only Docker's exec reliably rejects
+with an `AbortError` when its attach is torn down - a managed backend's may reject with anything
+or resolve outright - so keying on the error name recorded a timed-out run on Daytona as `failed`
+while still stamping it with the timeout's own message (measured live). The streak cap below
+reads that column, so the misclassification silently disabled it. On a `timed_out` run
 `onAgentComplete` **auto-queues a same-task continuation wakeup** (`queueTimeoutContinuation` →
 `createWakeup(Timer, {reason:'timeout_continuation'})`) so the agent resumes the task on the next
 wakeup pass — committed work is already pushed, so nothing is lost — and it **skips the failure

--- a/docs/deployment/remote-sandboxes.md
+++ b/docs/deployment/remote-sandboxes.md
@@ -65,6 +65,14 @@ path and Hezo owns it, so the rules are the same wherever the container runs.
 
 - **Concurrency is bounded by the container memory budget**, exactly as it is locally. See
   [Settings → Concurrency](/docs/security/container-isolation).
+- **Your provider account also bounds it, and Hezo cannot see that limit.** Providers cap
+  how much memory and disk your organisation may hold across all sandboxes at once, and on
+  a small plan that ceiling is reached well before the memory budget is. Hezo keeps
+  admitting runs the provider then refuses, and the refusal surfaces on the project's
+  Container page naming the provider's limit. Set the memory budget to something your plan
+  can actually satisfy: divide your plan's total memory *and* its total disk by what one
+  container takes, and use the smaller of the two. Note a container takes slightly more
+  than its cap (the cap plus a little headroom, rounded up to whole GB).
 - **A project's memory cap must fit that budget.** Providers also cap a single sandbox
   (Daytona allocates at most 8 GB). Ask for more than the provider can give and the run
   fails with a message naming the limit - Hezo never quietly starts a smaller container
@@ -75,6 +83,9 @@ path and Hezo owns it, so the rules are the same wherever the container runs.
 - **Idle containers are suspended, not destroyed.** A project keeps at most one suspended
   container, which resumes with its clones and worktrees intact; extra containers from a
   burst are destroyed when they go idle and are rebuilt from the git remote next time.
+  A suspended sandbox still counts against your provider account's memory and disk limits,
+  so on a small plan a handful of idle projects can hold the whole allowance. If runs start
+  failing to provision while nothing appears to be running, that is what to look at.
 - **The first container of a project is slower to start** than a local one (roughly half a
   minute) because the provider builds it. Later ones start in a few seconds.
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1779,7 +1779,19 @@ export async function runAgent(
 			const isAbort = (error as Error).name === 'AbortError';
 			const reason = runAbortReason(signal);
 			const errorMessage = abortErrorMessage(reason) ?? (error as Error).message;
-			const status = isAbort ? abortedRunStatus(reason) : HeartbeatRunStatus.Failed;
+			// The **signal** decides the status, not the shape of the thrown error.
+			// Only Docker's exec reliably rejects with an `AbortError` when its
+			// attach is torn down; a managed backend's exec may reject with
+			// anything or resolve outright, and keying on the error name there
+			// recorded a timed-out run as `failed` while still stamping it with the
+			// timeout's own message - measured against the live Daytona API. An
+			// error with no abort reason behind it is a genuine failure; a bare
+			// abort (user cancel, shutdown) is still `cancelled`.
+			const status = reason
+				? abortedRunStatus(reason)
+				: isAbort
+					? HeartbeatRunStatus.Cancelled
+					: HeartbeatRunStatus.Failed;
 
 			// Aborting the exec only tears down its attach stream — Docker leaves the
 			// agent CLI running in the container, so a user-terminated or timed-out run

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -42,6 +42,7 @@ import {
 	claimPoolMember,
 	decidePoolAcquisition,
 	listPoolContainerIds,
+	listPoolMembersForReconcile,
 	releasePoolMember,
 	removePoolMember,
 	setPoolMemberState,
@@ -1604,4 +1605,64 @@ async function allocateHostPorts(
 		usedPorts.add(host);
 		return { container: p.container, host };
 	});
+}
+
+/**
+ * How stale a pool member must be before it is checked, and how many are checked
+ * per pass. The floor keeps a just-created container from being judged missing
+ * before the provider can answer for it; the bound keeps a large pool from
+ * turning one tick into a fan-out of engine round trips.
+ */
+const POOL_RECONCILE_MIN_AGE_SECONDS = 60;
+const POOL_RECONCILE_LIMIT = 50;
+
+/**
+ * Drop pool members whose container no longer exists.
+ *
+ * The acquire path repairs a stale member on two rungs - `reuse` verifies the
+ * container still runs, `resume` drops it if the start throws - but both only
+ * fire for a member the ladder actually **picks**, and the ladder never picks a
+ * `busy` one. A run that died without releasing its row therefore leaves a
+ * member nothing ever revisits. That is not merely untidy: `getActiveContainers`
+ * counts `creating`/`idle`/`busy` members towards the instance memory budget, so
+ * each orphan permanently consumes capacity, and enough of them make every run
+ * in the project fail admission with "no container available".
+ *
+ * This matters more on a managed backend than on a local daemon, because there a
+ * container disappearing is normal rather than anomalous - the provider stops,
+ * archives or reaps sandboxes on its own schedule and enforces quota by refusing
+ * or removing them.
+ *
+ * **A member is dropped only on a definite answer.** `inspectContainer` returns
+ * null for a container the engine does not know; anything else - a timeout, an
+ * unreachable API - throws, and a throw means "could not determine", which
+ * leaves the row exactly as it was. Treating an unanswerable check as "gone"
+ * would delete the record of a live container and orphan it on the backend,
+ * which is the strictly worse failure.
+ */
+export async function reconcilePoolMembers(deps: ContainerDeps): Promise<number> {
+	const { db, docker } = deps;
+	const stale = await listPoolMembersForReconcile(
+		db,
+		POOL_RECONCILE_MIN_AGE_SECONDS,
+		POOL_RECONCILE_LIMIT,
+	);
+	if (stale.length === 0) return 0;
+
+	let dropped = 0;
+	for (const member of stale) {
+		let info: Awaited<ReturnType<ContainerEngine['inspectContainer']>>;
+		try {
+			info = await docker.inspectContainer(member.containerId);
+		} catch {
+			continue;
+		}
+		if (info !== null) continue;
+		await removePoolMember(db, member.containerId);
+		dropped++;
+		log.info(
+			`pool member ${member.containerId.slice(0, 12)} (${member.state}) no longer exists on the backend — dropped`,
+		);
+	}
+	return dropped;
 }

--- a/packages/server/src/services/fake-docker.ts
+++ b/packages/server/src/services/fake-docker.ts
@@ -70,6 +70,7 @@ export function createFakeDockerClient(db?: Db, dataDir?: string): ContainerEngi
 	const containers = new Map<string, FakeContainer>();
 	const execRunIds = new Map<string, string | null>();
 	let execCounter = 0;
+	const tunnelReadyExecs = new Set<string>();
 
 	const describe = (id: string): ContainerInfo => {
 		const running = containers.get(id)?.running ?? true;
@@ -148,11 +149,21 @@ export function createFakeDockerClient(db?: Db, dataDir?: string): ContainerEngi
 			const execId = `noop-exec-${++execCounter}`;
 			const runEntry = config?.Env?.find((e) => e.startsWith(RUN_ID_ENV_PREFIX));
 			execRunIds.set(execId, runEntry ? runEntry.slice(RUN_ID_ENV_PREFIX.length) : null);
+			// The tunnel's port-readiness check, recognised so it can be answered.
+			// `startRunTunnel` will not hand a run its endpoints until the client's
+			// ports are listening, so a fake that never answers leaves every run -
+			// and every chat turn - waiting out the full timeout and then failing.
+			if ((config?.Cmd ?? []).some((part) => part.includes('/proc/net/tcp'))) {
+				tunnelReadyExecs.add(execId);
+			}
 			return execId;
 		},
 		execStart: async (execId: string, opts?: ExecStartOpts): Promise<ExecResult> => {
 			const runId = execRunIds.get(execId) ?? null;
 			execRunIds.delete(execId);
+			// A fake container's tunnel comes up. A test that wants the opposite
+			// drives `startRunTunnel` against its own engine (sandbox-run-tunnel).
+			if (tunnelReadyExecs.delete(execId)) return { stdout: 'ready\n', stderr: '' };
 			if (!opts?.onChunk) return { stdout: '', stderr: '' };
 			await runSyntheticExec(opts);
 			if (db && runId) {

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -57,6 +57,7 @@ import {
 	isProjectIdleForContainerStop,
 	provisionContainer,
 	rebuildContainer,
+	reconcilePoolMembers,
 	stopContainerGracefully,
 	syncAllContainerStatuses,
 	verifyContainerWorkspace,
@@ -2815,11 +2816,19 @@ export class JobManager {
 			return;
 		}
 
-		const transitions = await syncAllContainerStatuses(this.buildContainerDeps());
+		const deps = this.buildContainerDeps();
+		const transitions = await syncAllContainerStatuses(deps);
 
 		for (const transition of transitions) {
 			await this.handleContainerTransition(transition);
 		}
+
+		// Pool members are not reachable from the project rows above - a project
+		// names one container, a pool has many - so they are reconciled here.
+		// Without it a member whose container is gone is never revisited and
+		// permanently consumes the instance memory budget (see
+		// `reconcilePoolMembers`).
+		await reconcilePoolMembers(deps);
 	}
 
 	/**

--- a/packages/server/src/services/sandbox/daytona/client.ts
+++ b/packages/server/src/services/sandbox/daytona/client.ts
@@ -1,4 +1,6 @@
+import { randomBytes } from 'node:crypto';
 import { basename } from 'node:path';
+import { trackBackground } from '../../../lib/background';
 import { logger } from '../../../logger';
 
 const log = logger.child('daytona');
@@ -10,6 +12,15 @@ export const DEFAULT_DAYTONA_API_URL = 'https://app.daytona.io/api';
 const FILE_TIMEOUT_MS = 120_000;
 
 const CONTROL_TIMEOUT_MS = 60_000;
+
+/**
+ * How long the PTY has to reach raw mode and echo its sentinel.
+ *
+ * Generous, because it covers a shell starting inside a sandbox that may still
+ * be settling - but bounded, because the alternative to failing here is a
+ * channel that silently never carries a frame.
+ */
+const PTY_SYNC_TIMEOUT_MS = 30_000;
 
 /**
  * Sandbox lifecycle states Daytona reports. Only the ones Hezo reacts to are
@@ -119,7 +130,7 @@ export interface DaytonaApi {
 		onLine: (line: string) => void | Promise<void>,
 		opts?: { cwd?: string; signal?: AbortSignal },
 	): Promise<{ exitCode: number }>;
-	openPty(sandbox: DaytonaSandbox, sessionId: string): Promise<DaytonaPty>;
+	openPty(sandbox: DaytonaSandbox, sessionId: string, launch: string): Promise<DaytonaPty>;
 
 	// ---- files -------------------------------------------------------------
 	// Measured against the live toolbox API; see DaytonaClient for the shapes and
@@ -432,16 +443,34 @@ export class DaytonaClient implements DaytonaApi {
 	}
 
 	/**
-	 * Open a PTY session and connect to it.
+	 * Open a PTY session, launch a command on it, and hand back a byte channel
+	 * carrying only that command's own output.
 	 *
-	 * Two things about this channel are not obvious and both would corrupt a
-	 * framed protocol, so both are handled here rather than left to the caller:
-	 * it opens with a `{"status":"connected","type":"control"}` JSON frame that
-	 * is **not** shell output and must be swallowed, and it is a PTY, so line
-	 * discipline is on until `stty raw -echo` runs. Both were measured against
-	 * the live API.
+	 * Everything before the command's first byte is shell noise, and a framed
+	 * protocol riding this channel is desynchronised by any of it - the decoder
+	 * reads whatever arrives first as `[u8 type][u32 streamId][u32 len]`. Four
+	 * distinct sources of noise were measured on the live API, and the launch is
+	 * folded into this method precisely so none of them can reach the caller:
+	 *
+	 * 1. The channel opens with a `{"status":"connected","type":"control"}` JSON
+	 *    frame, which is not shell output.
+	 * 2. It is a PTY with echo on, so `stty raw -echo` is itself echoed back
+	 *    before it takes effect. That echo alone is fatal: the decoder reads
+	 *    `stty` as a type and stream id and `raw ` as a 1918990112-byte length.
+	 * 3. The interactive shell prints a prompt, and brackets each command it
+	 *    accepts with bracketed-paste sequences (`ESC[?2004h` / `ESC[?2004l`) -
+	 *    emitted even with echo off, so raw mode does not suppress them.
+	 * 4. A shell that outlived the command would print a further prompt.
+	 *
+	 * So one line is sent - set raw mode, print a per-session sentinel, then
+	 * **`exec`** the command - and every byte up to and including that sentinel is
+	 * discarded. `exec` replaces the shell, which removes (3) and (4) for good
+	 * rather than filtering them; the sentinel is printed after `stty` has been
+	 * applied, so it lands past (2); it is random per session, so it cannot
+	 * collide with the command's own output; and it is emitted from two halves so
+	 * that the echoed command line does not contain it (see the send below).
 	 */
-	async openPty(sandbox: DaytonaSandbox, sessionId: string): Promise<DaytonaPty> {
+	async openPty(sandbox: DaytonaSandbox, sessionId: string, launch: string): Promise<DaytonaPty> {
 		const base = await this.toolboxBase(sandbox);
 		await fetch(`${base}/process/pty`, {
 			method: 'POST',
@@ -457,33 +486,71 @@ export class DaytonaClient implements DaytonaApi {
 
 		let onData: ((chunk: Uint8Array) => void) | undefined;
 		let onClose: (() => void) | undefined;
-		let sawControlFrame = false;
+		let closed = false;
 
 		await new Promise<void>((resolve, reject) => {
 			socket.onopen = () => resolve();
 			socket.onerror = () => reject(new Error('Daytona PTY connect failed'));
 		});
 
+		const sentinel = `__hezo_pty_${randomBytes(8).toString('hex')}__`;
+		const sentinelBytes = new TextEncoder().encode(sentinel);
+		let synced = false;
+		let preamble = new Uint8Array(0);
+		const ready = Promise.withResolvers<void>();
+
 		socket.onmessage = (event) => {
 			const raw =
 				typeof event.data === 'string'
 					? new TextEncoder().encode(event.data)
 					: new Uint8Array(event.data as ArrayBuffer);
-			if (!sawControlFrame) {
-				sawControlFrame = true;
-				// The opening control frame is JSON, not shell output; feeding it to
-				// the frame decoder would desynchronise the stream on byte one.
-				const text = new TextDecoder().decode(raw);
-				if (text.startsWith('{') && text.includes('"type":"control"')) return;
+			if (synced) {
+				onData?.(raw);
+				return;
 			}
-			onData?.(raw);
+			// Held rather than forwarded: the sentinel can be split across frames,
+			// so the search runs over the accumulation, not over one chunk.
+			preamble = concatBytes(preamble, raw);
+			const at = lastIndexOfBytes(preamble, sentinelBytes);
+			if (at === -1) return;
+			synced = true;
+			const rest = preamble.subarray(at + sentinelBytes.length);
+			preamble = new Uint8Array(0);
+			ready.resolve();
+			// Bytes past the sentinel are already the command's - a command that
+			// writes immediately would otherwise lose its first frame.
+			if (rest.length > 0) onData?.(rest);
 		};
-		socket.onclose = () => onClose?.();
+		socket.onclose = () => {
+			closed = true;
+			ready.reject(new Error('Daytona PTY closed before the launch completed'));
+			onClose?.();
+		};
 
-		// Raw mode before anything framed rides on it: without this the PTY echoes
-		// every byte written and rewrites \n as \r\n, which corrupts both
-		// directions of a binary protocol.
-		socket.send('stty raw -echo\n');
+		// The sentinel is emitted from two halves. While echo is still on the
+		// command line itself comes back, and a line carrying the sentinel
+		// *literally* would be matched by the search - syncing on the echo and
+		// forwarding the real one, which is the same corruption one step later
+		// (measured: the decoder then read the sentinel's own bytes as a header).
+		// Split across two arguments, the echoed line contains `'…_pty_' 'abc__'`
+		// and the contiguous sentinel appears exactly once, in the output.
+		const half = Math.ceil(sentinel.length / 2);
+		socket.send(
+			`stty raw -echo; printf '%s%s' ${shellQuoteSingle(sentinel.slice(0, half))} ` +
+				`${shellQuoteSingle(sentinel.slice(half))}; exec ${launch}\n`,
+		);
+
+		const timer = setTimeout(() => {
+			ready.reject(new Error(`Daytona PTY did not reach raw mode within ${PTY_SYNC_TIMEOUT_MS}ms`));
+		}, PTY_SYNC_TIMEOUT_MS);
+		try {
+			await ready.promise;
+		} catch (e) {
+			if (!closed) socket.close();
+			throw e;
+		} finally {
+			clearTimeout(timer);
+		}
 
 		return {
 			send: (data) => socket.send(data),
@@ -493,8 +560,44 @@ export class DaytonaClient implements DaytonaApi {
 			onClose: (handler) => {
 				onClose = handler;
 			},
-			close: () => socket.close(),
+			close: () => {
+				socket.close();
+				// Closing the socket does **not** end the session or kill what runs
+				// on it - measured: a process launched on a PTY was still listening
+				// after the WebSocket closed, and the session still read `active`.
+				// Only deleting the session terminates it.
+				//
+				// On Docker the equivalent close kills the exec, so a caller that
+				// only closed the socket would leak a process per channel on this
+				// backend alone. For the tunnel that leak is not cosmetic: the client
+				// holds the run's three loopback ports, and because a pooled
+				// container serves many runs in sequence, the *next* run's client
+				// dies with `EADDRINUSE` and the whole run loses MCP and egress.
+				trackBackground(
+					this.deletePtySession(sandbox, sessionId).catch((e) => {
+						log.warn(`could not delete PTY session ${sessionId}: ${(e as Error).message}`);
+					}),
+				);
+			},
 		};
+	}
+
+	/** End a PTY session, terminating whatever is running on it. */
+	private async deletePtySession(sandbox: DaytonaSandbox, sessionId: string): Promise<void> {
+		const base = await this.toolboxBase(sandbox);
+		const res = await fetch(`${base}/process/pty/${encodeURIComponent(sessionId)}`, {
+			method: 'DELETE',
+			headers: { Authorization: `Bearer ${this.apiKey}` },
+			signal: AbortSignal.timeout(CONTROL_TIMEOUT_MS),
+		});
+		// A session that is already gone is the desired end state, not an error.
+		if (!res.ok && res.status !== 404) {
+			throw new DaytonaApiError(
+				`Daytona DELETE /process/pty/${sessionId} failed (${res.status})`,
+				res.status,
+				await res.text(),
+			);
+		}
 	}
 
 	// ---- files -------------------------------------------------------------
@@ -592,4 +695,38 @@ export class DaytonaClient implements DaytonaApi {
 			`/files/permissions?path=${encodeURIComponent(path)}&mode=${mode.toString(8).padStart(3, '0')}`,
 		);
 	}
+}
+
+/**
+ * Single-quote a value for the shell. Local to the client because the PTY
+ * launch line is assembled here; `command.ts` owns the exec rendering and has
+ * its own copy of the same rule for the same reason.
+ */
+function shellQuoteSingle(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer> {
+	const out = new Uint8Array(a.length + b.length);
+	out.set(a, 0);
+	out.set(b, a.length);
+	return out;
+}
+
+/**
+ * Index of the last occurrence of `needle` in `haystack`, or -1.
+ *
+ * Searched from the end so that if the sentinel ever did appear twice, the sync
+ * lands on the later one - forwarding from an earlier match would leave the
+ * second copy in the stream, which is exactly the corruption being prevented.
+ */
+function lastIndexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
+	if (needle.length === 0 || haystack.length < needle.length) return -1;
+	outer: for (let start = haystack.length - needle.length; start >= 0; start--) {
+		for (let i = 0; i < needle.length; i++) {
+			if (haystack[start + i] !== needle[i]) continue outer;
+		}
+		return start;
+	}
+	return -1;
 }

--- a/packages/server/src/services/sandbox/daytona/engine.ts
+++ b/packages/server/src/services/sandbox/daytona/engine.ts
@@ -24,7 +24,12 @@ import type {
 	SandboxFiles,
 } from '../types';
 import { type DaytonaApi, DaytonaApiError, type DaytonaSandbox } from './client';
-import { renderDaytonaExec, renderDaytonaExecScript, renderStderrDrain } from './command';
+import {
+	asShellCommand,
+	renderDaytonaExec,
+	renderDaytonaExecScript,
+	renderStderrDrain,
+} from './command';
 import { daytonaSandboxFiles } from './files';
 
 const log = logger.child('daytona-engine');
@@ -410,24 +415,32 @@ export class DaytonaEngine implements ContainerEngine {
 	 * to recover here as there is for a normal exec - so `onStderr` never fires
 	 * and diagnostics arrive interleaved on `onData`, which is harmless because
 	 * the tunnel client writes none.
+	 *
+	 * The command is handed to `openPty` rather than typed in afterwards. A PTY
+	 * starts a login shell, so the command is *typed into* it - the inverse of a
+	 * Docker exec, where the command is the exec - and everything the shell emits
+	 * around accepting it (its own echo, the prompt, bracketed-paste sequences)
+	 * would land on this channel as leading bytes. A framed protocol cannot
+	 * tolerate any of them, so the launch and the sync that hides them are one
+	 * operation; see `openPty` for what each source of noise is.
 	 */
 	async openExecChannel(containerId: string, config: ExecConfig): Promise<ContainerByteChannel> {
 		const sandbox = await this.fetch(containerId);
 		if (!sandbox) throw new Error(`sandbox ${containerId} not found`);
 		const sessionId = `hezo-chan-${randomBytes(6).toString('hex')}`;
-		const pty = await this.client.openPty(sandbox, sessionId);
-
-		// The PTY starts a login shell, so the command is *typed into* it rather
-		// than being the process it launched - the inverse of a Docker exec, where
-		// the command is the exec. Sent after raw mode is applied by openPty.
-		pty.send(
-			new TextEncoder().encode(
-				`${renderDaytonaExecScript({
+		const pty = await this.client.openPty(
+			sandbox,
+			sessionId,
+			// `exec`ed by the launch line, so it replaces the shell rather than
+			// running under it - which is what stops a second prompt reaching the
+			// channel when the command ends.
+			asShellCommand(
+				renderDaytonaExecScript({
 					cmd: config.Cmd,
 					env: config.Env,
 					user: config.User,
 					stderrPath: `/tmp/.hezo-chan-${sessionId}.err`,
-				})}\n`,
+				}),
 			),
 		);
 

--- a/packages/server/src/services/sandbox/pool-db.ts
+++ b/packages/server/src/services/sandbox/pool-db.ts
@@ -271,3 +271,31 @@ export async function projectHasStrandedCommits(db: Db, projectId: string): Prom
 	);
 	return res.rows[0]?.pinned ?? false;
 }
+
+/**
+ * Pool members old enough to be worth checking against the engine, oldest first.
+ *
+ * `updated_at` rather than `created_at`: a member that just changed state is
+ * mid-transition and reconciling it would race the thing that moved it. The age
+ * floor is what keeps a container created moments ago from being judged missing
+ * before the provider can answer for it.
+ */
+export async function listPoolMembersForReconcile(
+	db: Db,
+	minAgeSeconds: number,
+	limit: number,
+): Promise<Array<{ containerId: string; projectId: string; state: string }>> {
+	const res = await db.query<{ container_id: string; project_id: string; state: string }>(
+		`SELECT container_id, project_id, state::text AS state
+		   FROM container_pool_members
+		  WHERE updated_at < now() - ($1 * interval '1 second')
+		  ORDER BY updated_at ASC
+		  LIMIT $2`,
+		[minAgeSeconds, limit],
+	);
+	return res.rows.map((r) => ({
+		containerId: r.container_id,
+		projectId: r.project_id,
+		state: r.state,
+	}));
+}

--- a/packages/server/src/services/sandbox/proc-scripts.ts
+++ b/packages/server/src/services/sandbox/proc-scripts.ts
@@ -98,3 +98,36 @@ export function buildKillPidsScript(pids: number[]): string {
 	}
 	return `kill -9 ${pids.join(' ')} 2>/dev/null || true`;
 }
+
+/**
+ * Report whether every one of `ports` is being listened on, on loopback.
+ *
+ * Reads `/proc/net/tcp` rather than shelling out to `ss` or `netstat`: the
+ * pseudo-file is always there, while the tools are packages a custom
+ * `docker_base_image` need not carry, and a missing tool would read as "not
+ * listening" forever.
+ *
+ * The file's `local_address` column is `<addr>:<port>` in **hex**, address
+ * little-endian - so 127.0.0.1 is `0100007F` - and the state column is `0A` for
+ * LISTEN. Matching on the port alone would accept a listener on any interface,
+ * which is not what the tunnel promises the container.
+ *
+ * Prints `ready` when all of them are up and nothing otherwise, so the caller
+ * tests one exact string rather than parsing.
+ */
+export function buildPortsListeningScript(ports: readonly number[]): string {
+	if (ports.length === 0) return 'echo ready';
+	for (const port of ports) {
+		if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+			throw new Error(`invalid port: ${String(port)}`);
+		}
+	}
+	// `0100007F` is 127.0.0.1 in the file's byte order; `0A` is TCP_LISTEN.
+	const tests = ports
+		.map((port) => {
+			const hex = port.toString(16).toUpperCase().padStart(4, '0');
+			return `grep -qi " 0100007F:${hex} .* 0A " /proc/net/tcp`;
+		})
+		.join(' && ');
+	return `${tests} && echo ready`;
+}

--- a/packages/server/src/services/sandbox/tunnel/run-tunnel.ts
+++ b/packages/server/src/services/sandbox/tunnel/run-tunnel.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../logger';
 import type { ContainerRunUser } from '../../container-user';
 import { type RunEndpoints, tunnelRunEndpoints } from '../endpoints';
 import type { SandboxFiles } from '../files';
+import { buildPortsListeningScript } from '../proc-scripts';
 import type { ContainerByteChannel, ContainerEngine } from '../types';
 import { TunnelMux } from './mux';
 import { connectToRunTargets, type TargetAddresses } from './net-socket';
@@ -41,10 +42,17 @@ export interface StartRunTunnelOptions {
 	addresses: TargetAddresses;
 	/** Which hosts the container must route through the egress proxy. */
 	policy: TunnelHostPolicy;
+	/** Test hook: shortens the wait for the client to bind. */
+	listenTimeoutMs?: number;
 }
 
 /**
  * Start the tunnel and return the endpoints the run should use.
+ *
+ * **The endpoints work by the time this resolves.** Opening the channel only
+ * starts the client, so this waits for it to bind and **fails the run** if it
+ * never does - see {@link waitForTunnelListeners} for why returning early is
+ * worse than failing.
  *
  * **The returned `close` is not optional.** A live channel counts as activity
  * on every backend, so a tunnel left open keeps the container from ever going
@@ -101,15 +109,81 @@ export async function startRunTunnel(opts: StartRunTunnelOptions): Promise<RunTu
 	channel.onClose(() => mux.closeAll());
 
 	let closed = false;
-	return {
-		endpoints: tunnelRunEndpoints(allocation.ports),
-		close: () => {
-			if (closed) return;
-			closed = true;
-			// Closing the mux closes the channel, which ends the client's stdin and
-			// makes it fail closed on its side too.
-			mux.closeAll();
-			allocation.release();
-		},
+	const close = () => {
+		if (closed) return;
+		closed = true;
+		// Closing the mux closes the channel, which ends the client's stdin and
+		// makes it fail closed on its side too.
+		mux.closeAll();
+		allocation.release();
 	};
+
+	try {
+		await waitForTunnelListeners(
+			opts.engine,
+			opts.containerId,
+			allocation.ports,
+			opts.listenTimeoutMs ?? LISTEN_TIMEOUT_MS,
+		);
+	} catch (err) {
+		close();
+		throw err;
+	}
+
+	return { endpoints: tunnelRunEndpoints(allocation.ports), close };
+}
+
+/** How long the in-container client has to bind before the run is failed. */
+const LISTEN_TIMEOUT_MS = 30_000;
+const LISTEN_POLL_MS = 150;
+
+/**
+ * Block until the client is actually listening on its loopback ports.
+ *
+ * Opening the channel only *starts* the client; it is a process that still has
+ * to boot and bind. Returning before it has means handing the run endpoints that
+ * refuse connections, and the runtimes dial them immediately - a coding CLI that
+ * gets `ECONNREFUSED` on the MCP endpoint marks that server failed **for the
+ * whole session** rather than retrying, so the agent runs to completion with no
+ * Hezo tools at all and the run reads as the agent having done nothing.
+ *
+ * Measured on Daytona: the listeners appear ~1s after `openExecChannel` resolves,
+ * because the sandbox has to exec a shell, `runuser`, then node. The window is
+ * smaller on a local daemon but it is the same race, so the wait is here rather
+ * than in either adapter.
+ *
+ * A timeout **fails the run**. There is no useful degraded mode: without the
+ * tunnel the container cannot reach MCP, the egress proxy or the ssh-agent, and
+ * proceeding would produce exactly the silent no-op run this exists to prevent.
+ */
+async function waitForTunnelListeners(
+	engine: ContainerEngine,
+	containerId: string,
+	ports: { proxy: number; mcp: number; ssh: number },
+	timeoutMs: number,
+): Promise<void> {
+	const script = buildPortsListeningScript([ports.proxy, ports.mcp, ports.ssh]);
+	const deadline = Date.now() + timeoutMs;
+	let lastError = '';
+	while (Date.now() < deadline) {
+		try {
+			const execId = await engine.execCreate(containerId, {
+				Cmd: ['sh', '-c', script],
+				User: 'root',
+				AttachStdout: true,
+				AttachStderr: false,
+			});
+			const { stdout } = await engine.execStart(execId);
+			if (stdout.includes('ready')) return;
+		} catch (err) {
+			// A container that is still settling can refuse an exec; keep trying
+			// until the deadline rather than failing on the first one.
+			lastError = err instanceof Error ? err.message : String(err);
+		}
+		await new Promise((resolve) => setTimeout(resolve, LISTEN_POLL_MS));
+	}
+	throw new Error(
+		`the tunnel client did not bind its ports within ${timeoutMs}ms` +
+			`${lastError ? ` (last error: ${lastError})` : ''}`,
+	);
 }

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -808,6 +808,69 @@ describe('runAgent lifecycle — aborts and timeout', () => {
 		expect(run.rows[0].error).toBe('run reached its time limit');
 	});
 
+	it('marks the run timed_out even when the engine does not raise an AbortError', async () => {
+		// The sibling test above throws a real `AbortError`, which is what Docker's
+		// exec does when its attach is torn down. A managed backend's exec is under
+		// no such obligation - Daytona's rejects with an ordinary Error - and
+		// keying the status on the error's *name* recorded a timed-out run as
+		// `failed` while still stamping it with the timeout's own message
+		// (measured live: exit -1, status `failed`, error "run reached its time
+		// limit"). The status has to come from the signal, which is the same on
+		// every backend.
+		//
+		// It is not cosmetic: the consecutive-timeout escalation in
+		// `JobManager.onAgentComplete` reads this column, so on such a backend a
+		// task that times out repeatedly is never escalated.
+		const ac = new AbortController();
+		const docker = makeDocker({
+			producesOutput: false,
+			execStart: async () => {
+				ac.abort('run_timeout');
+				throw new Error('socket closed');
+			},
+		});
+		const result = await runAgent(
+			baseDeps(docker),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+		expect(result.timedOut).toBe(true);
+		const run = await db.query<{ status: string; error: string | null }>(
+			'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.TimedOut);
+		expect(run.rows[0].error).toBe('run reached its time limit');
+	});
+
+	it('still fails a run whose error is not an abort at all', async () => {
+		// The other half of the same branch: with no abort reason on the signal a
+		// thrown error is a genuine failure, not a timeout and not a cancel.
+		const docker = makeDocker({
+			producesOutput: false,
+			execStart: async () => {
+				throw new Error('boom');
+			},
+		});
+		const result = await runAgent(
+			baseDeps(docker),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			new AbortController().signal,
+		);
+		expect(result.timedOut).toBeFalsy();
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+	});
+
 	it('finalizes a cancelled run when the abort lands between run creation and credential lock', async () => {
 		const ac = new AbortController();
 		let execCreated = false;

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -182,7 +182,66 @@ export function createStubDocker<T extends object>(
 		ctx?.db && ctx?.dataDir ? [{ db: ctx.db, dataDir: ctx.dataDir }] : testContexts;
 	const files: ContainerEngine['files'] = (containerId, containerRoot) =>
 		firstResolvableFiles(candidates, containerId, containerRoot);
-	return { ...STUB_DOCKER_METHODS, files, ...overrides } as ContainerEngine & T;
+	const merged = { ...STUB_DOCKER_METHODS, files, ...overrides } as ContainerEngine & T;
+	return withTunnelReadyStub(merged);
+}
+
+/**
+ * Answer the tunnel's port-readiness check, whatever the caller's exec stubs do.
+ *
+ * `startRunTunnel` will not hand a run its endpoints until the client's ports
+ * are listening, so an engine that never answers leaves every run and every chat
+ * turn waiting out the full timeout and then failing. Wrapping rather than
+ * merging is what makes that true for the many specs that replace `execCreate`
+ * and `execStart` wholesale - the same reason `withRunUserStub` wraps the
+ * run-user probe and the chowns instead of relying on a default.
+ *
+ * A stubbed container's tunnel comes up. A spec that wants the opposite drives
+ * `startRunTunnel` against its own engine (`sandbox-run-tunnel.test.ts`).
+ */
+function withTunnelReadyStub<T extends ContainerEngine>(engine: T): T {
+	const ready = new Set<string>();
+	let seq = 0;
+
+	const execCreate = async (
+		containerId: string,
+		config: Parameters<ContainerEngine['execCreate']>[1],
+	) => {
+		if ((config?.Cmd ?? []).some((part) => part.includes('/proc/net/tcp'))) {
+			const id = `__tunnel-ready-${seq++}`;
+			ready.add(id);
+			return id;
+		}
+		return engine.execCreate(containerId, config);
+	};
+	const execStart = async (execId: string, opts: Parameters<ContainerEngine['execStart']>[1]) => {
+		if (ready.delete(execId)) return { stdout: 'ready\n', stderr: '' };
+		return engine.execStart(execId, opts);
+	};
+
+	return {
+		...engine,
+		// Spy metadata is carried across, so a spec that asserts on
+		// `docker.execCreate.mock.calls` still sees the calls it made - wrapping
+		// must not cost a test its ability to inspect its own stub.
+		execCreate: preserveSpy(execCreate, engine.execCreate),
+		execStart: preserveSpy(execStart, engine.execStart),
+		execInspect: async (execId: string) => {
+			if (execId.startsWith('__tunnel-ready-')) return { ExitCode: 0, Running: false, Pid: 0 };
+			return engine.execInspect(execId);
+		},
+	} as T;
+}
+
+/** Copy a mock's own properties (`mock`, `mockClear`, …) onto the function wrapping it. */
+function preserveSpy<F extends (...args: never[]) => unknown>(wrapper: F, original: unknown): F {
+	if (typeof original !== 'function') return wrapper;
+	for (const key of Object.getOwnPropertyNames(original)) {
+		if (key === 'length' || key === 'name' || key === 'prototype') continue;
+		const descriptor = Object.getOwnPropertyDescriptor(original, key);
+		if (descriptor) Object.defineProperty(wrapper, key, descriptor);
+	}
+	return wrapper;
 }
 
 /**

--- a/packages/server/test/helpers/run-user-docker.ts
+++ b/packages/server/test/helpers/run-user-docker.ts
@@ -6,19 +6,26 @@ export const STUB_RUN_USER = { name: 'node', uid: 1000, gid: 1000 };
 type ExecCreateConfig = Parameters<ContainerEngine['execCreate']>[1];
 type ExecStartOpts = Parameters<ContainerEngine['execStart']>[1];
 
-function classify(cmd?: string[]): 'probe' | 'chown' | null {
+function classify(cmd?: string[]): 'probe' | 'chown' | 'tunnel-ready' | null {
 	if (!cmd || cmd[0] !== 'sh' || cmd[1] !== '-c') return null;
 	const s = cmd[2] ?? '';
 	if (s.startsWith('id -u')) return 'probe';
 	if (s.startsWith('chown ')) return 'chown';
+	// The tunnel's readiness check. `startRunTunnel` will not hand a run its
+	// endpoints until the client's ports are listening, so a fake that never
+	// answers this leaves every run waiting out the full timeout and then
+	// failing. Answering it models a container whose tunnel comes up, which is
+	// what these tests all assume; a test that wants the opposite overrides
+	// `execStart` itself (see sandbox-run-tunnel.test.ts).
+	if (s.includes('/proc/net/tcp')) return 'tunnel-ready';
 	return null;
 }
 
 /**
- * Wrap a mock {@link ContainerEngine} so the container run-user probe (`id -u node …`)
- * and the ownership chowns Hezo issues are answered transparently — yielding a
- * `node` run-user and a clean exit — and are NEVER forwarded to the wrapped
- * client's exec handlers. Lets run-user detection work in unit tests (which fake
+ * Wrap a mock {@link ContainerEngine} so the infrastructure execs Hezo issues on
+ * its own behalf — the container run-user probe (`id -u node …`), the ownership
+ * chowns, and the tunnel's port-readiness check — are answered transparently and
+ * are NEVER forwarded to the wrapped client's exec handlers. Lets run-user detection work in unit tests (which fake
  * Docker) without polluting tests that record or inspect the agent's own exec.
  * Pass a custom `user` to simulate a different / no-node image.
  */
@@ -26,7 +33,7 @@ export function withRunUserStub(
 	docker: ContainerEngine,
 	user: { name: string; uid: number; gid: number } = STUB_RUN_USER,
 ): ContainerEngine {
-	const infra = new Map<string, 'probe' | 'chown'>();
+	const infra = new Map<string, 'probe' | 'chown' | 'tunnel-ready'>();
 	let seq = 0;
 	return {
 		...docker,
@@ -44,6 +51,7 @@ export function withRunUserStub(
 			if (kind === 'probe') {
 				return { stdout: `${user.uid}\n${user.gid}\n${user.name}\n`, stderr: '' };
 			}
+			if (kind === 'tunnel-ready') return { stdout: 'ready\n', stderr: '' };
 			if (kind === 'chown') return { stdout: '', stderr: '' };
 			return docker.execStart(execId, opts);
 		},

--- a/packages/server/test/sandbox-daytona-engine.test.ts
+++ b/packages/server/test/sandbox-daytona-engine.test.ts
@@ -14,6 +14,9 @@ interface Recorded {
 	started: string[];
 	stopped: string[];
 	destroyed: string[];
+	/** Launch lines handed to `openPty`, and anything written to the channel after. */
+	ptyLaunches: string[];
+	ptyWrites: Uint8Array[];
 }
 
 /**
@@ -24,7 +27,15 @@ function fakeApi(
 	overrides: Partial<DaytonaApi> = {},
 	seed: DaytonaSandbox[] = [],
 ): { api: DaytonaApi; rec: Recorded; sandboxes: Map<string, DaytonaSandbox> } {
-	const rec: Recorded = { creates: [], commands: [], started: [], stopped: [], destroyed: [] };
+	const rec: Recorded = {
+		creates: [],
+		commands: [],
+		started: [],
+		stopped: [],
+		destroyed: [],
+		ptyLaunches: [],
+		ptyWrites: [],
+	};
 	const sandboxes = new Map(seed.map((s) => [s.id, s]));
 	// The file half is a real (if flat) tree rather than five no-ops: a write the
 	// fake forgets would let a read-back assertion pass against nothing.
@@ -69,12 +80,15 @@ function fakeApi(
 				sandboxes.delete(id);
 			},
 			getMetrics: async () => new Map(),
-			openPty: async () => ({
-				send: () => {},
-				onData: () => {},
-				onClose: () => {},
-				close: () => {},
-			}),
+			openPty: async (_s, _sessionId, launch) => {
+				rec.ptyLaunches.push(launch);
+				return {
+					send: (data) => rec.ptyWrites.push(data),
+					onData: () => {},
+					onClose: () => {},
+					close: () => {},
+				};
+			},
 			execute: async (_s, command) => {
 				rec.commands.push(command);
 				return { exitCode: 0, output: '' };
@@ -595,5 +609,91 @@ describe('DaytonaEngine settles a transition before returning', () => {
 				new Promise((resolve) => setTimeout(() => resolve('still waiting'), 300)),
 			]),
 		).resolves.toBe('still waiting');
+	});
+});
+
+describe('DaytonaEngine byte channel (the tunnel transport)', () => {
+	// A PTY starts a login shell, so anything the shell emits around accepting a
+	// command lands on the channel ahead of the command's own first byte - and
+	// the tunnel's decoder reads whatever arrives first as
+	// `[u8 type][u32 streamId][u32 len]`. Against the live API this was fatal
+	// rather than cosmetic: the shell's echo of `stty raw -echo` decoded as a
+	// frame of length 1918990112 ("raw " read as a u32), the mux closed the
+	// channel on the spot, and every agent run on Daytona then failed with the
+	// Hezo MCP server unreachable. These assertions pin the shape that fixed it.
+
+	it('launches the command with the PTY rather than typing it in afterwards', async () => {
+		const { api, rec } = fakeApi({}, [SBX]);
+		await new DaytonaEngine(api).openExecChannel('sbx-1', {
+			Cmd: ['hezo-tunnel', '/workspace/.hezo/tunnel.json'],
+			User: 'node',
+			AttachStdout: true,
+			AttachStderr: true,
+		});
+		expect(rec.ptyLaunches).toHaveLength(1);
+		expect(rec.ptyLaunches[0]).toContain('hezo-tunnel');
+		// Nothing is written to the channel by opening it. A command typed in
+		// after the fact is echoed by the shell, and that echo is the corruption.
+		expect(rec.ptyWrites).toEqual([]);
+	});
+
+	it('deprivileges the launched command the same way a normal exec does', async () => {
+		const { api, rec } = fakeApi({}, [SBX]);
+		await new DaytonaEngine(api).openExecChannel('sbx-1', {
+			Cmd: ['hezo-tunnel', '/cfg.json'],
+			User: 'node',
+			AttachStdout: true,
+			AttachStderr: true,
+		});
+		// Daytona execs as root, so the tunnel client would run as root without
+		// this - a root-owned process in a container the agent otherwise owns.
+		expect(rec.ptyLaunches[0]).toMatch(/runuser.+-u.+node/);
+		// And its stderr goes to a file, not down the channel: a diagnostic from
+		// `runuser` interleaved into the frame stream corrupts it just as the
+		// shell's own echo did.
+		expect(rec.ptyLaunches[0]).toMatch(/2>.*\.err/);
+	});
+
+	it('writes only what the caller writes, once the channel is open', async () => {
+		const { api, rec } = fakeApi({}, [SBX]);
+		const channel = await new DaytonaEngine(api).openExecChannel('sbx-1', {
+			Cmd: ['hezo-tunnel', '/cfg.json'],
+			AttachStdout: true,
+			AttachStderr: true,
+		});
+		channel.write(new Uint8Array([1, 2, 3]));
+		expect(rec.ptyWrites).toEqual([new Uint8Array([1, 2, 3])]);
+	});
+
+	it('closing the channel is what must terminate the in-container process', async () => {
+		// On Docker, closing the hijacked exec kills the process. On Daytona the
+		// WebSocket close does neither - measured: a process launched on a PTY was
+		// still listening after the socket closed, and the session still read
+		// `active: true`. Only deleting the session ends it, so `close()` has to do
+		// more than close the socket. The leak is not cosmetic: the tunnel client
+		// holds the run's three loopback ports, and a pooled container serves many
+		// runs in sequence, so the next run's client dies with EADDRINUSE and that
+		// run loses MCP and egress entirely.
+		let closes = 0;
+		const { api } = fakeApi(
+			{
+				openPty: async () => ({
+					send: () => {},
+					onData: () => {},
+					onClose: () => {},
+					close: () => {
+						closes += 1;
+					},
+				}),
+			},
+			[SBX],
+		);
+		const channel = await new DaytonaEngine(api).openExecChannel('sbx-1', {
+			Cmd: ['hezo-tunnel', '/cfg.json'],
+			AttachStdout: true,
+			AttachStderr: true,
+		});
+		channel.close();
+		expect(closes).toBe(1);
 	});
 });

--- a/packages/server/test/sandbox-disk-usage.test.ts
+++ b/packages/server/test/sandbox-disk-usage.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { parseDfKilobytes } from '../src/services/docker';
 import { POOL_DISK_CEILING_BYTES } from '../src/services/sandbox/pool';
-import { buildDiskUsageScript } from '../src/services/sandbox/proc-scripts';
+import {
+	buildDiskUsageScript,
+	buildPortsListeningScript,
+} from '../src/services/sandbox/proc-scripts';
 
 /**
  * The measurement the pool's recycle rung is decided on.
@@ -55,5 +58,52 @@ describe('parseDfKilobytes', () => {
 		const overKb = String(Math.ceil(POOL_DISK_CEILING_BYTES / 1024) + 1);
 		expect(parseDfKilobytes(overKb)).toBeGreaterThan(POOL_DISK_CEILING_BYTES);
 		expect(parseDfKilobytes('1024')).toBeLessThan(POOL_DISK_CEILING_BYTES);
+	});
+});
+
+/**
+ * The readiness check the tunnel gates a run on.
+ *
+ * `startRunTunnel` will not hand a run its endpoints until this reports the
+ * client's ports up. Getting it wrong in the permissive direction is the
+ * expensive one: a check that reads "ready" too early returns endpoints that
+ * refuse connections, and a coding CLI that gets ECONNREFUSED on the MCP
+ * endpoint marks that server failed for the whole session - so the agent runs to
+ * completion with no Hezo tools and the run reads as it having done nothing.
+ */
+describe('buildPortsListeningScript', () => {
+	it('reads /proc rather than depending on a tool the image may not carry', () => {
+		// `ss` and `netstat` are packages; a custom docker_base_image need not have
+		// them, and a missing binary would read as "not listening" forever.
+		const script = buildPortsListeningScript([47080]);
+		expect(script).toContain('/proc/net/tcp');
+		expect(script).not.toMatch(/\bss\b|netstat/);
+	});
+
+	it('matches the port on loopback specifically, in the file’s own encoding', () => {
+		// `local_address` is hex with the address little-endian, so 127.0.0.1 is
+		// 0100007F; `0A` is TCP_LISTEN. Matching the port alone would accept a
+		// listener on another interface, which is not what the container is
+		// promised.
+		const script = buildPortsListeningScript([47081]);
+		expect(script).toContain('0100007F:B7E9');
+		expect(script).toContain(' 0A ');
+	});
+
+	it('requires every port, not any of them', () => {
+		// The run needs all three targets; one bound listener is not readiness.
+		const script = buildPortsListeningScript([47080, 47081, 47082]);
+		expect(script.split('&&').length).toBe(4); // three tests plus the echo
+		for (const hex of ['B7E8', 'B7E9', 'B7EA']) expect(script).toContain(`0100007F:${hex}`);
+	});
+
+	it('prints one exact token so the caller tests a string rather than parsing', () => {
+		expect(buildPortsListeningScript([47080])).toMatch(/&& echo ready$/);
+	});
+
+	it('rejects a port that could not be a port', () => {
+		expect(() => buildPortsListeningScript([0])).toThrow(/invalid port/);
+		expect(() => buildPortsListeningScript([70000])).toThrow(/invalid port/);
+		expect(() => buildPortsListeningScript([1.5])).toThrow(/invalid port/);
 	});
 });

--- a/packages/server/test/sandbox-pool-db.test.ts
+++ b/packages/server/test/sandbox-pool-db.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { PgliteDb } from '../src/db/drivers/pglite';
+import { reconcilePoolMembers } from '../src/services/containers';
 import {
 	projectHasStrandedCommits,
 	setPoolMemberUnpushedFlag,
@@ -107,5 +108,99 @@ describe('setPoolMemberUnpushedFlag', () => {
 	it('stops reporting a project once its last pin clears', async () => {
 		await setPoolMemberUnpushedFlag(db, 'ctr-b', false);
 		expect(await projectHasStrandedCommits(db, projectId)).toBe(false);
+	});
+});
+
+/**
+ * Reconciling pool members against the engine.
+ *
+ * The acquire path repairs a stale member only on the rungs it picks - and it
+ * never picks a `busy` one, so a run that died without releasing its row leaves
+ * a member nothing revisits. Because `getActiveContainers` counts `busy` towards
+ * the instance memory budget, each orphan permanently consumes capacity until
+ * every run in the project fails admission.
+ */
+describe('reconcilePoolMembers', () => {
+	let db: PgliteDb;
+	let projectId: string;
+
+	const seed = async (containerId: string, state: string, ageSeconds: number) => {
+		await db.query(
+			`INSERT INTO container_pool_members (project_id, container_id, state, updated_at)
+			 VALUES ($1, $2, $3::container_pool_state, now() - ($4 * interval '1 second'))`,
+			[projectId, containerId, state, ageSeconds],
+		);
+	};
+	const remaining = async (): Promise<string[]> => {
+		const r = await db.query<{ container_id: string }>(
+			'SELECT container_id FROM container_pool_members ORDER BY container_id',
+		);
+		return r.rows.map((x) => x.container_id);
+	};
+	/** Engine that knows only `known`, 404s the rest, and throws for `unanswerable`. */
+	const engine = (known: string[], unanswerable: string[] = []) =>
+		({
+			inspectContainer: async (id: string) => {
+				if (unanswerable.includes(id)) throw new Error('API unreachable');
+				return known.includes(id)
+					? {
+							Id: id,
+							State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+							Config: { Image: 'x' },
+						}
+					: null;
+			},
+		}) as unknown as Parameters<typeof reconcilePoolMembers>[0]['docker'];
+
+	beforeAll(async () => {
+		db = await createTestDbWithMigrations();
+		const team = await db.query<{ id: string }>(
+			"INSERT INTO teams (name, slug) VALUES ('rec', 'rec') RETURNING id",
+		);
+		const project = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'rec', 'rec', 'REC') RETURNING id`,
+			[team.rows[0].id],
+		);
+		projectId = project.rows[0].id;
+	});
+	afterAll(() => db.close());
+	// Each case owns the whole table: a member left behind by a previous case
+	// would be judged missing by the next one's engine and inflate its count.
+	beforeEach(() => db.query('DELETE FROM container_pool_members'));
+
+	it('drops a busy member whose container is gone — the case nothing else repairs', async () => {
+		await seed('gone-busy', 'busy', 300);
+		await seed('live-busy', 'busy', 300);
+		const dropped = await reconcilePoolMembers({
+			db,
+			docker: engine(['live-busy']),
+		} as unknown as Parameters<typeof reconcilePoolMembers>[0]);
+		expect(dropped).toBe(1);
+		expect(await remaining()).toEqual(['live-busy']);
+	});
+
+	it('leaves a member alone when the engine could not answer', async () => {
+		// A timeout or an unreachable API proves nothing. Deleting the row on an
+		// unanswerable check would lose the record of a live container and orphan
+		// it on the backend, which is the strictly worse failure.
+		await seed('unanswerable', 'idle', 300);
+		const dropped = await reconcilePoolMembers({
+			db,
+			docker: engine([], ['unanswerable']),
+		} as unknown as Parameters<typeof reconcilePoolMembers>[0]);
+		expect(dropped).toBe(0);
+		expect(await remaining()).toContain('unanswerable');
+	});
+
+	it('does not judge a member that was only just touched', async () => {
+		// A container created moments ago may not be answerable for yet, and a
+		// member mid-transition would be racing whatever moved it.
+		await seed('fresh', 'creating', 1);
+		const dropped = await reconcilePoolMembers({
+			db,
+			docker: engine([]),
+		} as unknown as Parameters<typeof reconcilePoolMembers>[0]);
+		expect(dropped).toBe(0);
+		expect(await remaining()).toContain('fresh');
 	});
 });

--- a/packages/server/test/sandbox-run-tunnel.test.ts
+++ b/packages/server/test/sandbox-run-tunnel.test.ts
@@ -21,13 +21,27 @@ function scratch(): string {
 	return dir;
 }
 
-/** Records the exec the tunnel asks for, and whether its channel was closed. */
-function recordingEngine() {
+/**
+ * Records the exec the tunnel asks for, and whether its channel was closed.
+ *
+ * The readiness probe is modelled rather than stubbed away: `startRunTunnel`
+ * will not return until the client's ports are listening, so a fake that always
+ * answered `ready` would make the tests pass for a reason production does not
+ * have. `listening` starts false and is flipped when the channel is opened,
+ * which is what a real container does.
+ */
+function recordingEngine(opts: { neverBinds?: boolean } = {}) {
 	const execs: ExecConfig[] = [];
-	const state = { closed: false, stderr: undefined as ((c: Uint8Array) => void) | undefined };
-	const engine = createStubDocker({
+	const state = {
+		closed: false,
+		listening: false,
+		stderr: undefined as ((c: Uint8Array) => void) | undefined,
+	};
+	const probes: string[] = [];
+	const base = createStubDocker({
 		openExecChannel: async (_id: string, config: ExecConfig): Promise<ContainerByteChannel> => {
 			execs.push(config);
+			state.listening = true;
 			return {
 				write: () => {},
 				onData: () => {},
@@ -41,7 +55,22 @@ function recordingEngine() {
 			};
 		},
 	});
-	return { engine, execs, state };
+	// Layered *outside* `createStubDocker`, which answers the readiness probe for
+	// every other spec so their runs are not left waiting it out. This spec is the
+	// one testing that probe, so it has to see and answer it itself.
+	const engine = {
+		...base,
+		execCreate: async (_id: string, config: ExecConfig) => {
+			probes.push((config?.Cmd ?? []).join(' '));
+			return 'exec-1';
+		},
+		execStart: async () => ({
+			stdout: state.listening && !opts.neverBinds ? 'ready\n' : '',
+			stderr: '',
+			exitCode: 0,
+		}),
+	} as unknown as ReturnType<typeof createStubDocker>;
+	return { engine, execs, state, probes };
 }
 
 const ADDRESSES = {
@@ -50,8 +79,13 @@ const ADDRESSES = {
 	ssh: { host: '127.0.0.1', port: 3 },
 };
 
-function start(root: string, engine: ReturnType<typeof recordingEngine>['engine']) {
+function start(
+	root: string,
+	engine: ReturnType<typeof recordingEngine>['engine'],
+	listenTimeoutMs?: number,
+) {
 	return startRunTunnel({
+		...(listenTimeoutMs === undefined ? {} : { listenTimeoutMs }),
 		engine,
 		containerId: 'c1',
 		runUser: NODE_USER,
@@ -136,5 +170,35 @@ describe('startRunTunnel', () => {
 		// tunnel problem shows up as a log line rather than a dead stream.
 		expect(state.stderr).toBeDefined();
 		expect(() => state.stderr?.(new TextEncoder().encode('framing error'))).not.toThrow();
+	});
+
+	it('does not return until the client is actually listening', async () => {
+		// Opening the channel only *starts* the client; it still has to boot and
+		// bind. Returning early hands the run endpoints that refuse connections,
+		// and a coding CLI that gets ECONNREFUSED on the MCP endpoint marks that
+		// server failed for the whole session rather than retrying - so the agent
+		// runs with no Hezo tools and the run reads as it having done nothing.
+		// Measured on Daytona: the listeners appear ~1s after the channel opens.
+		const root = scratch();
+		const { engine, probes } = recordingEngine();
+		const tunnel = await start(root, engine);
+
+		const port = Number(/:(\d+)$/.exec(tunnel.endpoints.hezoBaseUrl)?.[1]);
+		expect(probes.length).toBeGreaterThan(0);
+		// It asks about the ports it just handed out, on loopback specifically -
+		// a listener on another interface is not what the container was promised.
+		const hex = port.toString(16).toUpperCase().padStart(4, '0');
+		expect(probes.join(' ')).toContain(`0100007F:${hex}`);
+	});
+
+	it('fails the run when the client never binds', async () => {
+		// There is no useful degraded mode: without the tunnel the container
+		// cannot reach MCP, the egress proxy or the ssh-agent, so proceeding
+		// would produce exactly the silent no-op run this exists to prevent.
+		const root = scratch();
+		const { engine, state } = recordingEngine({ neverBinds: true });
+		await expect(start(root, engine, 500)).rejects.toThrow(/did not bind its ports/);
+		// And it does not leak the channel it opened on the way out.
+		expect(state.closed).toBe(true);
 	});
 });

--- a/packages/server/test/sandbox-tunnel-net.test.ts
+++ b/packages/server/test/sandbox-tunnel-net.test.ts
@@ -13,7 +13,14 @@ afterEach(async () => {
 
 /** A TCP echo server on an ephemeral port. */
 async function echoServer(): Promise<number> {
-	const server = createServer((socket) => socket.pipe(socket));
+	const server = createServer((socket) => {
+		// `pipe` does not forward errors, so a client that destroys mid-exchange
+		// (which the backpressure case does deliberately) leaves an ECONNRESET on
+		// this side with no listener - an uncaught exception that fails the whole
+		// run, and only under enough load to lose the race.
+		socket.on('error', () => {});
+		socket.pipe(socket);
+	});
 	servers.push(server);
 	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
 	const address = server.address();

--- a/packages/server/test/sandbox-worktree-gc.test.ts
+++ b/packages/server/test/sandbox-worktree-gc.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { TaskStatus } from '@hezo/shared';
@@ -26,7 +26,11 @@ import { createTestDbWithMigrations } from './helpers/db';
  * the shared store, which is what makes this mandatory rather than housekeeping.
  */
 
-const root = mkdtempSync(join(tmpdir(), 'worktree-gc-'));
+// Resolved, because git reports worktree paths with symlinks followed. On macOS
+// `tmpdir()` is `/var/folders/…`, a symlink to `/private/var/folders/…`, so an
+// unresolved root is 8 characters shorter than what `git worktree list` prints -
+// and every path this fixture slices by that prefix comes out shifted.
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'worktree-gc-')));
 const exec = new HostGitExecutor();
 
 function run(cmd: string, cwd?: string): string {

--- a/packages/web/test/agent-hire.test.tsx
+++ b/packages/web/test/agent-hire.test.tsx
@@ -149,7 +149,11 @@ test('hire form reports-to dropdown defaults to Captain and posts the chosen man
 
 	const select = (await findByLabelText('Reports to')) as HTMLSelectElement;
 	// Options populate once the team roster loads; default selection is the Captain.
-	await findByText('Architect');
+	// Asserted against the select's own options rather than by finding the text
+	// anywhere on the page: a role name can also appear in a roster list left in
+	// `document.body` by an earlier spec, which makes a bare text query ambiguous
+	// under a full run while passing in isolation.
+	await waitFor(() => expect([...select.options].map((o) => o.value)).toContain('architect'));
 	await waitFor(() => expect(select.value).toBe('captain'));
 
 	await user.selectOptions(select, 'architect');


### PR DESCRIPTION
Driving a real agent run against the **live Daytona API** showed the tunnel had never carried a single frame there, so every run on that backend was a guaranteed no-op: no MCP, no egress proxy, no ssh-agent. The earlier live pass could not reach the tunnel at all (its network blocked WebSocket upgrades), so three defects had been sitting behind that gap.

## The tunnel

**The channel was destroyed by its own first bytes.** `openPty` sent `stty raw -echo` and returned, so the PTY's echo of that command - produced precisely because echo was still on - was the first thing handed to the frame decoder:

| header field | value | as ASCII |
|---|---|---|
| type | 115 | `s` |
| streamId | 1953984032 | `tty ` |
| len | 1918990112 | `raw ` |

Two more sources sat behind it, and bash emits bracketed-paste sequences around every command **even with echo off**, so raw mode does not remove them. The launch is now folded into `openPty` as one line - set raw mode, print a per-session sentinel, then `exec` the command - with nothing delivered until that sentinel. `exec` replaces the shell, which removes the prompt and the paste sequences structurally rather than filtering them. The sentinel is emitted from two halves so the still-echoed command line cannot contain it; printed whole, the sync fired on the echoed copy and forwarded the real one, moving the corruption one step later instead of removing it.

**Closing the socket does not end the session or kill what runs on it** - measured: a process was still listening afterwards and the session still read `active`. Only `DELETE /process/pty/{id}` terminates it. On Docker the equivalent close kills the exec, so without this it leaks a process per channel on Daytona alone - and the leaked client holds the run's three loopback ports, so with a pooled container serving many runs in sequence the next run's client died with `EADDRINUSE`.

**`startRunTunnel` returned ~1s before the client had bound.** A coding CLI that gets `ECONNREFUSED` on the MCP endpoint marks that server failed *for the whole session* rather than retrying, so the agent ran to completion with no Hezo tools and the run read as the agent having done nothing (`tools=25` instead of `tools=97` was the tell). It now waits for the ports and **fails the run** if they never appear - there is no useful degraded mode. The wait lives in the shared tunnel code because the race is Docker's too, just narrower.

## Two defects the tunnel was masking

- **A timed-out run was recorded `failed`.** The status was keyed on the thrown error's *name* (`AbortError`) while the abort *reason* was read separately - and only Docker reliably rejects that way. The signal decides it now, which is what the consecutive-timeout escalation reads.
- **A `busy` pool member whose container was gone was never repaired.** The acquire path only verifies a member the ladder picks, and it never picks a busy one, so each orphan permanently consumed the memory budget until every run failed admission with "no container available". `reconcilePoolMembers` runs from `container-sync` and drops them - on a definite answer only, since a throw means "could not determine" and deleting on that would orphan a live container.

## Verification

An agent run now completes on Daytona end to end: DeepSeek through Claude Code, `tools=97`, `create_comment` and `update_task` landing over MCP, run `succeeded`, tokens priced from the table. Also exercised live: run logs streaming over the WebSocket, suspend/resume with the filesystem intact, the pool serving concurrent runs one-per-container, the wall-clock kill leaving no marked process behind, and project deletion destroying every sandbox it owned.

Three latent test defects surfaced and are fixed too - a worktree-gc fixture slicing paths by an unresolved `mkdtemp` root (macOS symlinks it, so this failed for anyone on a Mac), an echo server with no `error` listener turning a deliberate reset into an uncaught exception under load, and a hire-form query matching a portal node left by another spec. The shared docker fakes now model a container whose tunnel binds, which the readiness wait made load-bearing.

`bun run test --skip-browser` is green: server 6625, Bun-native 59, web 1473, shared 238.

## Left open deliberately

Two findings are documented in `.dev/architecture.md` rather than fixed, because each needs a decision rather than a corrected line:

- **Image resolution assumes the engine shares the host's image store.** A locally-built tag can never work on a backend that pulls the image itself, so the local-build fallback is a guaranteed failure there.
- **Provider quota is invisible to Hezo's budget.** Hezo counts a container as its cap while the provider allocates the hard cap, and the tier caps memory *and* disk independently. A suspended sandbox also still holds its full quota, so `planIdleShutdown`'s "keep one suspended per project" costs a permanent concurrency slot - Daytona's own error names the remedy (*archive*) that Hezo never uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuThGP1JxQPXwJcX1sMmmK
