### PR TITLE
fix(web): close shell-hosted overlays when the app navigates

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2417,6 +2417,21 @@ transient state** (`creating` / `stopping` — deliberately not the `null` of a 
 project, which would poll forever). That bounds the damage of a missed transition to a few
 seconds of stale banner instead of "stuck until the operator reloads the page."
 
+**Overlay lifetime across navigation.** Overlays rendered under the `<Outlet />` unmount on
+navigation; the ones rendered by the shell chrome in `routes/__root.tsx` — the project rail's
+New project dialog, the mobile nav drawer, the Cmd/Ctrl+K search palette, the CEO chat — sit
+above it and keep their `open` state, so a link inside them swaps the page underneath and
+leaves the overlay covering it. `hooks/use-close-on-route-change.ts` is the single seam. It
+fires on a real **pathname** change only: search params are page state (a task filter, an
+assets folder) and a hash is an in-page jump (the comment deep-link executor strips
+`#comment-…` once it settles), so neither counts, and it never fires on mount. Closing at the
+route rather than in each link's `onClick` is deliberate — the global Cmd/Ctrl+K handler is a
+`window` keydown listener and Radix only intercepts Escape, so the palette opens on top of an
+open modal and navigates from somewhere that modal never sees. The CEO chat is
+**viewport-conditional**: only its blocking presentations (the mobile full-screen sheet, the
+desktop expanded view) react, and expanded collapses back to anchored rather than closing; the
+anchored desktop panel is a deliberately persistent companion that survives navigation.
+
 **Connection indicator.** `useConnectionMonitor` (`hooks/use-connection-status.ts`) drives a
 module-level store from two signals - `navigator.onLine` (catches a dropped network an
 already-open half-open socket hasn't noticed) and the socket's own `connected` flag (catches a

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -27,6 +27,7 @@ import {
 	useChatConversations,
 	writeStoredThreadId,
 } from '../../hooks/use-chat';
+import { useCloseOnRouteChange } from '../../hooks/use-close-on-route-change';
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
 import { useFileAttachments } from '../../hooks/use-file-attachments';
@@ -177,6 +178,20 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
 	}, [open, setOpen]);
+
+	// Navigating away only strands the reader in the BLOCKING presentations: the
+	// mobile full-screen panel and the desktop expanded view, both of which carry
+	// the backdrop below. The anchored desktop corner panel is a deliberately
+	// persistent companion — it doesn't cover the page, and it is meant to survive
+	// navigation — so it is excluded. Expanding is a view mode rather than a
+	// session, so desktop collapses back to anchored instead of closing, keeping
+	// the thread up while the page is unblocked. (`md` matches the backdrop's
+	// `md:hidden`.)
+	const isDesktop = useMediaQuery('(min-width: 768px)');
+	useCloseOnRouteChange(open && (!isDesktop || expanded), () => {
+		if (isDesktop) setExpanded(false);
+		else setOpen(false);
+	});
 
 	// Grow the composer with its content (capped by `max-h-32`, then it scrolls),
 	// and collapse it back to a single row when the draft is cleared on submit.

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
 import { useAgents } from '../hooks/use-agents';
+import { useCloseOnRouteChange } from '../hooks/use-close-on-route-change';
 import { useContainerHealth } from '../hooks/use-container-health';
 import { useMarketplaceTeam, useMarketplaceTeams } from '../hooks/use-marketplace';
 import { useStartProjectIntake } from '../hooks/use-project-intake';
@@ -289,6 +290,16 @@ export function CreateProjectWithTeamDialog({
 		);
 	}, [open, initialMarketplaceSlug]);
 
+	// This dialog outlives a navigation whenever its host is shell chrome:
+	// `ProjectRail` is rendered by `ShellChrome` above the `<Outlet />`
+	// (routes/__root.tsx), so a client-side navigation swaps the page underneath
+	// while the modal keeps covering it. That is reachable from inside the dialog
+	// — the blocked state's "View container" link — and from outside it, via the
+	// Cmd/Ctrl+K palette, which opens on top of an open modal. The invariant
+	// belongs to the modal rather than to whichever host owns the boolean, so the
+	// next host to mount it can't forget.
+	useCloseOnRouteChange(open, () => onOpenChange(false));
+
 	const createProject = useCreateProjectWithTeam();
 	const startIntake = useStartProjectIntake();
 	const navigate = useNavigate();
@@ -435,7 +446,10 @@ export function CreateProjectWithTeamDialog({
 
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<DialogContent size={view === 'entry' ? 'lg' : view === 'all' ? 'xl' : '2xl'}>
+			<DialogContent
+				size={view === 'entry' ? 'lg' : view === 'all' ? 'xl' : '2xl'}
+				data-testid="create-project-dialog"
+			>
 				<Dialog.Title className="shrink-0 text-base font-medium mb-1 pr-8">
 					New project
 				</Dialog.Title>

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from '@tanstack/react-router';
 import { ChevronDown, LogOut } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
+import { useCloseOnRouteChange } from '../hooks/use-close-on-route-change';
 import { useMe } from '../hooks/use-me';
 import { logout } from '../lib/auth';
 import { type MessageKey, useI18n } from '../lib/i18n';
@@ -88,11 +89,9 @@ export function SettingsSidebar() {
 	const items = me?.is_superuser ? [...PUBLIC_ITEMS, ...ADMIN_ITEMS] : PUBLIC_ITEMS;
 	const current = items.find((i) => isActive(i.to, pathname)) ?? items[0];
 
-	// Collapse the mobile dropdown on any route change.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the deliberate trigger
-	useEffect(() => {
-		setOpen(false);
-	}, [pathname]);
+	// Collapse the mobile dropdown on any route change — every item in it is a nav
+	// link, and the panel covers the page one just opened.
+	useCloseOnRouteChange(open, () => setOpen(false));
 
 	const handleLogout = useCallback(() => {
 		setOpen(false);

--- a/packages/web/src/hooks/use-close-on-route-change.ts
+++ b/packages/web/src/hooks/use-close-on-route-change.ts
@@ -1,0 +1,54 @@
+import { useLocation } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Close a transient overlay — a modal dialog, the mobile nav drawer, a collapsed
+ * menu — when the app navigates to a different page.
+ *
+ * Not every overlay unmounts on navigation. The ones rendered under `<Outlet />`
+ * do, by accident of where they live; the ones rendered by the shell chrome in
+ * `routes/__root.tsx` sit ABOVE the `<Outlet />` and never unmount, so their
+ * `open` state survives a client-side navigation. The failure mode is a link
+ * inside the overlay: the page underneath swaps, the overlay does not, and a
+ * full-screen Radix modal (overlay `z-[80]`, content `z-[90]`) is left covering
+ * the page the reader just asked for, with no way through but its close button.
+ * That is what the create-project dialog's "View container" link did while the
+ * HQ container was provisioning.
+ *
+ * Closing at the *route* rather than in each link's `onClick` is deliberate: the
+ * navigation can come from somewhere the overlay never sees. The global
+ * Cmd/Ctrl+K handler is a `window` keydown listener (`ShellChrome`) and Radix
+ * only intercepts Escape, so the search palette opens on top of an open dialog
+ * and navigates from there. A per-link handler would miss that, and would miss
+ * the next link somebody adds.
+ *
+ * Two guards keep it from firing when nothing actually changed — the same two the
+ * `<main>` scroll reset in `routes/__root.tsx` needs:
+ *   - Only a PATHNAME change counts. Search params are page state (a task filter,
+ *     an assets folder) and a hash is an in-page jump — notably the comment
+ *     deep-link executor strips `#comment-…` once it settles, and treating that
+ *     as a page change would shut the overlay under the reader.
+ *   - The first effect run never closes. Mount is not a navigation.
+ *
+ * `open` is passed in so a closed overlay's `onClose` is never called
+ * spuriously — a `Dialog.Root`'s `onOpenChange(false)` should mean the open
+ * state actually changed.
+ */
+export function useCloseOnRouteChange(open: boolean, onClose: () => void): void {
+	const pathname = useLocation({ select: (l) => l.pathname });
+	const lastPathnameRef = useRef(pathname);
+	// Read the callback through a ref so the natural call shape — an inline arrow —
+	// doesn't re-run the effect on every render and re-arm it against a pathname
+	// that never moved.
+	const onCloseRef = useRef(onClose);
+	onCloseRef.current = onClose;
+
+	useEffect(() => {
+		const pathnameChanged = lastPathnameRef.current !== pathname;
+		// Track the pathname even while closed, so reopening never compares against
+		// a stale value and closes on the next unrelated render.
+		lastPathnameRef.current = pathname;
+		if (!pathnameChanged || !open) return;
+		onCloseRef.current();
+	}, [pathname, open]);
+}

--- a/packages/web/src/hooks/use-media-query.ts
+++ b/packages/web/src/hooks/use-media-query.ts
@@ -2,8 +2,13 @@ import { useEffect, useState } from 'react';
 
 /**
  * Reactive `window.matchMedia` — re-renders when the query flips. Guards for
- * environments without `matchMedia` (happy-dom in component tests), where it
- * always reports `false`.
+ * environments without `matchMedia`, where it always reports `false`.
+ *
+ * Note happy-dom is NOT such an environment: it implements `matchMedia` and
+ * reports a 1024px-wide viewport, so component tests evaluate every query
+ * against that width and land on the desktop side of a `min-width` breakpoint.
+ * Behaviour that differs by breakpoint needs a Playwright spec at the viewport
+ * in question, not a component test that assumes mobile.
  */
 export function useMediaQuery(query: string): boolean {
 	const [matches, setMatches] = useState(() => {

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -29,6 +29,7 @@ import { UpdateBanner } from '../components/update-banner';
 import { ScrollContentContext } from '../contexts/scroll-content-context';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
+import { useCloseOnRouteChange } from '../hooks/use-close-on-route-change';
 import { useMe } from '../hooks/use-me';
 import { useProjectMenuCollapsed } from '../hooks/use-project-menu-collapsed';
 import { useAllVisibleProjects, useHqProject, useProjectsIndex } from '../hooks/use-projects';
@@ -223,6 +224,12 @@ function ShellLayout() {
 	const [drawerOpen, setDrawerOpen] = useState(false);
 	const [chatOpen, setChatOpen] = useState(false);
 
+	// The drawer is shell chrome, not route content: it renders outside the
+	// <Outlet /> below and so survives navigation. It holds nothing but nav links,
+	// so leaving it open after one is followed parks a full-screen panel over the
+	// page it just opened. Must be called before the `bare` early return.
+	useCloseOnRouteChange(drawerOpen, () => setDrawerOpen(false));
+
 	// Bare routes (e.g. the standalone document preview) render full-viewport
 	// without the header, project rail, or mobile drawer.
 	if (bare) return <Outlet />;
@@ -243,6 +250,11 @@ interface ShellChromeProps {
 
 function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
+	// Also shell chrome, and also a full-screen modal. Picking a result closes the
+	// palette on its own way out (`search-results.tsx` calls `onSelect` from the
+	// row's Link), but that only covers navigations the palette itself started —
+	// anything else leaves it stacked over the new page.
+	useCloseOnRouteChange(searchOpen, () => setSearchOpen(false));
 	const active = useActiveProject();
 	const hq = useHqProject();
 	const { projects, isLoading: projectsLoading } = useAllVisibleProjects();

--- a/packages/web/test/overlay-close-on-navigate.test.tsx
+++ b/packages/web/test/overlay-close-on-navigate.test.tsx
@@ -1,0 +1,198 @@
+// Regression: a navigation must not leave an overlay covering the page it opened.
+//
+// The create-project dialog (via `ProjectRail`), the mobile nav drawer and the
+// CEO chat are all rendered by `ShellChrome`/`ShellLayout` in routes/__root.tsx,
+// ABOVE the <Outlet />. They never unmount on a client-side navigation, so their
+// `open` state survives it — and a full-screen Radix modal (overlay z-[80],
+// content z-[90]) was left parked over the container page the reader had just
+// asked for by clicking "View container". `useCloseOnRouteChange` closes them on
+// a real pathname change; the last test pins the guard that keeps it from firing
+// on a hash-only one.
+//
+// Component tier per the AGENTS.md decision tree: these assert unmounting (React
+// state + DOM presence), not layout, and both rails and the drawer are
+// state-mounted — only their visibility is class-driven, and happy-dom loads no
+// Tailwind. project-rail.test.tsx already drives the drawer at this tier.
+//
+// The chat is the one surface split across tiers, because its rule is
+// viewport-conditional (only the presentations that BLOCK the page close). happy-dom
+// implements matchMedia and reports a 1024px viewport, so this file covers the two
+// desktop branches — anchored survives, expanded collapses — and the mobile
+// full-screen sheet is covered in test/browser/chat.spec.ts ("dismissal on navigation").
+
+import { screen, waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+/** Put HQ mid-provision so the HQ-gated surfaces render their blocked panel. */
+const blockHqContainer = (db: { query: (sql: string) => Promise<unknown> }) =>
+	db.query(`UPDATE projects SET container_status = 'creating' WHERE is_internal = true`);
+
+const dialogGone = () =>
+	waitFor(() => {
+		expect(screen.queryByTestId('create-project-dialog')).toBeNull();
+		// Nothing of the modal layer survives — overlay included.
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+test('the create-project dialog closes when its "View container" link navigates', async () => {
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			await blockHqContainer(ctx.db);
+		},
+	});
+
+	await user.click(await findByTestId('project-rail-new', undefined, { timeout: 15_000 }));
+
+	const dialog = await screen.findByTestId('create-project-dialog');
+	const notice = await within(dialog).findByTestId('hq-container-notice');
+	expect(notice.textContent ?? '').toContain('Starting the HQ container');
+
+	await user.click(within(dialog).getByTestId('hq-container-notice-link'));
+
+	await waitFor(() => expect(router.state.location.pathname).toBe('/projects/hq/container'));
+	await dialogGone();
+});
+
+test('a navigation from outside the dialog closes it too', async () => {
+	let projectSlug = '';
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws: SeededWorkspace = await seedWorkspace();
+			projectSlug = (await seedProject(ws, { name: 'Operations' })).slug;
+		},
+	});
+
+	await user.click(await findByTestId('project-rail-new', undefined, { timeout: 15_000 }));
+	await screen.findByTestId('create-project-dialog');
+
+	// The palette's toggle is a `window` keydown listener in ShellChrome and Radix
+	// only intercepts Escape, so Cmd+K fires straight through an open modal and
+	// the search dialog stacks on top of it. That is the exposure a per-link
+	// onClick fix cannot reach, so assert it exists rather than assuming it away.
+	await user.keyboard('{Meta>}k{/Meta}');
+	expect(await screen.findByTestId('global-search-dialog')).toBeTruthy();
+
+	// Selecting a result navigates (search-results.tsx `<Link onClick={onSelect}>`).
+	// Drive the navigation directly so the assertion is about the route change
+	// itself and not about typing through two stacked focus scopes.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	await waitFor(() =>
+		expect(router.state.location.pathname).toBe(`/projects/${projectSlug}/tasks`),
+	);
+	await dialogGone();
+});
+
+test('the mobile nav drawer closes when a rail link navigates', async () => {
+	let projectSlug = '';
+	const { findByTestId, getByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws: SeededWorkspace = await seedWorkspace();
+			projectSlug = (await seedProject(ws, { name: 'Operations' })).slug;
+		},
+	});
+
+	await findByTestId('project-rail', undefined, { timeout: 15_000 });
+	await user.click(getByTestId('mobile-nav-toggle'));
+	const drawer = await findByTestId('mobile-nav-drawer');
+
+	// The drawer hosts a SECOND ProjectRail, so every rail testid is duplicated —
+	// scope to the drawer's copy.
+	await user.click(
+		await within(drawer).findByTestId(`project-rail-avatar-${projectSlug}`, undefined, {
+			timeout: 15_000,
+		}),
+	);
+
+	// The project route lands on its tasks board, so match the prefix.
+	await waitFor(() =>
+		expect(router.state.location.pathname).toMatch(new RegExp(`^/projects/${projectSlug}`)),
+	);
+	await waitFor(() => expect(screen.queryByTestId('mobile-nav-drawer')).toBeNull());
+});
+
+test('the anchored CEO chat survives navigation', async () => {
+	// The deliberate exclusion, worth pinning so nobody "fixes" it later: the
+	// anchored desktop corner panel does not cover the page, so it stays open
+	// across a navigation. happy-dom reports a 1024px viewport, so this tier is
+	// the desktop branch; the mobile full-screen sheet — which DOES strand the
+	// reader, and closes — is covered in test/browser/chat.spec.ts.
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			await blockHqContainer(ctx.db);
+		},
+	});
+
+	await user.click(await findByTestId('chat-launcher', undefined, { timeout: 15_000 }));
+	const panel = await findByTestId('chat-panel');
+	await user.click(await within(panel).findByTestId('hq-container-notice-link'));
+
+	await waitFor(() => expect(router.state.location.pathname).toBe('/projects/hq/container'));
+	expect(screen.getByTestId('chat-panel')).toBeTruthy();
+	expect(screen.getByTestId('chat-panel').getAttribute('data-expanded')).toBe('false');
+});
+
+test('the expanded CEO chat collapses to anchored on navigation rather than closing', async () => {
+	// Expanded, the panel takes the viewport and carries the backdrop at every
+	// width, so it blocks the page like any modal. Expanding is a view mode rather
+	// than a session, so it collapses back to the anchored panel — the page is
+	// unblocked and the thread is still there.
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			await blockHqContainer(ctx.db);
+		},
+	});
+
+	await user.click(await findByTestId('chat-launcher', undefined, { timeout: 15_000 }));
+	const panel = await findByTestId('chat-panel');
+	await user.click(within(panel).getByTestId('chat-expand'));
+	await waitFor(() =>
+		expect(screen.getByTestId('chat-panel').getAttribute('data-expanded')).toBe('true'),
+	);
+
+	await user.click(
+		within(screen.getByTestId('chat-panel')).getByTestId('hq-container-notice-link'),
+	);
+
+	await waitFor(() => expect(router.state.location.pathname).toBe('/projects/hq/container'));
+	await waitFor(() =>
+		expect(screen.getByTestId('chat-panel').getAttribute('data-expanded')).toBe('false'),
+	);
+	expect(screen.getByTestId('chat-panel')).toBeTruthy();
+});
+
+test('a hash-only navigation leaves the open dialog and its half-filled form alone', async () => {
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	await user.click(await findByTestId('project-rail-new', undefined, { timeout: 15_000 }));
+	await screen.findByTestId('create-project-dialog');
+	await user.type(screen.getByPlaceholderText('e.g. Marketing Site'), 'Half typed');
+
+	// The comment deep-link executor strips `#comment-…` off the URL once it
+	// settles (TanStack patches replaceState), so a hash change must not read as a
+	// page change and discard what the operator was typing.
+	await router.navigate({ to: '/home', hash: 'anything' });
+	await waitFor(() => expect(router.state.location.hash).toBe('anything'));
+	await router.navigate({ to: '/home', hash: '' });
+	await waitFor(() => expect(router.state.location.hash).toBe(''));
+
+	expect(screen.getByTestId('create-project-dialog')).toBeTruthy();
+	expect((screen.getByPlaceholderText('e.g. Marketing Site') as HTMLInputElement).value).toBe(
+		'Half typed',
+	);
+});

--- a/test/browser/chat.spec.ts
+++ b/test/browser/chat.spec.ts
@@ -463,3 +463,54 @@ test.describe('CEO chat widget — composer auto-grow', () => {
 		expect(await isClipped()).toBe(false);
 	});
 });
+
+// Kept in Playwright by decision-tree item 2 (viewport-conditional behavior):
+// the chat closes on navigation only in the presentations that BLOCK the page,
+// and which presentation is live depends on the viewport. happy-dom implements
+// matchMedia but reports a fixed 1024px width, so the component tier can only
+// reach the desktop branches (covered in
+// packages/web/test/overlay-close-on-navigate.test.tsx); the mobile
+// full-screen sheet needs Chromium at a real mobile viewport.
+test.describe('CEO chat widget — dismissal on navigation', () => {
+	test('mobile: following "View container" leaves no sheet over the page', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		const page = sharedPage;
+
+		// Put HQ mid-provision so the chat renders its blocked panel, whose only
+		// affordance is the link out to the container page.
+		await page.route('**/api/projects', async (route) => {
+			const res = await route.fetch();
+			const json = (await res.json()) as { data: Array<Record<string, unknown>> };
+			await route.fulfill({
+				response: res,
+				body: JSON.stringify({
+					...json,
+					data: json.data.map((p) =>
+						p.is_internal === true ? { ...p, container_status: 'creating' } : p,
+					),
+				}),
+			});
+		});
+
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+
+		const panel = page.getByTestId('chat-panel');
+		await expect(panel).toBeVisible();
+		await panel.getByTestId('hq-container-notice-link').click();
+
+		// The sheet and its scrim both go, and the page it navigated to is what the
+		// reader is actually left looking at.
+		await expect(page).toHaveURL(/\/projects\/hq\/container$/);
+		await expect(panel).toBeHidden();
+		await expect(page.getByTestId('chat-overlay')).toBeHidden();
+		await expect(launcher).toBeVisible();
+	});
+});


### PR DESCRIPTION
## The bug

With the HQ container rebuilding, the **New project** dialog shows a blocked panel whose only affordance is a "View container →" link. Clicking it navigated the page underneath, but the modal stayed parked on top - no way through but its close button.

`ProjectRail` owns `createOpen` and is rendered by `ShellChrome` in `routes/__root.tsx`, **above** the `<Outlet />`. Shell chrome never unmounts on a client-side navigation, so the open state survived it and the Radix modal (overlay `z-[80]`, content `z-[90]`) kept covering the container page. The dialog's other two hosts live under the `<Outlet />` and unmount on their own, which is why only the rail-hosted one showed it.

## The fix

New `useCloseOnRouteChange(open, onClose)` (`packages/web/src/hooks/use-close-on-route-change.ts`), called from each **blocking** shell-hosted overlay:

| Overlay | Behaviour |
|---|---|
| Create-project dialog | Closes. Called inside the dialog, not `ProjectRail`, so all three of its hosts inherit the invariant |
| Mobile nav drawer | Closes |
| Cmd/Ctrl+K search palette | Closes - the new tests surfaced the same gap here |
| CEO chat | Viewport-conditional, see below |

Closing at the **route** rather than in each link's `onClick` is deliberate: the palette's toggle is a `window` keydown listener and Radix only intercepts Escape, so the palette opens on top of an open modal and navigates from somewhere that modal never sees. A per-link handler cannot reach that, and would miss the next link anyone adds. It also keeps host policy off `HqContainerNotice`, whose three hosts want three different behaviours.

The hook fires on a real **pathname** change only - search params are page state (a task filter, an assets folder) and a hash is an in-page jump (the comment deep-link executor strips `#comment-…` once it settles) - and never on mount.

**The CEO chat is the deliberate exception.** Only its blocking presentations react: the mobile full-screen sheet closes, and the desktop **expanded** view collapses back to anchored rather than closing, so the thread survives while the page is unblocked. The anchored desktop corner panel does not cover the page and is a persistent companion by design, so it stays open across navigation - pinned by a test so it is not "fixed" later.

`settings-sidebar.tsx` held an inline, naive version of this effect; it moves onto the shared hook so there is one seam rather than two (and drops a `biome-ignore`).

## Also

Corrects the `use-media-query.ts` doc comment. It claimed happy-dom has no `matchMedia`; it does, and reports a 1024px viewport, so component tests land on the **desktop** side of a `min-width` breakpoint. The stale comment sent the first draft of the chat test at the wrong branch.

## Tests

- **`packages/web/test/overlay-close-on-navigate.test.tsx`** (new, 6 tests): the reported bug end to end; navigation from outside the dialog (asserting the Cmd+K palette really does stack on an open modal); the drawer; both chat desktop branches; and a hash-only guard that pins a half-filled form surviving.
- **`test/browser/chat.spec.ts`**: one added case for the chat's mobile sheet, which is viewport-conditional and so needs Chromium at 375px per the AGENTS.md decision tree.

Verified: the 6 new component tests pass; the new browser case passes; 9 existing drawer/rail mobile browser specs pass; `typecheck` and `biome check` clean. The full web tier is 1496/1497 - the one failure (`progress-page.test.tsx`) passes in isolation, is unrelated to any file here, and flaked under full-suite contention.

## Docs

`.dev/architecture.md` § 11 gains an **Overlay lifetime across navigation** note. No user-facing `docs/` page documents dialog dismissal and no route, flag or documented surface changed, so none needed an edit. No string changes, so all 12 catalogs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsptcMP9WdF53z8a1EDRgZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsptcMP9WdF53z8a1EDRgZ)_