### PR TITLE
fix(web): put the run-row expand chevron beside the timestamp

### DIFF
--- a/packages/server/test/mcp-tools-branch-cov-c.test.ts
+++ b/packages/server/test/mcp-tools-branch-cov-c.test.ts
@@ -440,7 +440,7 @@ describe('skills', () => {
 			items: Array<{ slug: string }>;
 		};
 		expect(byTag.items.map((s) => s.slug)).toContain('tagged-skill');
-		const noMatch = (await admin('list_skills', { tags: 'zzz' })) as { skills: unknown[] };
+		const noMatch = (await admin('list_skills', { tags: 'zzz' })) as { items: unknown[] };
 		expect(noMatch.items).toEqual([]);
 
 		const got = (await admin('get_skill', { slug: 'tagged-skill' })) as { content: string };

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,7 +1,7 @@
 import { HeartbeatRunStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { DoorOpen, Loader2, RotateCw } from 'lucide-react';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { type ContainerHealth, useContainerHealth } from '../../hooks/use-container-health';
 import { formatElapsed } from '../../hooks/use-elapsed-duration';
 import {
@@ -194,7 +194,13 @@ export function RunCommentBody({
 	// out of width, so a narrow mobile viewport never forces the header — and
 	// with it the whole page — wider than the screen. Only a single segment
 	// longer than the full row width truncates (max-w-full).
-	const summaryRow = (
+	//
+	// `trailing` (the expand chevron, when this row is a toggle) rides inside the
+	// timestamp segment rather than at the end of the row: the row keeps `flex-1`
+	// so the Retry variant's full-width button stays one big click target, which
+	// would otherwise strand the chevron against the far right edge, detached from
+	// everything it toggles.
+	const summaryRow = (trailing?: ReactNode) => (
 		<span className="flex flex-1 flex-wrap items-center gap-x-2 gap-y-0.5 min-w-0">
 			<Link
 				to="/projects/$projectId/agents/$agentId"
@@ -247,24 +253,39 @@ export function RunCommentBody({
 					)}
 				</span>
 			)}
-			{publicId ? (
-				<CommentTimestampLink
-					publicId={publicId}
-					createdAt={createdAt}
-					className="whitespace-nowrap max-w-full truncate"
-				/>
-			) : (
-				<RelativeTime
-					iso={createdAt}
-					className="text-[11px] text-text-3 whitespace-nowrap max-w-full truncate"
-				/>
-			)}
+			<span className="inline-flex items-center gap-1 min-w-0 max-w-full">
+				{publicId ? (
+					<CommentTimestampLink
+						publicId={publicId}
+						createdAt={createdAt}
+						className="whitespace-nowrap"
+					/>
+				) : (
+					<RelativeTime
+						iso={createdAt}
+						className="text-[11px] text-text-3 whitespace-nowrap min-w-0 truncate"
+					/>
+				)}
+				{trailing}
+			</span>
 		</span>
 	);
 
+	const chevron = (
+		<svg
+			aria-hidden="true"
+			className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+			viewBox="0 0 16 16"
+			fill="currentColor"
+		>
+			<path d="M6 3l5 5-5 5V3z" />
+		</svg>
+	);
+
 	// The expand/collapse toggle. `flex-1` is added only when a sibling Retry
-	// button shares the row; without it the markup stays byte-identical to the
-	// pre-Retry header, so a non-retryable run's clickable geometry is unchanged.
+	// button shares the row, so the whole header stays one click target; the
+	// chevron rides with the timestamp either way (see summaryRow) rather than
+	// being pushed to the stretched button's far edge.
 	// `max-w-full` is load-bearing: a <button> shrink-wraps to its content's
 	// max-content width (form controls ignore block-level auto-fill), so without
 	// it the nowrap header segments widen the button — and the whole page —
@@ -276,19 +297,11 @@ export function RunCommentBody({
 			aria-expanded={expanded}
 			aria-controls={logRegionId}
 			data-testid="run-comment-header"
-			className={`flex max-w-full items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer${
+			className={`flex max-w-full items-center min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer${
 				canRetry && taskId ? ' flex-1' : ''
 			}`}
 		>
-			{summaryRow}
-			<svg
-				aria-hidden="true"
-				className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
-				viewBox="0 0 16 16"
-				fill="currentColor"
-			>
-				<path d="M6 3l5 5-5 5V3z" />
-			</svg>
+			{summaryRow(chevron)}
 		</button>
 	);
 
@@ -299,7 +312,7 @@ export function RunCommentBody({
 					// Actively running/queued: the log is force-shown, so the header is a
 					// static (non-collapsible) summary with no toggle.
 					<div className="flex items-center min-h-[26px] min-w-0" data-testid="run-comment-header">
-						{summaryRow}
+						{summaryRow()}
 					</div>
 				) : canRetry && taskId ? (
 					<div className="flex items-center gap-1 min-w-0">

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -234,7 +234,12 @@ test('task page renders completed run as a collapsed inline comment with summary
 	await expect(header).toHaveAttribute('aria-expanded', 'false');
 });
 
-async function mockCompletedRun(page: Page, token: string, logTextOverride?: string) {
+async function mockCompletedRun(
+	page: Page,
+	token: string,
+	opts: { logText?: string; status?: 'succeeded' | 'failed' } = {},
+) {
+	const { logText: logTextOverride, status = 'succeeded' } = opts;
 	const headers = { Authorization: `Bearer ${token}` };
 
 	const projectRes = await createProjectAndClearPlanning(page, '', token, {
@@ -294,10 +299,10 @@ async function mockCompletedRun(page: Page, token: string, logTextOverride?: str
 					task_identifier: null,
 					task_title: null,
 					project_id: project.id,
-					status: 'succeeded',
+					status,
 					started_at: startedAt,
 					finished_at: finishedAt,
-					exit_code: 0,
+					exit_code: status === 'succeeded' ? 0 : 1,
 					error: null,
 					input_tokens: 0,
 					output_tokens: 0,
@@ -422,6 +427,67 @@ test('completed run header wraps within the viewport when the log expands (mobil
 	await assertNoHorizontalOverflow();
 });
 
+// #1 (real CSS layout): the chevron's position is decided by flex distribution —
+// only a real layout pass says where it lands (happy-dom returns 0 boxes). A
+// retryable (failed) run is the forcing case: its header shares a flex row with
+// the Retry button and takes `flex-1`, so the button stretches the full width.
+// With the chevron as a trailing sibling of the `flex-1` summary row it was
+// stranded against the far right edge, detached from what it toggles; it belongs
+// immediately after the "N ago" timestamp.
+test('the expand chevron sits beside the timestamp on a retryable run header', async ({ page }) => {
+	await authenticate(page);
+	const token = await getToken(page);
+
+	const { task, projectSlug } = await mockCompletedRun(page, token, { status: 'failed' });
+
+	// Retry only shows while no run is active, and assigning the task woke the
+	// agent for real — pin `has_active_run` so the header variant is deterministic.
+	await page.route('**/api/projects/*/tasks/*', async (route) => {
+		if (route.request().method() !== 'GET') return route.continue();
+		const response = await route.fetch();
+		const body = (await response.json()) as { data: Record<string, unknown> };
+		await route.fulfill({
+			response,
+			json: { data: { ...body.data, has_active_run: false } },
+		});
+	});
+
+	await page.goto(`/projects/${projectSlug}/tasks/${task.id}`);
+
+	const runCommentEl = page.getByTestId('run-comment').first();
+	await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+
+	// Retry present ⇒ this really is the stretched, full-width header variant.
+	await expect(runCommentEl.getByTestId('retry-failed-run')).toBeVisible({ timeout: 20_000 });
+
+	const header = runCommentEl.getByTestId('run-comment-header');
+	await expect(header.getByTestId('run-comment-summary')).toBeVisible({ timeout: 20_000 });
+
+	// The synthetic comment carries no public_id, so the timestamp renders as the
+	// plain <time> element rather than the self-anchor link variant.
+	const timestamp = header.locator('time');
+	// The chevron is the only <svg> in the header (the status dot is a <span>, and
+	// Retry's icon lives in a sibling button outside it).
+	const chevron = header.locator('svg');
+
+	const headerBox = await header.boundingBox();
+	const timestampBox = await timestamp.boundingBox();
+	const chevronBox = await chevron.boundingBox();
+	if (!headerBox || !timestampBox || !chevronBox) throw new Error('element has no bounding box');
+
+	// The header does stretch — otherwise this asserts nothing.
+	expect(headerBox.width).toBeGreaterThan(timestampBox.width * 3);
+	// Chevron hugs the timestamp: it starts right after it, on the same line…
+	const gap = chevronBox.x - (timestampBox.x + timestampBox.width);
+	expect(gap).toBeGreaterThanOrEqual(0);
+	expect(gap).toBeLessThanOrEqual(12);
+	expect(
+		Math.abs(chevronBox.y + chevronBox.height / 2 - (timestampBox.y + timestampBox.height / 2)),
+	).toBeLessThanOrEqual(2);
+	// …and is nowhere near the stretched header's right edge.
+	expect(headerBox.x + headerBox.width - (chevronBox.x + chevronBox.width)).toBeGreaterThan(40);
+});
+
 // #1 (real CSS layout): the leading inline-event icon must share a vertical
 // centre-line with the run summary's "<agent> run" label. The icon sits in a
 // 26px slot while the label is a 16px text-xs line, so their centres only line
@@ -520,7 +586,7 @@ test('formatted view collapses a long thinking block behind a Show more/less tog
 		'\n',
 	);
 
-	const { task, projectSlug } = await mockCompletedRun(page, token, logText);
+	const { task, projectSlug } = await mockCompletedRun(page, token, { logText });
 
 	await page.goto(`/projects/${projectSlug}/tasks/${task.id}`);
 


### PR DESCRIPTION
The collapsed run row's expand chevron sat at the far right edge of the header, detached from the summary it toggles:

```
>_  [ CEO run  ● failed  ·  1 line  ·  0s   4 minutes ago                    ▶ ]  [⟳ Retry]
```

It should read as a suffix of the "N ago" timestamp.

## Why it only looked wrong on failed runs

The chevron was a trailing sibling of the `flex-1` summary row. On a non-retryable run the header `<button>` shrink-wraps to its content, so the chevron already landed beside the timestamp. On a **failed/timed-out** run the header shares a flex row with the Retry button and takes `flex-1` itself, so the button stretches full width, the summary row eats the slack, and the chevron gets pushed ~274px clear of the timestamp - the case in the report.

## Change

`packages/web/src/components/comment-renderers/run-comment.tsx`:

- The chevron moves inside the summary row, grouped with the timestamp in one `inline-flex` segment, so it reads as a suffix of the relative time and cannot wrap onto a line of its own. The timestamp keeps `min-w-0 truncate` (it stays the segment that shrinks when the row runs out of room); the chevron stays `shrink-0`.
- `summaryRow` becomes a small factory taking the trailing node, so the active-run variant - which has no toggle - still renders without one.
- Markup, `transition-transform` / `rotate-90` rotation, `aria-expanded`/`aria-controls` and every `data-testid` are otherwise unchanged. The header `<button>` keeps `flex-1` on the Retry variant, so the full-width click target is preserved.

Second commit is unrelated and test-only: `mcp-tools-branch-cov-c.test.ts` cast a `list_skills` response to `{ skills: unknown[] }` while reading `.items`, left over from before `list_skills` adopted the paged shape. It never surfaced because `packages/server/tsconfig.json` only includes `src`, so the test tree is not typechecked.

## Testing

New Playwright geometry test (`test/browser/agent-run-logs.spec.ts`) on the retryable header - real CSS layout, so happy-dom can't cover it. It asserts Retry is present (proving the stretched variant), that the chevron starts within 12px of the timestamp's right edge on the same centre-line, and that it is well clear of the header's right edge. `mockCompletedRun` grew an options object so it can serve a failed run; the task GET is intercepted to pin `has_active_run` false.

- The new test **fails on the pre-fix layout** with a 274px gap, and passes after.
- `bunx playwright test test/browser/agent-run-logs.spec.ts` - 9/9 pass, including the existing mobile wrap test (`chevronBox.x + chevronBox.width <= 375`, no horizontal overflow of `<main>`).
- `bun run test --package web --pattern run-` - 33/33 pass across 9 files (collapse, retry, formatted-log, termination, created-tasks).
- `bunx vitest run test/mcp-tools-branch-cov-c.test.ts` - 22/22 pass.
- `bun run typecheck` and `bun run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWo2HZa8CM2Wm4nb8dfuaV


---
_Generated by [Claude Code](https://claude.ai/code/session_01RWo2HZa8CM2Wm4nb8dfuaV)_