### PR TITLE
fix(archival): freeze archived assets and docs against every writer

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -569,16 +569,37 @@ surface is active-only: the web pages default to an Active filter (Active/Archiv
 client-side; the REST lists return `archived_at` for all rows), the MCP doc/asset list+read
 tools take a `filter` key defaulting to `'active'` (`'archived'`/`'all'` opt in), full-text
 search, doc autocomplete, and the `{{project_docs_context}}` run manifest all exclude
-archived rows, and archived docs are read-only (writes/status/revision-restore return 409 /
-tool errors until restored). **Hard deletion is human/admin-only** (agents get 403 on both
+archived rows. **An archived row is frozen, not merely hidden**, and that rule lives in the
+two upsert helpers rather than at each call site: `upsertProjectAsset` (`lib/asset-name.ts`)
+and `upsertDocument` (`services/documents.ts`) each re-read `archived_at` **inside** the
+transaction that does the write and return a `status: 'archived'` discriminant instead of
+writing, so there is no check-then-write race and a new caller inherits the refusal (this
+is what closed the approved-`update_prd` handler and `restoreRevision`, which previously had
+no check at all). Callers map that status to their own surface error — 409 `ASSET_ARCHIVED`
+/ 409 `CONFLICT` on REST, an "unarchive it first" string on MCP — and the write paths keep a
+cheap pre-flight (`archivedAssetHolderId`, `isDocumentArchived`) so a 10 MB blob (possibly an
+S3 PUT) isn't spent on a doomed call. Beyond content writes, `PATCH …/assets/:assetId
+{ folder }` refuses an archived asset (409 `ASSET_ARCHIVED`, matching `move_project_asset`,
+whose client-side counterpart is the hidden Move action on archived cards),
+`move_project_asset`/`copy_project_asset` refuse an archived source, asset review mutations
+403, and `read_project_asset`'s width/height self-heal reports the parsed dimensions but
+skips the `UPDATE` on an archived row. **Hard deletion is human/admin-only** (agents get 403 on both
 DELETE routes; in the UI Delete only appears on archived items — a deliberate two-step).
 The legacy `request_asset_deletion` tool is gone, but its resolve endpoint
 (`POST …/comments/:commentId/resolve-asset-deletion`, agents 403) and comment renderer
 remain so pending `asset_deletion_request` cards from older instances stay resolvable —
 approve deletes rows + blobs server-side, deny keeps everything, both wake the requester
 (`asset_deletion_resolved`). `asset.created`, `asset.archived`, `asset.deletion_requested`,
-and `asset.deleted` domain events feed the audit log (doc archival rides
-`document.updated`); asset row-changes broadcast on the team room so the Assets page
+and `asset.deleted` domain events feed the audit log, and doc archival emits its own
+`document.archived` (**not** `document.updated`, which would render identically to a content
+edit). Both archival events carry `archived: boolean` plus `taskId`/`runId`, mapped into
+`audit_log.details` as `archived`/`task_id`/`run_id` — no new `AuditAction` (existing archive
+rows are already `updated`, and `details.archived` is the discriminator), so no migration:
+`action`/`entity_type` are plain `TEXT` and `details` is `JSONB`. `task_id` also feeds the
+audit-log route's existing join onto `tasks`, so an agent's archive/restore deep-links to its
+task for free. `packages/web/src/lib/audit-format.ts` reads the flag to render
+"Archived"/"Restored" (previously every asset row read "Uploaded", including archives and
+deletes). Asset row-changes broadcast on the team room so the Assets page
 live-refreshes. `project_icons`
 (1:1 with `projects`, `ON DELETE CASCADE`) holds an optional per-project icon image —
 unlike assets the **bytes live in the DB** (a `BYTEA` column) in a dedicated table so the

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -98,6 +98,13 @@ reserved and any existing `assets/<path>` links keep resolving. Agents archive s
 it), and you can archive one yourself from its card's **Archive** action. Nothing is lost:
 restore it at any time.
 
+**While archived, an asset is read-only.** It can't be overwritten, moved, or renamed -
+by you or by an agent - until it is restored. An agent that tries to save over an archived
+path is told to restore it first rather than quietly replacing the retired file, and the
+path stays reserved the whole time, so nothing else can take it. Archiving and restoring
+are both recorded in the project's [activity log](/docs/security/activity-log), and when an
+agent does either, the entry names the task and run it came from.
+
 The Assets page shows **active** items by default. The filter button (funnel icon) next to
 "Showing active items" switches the view to **Archived** or **All** - archived cards render
 dimmed with an "Archived" badge, and offer **Restore** plus **Delete**.

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -110,9 +110,12 @@ The list in the rail shows **Active** documents by default; the **Active / Archi
 pills under the filter box switch views, each with a live count, and archived entries carry
 an "Archived" chip. Opening an archived document shows a banner naming who archived it and
 when, with a one-click **Restore**. While archived, a document is **read-only** - no edits,
-status changes, or version restores until you restore it. (The repo-backed `AGENTS.md`
-entry is a file in your repository, not a project document - it's always visible and can't
-be archived.)
+status changes, or version restores until you restore it, and that holds for agents and
+for changes you had already approved. Archiving and restoring are both recorded in the
+project's [activity log](/docs/security/activity-log), separately from ordinary edits, and
+when an agent does either, the entry names the task and run it came from. (The repo-backed
+`AGENTS.md` entry is a file in your repository, not a project document - it's always
+visible and can't be archived.)
 
 **Deletion is permanent and admin-only.** Agents can never delete a document. The Delete
 action only appears on archived documents, so removing one for good is a deliberate

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1237,7 +1237,7 @@ Archive a project asset - the reversible soft delete, and the ONLY way an agent 
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Asset path to archive - the full path exactly as list_project_assets returns it (e.g. "drafts/old-v1.md") |
 
-**Returns:** `{ archived: true, reference: "assets/<path>", changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the asset is not found. The archived asset leaves listings and default reads but keeps its path reserved; existing `assets/<path>` references keep resolving.
+**Returns:** `{ archived: true, reference: "assets/<path>", changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the asset is not found. The archived asset leaves listings and default reads but keeps its path reserved; existing `assets/<path>` references keep resolving. While archived it is read-only: it cannot be overwritten, moved, renamed, or reviewed until unarchive_project_asset restores it.
 
 **Authorization:** Archival is the agent-facing soft delete; hard deletion of assets is admin-only in the web app.
 
@@ -1254,7 +1254,7 @@ Restore an archived project asset to active. It reappears in list_project_assets
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Asset path to restore (the same path it was archived under) |
 
-**Returns:** `{ archived: false, reference: "assets/<path>", changed }` (`changed: false` when it was already active), or `{ error }` if the asset is not found.
+**Returns:** `{ archived: false, reference: "assets/<path>", changed }` (`changed: false` when it was already active), or `{ error }` if the asset is not found. Restoring is recorded in the project activity log, naming the task and run it came from - so restore an asset because it is genuinely back in use, not merely to get around the archived-write refusal.
 
 ### `read_project_doc`
 
@@ -1305,7 +1305,7 @@ Archive a project doc - the reversible soft delete, and the ONLY way an agent re
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Doc filename to archive (e.g. "old-plan.md") |
 
-**Returns:** `{ archived: true, filename, changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the file is not found. The archived doc leaves listings, search, and agent-run context but keeps its filename reserved and its revision history.
+**Returns:** `{ archived: true, filename, changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the file is not found. The archived doc leaves listings, search, and agent-run context but keeps its filename reserved and its revision history. While archived it is read-only: no writes and no revision restores until unarchive_project_doc restores it.
 
 **Authorization:** Archival is the agent-facing soft delete; hard deletion of docs is admin-only in the web app.
 
@@ -1322,7 +1322,7 @@ Restore an archived project doc to active. It reappears in list_project_docs and
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Doc filename to restore (e.g. "old-plan.md") |
 
-**Returns:** `{ archived: false, filename, changed }` (`changed: false` when it was already active), or `{ error }` if the file is not found.
+**Returns:** `{ archived: false, filename, changed }` (`changed: false` when it was already active), or `{ error }` if the file is not found. Restoring is recorded in the project activity log, naming the task and run it came from - so restore a doc because it is genuinely back in use, not merely to get around the archived-write refusal.
 
 ## Costs
 

--- a/docs/security/activity-log.md
+++ b/docs/security/activity-log.md
@@ -17,13 +17,18 @@ The log captures every state-changing action on the project:
 
 - **Tasks** - created, renamed, status changes, reassignments.
 - **Agent runs** - each run started and completed, with its outcome.
-- **Documents** - created, updated, and deleted, including edits to an agent's instructions.
-- **Assets** - files uploaded to the project or a task.
+- **Documents** - created, updated, archived, restored, and deleted, including edits to an
+  agent's instructions.
+- **Assets** - files uploaded to the project or a task, and files archived, restored, or
+  deleted.
 - **Agents** - hired, updated, enabled, and disabled.
 - **Connectors** - MCP connections and OAuth account connections changing.
 
 Each entry names the **actor** (you, an agent, the system, or an external MCP client),
-so a human action and an automated one are always told apart.
+so a human action and an automated one are always told apart. Archiving and restoring are
+recorded distinctly from an ordinary edit, so restoring a retired document or asset is
+never mistaken for a routine change - and when an agent does it, the entry names the task
+and run it came from.
 
 ## Reading the log
 
@@ -35,8 +40,6 @@ three columns:
 - **Activity** - a plain-language description ("Created task TO-4", "Changed status of TO-4
   from Backlog to In Progress"). Most rows link straight to the task, agent, or page they
   concern.
-
-You can narrow the view by entity type, action, and date range.
 
 The log loads the most recent entries first, in pages. **Load older activity** at the
 bottom of the list fetches the next page and appends it, so you can walk back through the

--- a/packages/server/src/events/audit-observer.ts
+++ b/packages/server/src/events/audit-observer.ts
@@ -154,10 +154,25 @@ const AUDIT_MAPPERS: AuditMappers = {
 		row(event, AuditAction.Updated, AuditEntityType.Asset, event.assetId, {
 			filename: event.filename,
 			archived: event.archived,
+			task_id: event.taskId ?? null,
+			run_id: event.runId ?? null,
 		}),
 	'document.created': mapDocument,
 	'document.updated': mapDocument,
 	'document.deleted': mapDocument,
+	// `details.archived` is the discriminator (as for assets) rather than a new
+	// AuditAction — existing archive rows are already recorded as `updated`, and a
+	// new action would split the history. `task_id` also lights up the audit-log
+	// route's join onto tasks, so the row deep-links to the run's task for free.
+	'document.archived': (event) =>
+		row(event, AuditAction.Updated, AuditEntityType.Document, event.documentId, {
+			document_type: event.documentType,
+			slug: event.slug ?? null,
+			title: event.title ?? null,
+			archived: event.archived,
+			task_id: event.taskId ?? null,
+			run_id: event.runId ?? null,
+		}),
 	'agent.created': mapAgent,
 	'agent.updated': mapAgent,
 	'agent.disabled': mapAgent,

--- a/packages/server/src/events/types.ts
+++ b/packages/server/src/events/types.ts
@@ -90,6 +90,8 @@ export type DomainEvent =
 			filename: string;
 			/** true = archived, false = restored. */
 			archived: boolean;
+			taskId?: string | null;
+			runId?: string | null;
 	  } & Scope &
 			Actor)
 	| ({
@@ -100,6 +102,19 @@ export type DomainEvent =
 			title?: string | null;
 			/** When set, the audit row is attributed to the agent entity (system prompt edits). */
 			agentMemberId?: string | null;
+	  } & Scope &
+			Actor)
+	/** Deliberately separate from document.updated so a restore is distinguishable from an edit. */
+	| ({
+			type: 'document.archived';
+			documentId: string;
+			documentType: string;
+			slug?: string | null;
+			title?: string | null;
+			/** true = archived, false = restored. */
+			archived: boolean;
+			taskId?: string | null;
+			runId?: string | null;
 	  } & Scope &
 			Actor)
 	| ({

--- a/packages/server/src/lib/asset-name.ts
+++ b/packages/server/src/lib/asset-name.ts
@@ -111,12 +111,46 @@ export async function insertAssetWithUniqueName(
 }
 
 /**
+ * The id of the archived asset holding `filename` in this project, or null when
+ * the path is free or held by an active asset. An archived asset keeps its path
+ * reserved, so callers use this as a pre-flight before spending bytes on a write
+ * that `upsertProjectAsset` would refuse anyway.
+ */
+export async function archivedAssetHolderId(
+	db: Db,
+	projectId: string,
+	filename: string,
+): Promise<string | null> {
+	const r = await db.query<{ id: string }>(
+		'SELECT id FROM assets WHERE project_id = $1 AND original_filename = $2 AND archived_at IS NOT NULL',
+		[projectId, filename],
+	);
+	return r.rows[0]?.id ?? null;
+}
+
+export type UpsertProjectAssetResult =
+	| {
+			status: 'written';
+			asset: InsertedAsset;
+			replacedAssetId: string | null;
+			wipedReviewComments: boolean;
+	  }
+	/** The path is held by an archived asset — nothing was written. */
+	| { status: 'archived'; assetId: string };
+
+/**
  * Insert an asset under an exact filename, or overwrite the row if one already
  * exists for that `(project_id, original_filename)`. Used by agent-authored
  * assets (e.g. an iterated HTML mockup) so the reference stays stable at
  * `assets/<filename>` instead of accreting random suffixes on each re-save. The
  * caller writes the new blob keyed by `assetId`; on overwrite the previous
  * `assetId`'s blob is orphaned and should be cleaned up by the caller.
+ *
+ * An **archived** holder is refused (`status: 'archived'`, no writes issued):
+ * archival keeps the path reserved, so overwriting would silently clobber
+ * soft-deleted content. The rule lives here rather than at each call site so a
+ * new caller inherits it, and the lookup runs inside the transaction that does
+ * the write so an archive landing mid-request can't slip past it.
  *
  * Overwriting deletes the asset's pending review comments in the same
  * transaction (they are version-scoped, like document review comments — and the
@@ -126,17 +160,21 @@ export async function insertAssetWithUniqueName(
 export async function upsertProjectAsset(
 	db: Db,
 	input: InsertAssetInput,
-): Promise<InsertedAsset & { replacedAssetId: string | null; wipedReviewComments: boolean }> {
-	const existing = await db.query<{ id: string }>(
-		'SELECT id FROM assets WHERE project_id = $1 AND original_filename = $2 LIMIT 1',
-		[input.projectId, input.desiredName],
-	);
-	const prior = existing.rows[0]?.id ?? null;
-	if (prior) {
-		return db.transaction(async (tx) => {
+): Promise<UpsertProjectAssetResult> {
+	return db.transaction(async (tx) => {
+		const existing = await tx.query<{ id: string; archived_at: string | null }>(
+			`SELECT id, archived_at FROM assets
+			 WHERE project_id = $1 AND original_filename = $2 LIMIT 1 FOR UPDATE`,
+			[input.projectId, input.desiredName],
+		);
+		const prior = existing.rows[0] ?? null;
+		if (prior?.archived_at != null) {
+			return { status: 'archived', assetId: prior.id };
+		}
+		if (prior) {
 			const wiped = await tx.query<{ id: string }>(
 				'DELETE FROM review_comments WHERE asset_id = $1 RETURNING id',
-				[prior],
+				[prior.id],
 			);
 			const r = await tx.query<InsertedAsset>(
 				`UPDATE assets
@@ -156,25 +194,37 @@ export async function upsertProjectAsset(
 					input.desiredName,
 				],
 			);
-			return { ...r.rows[0], replacedAssetId: prior, wipedReviewComments: wiped.rows.length > 0 };
-		});
-	}
-	const r = await db.query<InsertedAsset>(
-		`INSERT INTO assets (id, team_id, project_id, content_type, byte_size, sha256, original_filename, uploaded_by_member_id, width, height)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		 RETURNING id, content_type, byte_size, original_filename, width, height`,
-		[
-			input.assetId,
-			input.teamId,
-			input.projectId,
-			input.contentType,
-			input.byteSize,
-			input.sha256,
-			input.desiredName,
-			input.uploadedByMemberId,
-			input.width ?? null,
-			input.height ?? null,
-		],
-	);
-	return { ...r.rows[0], replacedAssetId: null, wipedReviewComments: false };
+			return {
+				status: 'written',
+				asset: r.rows[0],
+				replacedAssetId: prior.id,
+				wipedReviewComments: wiped.rows.length > 0,
+			};
+		}
+		// No row to lock, so UNIQUE(project_id, original_filename) is still the
+		// backstop against a concurrent insert — callers handle the violation.
+		const r = await tx.query<InsertedAsset>(
+			`INSERT INTO assets (id, team_id, project_id, content_type, byte_size, sha256, original_filename, uploaded_by_member_id, width, height)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			 RETURNING id, content_type, byte_size, original_filename, width, height`,
+			[
+				input.assetId,
+				input.teamId,
+				input.projectId,
+				input.contentType,
+				input.byteSize,
+				input.sha256,
+				input.desiredName,
+				input.uploadedByMemberId,
+				input.width ?? null,
+				input.height ?? null,
+			],
+		);
+		return {
+			status: 'written',
+			asset: r.rows[0],
+			replacedAssetId: null,
+			wipedReviewComments: false,
+		};
+	});
 }

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -424,13 +424,13 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	archive_project_doc: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ archived: true, filename, changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the file is not found. The archived doc leaves listings, search, and agent-run context but keeps its filename reserved and its revision history.',
+			'`{ archived: true, filename, changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the file is not found. The archived doc leaves listings, search, and agent-run context but keeps its filename reserved and its revision history. While archived it is read-only: no writes and no revision restores until unarchive_project_doc restores it.',
 		auth: 'Archival is the agent-facing soft delete; hard deletion of docs is admin-only in the web app.',
 	},
 	unarchive_project_doc: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ archived: false, filename, changed }` (`changed: false` when it was already active), or `{ error }` if the file is not found.',
+			'`{ archived: false, filename, changed }` (`changed: false` when it was already active), or `{ error }` if the file is not found. Restoring is recorded in the project activity log, naming the task and run it came from - so restore a doc because it is genuinely back in use, not merely to get around the archived-write refusal.',
 	},
 	list_project_assets: {
 		category: 'Project docs & assets',
@@ -460,13 +460,13 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	archive_project_asset: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ archived: true, reference: "assets/<path>", changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the asset is not found. The archived asset leaves listings and default reads but keeps its path reserved; existing `assets/<path>` references keep resolving.',
+			'`{ archived: true, reference: "assets/<path>", changed }` (`changed: false` when it was already archived - the call is idempotent), or `{ error }` if the asset is not found. The archived asset leaves listings and default reads but keeps its path reserved; existing `assets/<path>` references keep resolving. While archived it is read-only: it cannot be overwritten, moved, renamed, or reviewed until unarchive_project_asset restores it.',
 		auth: 'Archival is the agent-facing soft delete; hard deletion of assets is admin-only in the web app.',
 	},
 	unarchive_project_asset: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ archived: false, reference: "assets/<path>", changed }` (`changed: false` when it was already active), or `{ error }` if the asset is not found.',
+			'`{ archived: false, reference: "assets/<path>", changed }` (`changed: false` when it was already active), or `{ error }` if the asset is not found. Restoring is recorded in the project activity log, naming the task and run it came from - so restore an asset because it is genuinely back in use, not merely to get around the archived-write refusal.',
 	},
 
 	// Costs

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -58,7 +58,7 @@ import { readRunLogTail, runLogLengthSql } from '../db/run-log-chunks';
 import type { DomainEventBus } from '../events/bus';
 import { assertNoActiveRun } from '../lib/active-run';
 import { isHqInstanceAgent, isVirtualHqMemberInTeam } from '../lib/agent-roles';
-import { upsertProjectAsset } from '../lib/asset-name';
+import { archivedAssetHolderId, upsertProjectAsset } from '../lib/asset-name';
 import { assetSortOrderBy } from '../lib/asset-sort';
 import { signAgentAssetUrl } from '../lib/asset-urls';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
@@ -3964,7 +3964,7 @@ export function registerTools(
 				),
 			);
 
-			return { applied: true, document_id: doc.id };
+			return { applied: true, document_id: doc.row.id };
 		},
 		db,
 	);
@@ -4047,7 +4047,7 @@ export function registerTools(
 					changeSummary: u.change_summary,
 					authorMemberId: callerMemberId,
 				});
-				results.push({ index: i, agent_id: u.agent_id, slug, ok: true, document_id: doc.id });
+				results.push({ index: i, agent_id: u.agent_id, slug, ok: true, document_id: doc.row.id });
 				applied.push({ slug, change_summary: u.change_summary });
 			}
 
@@ -4143,7 +4143,7 @@ export function registerTools(
 				);
 			}
 
-			return { applied: true, document_id: doc.id, length: (args.content as string).length };
+			return { applied: true, document_id: doc.row.id, length: (args.content as string).length };
 		},
 		db,
 	);
@@ -4562,6 +4562,10 @@ export function registerTools(
 	const assetPathError = (raw: string) =>
 		`Invalid asset path '${raw}': up to ${ASSET_MAX_FOLDER_DEPTH} folder levels, each segment starting with a letter or digit (e.g. "launch/images/hero.png").`;
 
+	/** Refusal copy for a write aimed at a path an archived asset still holds. */
+	const archivedAssetWriteError = (filename: string) =>
+		`Asset 'assets/${filename}' exists but is archived - call unarchive_project_asset first to overwrite it, or write under a different path.`;
+
 	tool(
 		server,
 		'list_project_assets',
@@ -4710,15 +4714,11 @@ export function registerTools(
 			}
 
 			// An archived asset keeps its path reserved; overwriting it would
-			// silently resurrect (and clobber) soft-deleted content.
-			const archivedHolder = await db.query<{ id: string }>(
-				'SELECT id FROM assets WHERE project_id = $1 AND original_filename = $2 AND archived_at IS NOT NULL',
-				[projectId, filename],
-			);
-			if (archivedHolder.rows.length > 0) {
-				return {
-					error: `Asset 'assets/${filename}' exists but is archived - call unarchive_project_asset first to overwrite it, or write under a different path.`,
-				};
+			// silently resurrect (and clobber) soft-deleted content. The upsert
+			// refuses it transactionally too — this pre-flight just avoids spending
+			// the blob write on a doomed call.
+			if (await archivedAssetHolderId(db, projectId, filename)) {
+				return { error: archivedAssetWriteError(filename) };
 			}
 
 			// Capture raster-image pixel dimensions so read_project_asset /
@@ -4747,6 +4747,12 @@ export function registerTools(
 				await assets.delete(projectId, assetId).catch(() => {});
 				throw e;
 			}
+			if (result.status === 'archived') {
+				// Archived between the pre-flight and the upsert — the bytes we just
+				// stored have no row pointing at them.
+				await assets.delete(projectId, assetId).catch(() => {});
+				return { error: archivedAssetWriteError(filename) };
+			}
 			if (result.replacedAssetId) {
 				await assets.delete(projectId, result.replacedAssetId).catch(() => {});
 			}
@@ -4766,16 +4772,16 @@ export function registerTools(
 				);
 			}
 			broadcastRowChange(wsManager, wsRoom.team(teamId), 'assets', 'INSERT', {
-				id: result.id,
+				id: result.asset.id,
 				team_id: teamId,
 				project_id: projectId,
-				original_filename: result.original_filename,
+				original_filename: result.asset.original_filename,
 			});
 			return {
 				written: true,
-				id: result.id,
-				reference: `assets/${result.original_filename}`,
-				byte_size: result.byte_size,
+				id: result.asset.id,
+				reference: `assets/${result.asset.original_filename}`,
+				byte_size: result.asset.byte_size,
 				...(dims ? { width: dims.width, height: dims.height } : {}),
 			};
 		},
@@ -4878,14 +4884,20 @@ export function registerTools(
 							width = dims.width;
 							height = dims.height;
 							// Self-heal: persist so future reads / list_project_assets
-							// don't re-parse this pre-existing asset's blob.
-							await db
-								.query('UPDATE assets SET width = $1, height = $2 WHERE id = $3', [
-									dims.width,
-									dims.height,
-									asset.id,
-								])
-								.catch(() => {});
+							// don't re-parse this pre-existing asset's blob. Skipped on an
+							// archived row — nothing writes an archived asset, and an
+							// invariant with a carve-out is one no reader can rely on. The
+							// dimensions are still reported; only the caching is skipped,
+							// and archived reads are rare (explicitly opted into).
+							if (!archived) {
+								await db
+									.query('UPDATE assets SET width = $1, height = $2 WHERE id = $3', [
+										dims.width,
+										dims.height,
+										asset.id,
+									])
+									.catch(() => {});
+							}
 						}
 					}
 				}
@@ -5116,6 +5128,10 @@ export function registerTools(
 			assetId: asset.id,
 			filename,
 			archived,
+			// Attribution: an agent restoring an asset so it can overwrite it is
+			// exactly what the operator needs to trace back to a run.
+			taskId: auth.type === AuthType.Agent ? auth.taskId : null,
+			runId: auth.type === AuthType.Agent ? auth.runId : null,
 		});
 		broadcastRowChange(wsManager, wsRoom.team(scope.teamId), 'assets', 'UPDATE', {
 			id: asset.id,
@@ -5305,18 +5321,6 @@ export function registerTools(
 						'Project docs must be markdown (.md). Non-markdown files belong in the assets library, referenced as assets/<filename>.',
 				};
 			}
-			// An archived doc is read-only; writing would silently resurrect it.
-			const prior = await getDocument(db, {
-				type: DocumentType.ProjectDoc,
-				teamId: scope.teamId,
-				projectId: scope.projectId,
-				slug: args.filename as string,
-			});
-			if (prior?.archived_at) {
-				return {
-					error: `Doc '${args.filename}' is archived - call unarchive_project_doc first, or write under a different filename.`,
-				};
-			}
 			const callerMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
 			const callerApiKeyId = apiKeyIdFromAuth(auth);
 			const doc = await upsertDocument(db, wsManager, {
@@ -5337,7 +5341,14 @@ export function registerTools(
 					actorApiKeyId: callerApiKeyId,
 				},
 			});
-			return { written: true, id: doc.id, filename: doc.slug };
+			// An archived doc is read-only; writing would silently resurrect it. The
+			// refusal comes from upsertDocument itself, so no caller can forget it.
+			if (doc.status === 'archived') {
+				return {
+					error: `Doc '${args.filename}' is archived - call unarchive_project_doc first, or write under a different filename.`,
+				};
+			}
+			return { written: true, id: doc.row.id, filename: doc.row.slug };
 		},
 		db,
 	);
@@ -5369,6 +5380,10 @@ export function registerTools(
 				events,
 				actorType: actorTypeFromAuth(auth),
 				actorApiKeyId: apiKeyIdFromAuth(auth),
+				// Attribution: an agent restoring a doc so it can overwrite it is
+				// exactly what the operator needs to trace back to a run.
+				taskId: auth.type === AuthType.Agent ? auth.taskId : null,
+				runId: auth.type === AuthType.Agent ? auth.runId : null,
 			},
 		);
 		if (!result) return { error: `File '${args.filename}' not found` };

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -920,9 +920,11 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/system-prompt/restore', 
 		restoredByMemberId: null,
 		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
 	});
-	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
+	// 'archived' is unreachable here — only project docs are ever archived — but
+	// the union makes that explicit rather than assumed.
+	if (restored.status !== 'restored') return err(c, 'NOT_FOUND', 'Revision not found', 404);
 
-	return ok(c, restored);
+	return ok(c, restored.row);
 });
 
 agentsRoutes.patch('/projects/:projectId/agents/:agentId', async (c) => {

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -19,7 +19,11 @@ import {
 import { type Context, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { AssetNotFoundError, AttachmentTooLargeError } from '../assets/store';
-import { insertAssetWithUniqueName, upsertProjectAsset } from '../lib/asset-name';
+import {
+	archivedAssetHolderId,
+	insertAssetWithUniqueName,
+	upsertProjectAsset,
+} from '../lib/asset-name';
 import { assetSortOrderBy } from '../lib/asset-sort';
 import { signAssetUrl, verifyAssetUrl } from '../lib/asset-urls';
 import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast';
@@ -41,6 +45,10 @@ import { logger } from '../logger';
 const log = logger.child('routes');
 
 export const assetsRoutes = new Hono<Env>();
+
+/** Refusal text for an overwrite aimed at a path an archived asset still holds. */
+const archivedOverwriteMessage = (name: string) =>
+	`Asset 'assets/${name}' exists but is archived — unarchive it first to overwrite it, or upload under a different path.`;
 
 /**
  * Validate an uploaded file, write its bytes to disk, and insert an `assets` row.
@@ -123,21 +131,11 @@ export async function storeUploadedAsset(
 	const store = c.get('assetStore');
 
 	// An archived asset keeps its path reserved; overwriting it would silently
-	// resurrect (and clobber) soft-deleted content — reject before writing any
-	// bytes, matching write_project_asset.
-	if (opts?.overwrite) {
-		const archivedHolder = await db.query<{ id: string }>(
-			'SELECT id FROM assets WHERE project_id = $1 AND original_filename = $2 AND archived_at IS NOT NULL',
-			[projectId, desiredName],
-		);
-		if (archivedHolder.rows.length > 0) {
-			return err(
-				c,
-				'ASSET_ARCHIVED',
-				`Asset 'assets/${desiredName}' exists but is archived — unarchive it first to overwrite it, or upload under a different path.`,
-				409,
-			);
-		}
+	// resurrect (and clobber) soft-deleted content. `upsertProjectAsset` refuses
+	// it transactionally, but check up front too so 10 MB of bytes (possibly an
+	// S3 PUT) aren't spent on a doomed request.
+	if (opts?.overwrite && (await archivedAssetHolderId(db, projectId, desiredName))) {
+		return err(c, 'ASSET_ARCHIVED', archivedOverwriteMessage(desiredName), 409);
 	}
 
 	const assetId = randomUUID();
@@ -172,6 +170,12 @@ export async function storeUploadedAsset(
 				width: dims?.width ?? null,
 				height: dims?.height ?? null,
 			});
+			if (result.status === 'archived') {
+				// Archived between the pre-flight above and here. The bytes we just
+				// stored have no row pointing at them, so drop them.
+				await store.delete(projectId, assetId).catch(() => {});
+				return err(c, 'ASSET_ARCHIVED', archivedOverwriteMessage(desiredName), 409);
+			}
 			// The prior blob at this path is now orphaned (the row points at the new
 			// assetId); drop it rather than leak it.
 			if (result.replacedAssetId) {
@@ -190,10 +194,10 @@ export async function storeUploadedAsset(
 				);
 			}
 			asset = {
-				id: result.id,
-				content_type: result.content_type,
-				byte_size: result.byte_size,
-				original_filename: result.original_filename,
+				id: result.asset.id,
+				content_type: result.asset.content_type,
+				byte_size: result.asset.byte_size,
+				original_filename: result.asset.original_filename,
 			};
 		} else {
 			asset = await insertAssetWithUniqueName(db, {
@@ -482,6 +486,17 @@ assetsRoutes.patch('/projects/:projectId/assets/:assetId', async (c) => {
 			});
 		}
 	} else {
+		// An archived asset is frozen, so it can't be moved or renamed either —
+		// matching move_project_asset, which refuses an archived source. The web
+		// app hides the Move action on archived cards; this is the real rule.
+		if (found.rows[0].archived_at !== null) {
+			return err(
+				c,
+				'ASSET_ARCHIVED',
+				`Asset 'assets/${found.rows[0].original_filename}' is archived - restore it first to move or rename it.`,
+				409,
+			);
+		}
 		if (typeof body.folder !== 'string') {
 			return err(c, 'INVALID_REQUEST', 'folder is required (empty string = library root)', 400);
 		}

--- a/packages/server/src/routes/custom-prompt.ts
+++ b/packages/server/src/routes/custom-prompt.ts
@@ -60,7 +60,7 @@ customPromptRoutes.patch('/projects/:projectId/custom-prompt', async (c) => {
 		);
 	}
 
-	return ok(c, doc, existing ? 200 : 201);
+	return ok(c, doc.row, existing ? 200 : 201);
 });
 
 customPromptRoutes.get('/projects/:projectId/custom-prompt/revisions', async (c) => {
@@ -102,7 +102,9 @@ customPromptRoutes.post('/projects/:projectId/custom-prompt/restore', async (c) 
 		revisionNumber: body.revision_number,
 		restoredByMemberId,
 	});
-	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
+	// 'archived' is unreachable here — only project docs are ever archived — but
+	// the union makes that explicit rather than assumed.
+	if (restored.status !== 'restored') return err(c, 'NOT_FOUND', 'Revision not found', 404);
 
-	return ok(c, restored);
+	return ok(c, restored.row);
 });

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -20,6 +20,7 @@ import {
 	type DocumentRowWithAuthor,
 	deleteDocument,
 	getDocument,
+	isDocumentArchived,
 	listDocuments,
 	listRevisions,
 	restoreRevision,
@@ -114,13 +115,16 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 
 	// Archived docs are read-only: restore first, then edit. Creating a new doc
 	// under an archived name would silently resurrect old history otherwise.
-	const prior = await getDocument(db, {
-		type: DocumentType.ProjectDoc,
-		teamId,
-		projectId,
-		slug: filename,
-	});
-	if (prior?.archived_at) {
+	// Checked here as well as inside upsertDocument because the prd.md branch
+	// below files an approval instead of writing, and never reaches the upsert.
+	if (
+		await isDocumentArchived(db, {
+			type: DocumentType.ProjectDoc,
+			teamId,
+			projectId,
+			slug: filename,
+		})
+	) {
 		return err(c, 'CONFLICT', `Document '${filename}' is archived — restore it first`, 409);
 	}
 
@@ -169,6 +173,12 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 		},
 	});
 
+	// Belt and braces: the pre-check above already refuses an archived doc, but
+	// upsertDocument enforces it transactionally too, so honour its verdict.
+	if (doc.status === 'archived') {
+		return err(c, 'CONFLICT', `Document '${filename}' is archived — restore it first`, 409);
+	}
+
 	// Re-read WITH_AUTHOR so the response carries created_at + resolved last editor.
 	const saved = await getDocument(db, {
 		type: DocumentType.ProjectDoc,
@@ -180,7 +190,7 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 		c,
 		toDocResponse(
 			saved ?? {
-				...doc,
+				...doc.row,
 				last_updated_by_name: null,
 				last_updated_by_type: 'admin',
 				archived_by_name: null,
@@ -307,9 +317,6 @@ projectDocsRoutes.post('/projects/:projectId/docs/:filename/restore', async (c) 
 		slug: filename,
 	});
 	if (!doc) return err(c, 'NOT_FOUND', `Document '${filename}' not found`, 404);
-	if (doc.archived_at) {
-		return err(c, 'CONFLICT', `Document '${filename}' is archived — restore it first`, 409);
-	}
 
 	const restoredByMemberId = await resolveActorMemberId(db, auth, teamId);
 	const restored = await restoreRevision(db, c.get('wsManager'), {
@@ -323,7 +330,11 @@ projectDocsRoutes.post('/projects/:projectId/docs/:filename/restore', async (c) 
 			actorApiKeyId: apiKeyIdFromAuth(auth),
 		},
 	});
-	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
+	// An archived doc's content is frozen — restoreRevision owns that rule now.
+	if (restored.status === 'archived') {
+		return err(c, 'CONFLICT', `Document '${filename}' is archived — restore it first`, 409);
+	}
+	if (restored.status === 'not_found') return err(c, 'NOT_FOUND', 'Revision not found', 404);
 
 	const saved = await getDocument(db, {
 		type: DocumentType.ProjectDoc,
@@ -335,7 +346,7 @@ projectDocsRoutes.post('/projects/:projectId/docs/:filename/restore', async (c) 
 		c,
 		toDocResponse(
 			saved ?? {
-				...restored,
+				...restored.row,
 				last_updated_by_name: null,
 				last_updated_by_type: 'admin',
 				archived_by_name: null,

--- a/packages/server/src/services/approval-handlers/hire.ts
+++ b/packages/server/src/services/approval-handlers/hire.ts
@@ -91,7 +91,7 @@ export const hireHandler: ApprovalHandler = {
 		broadcasts.push({
 			table: 'documents',
 			op: 'INSERT',
-			row: promptDoc as unknown as Record<string, unknown>,
+			row: promptDoc.row as unknown as Record<string, unknown>,
 		});
 
 		const newAgent = await db.query<Record<string, unknown>>(

--- a/packages/server/src/services/approval-handlers/strategy.ts
+++ b/packages/server/src/services/approval-handlers/strategy.ts
@@ -1,6 +1,9 @@
 import { DocumentType } from '@hezo/shared';
+import { logger } from '../../logger';
 import { upsertDocument } from '../documents';
 import type { ApprovalHandler, ApprovalSideEffectCtx, SideEffectBroadcast } from './types';
+
+const log = logger.child('approvals');
 
 /** Apply an approved strategy action — today only the `update_prd` document write. */
 export const strategyHandler: ApprovalHandler = {
@@ -26,10 +29,22 @@ export const strategyHandler: ApprovalHandler = {
 				content: payload.content,
 				authorMemberId: requestedBy,
 			});
+			// The doc was archived between the agent filing this approval and the
+			// admin resolving it. An archived doc is read-only, so the write is
+			// dropped rather than resurrecting retired content. Not an exception:
+			// `applyApproved` runs after the approval row is already `approved`
+			// (see approval-resolve.ts), so throwing here would leave a resolved
+			// but unapplied approval and a 500.
+			if (doc.status === 'archived') {
+				log.warn(
+					`Approval ${approval.id as string}: skipped update_prd write - '${payload.filename}' is archived; restore it and re-file the change.`,
+				);
+				return broadcasts;
+			}
 			broadcasts.push({
 				table: 'documents',
 				op: 'UPDATE',
-				row: doc as unknown as Record<string, unknown>,
+				row: doc.row as unknown as Record<string, unknown>,
 			});
 		}
 

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -11,6 +11,9 @@ export interface DocumentAuditContext {
 	actorType?: AuditActorType;
 	/** Set when the actor is an API key. */
 	actorApiKeyId?: string | null;
+	/** The agent run's task/run, when the mutation came from one — attribution for the audit row. */
+	taskId?: string | null;
+	runId?: string | null;
 }
 
 function emitDocumentEvent(
@@ -195,25 +198,44 @@ export interface UpsertDocumentInput {
 	audit?: DocumentAuditContext;
 }
 
+export type UpsertDocumentResult =
+	| { status: 'written'; row: DocumentRow }
+	/** The doc is archived — nothing was written; the caller reports "restore it first". */
+	| { status: 'archived'; row: DocumentRow };
+
+/**
+ * Create the scoped document, or replace its content when it already exists.
+ *
+ * An **archived** doc is refused (`status: 'archived'`, no revision recorded, no
+ * review comments wiped): archival keeps the slug reserved, so writing would
+ * silently resurrect retired content. The rule lives here rather than at each
+ * call site so every writer inherits it - including the approved-PRD handler and
+ * the template appliers, which never had a check of their own. Only project docs
+ * are ever archived, so it is a no-op for agent system prompts and team prefs.
+ */
 export async function upsertDocument(
 	db: Db,
 	wsManager: WebSocketManager | undefined,
 	input: UpsertDocumentInput,
-): Promise<DocumentRow> {
+): Promise<UpsertDocumentResult> {
 	const where = scopeWhere(input.scope, '');
-	const existing = await db.query<{ id: string; content: string }>(
-		`SELECT id, content FROM documents WHERE ${where.sql}`,
-		where.params,
-	);
-
-	const action: 'INSERT' | 'UPDATE' = existing.rows.length === 0 ? 'INSERT' : 'UPDATE';
 
 	let clearedReviewComments = false;
-	const row = await withTransaction(db, async () => {
+	let existedBefore = false;
+	const result = await withTransaction(db, async (): Promise<UpsertDocumentResult> => {
+		const existing = await db.query<{ id: string; content: string; archived_at: string | null }>(
+			`SELECT id, content, archived_at FROM documents WHERE ${where.sql}`,
+			where.params,
+		);
 		if (existing.rows.length === 0) {
-			return await insertDocument(db, input);
+			return { status: 'written', row: await insertDocument(db, input) };
 		}
+		existedBefore = true;
 		const prior = existing.rows[0];
+		if (prior.archived_at !== null) {
+			const asIs = await db.query<DocumentRow>('SELECT * FROM documents WHERE id = $1', [prior.id]);
+			return { status: 'archived', row: asIs.rows[0] };
+		}
 		if (prior.content !== input.content) {
 			await recordRevision(
 				db,
@@ -241,8 +263,12 @@ export async function upsertDocument(
 				prior.id,
 			],
 		);
-		return updateResult.rows[0];
+		return { status: 'written', row: updateResult.rows[0] };
 	});
+
+	if (result.status === 'archived') return result;
+	const row = result.row;
+	const action: 'INSERT' | 'UPDATE' = existedBefore ? 'UPDATE' : 'INSERT';
 
 	broadcastRowChange(
 		wsManager,
@@ -258,7 +284,7 @@ export async function upsertDocument(
 		row,
 		input.authorMemberId,
 	);
-	return row;
+	return result;
 }
 
 /**
@@ -305,7 +331,25 @@ export async function setDocumentArchived(
 		'UPDATE',
 		row as unknown as Record<string, unknown>,
 	);
-	emitDocumentEvent(audit, 'document.updated', row, actorMemberId);
+	// Its own event, not `document.updated`: archiving and restoring must be
+	// distinguishable from a content edit in the activity log (an agent restoring
+	// a doc so it can overwrite it is exactly what an operator needs to see), and
+	// the task/run make it traceable to the run that did it.
+	audit?.events?.emit({
+		type: 'document.archived',
+		teamId: row.team_id,
+		projectId: row.project_id,
+		actorType: audit.actorType ?? 'admin',
+		actorMemberId,
+		actorApiKeyId: audit.actorApiKeyId ?? null,
+		documentId: row.id,
+		documentType: row.type,
+		slug: row.slug,
+		title: row.title,
+		archived,
+		taskId: audit.taskId ?? null,
+		runId: audit.runId ?? null,
+	});
 	return { row, changed: true };
 }
 
@@ -444,21 +488,35 @@ export interface RestoreRevisionInput {
 	audit?: DocumentAuditContext;
 }
 
+export type RestoreRevisionResult =
+	| { status: 'restored'; row: DocumentRow }
+	/** The doc is archived — its content is frozen until it is restored. */
+	| { status: 'archived' }
+	/** No such document, or no such revision on it. */
+	| { status: 'not_found' };
+
+/**
+ * Roll a document's content back to an earlier revision. Refused while the doc
+ * is archived, for the same reason a write is: an archived doc is read-only.
+ */
 export async function restoreRevision(
 	db: Db,
 	wsManager: WebSocketManager | undefined,
 	input: RestoreRevisionInput,
-): Promise<DocumentRow | null> {
-	const doc = await db.query<{ id: string; content: string; team_id: string }>(
-		'SELECT id, content, team_id FROM documents WHERE id = $1',
-		[input.documentId],
-	);
-	if (doc.rows.length === 0) return null;
+): Promise<RestoreRevisionResult> {
+	const doc = await db.query<{
+		id: string;
+		content: string;
+		team_id: string;
+		archived_at: string | null;
+	}>('SELECT id, content, team_id, archived_at FROM documents WHERE id = $1', [input.documentId]);
+	if (doc.rows.length === 0) return { status: 'not_found' };
+	if (doc.rows[0].archived_at !== null) return { status: 'archived' };
 	const target = await db.query<{ content: string }>(
 		'SELECT content FROM document_revisions WHERE document_id = $1 AND revision_number = $2',
 		[input.documentId, input.revisionNumber],
 	);
-	if (target.rows.length === 0) return null;
+	if (target.rows.length === 0) return { status: 'not_found' };
 
 	let clearedReviewComments = false;
 	const row = await withTransaction(db, async () => {
@@ -493,7 +551,22 @@ export async function restoreRevision(
 	);
 	if (clearedReviewComments) broadcastReviewCommentsCleared(wsManager, row);
 	emitDocumentEvent(input.audit, 'document.updated', row, input.restoredByMemberId);
-	return row;
+	return { status: 'restored', row };
+}
+
+/**
+ * Whether the scoped document is archived, or null when there is no such doc.
+ * A narrow read for callers that only need the flag — `getDocument` would pull
+ * the whole unbounded `content` column to answer it.
+ */
+export async function isDocumentArchived(db: Db, scope: DocumentScope): Promise<boolean | null> {
+	const where = scopeWhere(scope, '');
+	const r = await db.query<{ archived_at: string | null }>(
+		`SELECT archived_at FROM documents WHERE ${where.sql}`,
+		where.params,
+	);
+	if (r.rows.length === 0) return null;
+	return r.rows[0].archived_at !== null;
 }
 
 export async function getAgentSystemPrompt(

--- a/packages/server/test/archival.test.ts
+++ b/packages/server/test/archival.test.ts
@@ -525,3 +525,211 @@ describe('archived items leave discovery surfaces', () => {
 		expect(manifest).not.toContain('out-of-context.md');
 	});
 });
+
+// Archival is not just a visibility filter: an archived item is frozen. These
+// cover the writers that used to slip past that rule, plus the audit trail that
+// makes an agent's self-serve restore visible to the operator.
+describe('archived items are read-only', () => {
+	/** Poll the audit_log — the observer writes via trackBackground. */
+	async function waitForAuditRow(
+		sql: string,
+		params: unknown[] = [],
+	): Promise<Record<string, unknown> | null> {
+		for (let i = 0; i < 40; i++) {
+			const r = await db.query<Record<string, unknown>>(sql, params);
+			if (r.rows.length > 0) return r.rows[0];
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		return null;
+	}
+
+	it('refuses to move or rename an archived asset (matching move_project_asset)', async () => {
+		const a = await uploadAsset('frozen-move.txt');
+		await patchAsset(a.id, { archived: true });
+
+		const res = await patchAsset(a.id, { folder: 'somewhere' });
+		expect(res.status).toBe(409);
+		expect((await res.json()).error.code).toBe('ASSET_ARCHIVED');
+
+		const row = await db.query<{ original_filename: string }>(
+			'SELECT original_filename FROM assets WHERE id = $1',
+			[a.id],
+		);
+		expect(row.rows[0].original_filename).toBe('frozen-move.txt');
+	});
+
+	it('does not persist a dimension backfill onto an archived asset', async () => {
+		// A 1x1 PNG, uploaded then stripped of its captured dimensions to look like
+		// a pre-existing row the self-heal would want to fix.
+		const png = Buffer.from(
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+			'base64',
+		);
+		const fd = new FormData();
+		fd.set('file', new File([new Uint8Array(png)], 'frozen-dims.png', { type: 'image/png' }));
+		const up = await app.request(`/api/projects/${projectId}/assets`, {
+			method: 'POST',
+			headers: { ...authHeader(token) },
+			body: fd,
+		});
+		const assetId = (await up.json()).data.id as string;
+		await db.query('UPDATE assets SET width = NULL, height = NULL WHERE id = $1', [assetId]);
+		await patchAsset(assetId, { archived: true });
+
+		const t = await agentToken();
+		const read = await callToolViaMcp(t, 'read_project_asset', {
+			project: projectId,
+			filename: 'frozen-dims.png',
+			filter: 'all',
+		});
+		// The caller still gets the dimensions; only the write-back is skipped.
+		expect(read.width).toBe(1);
+		expect(read.height).toBe(1);
+
+		const row = await db.query<{ width: number | null; height: number | null }>(
+			'SELECT width, height FROM assets WHERE id = $1',
+			[assetId],
+		);
+		expect(row.rows[0].width).toBeNull();
+		expect(row.rows[0].height).toBeNull();
+	});
+
+	it('does not resurrect an archived prd.md when its pending approval is approved', async () => {
+		await putDoc('prd.md', 'approved baseline');
+		const t = await agentToken();
+
+		// An agent PUT to prd.md files a strategy approval instead of writing.
+		const filed = await app.request(`/api/projects/${projectId}/docs/prd.md`, {
+			method: 'PUT',
+			headers: { ...authHeader(t), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: 'agent rewrite' }),
+		});
+		expect(filed.status).toBe(202);
+
+		const approval = await db.query<{ id: string }>(
+			`SELECT id FROM approvals WHERE team_id = $1 AND type = 'strategy' AND status = 'pending'
+			 ORDER BY created_at DESC LIMIT 1`,
+			[teamId],
+		);
+		expect(approval.rows.length).toBe(1);
+
+		// The admin archives the doc before getting to the approval.
+		await patchDoc('prd.md', { archived: true });
+		const revsBefore = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM document_revisions dr
+			 JOIN documents d ON d.id = dr.document_id
+			 WHERE d.project_id = $1 AND d.slug = 'prd.md'`,
+			[projectId],
+		);
+
+		const resolved = await app.request(`/api/approvals/${approval.rows[0].id}/resolve`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		expect(resolved.status).toBe(200);
+
+		const doc = await db.query<{ content: string; archived_at: string | null }>(
+			`SELECT content, archived_at FROM documents WHERE project_id = $1 AND slug = 'prd.md'`,
+			[projectId],
+		);
+		expect(doc.rows[0].content).toBe('approved baseline');
+		expect(doc.rows[0].archived_at).not.toBeNull();
+		const revsAfter = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM document_revisions dr
+			 JOIN documents d ON d.id = dr.document_id
+			 WHERE d.project_id = $1 AND d.slug = 'prd.md'`,
+			[projectId],
+		);
+		expect(revsAfter.rows[0].c).toBe(revsBefore.rows[0].c);
+	});
+
+	it('refuses a revision restore on an archived doc', async () => {
+		await putDoc('rollback.md', 'v1');
+		await putDoc('rollback.md', 'v2');
+		await patchDoc('rollback.md', { archived: true });
+
+		const res = await app.request(`/api/projects/${projectId}/docs/rollback.md/restore`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ revision_number: 1 }),
+		});
+		expect(res.status).toBe(409);
+
+		const doc = await db.query<{ content: string }>(
+			`SELECT content FROM documents WHERE project_id = $1 AND slug = 'rollback.md'`,
+			[projectId],
+		);
+		expect(doc.rows[0].content).toBe('v2');
+	});
+
+	it("attributes an agent's asset restore to the run that did it", async () => {
+		const { token: t, runId } = await mintAgentToken(db, masterKeyManager, agentId, teamId, taskId);
+		await callToolViaMcp(t, 'write_project_asset', {
+			project: projectId,
+			filename: 'traced-asset.txt',
+			content: 'v1',
+		});
+		await callToolViaMcp(t, 'archive_project_asset', {
+			project: projectId,
+			filename: 'traced-asset.txt',
+		});
+		await callToolViaMcp(t, 'unarchive_project_asset', {
+			project: projectId,
+			filename: 'traced-asset.txt',
+		});
+
+		const row = await waitForAuditRow(
+			`SELECT details FROM audit_log
+			 WHERE entity_type = 'asset' AND details->>'filename' = 'traced-asset.txt'
+			   AND details->>'archived' = 'false'`,
+		);
+		expect(row).not.toBeNull();
+		const details = row?.details as Record<string, unknown>;
+		expect(details.task_id).toBe(taskId);
+		expect(details.run_id).toBe(runId);
+	});
+
+	it('records a doc archive/restore distinguishably from a content edit', async () => {
+		const { token: t, runId } = await mintAgentToken(db, masterKeyManager, agentId, teamId, taskId);
+		await callToolViaMcp(t, 'write_project_doc', {
+			project: projectId,
+			filename: 'traced-doc.md',
+			content: 'body v1',
+		});
+		await callToolViaMcp(t, 'archive_project_doc', {
+			project: projectId,
+			filename: 'traced-doc.md',
+		});
+		await callToolViaMcp(t, 'unarchive_project_doc', {
+			project: projectId,
+			filename: 'traced-doc.md',
+		});
+
+		const restore = await waitForAuditRow(
+			`SELECT details FROM audit_log
+			 WHERE entity_type = 'document' AND details->>'slug' = 'traced-doc.md'
+			   AND details->>'archived' = 'false'`,
+		);
+		expect(restore).not.toBeNull();
+		const restoreDetails = restore?.details as Record<string, unknown>;
+		expect(restoreDetails.task_id).toBe(taskId);
+		expect(restoreDetails.run_id).toBe(runId);
+
+		const archive = await waitForAuditRow(
+			`SELECT details FROM audit_log
+			 WHERE entity_type = 'document' AND details->>'slug' = 'traced-doc.md'
+			   AND details->>'archived' = 'true'`,
+		);
+		expect(archive).not.toBeNull();
+
+		// The content write carries no `archived` key at all, so an edit can never
+		// be mistaken for an archive (they share the `updated` action).
+		const writes = await db.query<{ details: Record<string, unknown> }>(
+			`SELECT details FROM audit_log
+			 WHERE entity_type = 'document' AND details->>'slug' = 'traced-doc.md'
+			   AND details->>'archived' IS NULL`,
+		);
+		expect(writes.rows.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/server/test/audit-log.test.ts
+++ b/packages/server/test/audit-log.test.ts
@@ -63,6 +63,47 @@ describe('audit log', () => {
 		expect(entry.details).toEqual({ title: 'Test' });
 	});
 
+	// An archive/restore row records the run's task in `details.task_id`, which is
+	// what the route's join onto tasks reads — so the feed deep-links the row to
+	// the task whose run did it, with no extra column.
+	it('resolves ref_task_identifier from an archive row task_id', async () => {
+		const agentRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Curator' }),
+		});
+		const agentId = (await agentRes.json()).data.id as string;
+
+		const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projectId, title: 'Curation run', assignee_id: agentId }),
+		});
+		expect(taskRes.status).toBe(201);
+		const task = (await taskRes.json()).data as { id: string; identifier: string };
+
+		await auditLog(db, {
+			projectId,
+			actorType: 'agent',
+			actorMemberId: null,
+			action: 'updated',
+			entityType: 'asset',
+			entityId: null,
+			details: { filename: 'reports/q3.html', archived: false, task_id: task.id, run_id: 'r1' },
+		});
+
+		const res = await app.request(`/api/projects/${projectSlug}/audit-log?entity_type=asset`, {
+			headers: authHeader(token),
+		});
+		const body = await res.json();
+		const entry = body.data.find(
+			(e: Record<string, unknown>) =>
+				(e.details as Record<string, unknown>)?.filename === 'reports/q3.html',
+		);
+		expect(entry).toBeDefined();
+		expect(entry.ref_task_identifier).toBe(task.identifier);
+	});
+
 	it('filters by entity_type', async () => {
 		await auditLog(db, {
 			projectId,

--- a/packages/server/test/audit-mappers.test.ts
+++ b/packages/server/test/audit-mappers.test.ts
@@ -179,6 +179,67 @@ describe('mapEventToAudit', () => {
 		});
 	}
 
+	// Archival shares the `updated` action with a content edit, so `details` is
+	// what tells them apart — and the task/run are what trace an agent's
+	// self-serve restore back to the run that did it.
+	it('carries the archived flag and run attribution on an asset restore', () => {
+		const audit = mapEventToAudit({
+			type: 'asset.archived',
+			assetId: 'as9',
+			filename: 'reports/q3.html',
+			archived: false,
+			taskId: 't9',
+			runId: 'r9',
+			...scope,
+			...actor,
+		});
+		expect(audit?.entityType).toBe(AuditEntityType.Asset);
+		expect(audit?.action).toBe(AuditAction.Updated);
+		expect(audit?.entityId).toBe('as9');
+		expect(audit?.details).toMatchObject({
+			filename: 'reports/q3.html',
+			archived: false,
+			task_id: 't9',
+			run_id: 'r9',
+		});
+	});
+
+	it('maps a doc archive to its own event, distinguishable from an edit', () => {
+		const archived = mapEventToAudit({
+			type: 'document.archived',
+			documentId: 'd9',
+			documentType: 'project_doc',
+			slug: 'spec.md',
+			title: 'Spec',
+			archived: true,
+			taskId: 't9',
+			runId: 'r9',
+			...scope,
+			...actor,
+		});
+		expect(archived?.entityType).toBe(AuditEntityType.Document);
+		expect(archived?.action).toBe(AuditAction.Updated);
+		expect(archived?.entityId).toBe('d9');
+		expect(archived?.details).toMatchObject({
+			slug: 'spec.md',
+			title: 'Spec',
+			archived: true,
+			task_id: 't9',
+			run_id: 'r9',
+		});
+
+		// A content edit writes no `archived` key, so the two never collide.
+		const edited = mapEventToAudit({
+			type: 'document.updated',
+			documentId: 'd9',
+			documentType: 'project_doc',
+			slug: 'spec.md',
+			...scope,
+			...actor,
+		});
+		expect(edited?.details).not.toHaveProperty('archived');
+	});
+
 	it('attributes system-prompt doc edits to the agent entity', () => {
 		const audit = mapEventToAudit({
 			type: 'document.updated',

--- a/packages/server/test/documents.test.ts
+++ b/packages/server/test/documents.test.ts
@@ -6,6 +6,7 @@ import {
 	listDocuments,
 	listRevisions,
 	restoreRevision,
+	setDocumentArchived,
 	upsertDocument,
 } from '../src/services/documents';
 import { safeClose } from './helpers';
@@ -43,10 +44,11 @@ describe('documents service', () => {
 			content: 'first',
 			authorMemberId: null,
 		});
-		expect(doc.title).toBe('Service Test');
-		expect(doc.content).toBe('first');
+		expect(doc.status).toBe('written');
+		expect(doc.row.title).toBe('Service Test');
+		expect(doc.row.content).toBe('first');
 
-		const revs = await listRevisions(db, doc.id);
+		const revs = await listRevisions(db, doc.row.id);
 		expect(revs.length).toBe(0);
 	});
 
@@ -58,7 +60,7 @@ describe('documents service', () => {
 			authorMemberId: null,
 		});
 
-		const revs = await listRevisions(db, initial.id);
+		const revs = await listRevisions(db, initial.row.id);
 		expect(revs.length).toBe(1);
 		expect(revs[0].content).toBe('first');
 		expect(revs[0].change_summary).toBe('bumped');
@@ -101,7 +103,8 @@ describe('documents service', () => {
 			revisionNumber: 1,
 			restoredByMemberId: null,
 		});
-		expect(restored?.content).toBe('first');
+		expect(restored.status).toBe('restored');
+		expect(restored.status === 'restored' && restored.row.content).toBe('first');
 
 		const revs = await listRevisions(db, doc!.id);
 		expect(revs.length).toBe(3);
@@ -109,7 +112,7 @@ describe('documents service', () => {
 		expect(revs[0].content).toBe('third');
 	});
 
-	it('returns null when restoring a missing revision', async () => {
+	it('reports not_found when restoring a missing revision', async () => {
 		const doc = await getDocument(db, {
 			type: DocumentType.ProjectDoc,
 			teamId,
@@ -121,7 +124,7 @@ describe('documents service', () => {
 			revisionNumber: 999,
 			restoredByMemberId: null,
 		});
-		expect(result).toBeNull();
+		expect(result.status).toBe('not_found');
 	});
 
 	it('scopes project_doc upsert by project_id and treats slug as filename', async () => {
@@ -130,8 +133,9 @@ describe('documents service', () => {
 			content: 'pd v1',
 			authorMemberId: null,
 		});
-		expect(doc.slug).toBe('svc-spec.md');
-		expect(doc.project_id).toBe(projectId);
+		expect(doc.status).toBe('written');
+		expect(doc.row.slug).toBe('svc-spec.md');
+		expect(doc.row.project_id).toBe(projectId);
 
 		const list = await listDocuments(db, {
 			type: DocumentType.ProjectDoc,
@@ -139,6 +143,99 @@ describe('documents service', () => {
 			projectId,
 		});
 		expect(list.some((d) => d.slug === 'svc-spec.md')).toBe(true);
+	});
+
+	// The rule lives inside upsertDocument/restoreRevision rather than at each
+	// call site, so these exercise the service directly — bypassing every route
+	// pre-check — to prove a new caller inherits the refusal.
+	describe('archived docs are read-only', () => {
+		const slug = 'svc-archived.md';
+
+		beforeAll(async () => {
+			await upsertDocument(db, undefined, {
+				scope: { type: DocumentType.ProjectDoc, teamId, projectId, slug },
+				content: 'original body',
+				authorMemberId: null,
+			});
+			await setDocumentArchived(
+				db,
+				undefined,
+				{ type: DocumentType.ProjectDoc, teamId, projectId, slug },
+				true,
+				null,
+			);
+		});
+
+		it('refuses upsertDocument and leaves content and revisions untouched', async () => {
+			const before = await getDocument(db, {
+				type: DocumentType.ProjectDoc,
+				teamId,
+				projectId,
+				slug,
+			});
+			const revsBefore = await listRevisions(db, before!.id);
+
+			const result = await upsertDocument(db, undefined, {
+				scope: { type: DocumentType.ProjectDoc, teamId, projectId, slug },
+				content: 'resurrected body',
+				changeSummary: 'should not land',
+				authorMemberId: null,
+			});
+
+			expect(result.status).toBe('archived');
+			const after = await getDocument(db, {
+				type: DocumentType.ProjectDoc,
+				teamId,
+				projectId,
+				slug,
+			});
+			expect(after!.content).toBe('original body');
+			expect(after!.archived_at).not.toBeNull();
+			expect((await listRevisions(db, before!.id)).length).toBe(revsBefore.length);
+		});
+
+		it('refuses restoreRevision and leaves content untouched', async () => {
+			const doc = await getDocument(db, {
+				type: DocumentType.ProjectDoc,
+				teamId,
+				projectId,
+				slug,
+			});
+			const result = await restoreRevision(db, undefined, {
+				documentId: doc!.id,
+				revisionNumber: 1,
+				restoredByMemberId: null,
+			});
+
+			expect(result.status).toBe('archived');
+			const after = await getDocument(db, {
+				type: DocumentType.ProjectDoc,
+				teamId,
+				projectId,
+				slug,
+			});
+			expect(after!.content).toBe('original body');
+		});
+
+		it('is a no-op for scopes that are never archived (agent system prompts)', async () => {
+			const agent = await db.query<{ id: string }>(
+				`WITH m AS (
+				   INSERT INTO members (team_id, display_name, member_type) VALUES ($1, 'Prompt Agent', 'agent') RETURNING id
+				 )
+				 INSERT INTO member_agents (id, slug, title) SELECT id, 'prompt-agent', 'Prompt Agent' FROM m
+				 RETURNING id`,
+				[teamId],
+			);
+			const memberAgentId = agent.rows[0].id;
+			for (const content of ['prompt v1', 'prompt v2']) {
+				const r = await upsertDocument(db, undefined, {
+					scope: { type: DocumentType.AgentSystemPrompt, teamId, memberAgentId },
+					content,
+					authorMemberId: null,
+				});
+				expect(r.status).toBe('written');
+			}
+		});
 	});
 
 	it('enforces singleton team_preferences scoping', async () => {

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { upsertProjectAsset } from '../src/lib/asset-name';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import {
@@ -813,6 +815,47 @@ describe('MCP asset upload (POST /mcp/assets)', () => {
 		});
 		expect(res.status).toBe(409);
 		expect((await res.json()).error.code).toBe('ASSET_ARCHIVED');
+	});
+
+	// The route pre-check above is a fast path, not the rule. This drives the
+	// helper directly — the way any future caller would — to prove the refusal
+	// lives inside the transaction that does the write, not at each call site.
+	it('refuses the upsert helper itself, leaving the row and its review intact', async () => {
+		const upload = await uploadProjectAsset(
+			'helper-guard.txt',
+			'text/plain',
+			new TextEncoder().encode('original bytes'),
+		);
+		const assetId = (await upload.json()).data.id as string;
+		await app.request(`/api/projects/${projectId}/assets/${assetId}/review-comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ comment: 'please revise', quote: 'original' }),
+		});
+		await db.query('UPDATE assets SET archived_at = now() WHERE id = $1', [assetId]);
+
+		const result = await upsertProjectAsset(db, {
+			assetId: randomUUID(),
+			teamId,
+			projectId,
+			contentType: 'text/plain',
+			byteSize: 9,
+			sha256: 'deadbeef',
+			desiredName: 'helper-guard.txt',
+			uploadedByMemberId: null,
+		});
+
+		expect(result.status).toBe('archived');
+		const row = await db.query<{ id: string; byte_size: string; archived_at: string | null }>(
+			'SELECT id, byte_size, archived_at FROM assets WHERE original_filename = $1 AND project_id = $2',
+			['helper-guard.txt', projectId],
+		);
+		expect(row.rows[0].id).toBe(assetId);
+		expect(Number(row.rows[0].byte_size)).toBe('original bytes'.length);
+		expect(row.rows[0].archived_at).not.toBeNull();
+		// A refused write must not consume the pending review either.
+		const review = await db.query('SELECT 1 FROM review_comments WHERE asset_id = $1', [assetId]);
+		expect(review.rows.length).toBe(1);
 	});
 
 	it('rejects a path deeper than 2 folder levels', async () => {

--- a/packages/web/src/lib/audit-format.ts
+++ b/packages/web/src/lib/audit-format.ts
@@ -31,6 +31,20 @@ function str(details: Record<string, unknown>, key: string): string | null {
 	return typeof v === 'string' && v.length > 0 ? v : null;
 }
 
+/** A tri-state flag: true / false / absent (the key was never written). */
+function bool(details: Record<string, unknown>, key: string): boolean | null {
+	const v = details[key];
+	return typeof v === 'boolean' ? v : null;
+}
+
+/** Comma-joined `filenames`, the plural key the delete/deletion-request rows carry. */
+function fileList(details: Record<string, unknown>, key: string): string | null {
+	const v = details[key];
+	if (!Array.isArray(v)) return null;
+	const names = v.filter((n): n is string => typeof n === 'string' && n.length > 0);
+	return names.length > 0 ? names.join(', ') : null;
+}
+
 /** The task identifier a row concerns, whether it is the entity itself or referenced. */
 function taskRef(entry: AuditEntry): string | null {
 	return entry.entity_identifier ?? entry.ref_task_identifier;
@@ -84,11 +98,31 @@ export function describeAuditEntry(entry: AuditEntry): string {
 			if (entry.action === 'run_completed') return `Completed an agent run${on}${outcome}`;
 			return `${verb} an agent run${on}`;
 		}
-		case 'asset':
-			return `Uploaded ${str(d, 'filename') ?? 'a file'}${task ? ` to ${task}` : ''}`;
-		case 'document':
+		case 'asset': {
+			const name = str(d, 'filename');
+			// `archived` is only present on an archive/restore row, so it also tells
+			// these apart from an upload — every asset action shares the `updated`
+			// action verb.
+			const archived = bool(d, 'archived');
+			if (archived === true) return `Archived ${name ?? 'a file'}`;
+			if (archived === false) return `Restored ${name ?? 'a file'}`;
+			// Deletes and deletion requests carry `filenames` (plural), so reading
+			// `filename` alone made them read as uploads.
+			const names = fileList(d, 'filenames');
+			if (entry.action === 'deleted') return `Deleted ${names ?? name ?? 'a file'}`;
+			if (entry.action === 'requested') {
+				return `Requested deletion of ${names ?? name ?? 'a file'}${task ? ` in ${task}` : ''}`;
+			}
+			return `Uploaded ${name ?? 'a file'}${task ? ` to ${task}` : ''}`;
+		}
+		case 'document': {
 			if (str(d, 'field') === 'system_prompt') return `${verb} the system prompt`;
-			return `${verb} document ${str(d, 'title') ?? str(d, 'slug') ?? ''}`.trimEnd();
+			const name = str(d, 'title') ?? str(d, 'slug') ?? '';
+			const archived = bool(d, 'archived');
+			if (archived === true) return `Archived document ${name}`.trimEnd();
+			if (archived === false) return `Restored document ${name}`.trimEnd();
+			return `${verb} document ${name}`.trimEnd();
+		}
 		case 'agent': {
 			if (entry.action === 'created') return 'Created an agent';
 			const change = str(d, 'change');

--- a/packages/web/test/assets-archive.test.tsx
+++ b/packages/web/test/assets-archive.test.tsx
@@ -66,6 +66,10 @@ test('the funnel filter switches views and its caption tracks the selection', as
 	const activeCard = (await r.findByText('keep-me.png')).closest('li') as HTMLElement;
 	expect(activeCard.querySelector('[data-testid="asset-archive"]')).toBeTruthy();
 	expect(activeCard.querySelector('[data-testid="asset-delete"]')).toBeNull();
+	// Move is offered only while active — the server refuses a move on an
+	// archived asset (409 ASSET_ARCHIVED), so hiding it here matches the rule
+	// rather than merely papering over it.
+	expect(activeCard.querySelector('[data-testid="asset-move"]')).toBeTruthy();
 });
 
 test('restoring an archived asset returns it to the Active view', async () => {

--- a/packages/web/test/audit-format-extra.test.ts
+++ b/packages/web/test/audit-format-extra.test.ts
@@ -300,3 +300,82 @@ describe('auditEntryLink — remaining targets', () => {
 		expect(auditEntryLink(entry({ entity_type: 'team' }))).toBeNull();
 	});
 });
+
+// Archive/restore rows share the `updated` action with a content edit, so the
+// sentence has to come from `details.archived`. Before this, every asset row
+// read "Uploaded ..." — including archives, deletes and deletion requests.
+describe('describeAuditEntry — archive lifecycle', () => {
+	test('names an asset archive and restore instead of calling them uploads', () => {
+		const archived = entry({
+			entity_type: 'asset',
+			action: 'updated',
+			entity_identifier: null,
+			details: { filename: 'reports/q3.html', archived: true },
+		});
+		expect(describeAuditEntry(archived)).toBe('Archived reports/q3.html');
+
+		const restored = entry({
+			entity_type: 'asset',
+			action: 'updated',
+			entity_identifier: null,
+			details: { filename: 'reports/q3.html', archived: false },
+		});
+		expect(describeAuditEntry(restored)).toBe('Restored reports/q3.html');
+	});
+
+	test('still describes a plain upload as an upload', () => {
+		const uploaded = entry({
+			entity_type: 'asset',
+			action: 'created',
+			entity_identifier: null,
+			ref_task_identifier: 'OP-7',
+			details: { filename: 'hero.png' },
+		});
+		expect(describeAuditEntry(uploaded)).toBe('Uploaded hero.png to OP-7');
+	});
+
+	test('reads the plural filenames key on deletes and deletion requests', () => {
+		const deleted = entry({
+			entity_type: 'asset',
+			action: 'deleted',
+			entity_identifier: null,
+			details: { filenames: ['old.png', 'older.png'] },
+		});
+		expect(describeAuditEntry(deleted)).toBe('Deleted old.png, older.png');
+
+		const requested = entry({
+			entity_type: 'asset',
+			action: 'requested',
+			entity_identifier: null,
+			ref_task_identifier: 'OP-9',
+			details: { filenames: ['old.png'] },
+		});
+		expect(describeAuditEntry(requested)).toBe('Requested deletion of old.png in OP-9');
+	});
+
+	test('distinguishes a doc archive/restore from a content edit', () => {
+		const archived = entry({
+			entity_type: 'document',
+			action: 'updated',
+			entity_identifier: null,
+			details: { slug: 'spec.md', title: 'Spec', archived: true },
+		});
+		expect(describeAuditEntry(archived)).toBe('Archived document Spec');
+
+		const restored = entry({
+			entity_type: 'document',
+			action: 'updated',
+			entity_identifier: null,
+			details: { slug: 'spec.md', title: 'Spec', archived: false },
+		});
+		expect(describeAuditEntry(restored)).toBe('Restored document Spec');
+
+		const edited = entry({
+			entity_type: 'document',
+			action: 'updated',
+			entity_identifier: null,
+			details: { slug: 'spec.md', title: 'Spec' },
+		});
+		expect(describeAuditEntry(edited)).toBe('Updated document Spec');
+	});
+});

--- a/packages/web/test/project-audit-log.test.tsx
+++ b/packages/web/test/project-audit-log.test.tsx
@@ -1,6 +1,12 @@
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
-import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+import {
+	archiveSeededAsset,
+	seedAsset,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
 
 test('project Activity page lists the project audit trail', async () => {
 	const seeded = { projectSlug: '', identifier: '' };
@@ -38,4 +44,36 @@ test('project Activity page lists the project audit trail', async () => {
 	expect(link?.getAttribute('href')).toContain(
 		`/projects/${seeded.projectSlug}/tasks/${seeded.identifier.toLowerCase()}`,
 	);
+}, 30_000);
+
+// Every asset audit row used to render "Uploaded <file>", including archives —
+// so an agent restoring an asset in order to overwrite it was invisible in the
+// feed. The row now names what actually happened.
+test('project Activity page names an asset archive rather than calling it an upload', async () => {
+	const seeded = { projectSlug: '', filename: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Archive Activity' });
+			const asset = await seedAsset(ws, project, { filename: 'retired.png' });
+			await archiveSeededAsset(ws, project, asset.id);
+			seeded.projectSlug = project.slug;
+			seeded.filename = asset.original_filename;
+			return { ws, project, asset };
+		},
+	});
+
+	await helpers.router.navigate({
+		to: '/projects/$projectId/audit-log',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await helpers.findByText(new RegExp(`Archived ${seeded.filename}`, 'i'), undefined, {
+		timeout: 20_000,
+	});
+	// The upload row is still an upload — exactly one of them. Two would mean the
+	// archive row had rendered as an upload too, which is the bug.
+	const uploads = (document.body.textContent ?? '').split(`Uploaded ${seeded.filename}`).length - 1;
+	expect(uploads).toBe(1);
 }, 30_000);


### PR DESCRIPTION
Archiving is meant to freeze an item, not merely hide it - but the rule was hand-copied at each call site and lived in none of the shared helpers, so several writers slipped past it. An archived asset could still be updated, which is what prompted this.

## What was broken

- **`upsertProjectAsset` / `upsertDocument` had no guard of their own.** Both callers pre-checked with a separate, non-transactional `SELECT`, so there was a check-then-write race - and any new caller inherited nothing.
- **Two document writers had no check at all.** Approving an `update_prd` change that was filed *before* the doc was archived silently resurrected it, and `restoreRevision` would roll an archived doc's content back.
- **`PATCH /api/projects/:projectId/assets/:assetId { folder }` moved or renamed an archived asset.** Its MCP twin `move_project_asset` refuses; the web app only hid the button, so the rule was client-side only.
- **`read_project_asset`'s width/height self-heal wrote back to an archived row.**

## What changed

The refusal now lives **inside** `upsertProjectAsset` (`lib/asset-name.ts`) and `upsertDocument` (`services/documents.ts`): each re-reads `archived_at` in the same transaction that does the write and returns a `status: 'archived'` discriminant instead of writing. Callers map that to their own surface error, so every existing status code and message is byte-identical. The write paths keep a cheap pre-flight (`archivedAssetHolderId`, `isDocumentArchived`) so a 10 MB blob - possibly an S3 PUT - isn't spent on a doomed call.

The REST folder-move now 409s with `ASSET_ARCHIVED`, matching `move_project_asset`. The dimension self-heal still *reports* the parsed dimensions but skips the `UPDATE` on an archived row - a single carve-out would make the invariant one no reader could rely on.

## Making agent unarchive visible

Agents keep self-serve `unarchive_project_asset`/`unarchive_project_doc`, so a blocked write is only a speed bump for them. That is now visible rather than silent:

- `asset.archived` gains task/run attribution.
- Doc archival emits its own `document.archived` instead of a generic `document.updated`, which rendered identically to a content edit.
- The activity log renders "Archived"/"Restored". While in that switch, asset **deletes and deletion requests** are fixed too - they read `filename` where the row carries `filenames`, so they had been rendering as "Uploaded a file".

**No migration.** `audit_log.action`/`entity_type` are plain `TEXT` and `details` is `JSONB`, so this rides in `details` reusing `AuditAction.Updated` (a new action would split history against existing archive rows). `details.task_id` also feeds the audit-log route's existing join onto `tasks`, so an agent's restore deep-links to its task for free.

## Tests

- `archival.test.ts` - the folder-move refusal, the approved-PRD case (content, `archived_at` and revision count all unchanged), the revision-restore refusal, the skipped dimension backfill, run attribution on an asset restore, and a doc archive/restore being distinguishable from a content edit.
- `documents.test.ts` - drives the service directly: `upsertDocument`/`restoreRevision` refused on an archived doc, and always `written` for an `AgentSystemPrompt` scope (pinning the no-op claim for scopes that are never archived).
- `project-assets.test.ts` - calls `upsertProjectAsset` directly, bypassing every route pre-check, and asserts the row *and* its pending review survive. This is the test that proves the rule moved rather than being re-copied.
- `audit-mappers.test.ts`, `audit-log.test.ts` - the new mapper, and `ref_task_identifier` resolving end to end from `details.task_id`.
- Web: `audit-format-extra.test.ts`, `project-audit-log.test.tsx`, `assets-archive.test.tsx`.

## Docs

`docs/concepts/assets.md` and `documents-and-memory.md` (read-only while archived), `docs/security/activity-log.md` (archive/restore entries), `.dev/architecture.md` (rewritten archival paragraph), and a regenerated `docs/reference/mcp-api.md` via `build:docs`.

While verifying the activity-log page, its claim that "You can narrow the view by entity type, action, and date range" turned out to be false - neither the project nor the instance view renders any filter UI (only the API takes those params). That line is removed rather than left standing.

## One thing to know

I asked whether agents should keep the ability to unarchive, given that it lets a blocked write be routed around in one extra call, and the answer was to keep it and log it - which is what this does. If the reports you saw were an agent restoring and then overwriting, the activity log will now show it, but nothing here stops it. Making restore human-only is a separate, larger call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Amx1zYLyQDMs2hPGogYn5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Amx1zYLyQDMs2hPGogYn5v)_