### PR TITLE
feat(web): use the globe glyph for the pinned HQ project entry

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -640,7 +640,7 @@ live-refreshes. `project_icons`
 unlike assets the **bytes live in the DB** (a `BYTEA` column) in a dedicated table so the
 hot `projects.*` list query never pulls the blob; it is rendered on every surface that draws
 a project avatar — the project rail (including the pinned HQ entry, which falls back to a
-building glyph when HQ has no icon) and the home dashboard's Active cards and Other rows — and
+globe glyph when HQ has no icon) and the home dashboard's Active cards and Other rows — and
 served from a public HMAC-signed read route (`GET /api/projects/:projectId/icon`, the `sig`
 query param is the credential since an `<img>` carries no bearer token). The serialized
 project carries a freshly-signed `icon_url` (null when unset); the client normalizes any

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Building2, Home, Plus } from 'lucide-react';
+import { Globe, Home, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useInboxUnreadCount, useInboxUnreadCountsBySlug } from '../hooks/use-inbox-count';
@@ -168,7 +168,8 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 								data-testid="project-rail-hq"
 								// A full-bleed icon drops the border and surface fill (the same rule
 								// `Avatar` follows): keeping them would leave a grey ring between the
-								// image and the active ring. Without an icon, HQ keeps its glyph.
+								// image and the active ring. Without an icon, HQ keeps its globe glyph
+								// — the same mark the sidebar puts on the global agents HQ hosts.
 								className={`relative w-9 h-9 rounded-full flex items-center justify-center overflow-hidden transition-colors ${
 									hq.icon_url
 										? ''
@@ -178,7 +179,7 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 								{hq.icon_url ? (
 									<img src={hq.icon_url} alt="" className="w-full h-full object-cover" />
 								) : (
-									<Building2 className="w-4 h-4" />
+									<Globe className="w-4 h-4" />
 								)}
 								<CountOverlayBadge
 									count={hqInbox?.unread ?? 0}

--- a/packages/web/test/home-project-icons.test.tsx
+++ b/packages/web/test/home-project-icons.test.tsx
@@ -3,7 +3,7 @@
 // project's Settings page, and the Home dashboard - the first screen after login
 // - still shows the bare initials. These specs pin the icon onto both Home
 // surfaces (the Active card and the Other-projects row) and onto the rail's
-// pinned HQ entry, which used to hardcode a building glyph. Component tier.
+// pinned HQ entry, which used to hardcode a glyph. Component tier.
 
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
@@ -88,7 +88,7 @@ test('the Home Other-projects row renders the uploaded project icon', async () =
 	expect(img?.getAttribute('src') ?? '').toContain(`/api/projects/${ref.id}/icon`);
 });
 
-test('the project rail shows HQ’s uploaded icon in place of the building glyph', async () => {
+test('the project rail shows HQ’s uploaded icon in place of the globe glyph', async () => {
 	const ref = { hqId: '' };
 	const { findByTestId, router } = await renderApp({
 		initialPath: '/',
@@ -111,7 +111,7 @@ test('the project rail shows HQ’s uploaded icon in place of the building glyph
 	expect(img?.getAttribute('src') ?? '').toContain(`/api/projects/${ref.hqId}/icon`);
 });
 
-test('the project rail falls back to the building glyph when HQ has no icon', async () => {
+test('the project rail falls back to the globe glyph when HQ has no icon', async () => {
 	const { findByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -124,5 +124,7 @@ test('the project rail falls back to the building glyph when HQ has no icon', as
 
 	const hqEntry = await findByTestId('project-rail-hq', undefined, { timeout: 20_000 });
 	expect(hqEntry.querySelector('img')).toBeNull();
-	expect(hqEntry.querySelector('svg')).not.toBeNull();
+	// The globe specifically: HQ is the global project, and the sidebar already
+	// marks the global agents it hosts (CEO, Coach) with the same glyph.
+	expect(hqEntry.querySelector('svg.lucide-globe')).not.toBeNull();
 });


### PR DESCRIPTION
## What

The project rail's pinned HQ entry drew a `Building2` glyph when HQ has no uploaded icon. Swapped it for lucide's `Globe`.

## Why

HQ is the one global project, and the project sidebar already marks the global agents HQ hosts (CEO, Coach) with a globe. Sitting next to each other in the shell, the same concept read as two unrelated marks - the rail said "building", the agent list right beside it said "globe".

## Notes

- The icon-upload path is untouched: an uploaded HQ icon still replaces the glyph full-bleed, dropping the border and surface fill exactly as before.
- `packages/web/test/home-project-icons.test.tsx` previously asserted only that *some* `<svg>` rendered in the fallback case. It now asserts `svg.lucide-globe`, so a future swap has to be deliberate rather than silent.
- `.dev/architecture.md` named the building glyph as HQ's fallback in the `project_icons` section; updated in the same change.
- The "Get started with Hezo" welcome card on the home dashboard keeps its `Building2` - that's a generic empty-state illustration, not the HQ project's icon.

## Testing

- `bunx vitest run test/home-project-icons.test.tsx test/project-rail.test.tsx` - 13 passed
- `bun run typecheck` - clean
- `bunx biome check` on the changed files - clean

No user-facing strings added or changed (the entry's tooltip and aria-label both read the project name), so the catalogs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bPhHFwZBstn1MeRAoTFsc

---
_Generated by [Claude Code](https://claude.ai/code/session_012bPhHFwZBstn1MeRAoTFsc)_