### PR TITLE
fix(web): suffix the project info icon to its name, keep the expand tab visible

### DIFF
--- a/packages/web/src/components/budget-banner.tsx
+++ b/packages/web/src/components/budget-banner.tsx
@@ -1,9 +1,10 @@
 import { Link } from '@tanstack/react-router';
 import { AlertTriangle } from 'lucide-react';
 import { useBudgetStatus } from '../hooks/use-costs';
+import { useProjectMenuCollapsed } from '../hooks/use-project-menu-collapsed';
+import { bannerInnerClass } from '../lib/banner-classes';
 
 const BANNER_OUTER = 'sticky top-0 z-30 bg-surface';
-const BANNER_INNER = 'flex items-center gap-2 px-4 py-2 text-[13px] font-medium';
 
 /**
  * Warns at the top of a project when the project or one or more of its agents has
@@ -12,6 +13,7 @@ const BANNER_INNER = 'flex items-center gap-2 px-4 py-2 text-[13px] font-medium'
  */
 export function BudgetBanner({ projectId }: { projectId: string }) {
 	const { data: status } = useBudgetStatus(projectId);
+	const [menuCollapsed] = useProjectMenuCollapsed();
 	if (!status) return null;
 
 	const projectOver = status.project.overBudget;
@@ -31,7 +33,7 @@ export function BudgetBanner({ projectId }: { projectId: string }) {
 				params={{ projectId }}
 				data-testid="budget-banner"
 				aria-label={`${message}. View budgets`}
-				className={`${BANNER_INNER} bg-danger/10 text-danger transition-colors hover:bg-danger/20`}
+				className={`${bannerInnerClass(menuCollapsed)} bg-danger/10 text-danger transition-colors hover:bg-danger/20`}
 			>
 				<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
 				<span data-testid="budget-banner-message" className="min-w-0 truncate">

--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -2,19 +2,21 @@ import { Link } from '@tanstack/react-router';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useContainerHealth } from '../hooks/use-container-health';
+import { useProjectMenuCollapsed } from '../hooks/use-project-menu-collapsed';
 import { useProjectMeta } from '../hooks/use-projects';
 import { api } from '../lib/api';
+import { bannerInnerClass, bannerInsetClass } from '../lib/banner-classes';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { Button } from './ui/button';
 import { Progress } from './ui/progress';
 
 const BANNER_OUTER = 'sticky top-0 z-40 bg-surface';
-const BANNER_INNER = 'flex items-center gap-2 px-4 py-2 text-[13px] font-medium';
 
 export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const project = useProjectMeta(projectId);
 	const health = useContainerHealth(project);
+	const [menuCollapsed] = useProjectMenuCollapsed();
 	const [isRebuilding, setIsRebuilding] = useState(false);
 
 	const bannerRef = useCallback((node: HTMLDivElement | null) => {
@@ -46,7 +48,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 					params={{ projectId }}
 					data-testid="container-status-banner-building"
 					aria-label={`Rebuilding ${project.name}'s base image. View container logs`}
-					className="flex flex-col gap-1 px-4 py-2 bg-info/10 text-info transition-colors hover:bg-info/20"
+					className={`flex flex-col gap-1 px-4 py-2 ${bannerInsetClass(menuCollapsed)} bg-info/10 text-info transition-colors hover:bg-info/20`}
 				>
 					<div className="flex items-center gap-2 text-[13px] font-medium">
 						<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" />
@@ -75,7 +77,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 					params={{ projectId }}
 					data-testid="container-status-banner-provisioning"
 					aria-label={`${message} View container logs`}
-					className={`${BANNER_INNER} bg-info/10 text-info transition-colors hover:bg-info/20`}
+					className={`${bannerInnerClass(menuCollapsed)} bg-info/10 text-info transition-colors hover:bg-info/20`}
 				>
 					<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" />
 					<span data-testid="container-status-banner-message" className="min-w-0 truncate">
@@ -113,7 +115,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 				params={{ projectId }}
 				data-testid="container-status-banner"
 				aria-label={`${message}. View container`}
-				className={`${BANNER_INNER} ${tone} transition-colors`}
+				className={`${bannerInnerClass(menuCollapsed)} ${tone} transition-colors`}
 			>
 				<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
 				<span data-testid="container-status-banner-message" className="min-w-0 truncate">

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -281,7 +281,7 @@ export function ProjectSidebar({
 					to="/projects/$projectId"
 					params={projectParams}
 					data-testid="project-sidebar-name"
-					className="min-w-0 flex-1 text-[13px] font-semibold text-text-1 truncate"
+					className="min-w-0 text-[13px] font-semibold text-text-1 truncate"
 				>
 					{project ? (
 						isInternal ? (

--- a/packages/web/src/lib/banner-classes.ts
+++ b/packages/web/src/lib/banner-classes.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared class strings for the project-scoped sticky banners that render at the
+ * very top of `<main>` (container status, budget).
+ *
+ * They need a common home for one reason beyond deduplication: when the project
+ * menu is collapsed, `<main>` starts at the project rail's right edge, which is
+ * exactly where the expand tab docks (`__root.tsx`). The tab is drawn above the
+ * banners so it can never be buried, so without an inset it would sit on top of
+ * a banner's leading icon. Both banners therefore shift their content past the
+ * tab whenever the menu is collapsed.
+ */
+
+/** Width of the expand tab (28px) plus the banners' usual 16px gutter. */
+const EXPAND_TAB_CLEARANCE = 'lg:pl-11';
+
+/**
+ * Left inset that clears the collapsed-menu expand tab. Empty when the menu is
+ * expanded (no tab is rendered, so the default `px-4` gutter is correct), and
+ * `lg:`-gated because the tab itself is desktop-only.
+ */
+export function bannerInsetClass(menuCollapsed: boolean): string {
+	return menuCollapsed ? EXPAND_TAB_CLEARANCE : '';
+}
+
+/** The standard single-row banner body, inset past the expand tab when collapsed. */
+export function bannerInnerClass(menuCollapsed: boolean): string {
+	return `flex items-center gap-2 px-4 py-2 text-[13px] font-medium ${bannerInsetClass(menuCollapsed)}`;
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -399,7 +399,15 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 					)}
 					{/* Collapsed: a slim expand tab docked to the project rail's right
 					    edge, flush under the app header. Desktop-only — below lg the
-					    project menu is a drawer, so there is nothing to collapse. */}
+					    project menu is a drawer, so there is nothing to collapse.
+					    z-50 is load-bearing, not decorative: collapsed, <main> starts at
+					    the rail's right edge, so this tab shares its top-left corner with
+					    whatever <main> stickies there — today ContainerStatusBanner (z-40)
+					    and BudgetBanner (z-30), which sit in this same stacking context.
+					    Anything at or below their z-index gets painted over and the tab
+					    silently vanishes, stranding the user with no way to re-expand.
+					    Keep this above every sticky banner; the only other z-50 is the
+					    mobile drawer, which is lg:hidden and never coexists with it. */}
 					{menuProjectSlug && menuCollapsed && (
 						<Tooltip content="Expand menu" side="right">
 							<button
@@ -407,7 +415,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 								aria-label="Expand menu"
 								data-testid="project-sidebar-expand"
 								onClick={() => setMenuCollapsed(false)}
-								className="absolute left-[60px] top-0 z-20 hidden h-[22px] w-7 items-center justify-center rounded-br-[9px] border border-l-0 border-t-0 border-border bg-surface text-text-2 shadow-sm transition-colors hover:text-text-1 lg:flex"
+								className="absolute left-[60px] top-0 z-50 hidden h-[22px] w-7 items-center justify-center rounded-br-[9px] border border-l-0 border-t-0 border-border bg-surface text-text-2 shadow-sm transition-colors hover:text-text-1 lg:flex"
 							>
 								<ChevronsRight className="h-4 w-4" aria-hidden="true" />
 							</button>

--- a/test/browser/project-menu-collapse.spec.ts
+++ b/test/browser/project-menu-collapse.spec.ts
@@ -3,6 +3,9 @@
 // against the project rail's right edge) is measured with boundingBox from the
 // real flex/absolute layout, and the whole affordance is gated `lg:` so it must
 // be exercised at a real desktop width — neither is computable in happy-dom.
+// The sticky-banner test is point 1 too: occlusion is only observable from a real
+// layout pass plus a hit-test, and happy-dom has no notion of one element
+// covering another.
 
 import { expect, test } from './fixtures';
 import { waitForPageLoad } from './helpers';
@@ -62,6 +65,58 @@ test('the project menu collapses to a rail-docked expand tab and restores', asyn
 	await tab.click();
 	await expect(page.getByTestId('project-sidebar-name')).toBeVisible();
 	await expect(page.getByTestId('project-sidebar-expand')).toHaveCount(0);
+});
+
+test('the expand tab stays clickable when a sticky banner tops the page', async ({
+	page,
+	lightWorkspace,
+}) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+
+	// Force the project's container to `error` so ContainerStatusBanner renders.
+	// No REST route sets that status - the e2e server runs the in-process fake
+	// Docker client, where provisioning succeeds - so drive it from the projects
+	// index the banner reads (`useProjectMeta` -> `useProjectsIndex`), the same
+	// interception chat.spec.ts uses to pin a container state.
+	await page.route('**/api/projects', async (route) => {
+		if (route.request().method() !== 'GET') return route.fallback();
+		const response = await route.fetch();
+		const body = (await response.json()) as { data?: Array<Record<string, unknown>> };
+		const data = Array.isArray(body.data)
+			? body.data.map((p) =>
+					p.slug === lightWorkspace.projectSlug ? { ...p, container_status: 'error' } : p,
+				)
+			: body.data;
+		await route.fulfill({ response, json: { ...body, data } });
+	});
+
+	await page.goto(`/projects/${lightWorkspace.projectSlug}/tasks`);
+	await waitForPageLoad(page);
+
+	// The banner is `sticky top-0 z-40` at the very top of <main>; collapsed, <main>
+	// starts at the rail's right edge, so it lands on the expand tab's corner.
+	const banner = page.getByTestId('container-status-banner');
+	await expect(banner).toBeVisible({ timeout: 20000 });
+
+	await page.getByTestId('project-sidebar-collapse').click();
+	const tab = page.getByTestId('project-sidebar-expand');
+	await expect(tab).toBeVisible();
+
+	// The tab is drawn above the banner, so the banner insets its content past it
+	// rather than letting the tab bury the warning icon.
+	const tabBox = await tab.boundingBox();
+	const iconBox = await banner.locator('svg').first().boundingBox();
+	expect(tabBox).not.toBeNull();
+	expect(iconBox).not.toBeNull();
+	if (tabBox && iconBox) {
+		expect(iconBox.x).toBeGreaterThanOrEqual(tabBox.x + tabBox.width);
+	}
+
+	// Clicking is the assertion that actually catches the bug: toBeVisible() is
+	// satisfied by a fully covered element, but Playwright's actionability check
+	// hit-tests the click point and fails when another element intercepts it.
+	await tab.click();
+	await expect(page.getByTestId('project-sidebar-name')).toBeVisible();
 });
 
 test('the mobile drawer is unaffected — no collapse affordance there', async ({

--- a/test/browser/project-menu-name-info.spec.ts
+++ b/test/browser/project-menu-name-info.spec.ts
@@ -1,0 +1,101 @@
+// Real-CSS-layout assertions (testing decision tree, point 1): the claim is that
+// the ⓘ's left edge sits a `gap-1` after the project name's right edge, and that a
+// long name truncates instead of shoving the ⓘ out of the panel. Both are resolved
+// only by a real layout pass — happy-dom returns zeroed geometry for
+// getBoundingClientRect/scrollWidth. Point 2 applies as well: the menu panel is
+// `hidden lg:block`, so it needs a real desktop width.
+//
+// A component test here would be false confidence: the DOM order (name Link, then
+// the ⓘ button) is identical before and after the fix, so any DOM-order assertion
+// passes against the bug. Only the geometry distinguishes them.
+
+import { HQ_PROJECT_SLUG } from '@hezo/shared';
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+// The ⓘ renders only for an `is_internal` project, i.e. HQ.
+const HQ_TASKS = `/projects/${HQ_PROJECT_SLUG}/tasks`;
+
+test('the info tooltip is suffixed to the project name, not pushed to the panel edge', async ({
+	authedPage: page,
+}) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	await page.goto(HQ_TASKS);
+	await waitForPageLoad(page);
+
+	const name = page.getByTestId('project-sidebar-name');
+	const info = page.getByTestId('project-sidebar-info');
+	await expect(name).toBeVisible({ timeout: 20000 });
+	await expect(info).toBeVisible();
+
+	const nameBox = await name.boundingBox();
+	const infoBox = await info.boundingBox();
+	const menuBox = await page.getByTestId('project-menu').boundingBox();
+	expect(nameBox).not.toBeNull();
+	expect(infoBox).not.toBeNull();
+	expect(menuBox).not.toBeNull();
+
+	if (nameBox && infoBox && menuBox) {
+		// The row's `gap-1` is 4px; allow slack for sub-pixel text metrics. With the
+		// name Link still carrying `flex-1` this gap is ~130px, so this genuinely
+		// fails on the unfixed layout rather than passing either way.
+		const gap = infoBox.x - (nameBox.x + nameBox.width);
+		expect(gap).toBeGreaterThanOrEqual(0);
+		expect(gap).toBeLessThanOrEqual(8);
+
+		// And it reads as part of the title rather than as a right-hand control:
+		// it sits in the panel's left half, nowhere near the collapse button.
+		expect(infoBox.x).toBeLessThan(menuBox.x + menuBox.width / 2);
+	}
+});
+
+test('a long project name truncates and still keeps the info icon beside it', async ({
+	authedPage: page,
+}) => {
+	const LONG_NAME = 'Headquarters Coordination And Operations Programme Office';
+
+	// Rename HQ in flight rather than over the API: HQ is instance-wide state that
+	// parallel Playwright workers share, so a real rename would leak across tests.
+	// `useProjectMeta` resolves off `useProjectsIndex` -> GET /api/projects, and it
+	// matches on slug, so rewriting the name alone drives the sidebar.
+	await page.route('**/api/projects', async (route) => {
+		if (route.request().method() !== 'GET') return route.fallback();
+		const response = await route.fetch();
+		const body = (await response.json()) as { data?: Array<Record<string, unknown>> };
+		const data = Array.isArray(body.data)
+			? body.data.map((p) => (p.is_internal ? { ...p, name: LONG_NAME } : p))
+			: body.data;
+		await route.fulfill({ response, json: { ...body, data } });
+	});
+
+	await page.setViewportSize({ width: 1440, height: 900 });
+	await page.goto(HQ_TASKS);
+	await waitForPageLoad(page);
+
+	const name = page.getByTestId('project-sidebar-name');
+	const info = page.getByTestId('project-sidebar-info');
+	await expect(name).toHaveText(LONG_NAME, { timeout: 20000 });
+
+	// Visually clipped, but the full text stays in the DOM.
+	expect(await name.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
+
+	const nameBox = await name.boundingBox();
+	const infoBox = await info.boundingBox();
+	const menuBox = await page.getByTestId('project-menu').boundingBox();
+	const collapseBox = await page.getByTestId('project-sidebar-collapse').boundingBox();
+	expect(nameBox).not.toBeNull();
+	expect(infoBox).not.toBeNull();
+	expect(menuBox).not.toBeNull();
+	expect(collapseBox).not.toBeNull();
+
+	if (nameBox && infoBox && menuBox && collapseBox) {
+		// Still adjacent: the name shrank rather than displacing the icon.
+		const gap = infoBox.x - (nameBox.x + nameBox.width);
+		expect(gap).toBeGreaterThanOrEqual(0);
+		expect(gap).toBeLessThanOrEqual(8);
+
+		// The icon stayed inside the panel and clear of the collapse button's gutter.
+		expect(infoBox.x + infoBox.width).toBeLessThanOrEqual(menuBox.x + menuBox.width);
+		expect(infoBox.x + infoBox.width).toBeLessThanOrEqual(collapseBox.x + 1);
+	}
+});


### PR DESCRIPTION
Fixes two defects in the desktop project menu, both reproduced on HQ.

## 1. The info icon was right-aligned instead of suffixed to the project name

The name `<Link>` in `project-sidebar.tsx` carried `flex-1` (`flex: 1 1 0%`), so the name box grew to consume every pixel of free space in the header row. The `shrink-0` ⓘ was therefore pushed to the row's far right, landing against the `«` collapse button roughly 130px from the word "HQ" - nothing was right-aligning it, the name box was simply too wide.

Dropping `flex-1` lets the link fall back to `flex: 0 1 auto`, so its basis is its content width and the icon trails the name across the row's existing `gap-1`. Truncation is preserved: `min-w-0` plus the default `flex-shrink: 1` still let the item shrink below content width, and `truncate` clips with an ellipsis. `pr-7` stays, so a long name truncates before running under `«`.

## 2. Collapsing the menu left no visible way to expand it

The expand tab already existed - `absolute left-[60px] top-0 z-20` inside `content-well`, docked flush under the app header at the project rail's right edge. But with the menu collapsed `<main>` starts at exactly x=60, and the project route layout renders `ContainerStatusBanner` (`sticky top-0 z-40`) and `BudgetBanner` (`sticky top-0 z-30`) at the very top of `<main>`. Nothing between them establishes a stacking context, so the banners won the z-order comparison and painted straight over the 28x22px tab. The reported "HQ container hit an error" screenshot is exactly this: the tab was rendered, but buried.

Raised to `z-50`. It has to be strictly greater than 40 - at equal z-index the banner still wins on DOM order. `z-50` is otherwise used only by the mobile nav drawer, which is `lg:hidden` and can never coexist with the `lg:flex` tab. A comment now records why the value is load-bearing.

## 3. Banner clearance

Raising the tab meant it sat on top of the banner's leading `AlertTriangle` (the tab spans the row's first 28px; the icon sits at 16-30px), which read as a rendering bug. Both banners now inset their content past the tab while the menu is collapsed. Their byte-identical `BANNER_INNER` moved into a shared `packages/web/src/lib/banner-classes.ts` rather than duplicating the conditional in each; `BANNER_OUTER` stays per-file since the two deliberately differ.

## Tests

Both new assertions are Playwright per the testing decision tree (point 1 - real CSS layout; happy-dom has no geometry and no notion of occlusion). A component test would have been false confidence for the icon fix: the DOM order is identical before and after, so only the geometry distinguishes them.

- `test/browser/project-menu-collapse.spec.ts` - forces `container_status: 'error'` via the `page.route` interception on the projects index that `chat.spec.ts` already uses to pin a container state, then **clicks** the tab. `toBeVisible()` is satisfied by a fully covered element; Playwright's actionability hit-test is not, which is precisely the regression signal.
- `test/browser/project-menu-name-info.spec.ts` (new) - asserts the icon sits a `gap-1` after the name (~130px on the unfixed layout, so it genuinely fails without the change), and that a long name truncates without displacing the icon out of the panel.

Existing specs needed no changes - the tab does not move, so the position, height and collapse-corner assertions all still hold.

## Verification

- `bun run typecheck` and `bun run check` pass; the five touched source files are lint-clean.
- `project-menu-collapse`, `internal-project` and `hq-menu-no-projects` component specs pass (10/10).
- Built the bundle and confirmed Tailwind v4 emits `lg:pl-11` from a `.ts` file and that it lands after `px-4` in the cascade. Worth checking - there was no prior precedent in this repo for Tailwind classes outside `.tsx`, and a missed class would have made the clearance silently do nothing.

## Notes

Nothing in `docs/` or `.dev/architecture.md` describes the collapse/expand affordance or the HQ tooltip (`docs/` names the project menu only as the location of Progress, Goals and Skills), and no route, CLI flag, MCP tool or documented behaviour changed. No user-facing string was added, reworded or removed, so all 12 catalogs are untouched.

One trade-off worth flagging for review: raising the z-index fixes the reported bug but is not structurally immune - any future sticky element added to the top of `<main>` re-triggers the same collision, and the banner inset would need extending to it. Moving the control into the app header (a flex sibling above the content well) would make the overlap impossible instead. That was considered and deliberately not taken here to keep the affordance where users currently reach it; the comment on the tab flags the constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172h3wCvKJtvKjc46y83qfi)_