### PR TITLE
feat(nav): promote Connectors and Skills to top-level project menu items

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -80,7 +80,7 @@ references it.
 The global **Settings → Skills** page lists **every** skill, global and each project's,
 and each row has a scope drop-down so you can move a skill between global and any project (it
 works just like the [Connectors](/docs/mcp/connecting-mcp-servers) page). Each project also has its
-own **Skills** page, under **Connectors** in the project's settings menu, showing that
+own **Skills** page, in the project menu right below **Connectors**, showing that
 project's skills plus the globals; you can edit or remove the project's own skills there,
 while global ones are shown for reference and stay managed on the global page. Every row -
 on either page - has a **view** button that opens the skill and renders its full markdown so

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -179,7 +179,7 @@ and the global scope both define a connection of the same name, the project's ow
 
 Manage connections two ways:
 
-- **Project → Settings → Connectors** shows just that project's connectors. **Add** a
+- **Project → Connectors** shows just that project's connectors. **Add** a
   connector here - an MCP server (name + URL) or a REST API (base URL, allowed hosts,
   and where the credential goes) - and it's scoped to that project. For an MCP server,
   Hezo probes it for OAuth and opens the connect popup automatically, or you attach an

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -106,22 +106,26 @@ export function ProjectSidebar({
 		label: 'Git',
 		testId: 'project-sidebar-git',
 	};
-	// Connectors (this project's MCP servers + GitHub) also disclose under Settings.
+	// Connectors (this project's MCP servers + GitHub) and Skills (its scoped skills +
+	// globals) are top-level pages, not Settings sub-items: they're working surfaces the
+	// team reaches constantly, not configuration set once. Both exist on HQ too — neither
+	// route redirects internal projects away, unlike Git/Budget/Settings. They reuse the
+	// `settings.*` catalog keys the global settings nav already carries, rather than
+	// duplicating the same word into a `nav.*` key across all twelve catalogs.
 	const connectorsPage = {
 		to: '/projects/$projectId/connectors',
 		params: projectParams,
-		label: 'Connectors',
+		label: t('settings.connectors'),
 		testId: 'project-sidebar-connectors',
 	};
-	// Skills (this project's scoped skills + globals) disclose under Settings, below Connectors.
 	const skillsPage = {
 		to: '/projects/$projectId/skills',
 		params: projectParams,
-		label: 'Skills',
+		label: t('settings.skills'),
 		testId: 'project-sidebar-skills',
 	};
 	// Custom Prompt — the project-wide instruction block injected into every agent's
-	// prompt — discloses under Settings, alongside Skills.
+	// prompt — discloses under Settings, alongside Git.
 	const customPromptPage = {
 		to: '/projects/$projectId/custom-prompt',
 		params: projectParams,
@@ -190,8 +194,9 @@ export function ProjectSidebar({
 			label: t('nav.assets'),
 		},
 		...(isInternal
-			? // HQ has no Settings — keep Container and Activity at the top level.
-				[containerPage, activityPage]
+			? // HQ has no Budget or Settings — Container and Activity stay at the top level,
+				// after Connectors and Skills.
+				[connectorsPage, skillsPage, containerPage, activityPage]
 			: [
 					{
 						to: '/projects/$projectId/budget',
@@ -199,21 +204,16 @@ export function ProjectSidebar({
 						label: t('nav.budget'),
 						testId: 'project-sidebar-budget',
 					},
+					connectorsPage,
+					skillsPage,
 					{
 						to: '/projects/$projectId/settings',
 						params: projectParams,
 						label: t('nav.settings'),
 						testId: 'project-sidebar-settings',
-						// Git, Connectors, Skills, Container and Activity disclose under Settings
+						// Git, Custom Prompt, Container and Activity disclose under Settings
 						// when it (or one of them) is the active route.
-						subItems: [
-							gitPage,
-							connectorsPage,
-							skillsPage,
-							customPromptPage,
-							containerPage,
-							activityPage,
-						],
+						subItems: [gitPage, customPromptPage, containerPage, activityPage],
 					},
 				]),
 	];

--- a/packages/web/src/components/sidebar-nav.tsx
+++ b/packages/web/src/components/sidebar-nav.tsx
@@ -117,7 +117,7 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 					{section.items.map((item) => {
 						// A sub-item disclosure also stays open while the user is on one of the
 						// sub-item routes. Those routes come in two shapes: siblings that don't
-						// fuzzy-match the parent at all (Settings → /git, /connectors), and children
+						// fuzzy-match the parent at all (Settings → /git, /container), and children
 						// nested under it (Progress → /progress/goals).
 						const subActive =
 							item.subItems?.some((s) => matchRoute({ to: s.to, params: s.params, fuzzy: true })) ??

--- a/packages/web/test/internal-project.test.tsx
+++ b/packages/web/test/internal-project.test.tsx
@@ -28,7 +28,7 @@ test('HQ task list does not show the project progress bar', async () => {
 	expect(queryByTestId('task-progress-bar')).toBeNull();
 });
 
-test('sidebar exposes Tasks, Documents, Assets and Container for the HQ project (not Settings)', async () => {
+test('sidebar exposes Tasks, Documents, Assets, Connectors, Skills and Container for the HQ project (not Settings)', async () => {
 	const { findAllByRole, queryAllByRole, container, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -57,6 +57,21 @@ test('sidebar exposes Tasks, Documents, Assets and Container for the HQ project 
 		expect(queryAllByRole('link', { name: 'Documents' }).length).toBeGreaterThan(0),
 	);
 	await waitFor(() => expect(queryAllByRole('link', { name: 'Assets' }).length).toBeGreaterThan(0));
+
+	// Connectors and Skills are top-level pages on HQ too — HQ has no Settings row
+	// to nest them under, and neither route redirects an internal project away.
+	await waitFor(() =>
+		expect(
+			queryAllByRole('link', { name: 'Connectors' }).some(
+				(l) => l.getAttribute('href') === `/projects/${HQ_PROJECT_SLUG}/connectors`,
+			),
+		).toBe(true),
+	);
+	expect(
+		queryAllByRole('link', { name: 'Skills' }).some(
+			(l) => l.getAttribute('href') === `/projects/${HQ_PROJECT_SLUG}/skills`,
+		),
+	).toBe(true);
 
 	// No settings link pointing at the HQ project.
 	const settingsLinks = queryAllByRole('link', { name: 'Settings' });
@@ -116,6 +131,21 @@ test('HQ /documents and /assets render while /settings still redirects to /tasks
 	});
 	await new Promise((r) => setTimeout(r, 200));
 	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/assets`);
+
+	// Connectors and Skills are real pages for HQ — the menu rows have somewhere to land.
+	await router.navigate({
+		to: '/projects/$projectId/connectors',
+		params: { projectId: HQ_PROJECT_SLUG },
+	});
+	await new Promise((r) => setTimeout(r, 200));
+	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/connectors`);
+
+	await router.navigate({
+		to: '/projects/$projectId/skills',
+		params: { projectId: HQ_PROJECT_SLUG },
+	});
+	await new Promise((r) => setTimeout(r, 200));
+	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/skills`);
 
 	// Settings still redirects to tasks.
 	await router.navigate({

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -34,9 +34,14 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	expect(within(nav).getByRole('link', { name: 'Documents' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Assets' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Settings' })).toBeTruthy();
-	// Git, Container and Activity now nest under Settings — hidden until it (or
-	// one of them) is the active route.
+	// Connectors and Skills are top-level pages, not Settings sub-items: they're
+	// reachable without first opening Settings.
+	expect(within(nav).getByRole('link', { name: 'Connectors' })).toBeTruthy();
+	expect(within(nav).getByRole('link', { name: 'Skills' })).toBeTruthy();
+	// Git, Custom Prompt, Container and Activity do nest under Settings — hidden
+	// until it (or one of them) is the active route.
 	expect(within(nav).queryByRole('link', { name: 'Git' })).toBeNull();
+	expect(within(nav).queryByRole('link', { name: 'Custom Prompt' })).toBeNull();
 	expect(within(nav).queryByRole('link', { name: 'Container' })).toBeNull();
 	expect(within(nav).queryByRole('link', { name: 'Activity' })).toBeNull();
 
@@ -51,7 +56,7 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	expect(queryByTestId('project-sidebar-back')).toBeNull();
 });
 
-test('Git, Container and Activity nest under Settings, disclosed when Settings is the active route', async () => {
+test('Git, Custom Prompt, Container and Activity nest under Settings, disclosed when Settings is the active route', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';
 	const { container, findByTestId, router } = await renderApp({
@@ -70,10 +75,15 @@ test('Git, Container and Activity nest under Settings, disclosed when Settings i
 	});
 	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
 	expect(within(getNav(container)).queryByRole('link', { name: 'Git' })).toBeNull();
+	expect(within(getNav(container)).queryByRole('link', { name: 'Custom Prompt' })).toBeNull();
 	expect(within(getNav(container)).queryByRole('link', { name: 'Container' })).toBeNull();
 	expect(within(getNav(container)).queryByRole('link', { name: 'Activity' })).toBeNull();
+	// Connectors and Skills are not part of that disclosure — they render on a
+	// non-settings page because they sit at the top level.
+	expect(within(getNav(container)).getByRole('link', { name: 'Connectors' })).toBeTruthy();
+	expect(within(getNav(container)).getByRole('link', { name: 'Skills' })).toBeTruthy();
 
-	// Selecting Settings discloses Git, Container and Activity beneath it.
+	// Selecting Settings discloses Git, Custom Prompt, Container and Activity beneath it.
 	await router.navigate({
 		to: '/projects/$projectId/settings',
 		params: { projectId: projectSlug },
@@ -81,6 +91,7 @@ test('Git, Container and Activity nest under Settings, disclosed when Settings i
 	await waitFor(() =>
 		expect(within(getNav(container)).getByRole('link', { name: 'Git' })).toBeTruthy(),
 	);
+	expect(within(getNav(container)).getByRole('link', { name: 'Custom Prompt' })).toBeTruthy();
 	expect(within(getNav(container)).getByRole('link', { name: 'Container' })).toBeTruthy();
 	expect(within(getNav(container)).getByRole('link', { name: 'Activity' })).toBeTruthy();
 	expect(within(getNav(container)).getByRole('link', { name: 'Settings' })).toBeTruthy();


### PR DESCRIPTION
## What

**Connectors** and **Skills** were disclosure sub-items under **Settings** in the project menu, so they were only reachable after clicking Settings first. They are working surfaces the team reaches constantly - the MCP servers agents call and the know-how they read - not configuration set once. They now sit at the top level, between Budget and Settings.

| | Before | After |
|---|---|---|
| Normal project | Tasks, Documents, Assets, Budget, Settings *(Git, Connectors, Skills, Custom Prompt, Container, Activity)* | Tasks, Documents, Assets, Budget, **Connectors**, **Skills**, Settings *(Git, Custom Prompt, Container, Activity)* |
| HQ | Tasks, Documents, Assets, Container, Activity | Tasks, Documents, Assets, **Connectors**, **Skills**, Container, Activity |

## URLs are unchanged - and were already correct

The request included "update urls paths too", but there was nothing to move: **no project page is URL-nested under Settings.** `Settings` is purely a visual grouping built in `project-sidebar.tsx`; every item in it is a flat sibling route (`/projects/:project/connectors`, `/skills`, `/git`, `/custom-prompt`, `/container`, `/audit-log`). The only thing actually under `settings/` is the index page.

So this is a sidebar-only change: no route file moves, no redirect stubs, no `routeTree.gen.ts` churn, and every existing deep link, audit-log link and `?focus=` anchor keeps working.

## HQ gains both rows

`connectors.tsx` and `skills.tsx` carry no HQ guard (unlike `git.tsx`, `budget.tsx` and `settings/index.tsx`, which redirect internal projects to `/tasks`), and the server routes have no `is_internal` guard either - so both pages were already reachable on HQ, just unlinked. They are now in HQ's menu, with test coverage proving they land on a page rather than redirect.

## i18n

The two labels now go through `t()`, matching their new peers Assets and Budget (they were hardcoded English as sub-items). They **reuse** the existing `settings.connectors` / `settings.skills` keys the global settings nav already carries, rather than duplicating the same word into new `nav.*` keys across all twelve catalogs. No catalog file is touched.

## Files

- `packages/web/src/components/project-sidebar.tsx` - the whole functional change; lifts the two page descriptors out of the Settings `subItems` array into `projectPages` on both the normal and internal branches.
- `packages/web/src/components/sidebar-nav.tsx` - comment only; its example of a non-fuzzy-matching sub-item named `/connectors`, now `/container`. No logic change.
- `packages/web/test/project-sidebar.test.tsx` - asserts Connectors/Skills render at top level on a non-settings route and are not part of the disclosure; adds Custom Prompt to the disclosed set.
- `packages/web/test/internal-project.test.tsx` - asserts HQ's new rows exist with the right hrefs and that `/connectors` + `/skills` resolve without redirecting.
- `docs/mcp/connecting-mcp-servers.md`, `docs/concepts/skills.md` - the two prose lines that described the old Settings nesting.

## Testing

- `packages/web` full suite: **232 files, 1491 tests passed**
- `bun run typecheck` clean across all three packages
- `biome check` clean on all changed files
- `packages/server/test/docs-terminology.test.ts` passes (em/en dash ban on `docs/**`)

`.dev/architecture.md` needs no change - its `/settings/connectors` and `/settings/skills` references are all the global admin pages, `:458` is Custom Prompt (still under Settings), and `:258-261` describes the Progress/goals disclosure, which is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuskKUjrqpMffxWK387q3h)_