### PR TITLE
feat(locale): preview the picked language in the picker, plus a glyph on its label

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2489,10 +2489,23 @@ would freeze English word order into every translation. The system-comment timel
 still English, so a translated status sentence carries English status words until the board's
 status vocabulary is localized too.
 
+`LanguagePreview` (`lib/i18n`) nests a second `I18nContext.Provider` so the locale editor's
+card renders in the language the operator just picked, before it is saved - the card *is* the
+language picker, so it has to answer in the language being chosen. It shares `buildI18nValue`
+with the real provider (one lookup path, never two), overrides **language only** (date and
+money formats apply on save, and already preview inside their own option rows), and reuses the
+outer context value by identity when the previewed language matches the committed one. It
+touches nothing global - no render hint, no `document.documentElement.lang`, no
+`setActiveLocale`, no request - which is what makes it droppable with no cleanup on unmount or
+cancel. `LocaleEditor` therefore splits in two: the outer half owns the draft and reads the
+*committed* locale (so the re-seed effect can never be re-entered by a preview), the inner half
+renders under the preview. Its hosts pass a `MessageKey` rather than a translated
+`submitLabel`, since a string translated in the host is frozen in the committed language.
+
 `PATCH /api/instance-settings/locale` is the single write path. It is listed in
 `PUBLIC_PATHS` but self-authenticating: open only while no admin password is enrolled (the
 same window `POST /api/auth/setup` is open in), superuser-only after, resolving the bearer
-in-route via `requireAdminEquivalentBearer`. The globe button that hosts the editor appears
+in-route via `requireAdminEquivalentBearer`. The language button that hosts the editor appears
 only on pre-auth surfaces; an unauthorized save there applies to that browser alone rather
 than failing.
 

--- a/docs/concepts/languages-and-formats.md
+++ b/docs/concepts/languages-and-formats.md
@@ -29,9 +29,14 @@ language you don't speak is a bad way to start. See
 **After that**, in **Settings -> Languages & formats**.
 
 While you are signed out - at the unlock screen after a restart, or at the sign-in screen -
-there is a globe button in the top right, because those screens have no menu to reach
+there is a language button in the top right, because those screens have no menu to reach
 Settings through. Changing the language there applies to that browser only and tells you
 so; sign in to change it for everyone.
+
+Picking a language re-renders the picker itself straight away, so you can check it reads the
+way you expect before you commit to it. Nothing is saved at that point: the rest of the app,
+and your date and currency choices, change only when you press Continue or Save. Leave the
+screen without saving and everything stays as it was.
 
 ## It is a setting for the whole instance
 

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -18,11 +18,12 @@ is a bad way to start.
 
 Hezo guesses from your browser, so the screen usually arrives already answered and you can
 just continue. Alongside the language you pick a **date format** and a **currency format**;
-each option shows you a real example rather than a pattern to decode.
+each option shows you a real example rather than a pattern to decode. Picking a language
+re-renders the picker itself right away, so you can read it back before continuing.
 
-The choice applies to the whole instance and is saved straight away, so a refresh
+The choice applies to the whole instance and is saved when you continue, so a refresh
 mid-setup won't lose it. You can change it later in **Settings -> Languages & formats**, and
-a globe button in the top right stays available throughout setup. See
+a language button in the top right stays available throughout setup. See
 [Languages & formats](/docs/concepts/languages-and-formats).
 
 ## 2. Create your master key

--- a/packages/web/src/components/locale/locale-editor.tsx
+++ b/packages/web/src/components/locale/locale-editor.tsx
@@ -1,7 +1,7 @@
 import type { LocaleSettings } from '@hezo/shared';
-import { type ReactNode, useEffect, useState } from 'react';
-import { useSaveLocale } from '../../hooks/use-locale-settings';
-import { useI18n } from '../../lib/i18n';
+import { useEffect, useState } from 'react';
+import { type LocaleSaveScope, useSaveLocale } from '../../hooks/use-locale-settings';
+import { LanguagePreview, type MessageKey, useI18n } from '../../lib/i18n';
 import { Button } from '../ui/button';
 import { LocaleForm } from './locale-form';
 
@@ -10,15 +10,24 @@ import { LocaleForm } from './locale-form';
  * the error / saved-locally messages.
  *
  * Extracted because the same editor has three hosts: the onboarding language
- * step, the dialog behind the pre-auth globe button, and the Settings subpage.
+ * step, the dialog behind the pre-auth locale button, and the Settings subpage.
  * Only the surrounding chrome differs, so only the chrome is written three
  * times.
+ *
+ * The card renders inside a {@link LanguagePreview} keyed on the *draft*
+ * language, so picking a language re-translates the picker itself immediately -
+ * the operator sees the language they chose before committing to it. Nothing
+ * outside the card moves, and nothing is written, until Continue/Save.
  */
 interface LocaleEditorProps {
-	/** Label for the primary action ("Continue" during onboarding, "Save" after). */
-	submitLabel: string;
-	/** Rendered to the left of the submit button (e.g. a dialog Cancel). */
-	secondaryAction?: ReactNode;
+	/**
+	 * Message key for the primary action ("Continue" during onboarding, "Save"
+	 * after). A key rather than a rendered string - the hosts sit outside the
+	 * preview, so a string they translated would be frozen in the old language.
+	 */
+	submitLabelKey: MessageKey;
+	/** Render a Cancel beside the submit (the dialog host); called on click. */
+	onCancel?: () => void;
 	/** Called after a save lands, so a dialog host can close itself. */
 	onSaved?: () => void;
 	/** Stack the actions full-width (onboarding) instead of right-aligning them. */
@@ -27,14 +36,13 @@ interface LocaleEditorProps {
 }
 
 export function LocaleEditor({
-	submitLabel,
-	secondaryAction,
+	submitLabelKey,
+	onCancel,
 	onSaved,
 	fullWidthSubmit,
 	testId,
 }: LocaleEditorProps) {
 	const i18n = useI18n();
-	const { t } = i18n;
 	const [draft, setDraft] = useState<LocaleSettings>({
 		language: i18n.language,
 		date_format: i18n.date_format,
@@ -44,6 +52,8 @@ export function LocaleEditor({
 
 	// Re-seed whenever the active locale changes underneath us - another session
 	// may have changed it, and a cancelled dialog must not leave a stale draft.
+	// Keyed on the *committed* locale (this component sits outside its own
+	// preview), so previewing a draft can never re-enter and clobber it.
 	useEffect(() => {
 		setDraft({
 			language: i18n.language,
@@ -63,9 +73,56 @@ export function LocaleEditor({
 
 	return (
 		<div data-testid={testId}>
-			<LocaleForm value={draft} onChange={setDraft} disabled={isPending} />
+			<LanguagePreview language={draft.language}>
+				<LocaleEditorBody
+					draft={draft}
+					onChange={setDraft}
+					onSave={handleSave}
+					onCancel={onCancel}
+					submitLabelKey={submitLabelKey}
+					fullWidthSubmit={fullWidthSubmit}
+					isPending={isPending}
+					hasError={Boolean(error)}
+					scope={scope}
+				/>
+			</LanguagePreview>
+		</div>
+	);
+}
 
-			{error && (
+/**
+ * Everything that renders *in the draft language*. Split out so its `t()` calls
+ * resolve against the preview context rather than the committed one - a hook
+ * cannot read a provider its own component renders.
+ */
+function LocaleEditorBody({
+	draft,
+	onChange,
+	onSave,
+	onCancel,
+	submitLabelKey,
+	fullWidthSubmit,
+	isPending,
+	hasError,
+	scope,
+}: {
+	draft: LocaleSettings;
+	onChange: (next: LocaleSettings) => void;
+	onSave: () => void;
+	onCancel?: () => void;
+	submitLabelKey: MessageKey;
+	fullWidthSubmit?: boolean;
+	isPending: boolean;
+	hasError: boolean;
+	scope: LocaleSaveScope | null;
+}) {
+	const { t } = useI18n();
+
+	return (
+		<>
+			<LocaleForm value={draft} onChange={onChange} disabled={isPending} />
+
+			{hasError && (
 				<p className="mt-4 text-[13px] text-danger" role="alert">
 					{t('locale.saveFailed')}
 				</p>
@@ -81,16 +138,20 @@ export function LocaleEditor({
 					fullWidthSubmit ? 'mt-6' : 'mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end'
 				}
 			>
-				{secondaryAction}
+				{onCancel && (
+					<Button variant="secondary" onClick={onCancel}>
+						{t('locale.settings.cancel')}
+					</Button>
+				)}
 				<Button
-					onClick={handleSave}
+					onClick={onSave}
 					disabled={isPending}
 					className={fullWidthSubmit ? 'w-full' : undefined}
 					data-testid="locale-save"
 				>
-					{isPending ? t('locale.saving') : submitLabel}
+					{isPending ? t('locale.saving') : t(submitLabelKey)}
 				</Button>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/packages/web/src/components/locale/locale-form.tsx
+++ b/packages/web/src/components/locale/locale-form.tsx
@@ -10,7 +10,7 @@ import {
 	NUMBER_FORMATS,
 	type NumberFormat,
 } from '@hezo/shared';
-import { Check } from 'lucide-react';
+import { Check, Languages } from 'lucide-react';
 import { useI18n } from '../../lib/i18n';
 
 /**
@@ -41,7 +41,10 @@ interface LocaleFormProps {
 
 function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
 	return (
-		<label htmlFor={htmlFor} className="block text-[13px] font-medium text-text-1 mb-1.5">
+		<label
+			htmlFor={htmlFor}
+			className="flex items-center gap-1.5 text-[13px] font-medium text-text-1 mb-1.5"
+		>
 			{children}
 		</label>
 	);
@@ -100,7 +103,13 @@ export function LocaleForm({ value, onChange, disabled, children }: LocaleFormPr
 	return (
 		<div className="space-y-5">
 			<div>
-				<FieldLabel htmlFor="locale-language">{t('locale.language.label')}</FieldLabel>
+				<FieldLabel htmlFor="locale-language">
+					{t('locale.language.label')}
+					{/* The same translate glyph the pre-auth locale button carries - see
+					    locale-switcher.tsx for why it is that and not a globe. Decorative:
+					    the label text already names the field. */}
+					<Languages className="h-3.5 w-3.5 shrink-0 text-text-2" aria-hidden="true" />
+				</FieldLabel>
 				<select
 					id="locale-language"
 					value={value.language}

--- a/packages/web/src/components/locale/locale-switcher.tsx
+++ b/packages/web/src/components/locale/locale-switcher.tsx
@@ -2,7 +2,6 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { Languages } from 'lucide-react';
 import { useState } from 'react';
 import { useI18n } from '../../lib/i18n';
-import { Button } from '../ui/button';
 import { DialogContent } from '../ui/dialog';
 import { LocaleEditor } from './locale-editor';
 
@@ -44,14 +43,13 @@ export function LocaleSwitcher() {
 				<Dialog.Title className="text-base font-semibold text-text-1 mb-5 pr-8">
 					{t('locale.settings.title')}
 				</Dialog.Title>
+				{/* Cancel is the editor's own button, not a `Dialog.Close` passed in:
+				    it has to re-translate along with the rest of the card while a
+				    language is being previewed, and this dialog is already controlled. */}
 				<LocaleEditor
-					submitLabel={t('locale.settings.save')}
+					submitLabelKey="locale.settings.save"
 					onSaved={() => setOpen(false)}
-					secondaryAction={
-						<Dialog.Close asChild>
-							<Button variant="secondary">{t('locale.settings.cancel')}</Button>
-						</Dialog.Close>
-					}
+					onCancel={() => setOpen(false)}
 				/>
 			</DialogContent>
 		</Dialog.Root>

--- a/packages/web/src/components/setup/language-step.tsx
+++ b/packages/web/src/components/setup/language-step.tsx
@@ -28,7 +28,7 @@ export function LanguageStep() {
 			</div>
 			<div className="rounded-lg border border-border bg-surface p-5 sm:p-8 shadow-sm">
 				<LocaleEditor
-					submitLabel={t('locale.continue')}
+					submitLabelKey="locale.continue"
 					fullWidthSubmit
 					testId="setup-step-language"
 				/>

--- a/packages/web/src/lib/i18n/index.tsx
+++ b/packages/web/src/lib/i18n/index.tsx
@@ -99,6 +99,42 @@ function toDate(value: Date | string | null | undefined): Date | null {
 	return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * Build the context value for a locale. Shared by the real provider and by
+ * {@link LanguagePreview}, so the two can never resolve a key differently.
+ */
+function buildI18nValue(
+	locale: LocaleSettings,
+	applyServerLocale: (next: LocaleSettings) => void,
+): I18nContextValue {
+	const t = (key: MessageKey, vars?: Record<string, string | number>) =>
+		interpolate(lookup(locale.language, key), vars);
+
+	return {
+		...locale,
+		t,
+		plural: (key, count, vars) => {
+			const category = new Intl.PluralRules(locale.language).select(count);
+			const template =
+				lookup(locale.language, `${key}.${category}`) !== `${key}.${category}`
+					? lookup(locale.language, `${key}.${category}`)
+					: lookup(locale.language, `${key}.other`);
+			return interpolate(template, { count, ...vars });
+		},
+		formatDate: (value) => {
+			const date = toDate(value);
+			return date ? formatDateIn(date, locale) : '';
+		},
+		formatDateTime: (value) => {
+			const date = toDate(value);
+			return date ? formatDateTimeIn(date, locale) : '';
+		},
+		formatMoney: (cents) => formatMoneyUsd(cents, locale.number_format),
+		formatNumber: (value) => formatNumber(value, locale.number_format),
+		applyServerLocale,
+	};
+}
+
 export function I18nProvider({ children }: { children: ReactNode }) {
 	const [locale, setLocale] = useState<LocaleSettings>(initialLocale);
 
@@ -120,34 +156,57 @@ export function I18nProvider({ children }: { children: ReactNode }) {
 		setActiveLocale(locale);
 	}, [locale]);
 
-	const value = useMemo<I18nContextValue>(() => {
-		const t = (key: MessageKey, vars?: Record<string, string | number>) =>
-			interpolate(lookup(locale.language, key), vars);
+	const value = useMemo<I18nContextValue>(
+		() => buildI18nValue(locale, applyServerLocale),
+		[locale, applyServerLocale],
+	);
 
-		return {
-			...locale,
-			t,
-			plural: (key, count, vars) => {
-				const category = new Intl.PluralRules(locale.language).select(count);
-				const template =
-					lookup(locale.language, `${key}.${category}`) !== `${key}.${category}`
-						? lookup(locale.language, `${key}.${category}`)
-						: lookup(locale.language, `${key}.other`);
-				return interpolate(template, { count, ...vars });
-			},
-			formatDate: (value) => {
-				const date = toDate(value);
-				return date ? formatDateIn(date, locale) : '';
-			},
-			formatDateTime: (value) => {
-				const date = toDate(value);
-				return date ? formatDateTimeIn(date, locale) : '';
-			},
-			formatMoney: (cents) => formatMoneyUsd(cents, locale.number_format),
-			formatNumber: (value) => formatNumber(value, locale.number_format),
-			applyServerLocale,
-		};
-	}, [locale, applyServerLocale]);
+	return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+/**
+ * Render a subtree in a language the operator has picked but not yet saved.
+ *
+ * The locale editor's `<select>` writes to a local draft, so without this the
+ * card that *is* the language picker would keep rendering in the old language
+ * until the operator pressed Continue - no confirmation that they picked the
+ * language they meant. Wrapping the card re-translates it on the spot.
+ *
+ * **A preview is not a decision**, so it deliberately changes nothing global:
+ * no localStorage render hint, no `document.documentElement.lang`, no
+ * `setActiveLocale`, no request. That is what makes it safe to drop with no
+ * cleanup - unmounting, cancelling the dialog, or navigating away simply stops
+ * rendering it, and the committed locale was never touched.
+ *
+ * **Language only.** `date_format` and `number_format` stay committed: those
+ * two already preview inside their own option rows and apply everywhere else
+ * only on save, and nothing here should change that.
+ */
+export function LanguagePreview({
+	language,
+	children,
+}: {
+	language: Language;
+	children: ReactNode;
+}) {
+	const outer = useI18n();
+	const value = useMemo<I18nContextValue>(
+		() =>
+			// Reuse the outer value outright when nothing is being previewed - same
+			// identity, so an unchanged draft costs no re-render (the same reason
+			// `applyServerLocale` compares by value).
+			language === outer.language
+				? outer
+				: buildI18nValue(
+						{
+							language,
+							date_format: outer.date_format,
+							number_format: outer.number_format,
+						},
+						outer.applyServerLocale,
+					),
+		[language, outer],
+	);
 
 	return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 }

--- a/packages/web/src/routes/settings/locale.tsx
+++ b/packages/web/src/routes/settings/locale.tsx
@@ -4,8 +4,8 @@ import { useI18n } from '../../lib/i18n';
 
 /**
  * Settings -> Languages & formats. The signed-in home of the locale editor;
- * the globe button in the corner of the pre-auth gates is the same editor for
- * operators who have nowhere else to reach it yet.
+ * the language button in the corner of the pre-auth gates is the same editor
+ * for operators who have nowhere else to reach it yet.
  */
 function LocaleSettingsPage() {
 	const { t } = useI18n();
@@ -13,7 +13,7 @@ function LocaleSettingsPage() {
 		<div className="max-w-[560px]">
 			<h2 className="text-[15px] font-medium mb-1">{t('locale.settings.title')}</h2>
 			<p className="text-[13px] text-text-2 mb-5">{t('locale.settings.pageDescription')}</p>
-			<LocaleEditor submitLabel={t('locale.settings.save')} testId="locale-settings-page" />
+			<LocaleEditor submitLabelKey="locale.settings.save" testId="locale-settings-page" />
 		</div>
 	);
 }

--- a/packages/web/test/locale-provider.test.tsx
+++ b/packages/web/test/locale-provider.test.tsx
@@ -4,11 +4,11 @@
 // via Intl.PluralRules, and the format helpers. Rendered with renderHook (no app
 // shell).
 import { DateFormat, DEFAULT_LOCALE_SETTINGS, Language, NumberFormat } from '@hezo/shared';
-import { act, renderHook } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { act, render, renderHook } from '@testing-library/react';
+import { type ReactNode, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { getActiveLocale } from '../src/lib/format-date';
-import { I18nProvider, useI18n, useSyncInstanceLocale } from '../src/lib/i18n';
+import { I18nProvider, LanguagePreview, useI18n, useSyncInstanceLocale } from '../src/lib/i18n';
 import { writeStored } from '../src/lib/safe-storage';
 
 const STORAGE_KEY = 'locale';
@@ -225,5 +225,97 @@ describe('I18nProvider', () => {
 		expect(() => renderHook(() => useI18n())).toThrow(
 			'useI18n must be used within an I18nProvider',
 		);
+	});
+});
+
+/** Publish the context value a subtree sees, so two subtrees can be compared. */
+function Probe({ onValue }: { onValue: (value: ReturnType<typeof useI18n>) => void }) {
+	const value = useI18n();
+	useEffect(() => onValue(value), [value, onValue]);
+	return null;
+}
+
+describe('LanguagePreview', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		document.documentElement.lang = '';
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		localStorage.clear();
+	});
+
+	test('renders its subtree in the previewed language', () => {
+		installLanguages(['en-US']);
+		const { result } = renderHook(() => useI18n(), {
+			wrapper: ({ children }: { children: ReactNode }) => (
+				<I18nProvider>
+					<LanguagePreview language={Language.De}>{children}</LanguagePreview>
+				</I18nProvider>
+			),
+		});
+
+		expect(result.current.language).toBe(Language.De);
+		expect(result.current.t('locale.title')).toBe('Sprache auswählen');
+	});
+
+	test('previews the language only - the formats stay committed', () => {
+		// Date and currency format apply on save; only the language previews.
+		installLanguages(['en-US']);
+		const { result } = renderHook(() => useI18n(), {
+			wrapper: ({ children }: { children: ReactNode }) => (
+				<I18nProvider>
+					<LanguagePreview language={Language.De}>{children}</LanguagePreview>
+				</I18nProvider>
+			),
+		});
+
+		expect(result.current.date_format).toBe(DateFormat.Mdy);
+		expect(result.current.number_format).toBe(NumberFormat.DotComma);
+		expect(result.current.formatDate(new Date(2026, 6, 29))).toBe('07/29/2026');
+	});
+
+	test('commits nothing - an unsaved preview leaves every global alone', () => {
+		// This is what makes it safe to drop with no cleanup on unmount or cancel.
+		installLanguages(['en-US']);
+		renderHook(() => useI18n(), {
+			wrapper: ({ children }: { children: ReactNode }) => (
+				<I18nProvider>
+					<LanguagePreview language={Language.Ko}>{children}</LanguagePreview>
+				</I18nProvider>
+			),
+		});
+
+		expect(document.documentElement.lang).toBe(Language.En);
+		expect(getActiveLocale().language).toBe(Language.En);
+		expect(JSON.parse(localStorage.getItem(STORAGE_KEY) as string).language).toBe(Language.En);
+	});
+
+	test('previewing the committed language reuses the same context value', () => {
+		// An unchanged draft must not re-render the subtree, the same reason
+		// applyServerLocale compares by value.
+		installLanguages(['en-US']);
+		let outer: ReturnType<typeof useI18n> | null = null;
+		let inner: ReturnType<typeof useI18n> | null = null;
+
+		render(
+			<I18nProvider>
+				<Probe
+					onValue={(v) => {
+						outer = v;
+					}}
+				/>
+				<LanguagePreview language={Language.En}>
+					<Probe
+						onValue={(v) => {
+							inner = v;
+						}}
+					/>
+				</LanguagePreview>
+			</I18nProvider>,
+		);
+
+		expect(outer).not.toBeNull();
+		expect(inner).toBe(outer);
 	});
 });

--- a/packages/web/test/locale-settings.test.tsx
+++ b/packages/web/test/locale-settings.test.tsx
@@ -3,7 +3,7 @@
 // whole UI re-renders in the new language, and every option previews itself
 // with real formatted output.
 //
-// The pre-auth globe button that hosts the same editor is covered by the
+// The pre-auth language button that hosts the same editor is covered by the
 // Playwright tier - it only appears before any token is set, which the
 // component harness bypasses (decision-tree item 6).
 import { waitFor } from '@testing-library/react';
@@ -35,6 +35,18 @@ async function storedLocale() {
 	return body.data.locale as { language: string; date_format: string; number_format: string };
 }
 
+/** Everything inside the editor card - the surface the live preview covers. */
+function cardText(): string {
+	return document.querySelector('[data-testid="locale-settings-page"]')?.textContent ?? '';
+}
+
+function selectLanguage(
+	user: Awaited<ReturnType<typeof openLocaleSettings>>['user'],
+	code: string,
+) {
+	return user.selectOptions(document.querySelector('#locale-language') as HTMLSelectElement, code);
+}
+
 function optionLabels(name: string): string[] {
 	return Array.from(document.querySelectorAll(`input[name="${name}"]`)).map((input) =>
 		normalizeSpaces(input.closest('label')?.textContent ?? ''),
@@ -48,7 +60,7 @@ test('the settings page renders the locale editor', async () => {
 });
 
 test('the header carries no locale button once signed in', async () => {
-	// It lives in Settings from here; the globe is only for screens that have
+	// It lives in Settings from here; the button is only for screens that have
 	// no navigation yet.
 	await openLocaleSettings();
 	expect(document.querySelector('[data-testid="locale-switcher"]')).toBeNull();
@@ -105,8 +117,72 @@ test('the date format choice reaches the stored instance settings', async () => 
 test('navigating away without saving leaves the stored locale alone', async () => {
 	const { user, router } = await openLocaleSettings();
 
-	await user.selectOptions(document.querySelector('#locale-language') as HTMLSelectElement, 'ko');
+	await selectLanguage(user, 'ko');
 	await router.navigate({ to: '/settings' });
 
 	expect((await storedLocale()).language).toBe('en');
+});
+
+test('picking a language re-renders the card in it before anything is saved', async () => {
+	// The card *is* the language picker, so it has to answer in the language you
+	// just picked - otherwise there is no confirmation you picked the right one.
+	const { user } = await openLocaleSettings();
+
+	await selectLanguage(user, 'de');
+
+	const card = cardText();
+	expect(card).toContain('Sprache');
+	expect(card).toContain('Datumsformat');
+	expect(card).toContain('Währungsformat');
+	// The submit button too - it reads from a message key, not a string the host
+	// translated before the preview existed.
+	expect(document.querySelector('[data-testid="locale-save"]')?.textContent).toBe('Speichern');
+});
+
+test('the preview stays inside the card and writes nothing', async () => {
+	const { user, findByRole } = await openLocaleSettings();
+
+	await selectLanguage(user, 'de');
+
+	// The page heading sits outside the editor and keeps the committed language.
+	await findByRole('heading', { name: 'Languages & formats' });
+	// A preview is not a decision: no document language, no render hint, no write.
+	expect(document.documentElement.lang).toBe('en');
+	expect(JSON.parse(localStorage.getItem('locale') as string).language).toBe('en');
+	expect((await storedLocale()).language).toBe('en');
+});
+
+test('switching the language back restores the card', async () => {
+	const { user } = await openLocaleSettings();
+
+	await selectLanguage(user, 'ja');
+	expect(cardText()).toContain('言語');
+
+	await selectLanguage(user, 'en');
+	expect(cardText()).toContain('Language');
+	expect(cardText()).not.toContain('言語');
+});
+
+test('changing the date format does not re-translate the card', async () => {
+	// Only the language previews live; the other two formats apply on save, and
+	// already preview inside their own option rows.
+	const { user } = await openLocaleSettings();
+	await selectLanguage(user, 'de');
+
+	const isoOption = Array.from(
+		document.querySelectorAll<HTMLInputElement>('input[name="locale-date-format"]'),
+	).find((input) => /^\d{4}-/.test(input.closest('label')?.textContent ?? ''));
+	await user.click(isoOption as HTMLInputElement);
+
+	expect(cardText()).toContain('Datumsformat');
+	expect(document.querySelector('[data-testid="locale-save"]')?.textContent).toBe('Speichern');
+});
+
+test('the language label carries the translate glyph', async () => {
+	await openLocaleSettings();
+
+	const icon = document.querySelector('label[for="locale-language"] svg');
+	expect(icon).not.toBeNull();
+	// Decorative - the label text already names the field.
+	expect(icon?.getAttribute('aria-hidden')).toBe('true');
 });


### PR DESCRIPTION
## What

Two changes to the locale picker card (the first-run language step, Settings -> Languages & formats, and the pre-auth dialog):

1. **Picking a language re-translates the card immediately.** Until now the `<select>` wrote only to a local draft while every `t()` in the card read the committed provider locale, so choosing Italiano left the card reading "Language / Date format / Currency format / Continue". On the one screen whose entire job is picking a language, that gave no confirmation the operator picked the language they meant.
2. **The "Language" label carries the translate glyph** (lucide `Languages` - the same one the pre-auth locale button uses) as a decorative suffix.

## How

`LanguagePreview` (`packages/web/src/lib/i18n/index.tsx`) nests a second `I18nContext.Provider`. It shares the new `buildI18nValue` helper with the real provider, so there is one lookup path rather than two, and it reuses the outer context value **by identity** when the previewed language matches the committed one (no re-render for a no-op draft).

**A preview is not a decision**, so it deliberately changes nothing global: no localStorage render hint, no `document.documentElement.lang`, no `setActiveLocale`, no request. That is what makes it droppable with no cleanup on unmount, cancel, or navigation, and it preserves the existing guarantee that leaving without saving changes nothing.

**Language only.** Date format and currency format keep today's behaviour - they preview inside their own option rows and apply everywhere else on save.

`LocaleEditor` splits in two: the outer half owns the draft and reads the *committed* locale (so the re-seed effect can never be re-entered by a preview), the inner half renders under the preview. Its hosts now pass a `MessageKey` instead of a translated `submitLabel`, because a string translated in the host is frozen in the old language; the dialog's `secondaryAction` becomes `onCancel` for the same reason.

Deliberately out of scope: the headings *above* the card (onboarding title/subtitle, Settings page heading, dialog title) stay in the committed language until save.

## Screenshots

Captured from a running instance, dark theme, first-run language step.

| English (committed) | Immediately after picking Italiano |
|---|---|
| Label carries the translate glyph | Labels, hint and Continue all flip; nothing saved |

Full page in Japanese shows the scope: the card is translated, the "Choose your language" heading above it is not.

## Tests

- `packages/web/test/locale-settings.test.tsx` - 5 new component tests: the card flips language on select; the preview writes nothing (page heading, `document.documentElement.lang`, the render hint and the stored instance setting all stay English); switching back restores the card; changing the **date format** does *not* re-translate the card; the label carries the decorative icon.
- `packages/web/test/locale-provider.test.tsx` - 4 new `LanguagePreview` unit tests covering the previewed language, language-only scoping, the commits-nothing invariant, and the identity reuse.
- Existing coverage kept green unchanged, including `saving persists globally and re-renders the UI in the new language` and `navigating away without saving leaves the stored locale alone`.

Component tier throughout - none of the Playwright decision-tree triggers apply.

## Docs

- `docs/concepts/languages-and-formats.md` and `docs/getting-started/first-run.md` - describe the live picker preview; also corrects the stale "globe button" wording (the control has been the translate glyph for a while).
- `.dev/architecture.md` section Locale - records `LanguagePreview` and the editor split.

No catalog strings were added, reworded or removed; all twelve catalogs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QYrA6LLgfg2bHdpmLb3HT

---
_Generated by [Claude Code](https://claude.ai/code/session_013QYrA6LLgfg2bHdpmLb3HT)_