### PR TITLE
fix(git): route in-container git through the egress proxy

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2145,10 +2145,25 @@ unreachable, which is exactly how it shipped. `codeload.github.com` is in the Gi
 capability's `allowedHosts` because it serves the packfiles; without it the ref
 advertisement succeeds and the transfer is refused.
 
+**Every in-container git op that talks to a remote carries the run's proxy env**
+(`HTTP(S)_PROXY`/`NO_PROXY`, from the shared `buildEgressProxyEnv`), because that is the only
+way the placeholder in its remote URL ever becomes a credential. Git reads those variables the
+way any HTTP client does, so nothing git-specific carries a clone to the proxy - and nothing
+supplies them implicitly either: `ContainerGitExecutor` takes them through its `baseEnv`, so
+each caller passes them. Run prep gets them from the run's own allocation (`prepareWorktrees`);
+provisioning gets them from `withProvisionBridge`. A caller that omits them does not fail
+loudly - the clone connects direct, ships `__HEZO_SECRET_<NAME>__` as its Basic password, and
+the remote reports a bad token, which points at the credential rather than at the routing.
+
 Remote ops (`needsNetwork`, formerly `needsSsh`) carry git's own HTTP timeouts
 (`http.lowSpeedLimit`/`lowSpeedTime`) and still run under `hezo-run-with-bridge`, which is
 what scopes the process tree for the marker kill. Cloning outside a run (container provision,
-repo link) uses a short-lived `withProvisionBridge`. Each exec also carries a per-op timeout
+repo link) uses a short-lived `withProvisionBridge`, which allocates the same pair an agent run
+does - the ssh-agent socket **and** an egress proxy - points the tunnel's `ssh` and `proxy`
+targets at them, and derives the tunnel's split-routing policy from the vault via
+`buildTunnelHostPolicy(db, [])` (no descriptors: provisioning loads no connectors). Only `mcp`
+stays unrouted, since a provisioning op has no MCP identity. The egress leg is mandatory and
+missing one throws rather than standing up a tunnel with nowhere to route. Each exec also carries a per-op timeout
 (fetch 60s, clone 120s)
 and, for prep, the run's own abort signal — both abort the `docker exec` stream, so a hung
 transport can no longer block the run (or the per-project git lock) until it is killed by
@@ -3034,9 +3049,10 @@ ssh config is written into the container. The durability `post-commit` hook stil
 live `SSH_AUTH_SOCK` (§ Agent runtime, Commit durability): it gates on the socket because a
 commit it could not sign is one it should not push, not because the push needs ssh.
 Repo/worktree prep wraps individual git commands with the same `hezo-run-with-bridge` runner;
-cloning outside a run (provision, repo link) allocates a short-lived bridge via
-`withProvisionBridge`, whose per-op `provision-<hex>` id doubles as the exec scope marker
-(§ Agent execution, Process-tree lifecycle).
+cloning outside a run (provision, repo link) allocates a short-lived bridge **and egress proxy**
+via `withProvisionBridge`, whose per-op `provision-<hex>` id doubles as the exec scope marker
+(§ Agent execution, Process-tree lifecycle) and keys both allocations. The proxy is what
+substitutes the clone's credential, so it is as load-bearing here as the socket is for signing.
 
 **Verified-on-GitHub bootstrap.** On every successful GitHub OAuth connect the project's
 public key is auto-registered on the connecting user's account as **both** a signing key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ describe('099_example migration', () => {
 
 ## Testing
 
+**CI is the canonical check, not a local full run.** Do not run the whole suite locally to find out whether a change is green - **commit and push to your branch and let CI answer**. CI has the machines for it: `test-backend` fans across 5 shards, `test-integration` 5, `test-browser` 3, each on its own runner, with `test-postgres` and `test-s3` running the external-driver legs no local `bun run test` reaches at all. A single dev box runs those same suites serially against one PGlite, which is both far slower and a **worse** signal - a laptop or a container without a Docker daemon fails suites (`startup-real-docker-branch`, the `*-docker.test.ts` container suites) for reasons that have nothing to do with the change, and an under-resourced box OOMs the runner (exit 137), which reads as a failure but is not one.
+
+Run a **subset** locally whenever it helps you iterate - that is what it is for. Narrow to what you touched (`--pattern`, `--package`, or a single file via `bunx vitest run <path>`; see *Running one file or one test*), sanity-check, and push. `bun run typecheck` locally is cheap and worth it, since a type error blocks the commit hook anyway. Reserve a full local `bun run test` for when you are specifically chasing a cross-suite interaction that CI has already flagged.
+
 All changes ship with tests that exercise functionality (not "code runs without throwing"). Prefer integration over heavily-mocked unit tests. Five tiers:
 
 | Tier | Where | Run cost | What it tests | When to use |

--- a/packages/server/src/lib/container-deps.ts
+++ b/packages/server/src/lib/container-deps.ts
@@ -22,6 +22,7 @@ export function buildContainerDeps(c: Context<Env>): ContainerDeps {
 		logs: c.get('logs'),
 		containerLogStreamer: c.get('containerLogStreamer'),
 		sshAgentServer: c.get('sshAgentServer'),
+		egressProxy: c.get('egressProxy'),
 		egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
 	};
 }

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -307,6 +307,7 @@ approvalsRoutes.post('/approvals/:approvalId/resolve', async (c) => {
 			logs: c.get('logs'),
 			containerLogStreamer: c.get('containerLogStreamer'),
 			sshAgentServer: c.get('sshAgentServer'),
+			egressProxy: c.get('egressProxy'),
 			egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
 		},
 	});

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -12,6 +12,7 @@ import { logger } from '../logger';
 import { requireSuperuser } from '../middleware/auth';
 import { resolveContainerRunUser } from '../services/container-user';
 import type { ContainerDeps } from '../services/containers';
+import type { EgressProxy } from '../services/egress';
 import {
 	getCloneState,
 	getWorktreeState,
@@ -597,10 +598,22 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 					files: resetExecutor.files(repo.repoContainerPath),
 				});
 			};
-			return sshAgentServer && egressProxy
+			// Ssh server only — the egress proxy is mandatory, and
+			// `withProvisionBridge` enforces that by throwing. See the note at the
+			// equivalent guard in `containers.ts`.
+			return sshAgentServer
 				? withProvisionBridge(
 						sshAgentServer,
-						{ engine: docker, containerId, teamId, dataDir, runUser, db, egressProxy, projectId },
+						{
+							engine: docker,
+							containerId,
+							teamId,
+							dataDir,
+							runUser,
+							db,
+							egressProxy: egressProxy as EgressProxy,
+							projectId,
+						},
 						({ bridge, scopeId, proxyEnv }) => runReset(bridge, scopeId, proxyEnv),
 					)
 				: runReset(null, mintGitOpScopeId());

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -258,6 +258,7 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		logs: c.get('logs'),
 		containerLogStreamer: c.get('containerLogStreamer'),
 		sshAgentServer: c.get('sshAgentServer'),
+		egressProxy: c.get('egressProxy'),
 		egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
 	};
 	trackBackground(
@@ -505,6 +506,7 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 			logs: c.get('logs'),
 			containerLogStreamer: c.get('containerLogStreamer'),
 			sshAgentServer: c.get('sshAgentServer'),
+			egressProxy: c.get('egressProxy'),
 			egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
 		};
 		trackBackground(
@@ -569,9 +571,16 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 				);
 				return { success: true, removed };
 			}
-			// discard_local: the best-effort fetch needs the SSH bridge.
+			// discard_local: the best-effort fetch reaches the remote, so it needs the
+			// egress proxy to substitute the origin's credential placeholder as much
+			// as it needs the bridge.
 			const sshAgentServer = c.get('sshAgentServer');
-			const runReset = (bridge: BridgeRunnerArgs | null, scopeId: string) => {
+			const egressProxy = c.get('egressProxy');
+			const runReset = (
+				bridge: BridgeRunnerArgs | null,
+				scopeId: string,
+				proxyEnv: string[] = [],
+			) => {
 				// The loc's files come from this executor, not another: pairing a cwd
 				// with a seam rooted in a different container is the drift the shared
 				// `files()` accessor exists to prevent.
@@ -581,17 +590,18 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 					bridge,
 					runUser,
 					scopeId,
+					proxyEnv,
 				);
 				return resetCloneToOrigin(resetExecutor, {
 					containerPath: repo.repoContainerPath,
 					files: resetExecutor.files(repo.repoContainerPath),
 				});
 			};
-			return sshAgentServer
+			return sshAgentServer && egressProxy
 				? withProvisionBridge(
 						sshAgentServer,
-						{ engine: docker, containerId, teamId, dataDir, runUser },
-						({ bridge, scopeId }) => runReset(bridge, scopeId),
+						{ engine: docker, containerId, teamId, dataDir, runUser, db, egressProxy, projectId },
+						({ bridge, scopeId, proxyEnv }) => runReset(bridge, scopeId, proxyEnv),
 					)
 				: runReset(null, mintGitOpScopeId());
 		},

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -73,7 +73,7 @@ import { acquireRunContainer, PoolCapacityError } from './containers';
 import type { ContainerEngine, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
-import { type EgressProxy, formatEgressProxyUrl } from './egress';
+import { buildEgressProxyEnv, type EgressProxy } from './egress';
 import {
 	clearPushErrors,
 	describeUnpushedWork,
@@ -677,35 +677,13 @@ export async function buildRuntimeInvocation(
 		})),
 	);
 	if (egress) {
-		// Per-run token rides the userinfo so every client sends it as
-		// Proxy-Authorization; the proxy 407s any caller without it. A non-null
-		// token here means auth is on (the default).
-		const proxyUrl = formatEgressProxyUrl(egress.host, egress.port, egress.token);
-		const noProxyHosts = [
-			egress.host,
-			'localhost',
-			'127.0.0.1',
-			// The Hezo MCP endpoint and agent asset URLs arrive on container loopback,
-			// where the tunnel client listens — covered by the `127.0.0.1`/`localhost`
-			// entries above. MCP auth there is a real per-run JWT and asset URLs are
-			// HMAC-signed, so there is no `__HEZO_SECRET_*__` placeholder to
-			// substitute: routing them through the proxy would buy nothing and add a
-			// hop on every (potentially multi-MB) binary read. Connector MCP servers
-			// live on their own remote hosts (reached via HTTPS CONNECT) and still
-			// traverse the proxy.
+		env.push(
+			// The same entries every in-container git op gets, from the same builder -
+			// a run's agent CLI and its `git clone` reach the proxy identically.
 			// For a locally-hosted provider the upstream is the operator's own machine,
 			// known only from the config's stored base URL — pass it so that host
 			// bypasses the MITM proxy like any other model-provider endpoint.
-			...providerDirectUpstreamHosts(provider, credential.baseUrl),
-		];
-		const noProxy = [...new Set(noProxyHosts)].join(',');
-		env.push(
-			`HTTP_PROXY=${proxyUrl}`,
-			`http_proxy=${proxyUrl}`,
-			`HTTPS_PROXY=${proxyUrl}`,
-			`https_proxy=${proxyUrl}`,
-			`NO_PROXY=${noProxy}`,
-			`no_proxy=${noProxy}`,
+			...buildEgressProxyEnv(egress, providerDirectUpstreamHosts(provider, credential.baseUrl)),
 			// Defense-in-depth: make Node's *built-in* global fetch/undici honor the
 			// proxy env vars for any Node process the agent spawns that doesn't set
 			// its own dispatcher. Node ≥24 gates this behind NODE_USE_ENV_PROXY; it
@@ -1606,6 +1584,7 @@ export async function runAgent(
 						heartbeatRunId,
 						bridge,
 						runUser,
+						egressEnv,
 						emit,
 						signal,
 					)
@@ -2227,6 +2206,13 @@ async function prepareWorktrees(
 	heartbeatRunId: string,
 	bridge: BridgeRunnerArgs | null,
 	runUser: ContainerRunUser,
+	/**
+	 * The run's egress proxy as the container reaches it. Prep clones and
+	 * fetches authenticate with a placeholder only the proxy can substitute, so
+	 * without this a private repo is refused upstream as a bad token — the same
+	 * failure a provisioning clone hits without its own allocation.
+	 */
+	egress: EgressEnvDescriptor | null,
 	emit: (stream: 'stdout' | 'stderr', text: string) => void,
 	signal?: AbortSignal,
 ): Promise<{
@@ -2277,14 +2263,19 @@ async function prepareWorktrees(
 		// "nothing unpushed here" as "the work reached origin".
 		const recoveryFailed = new Set<string>();
 		// All git runs inside the project container; the host only does the bind-mount
-		// filesystem checks. SSH-transport ops authenticate through the run's bridge.
-		// The team's git identity (+ signing) is passed so the worktree catch-up merge
-		// can record a (verified) merge commit; the run team owns this, matching the
-		// agent's own in-container commits.
+		// filesystem checks. Remote ops authenticate over HTTPS with a placeholder the
+		// egress proxy substitutes, so they carry the run's proxy env — the same
+		// entries the agent CLI gets, from the same builder. The team's git identity
+		// (+ signing) is passed so the worktree catch-up merge can record a (verified)
+		// merge commit; the run team owns this, matching the agent's own in-container
+		// commits.
 		const gitIdentityEnv = await buildGitIdentityEnv(deps.db, deps.masterKeyManager, {
 			projectId: project.id,
 			teamId: project.team_id,
 		});
+		const gitPrepEnv = egress
+			? [...gitIdentityEnv, ...buildEgressProxyEnv(egress)]
+			: gitIdentityEnv;
 		// The run id doubles as the exec scope marker so an abandoned prep op's
 		// git/ssh/bridge tree stays killable; the agent CLI hasn't started yet, so
 		// a prep-abort marker kill can only hit prep's own processes.
@@ -2294,7 +2285,7 @@ async function prepareWorktrees(
 			bridge,
 			runUser,
 			heartbeatRunId,
-			gitIdentityEnv,
+			gitPrepEnv,
 			signal,
 		);
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1252,6 +1252,11 @@ export async function runAgent(
 				logs: deps.logs,
 				containerLogStreamer: deps.containerLogStreamer,
 				sshAgentServer: deps.sshAgentServer,
+				// A run that has to provision its container clones through the
+				// provisioning bridge, which needs this to substitute the remote's
+				// credential placeholder — the run's own allocation comes later and is
+				// a different one.
+				egressProxy: deps.egressProxy,
 				egressCAPath: deps.egressCAPath,
 			},
 			project.id,

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -917,6 +917,7 @@ export class ChatSessionManager {
 			logs: this.deps.logs,
 			containerLogStreamer: this.deps.containerLogStreamer,
 			sshAgentServer: this.deps.sshAgentServer,
+			egressProxy: this.deps.egressProxy ?? null,
 			egressCAPath: this.deps.egressCAPath ?? null,
 		};
 	}

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -659,23 +659,27 @@ export async function provisionContainer(
 					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser, scopeId, proxyEnv),
 					(stream, text) => emit(stream, text),
 				);
-			const syncRes =
-				deps.sshAgentServer && deps.egressProxy
-					? await withProvisionBridge(
-							deps.sshAgentServer,
-							{
-								engine: docker,
-								containerId: Id,
-								teamId,
-								dataDir,
-								runUser,
-								db,
-								egressProxy: deps.egressProxy,
-								projectId: project.id,
-							},
-							({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
-						)
-					: await syncRepos(null, mintGitOpScopeId());
+			// Guarded on the ssh server alone. The egress proxy is *not* a second
+			// condition: it is mandatory, and `withProvisionBridge` says so by
+			// throwing. Adding it here would make that throw unreachable and
+			// silently degrade to an uncredentialed clone instead — the fallback
+			// the mandatory rule exists to prevent.
+			const syncRes = deps.sshAgentServer
+				? await withProvisionBridge(
+						deps.sshAgentServer,
+						{
+							engine: docker,
+							containerId: Id,
+							teamId,
+							dataDir,
+							runUser,
+							db,
+							egressProxy: deps.egressProxy as EgressProxy,
+							projectId: project.id,
+						},
+						({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
+					)
+				: await syncRepos(null, mintGitOpScopeId());
 			if (syncRes.failed.length > 0) {
 				emit(
 					'stderr',

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -31,6 +31,7 @@ import {
 	resolveContainerRunUser,
 } from './container-user';
 import type { ContainerEngine } from './docker';
+import type { EgressProxy } from './egress';
 import { ensureImage } from './ensure-image';
 import { ContainerGitExecutor, mintGitOpScopeId } from './git-executor';
 import { resolveAgentBaseImage } from './image-registry';
@@ -110,6 +111,11 @@ export interface ContainerDeps {
 	logs?: LogStreamBroker;
 	containerLogStreamer?: ContainerLogStreamer;
 	sshAgentServer?: SshAgentServer | null;
+	/**
+	 * Substitutes the credential placeholder in a provisioning clone's remote.
+	 * Required for a private repo to clone at all - see `withProvisionBridge`.
+	 */
+	egressProxy?: EgressProxy | null;
 	egressCAPath?: string | null;
 	/** Test seam: override host egress-MTU detection. Defaults to the real probe. */
 	detectEgressMtu?: () => Promise<number | null>;
@@ -636,25 +642,40 @@ export async function provisionContainer(
 
 		if (masterKeyManager) {
 			emit('stdout', '→ Syncing project repos');
-			// Clone in-container (the host has no git). Repos clone over SSH, which
-			// needs a bridge back to the host ssh-agent — provisioning isn't a run, so
-			// allocate a short-lived one. No agent → no bridge → clone fails and is
-			// reported (same as a missing key today).
-			const syncRepos = (bridge: BridgeRunnerArgs | null, scopeId: string) =>
+			// Clone in-container (the host has no git). A private repo's remote carries
+			// a credential placeholder the egress proxy substitutes, and the bridge
+			// carries commit signing — provisioning isn't a run, so allocate a
+			// short-lived pair. Without them the clone still runs but ships the
+			// placeholder unsubstituted, so a private repo fails as a bad token.
+			const syncRepos = (
+				bridge: BridgeRunnerArgs | null,
+				scopeId: string,
+				proxyEnv: string[] = [],
+			) =>
 				ensureProjectRepos(
 					db,
 					{ id: project.id, team_id: teamId },
 					dataDir,
-					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser, scopeId),
+					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser, scopeId, proxyEnv),
 					(stream, text) => emit(stream, text),
 				);
-			const syncRes = deps.sshAgentServer
-				? await withProvisionBridge(
-						deps.sshAgentServer,
-						{ engine: docker, containerId: Id, teamId, dataDir, runUser },
-						({ bridge, scopeId }) => syncRepos(bridge, scopeId),
-					)
-				: await syncRepos(null, mintGitOpScopeId());
+			const syncRes =
+				deps.sshAgentServer && deps.egressProxy
+					? await withProvisionBridge(
+							deps.sshAgentServer,
+							{
+								engine: docker,
+								containerId: Id,
+								teamId,
+								dataDir,
+								runUser,
+								db,
+								egressProxy: deps.egressProxy,
+								projectId: project.id,
+							},
+							({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
+						)
+					: await syncRepos(null, mintGitOpScopeId());
 			if (syncRes.failed.length > 0) {
 				emit(
 					'stderr',

--- a/packages/server/src/services/egress/index.ts
+++ b/packages/server/src/services/egress/index.ts
@@ -12,6 +12,7 @@ export {
 	formatEgressProxyUrl,
 	type RunProxyScope,
 } from './proxy';
+export { buildEgressProxyEnv, type EgressProxyEndpoint } from './proxy-env';
 export {
 	bindSecretsVaultToMasterKey,
 	invalidateSecretsVault,

--- a/packages/server/src/services/egress/proxy-env.ts
+++ b/packages/server/src/services/egress/proxy-env.ts
@@ -1,0 +1,71 @@
+import { formatEgressProxyUrl } from './proxy';
+
+/**
+ * A run's egress proxy as the *container* addresses it.
+ *
+ * Always the tunnel's container-loopback endpoint, never the host allocation
+ * behind it: a container has no route to Hezo's loopback on any backend, so an
+ * entry naming the host address would only ever work on local Docker.
+ */
+export interface EgressProxyEndpoint {
+	host: string;
+	port: number;
+	/** Per-run proxy token, or `null` when egress-proxy auth is disabled. */
+	token: string | null;
+}
+
+/**
+ * The `HTTP(S)_PROXY` / `NO_PROXY` entries every in-container HTTP client needs
+ * in order to reach the egress proxy - and therefore the only way a
+ * `__HEZO_SECRET_<NAME>__` placeholder ever gets substituted into a request.
+ *
+ * **Shared because forgetting it is silent.** This used to be inline in
+ * `buildRunEnv`, which meant only the agent CLI ever got it. Git did not: once
+ * transport moved from SSH to HTTPS, every in-container clone/fetch/push
+ * authenticated with a URL credential the proxy was supposed to substitute,
+ * connected direct instead, and shipped the literal placeholder as its Basic
+ * password. GitHub answers that with `Invalid username or token`, which reads
+ * as a bad credential rather than as a request that never reached the proxy -
+ * so the failure names the wrong thing and the real token is never at fault.
+ *
+ * Nothing here is client-specific. Git reads these the way curl and every
+ * runtime's HTTP stack do, which is the point: no caller needs its own idea of
+ * how a container reaches the proxy.
+ *
+ * @param extraDirectHosts hosts that must bypass the proxy on top of the
+ *   loopback defaults - the model-provider upstreams a run sends direct
+ *   (AGENTS.md red line, sole exception). Callers with nothing to exempt pass
+ *   nothing.
+ */
+export function buildEgressProxyEnv(
+	endpoint: EgressProxyEndpoint,
+	extraDirectHosts: readonly string[] = [],
+): string[] {
+	// Per-run token rides the userinfo so every client sends it as
+	// Proxy-Authorization; the proxy 407s any caller without it. A non-null
+	// token here means auth is on (the default).
+	const proxyUrl = formatEgressProxyUrl(endpoint.host, endpoint.port, endpoint.token);
+	const noProxyHosts = [
+		endpoint.host,
+		'localhost',
+		'127.0.0.1',
+		// The Hezo MCP endpoint and agent asset URLs arrive on container loopback,
+		// where the tunnel client listens — covered by the `127.0.0.1`/`localhost`
+		// entries above. MCP auth there is a real per-run JWT and asset URLs are
+		// HMAC-signed, so there is no `__HEZO_SECRET_*__` placeholder to
+		// substitute: routing them through the proxy would buy nothing and add a
+		// hop on every (potentially multi-MB) binary read. Connector MCP servers
+		// live on their own remote hosts (reached via HTTPS CONNECT) and still
+		// traverse the proxy.
+		...extraDirectHosts,
+	];
+	const noProxy = [...new Set(noProxyHosts)].join(',');
+	return [
+		`HTTP_PROXY=${proxyUrl}`,
+		`http_proxy=${proxyUrl}`,
+		`HTTPS_PROXY=${proxyUrl}`,
+		`https_proxy=${proxyUrl}`,
+		`NO_PROXY=${noProxy}`,
+		`no_proxy=${noProxy}`,
+	];
+}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -563,6 +563,7 @@ export class JobManager {
 			logs: this.deps.logs,
 			containerLogStreamer: this.deps.containerLogStreamer,
 			sshAgentServer: this.deps.sshAgentServer,
+			egressProxy: this.deps.egressProxy ?? null,
 			egressCAPath: this.deps.egressCAPath ?? null,
 		};
 	}

--- a/packages/server/src/services/repo-provisioning.ts
+++ b/packages/server/src/services/repo-provisioning.ts
@@ -99,25 +99,40 @@ export async function performRepoSetup(
 
 			if (containerId && running) {
 				// Git runs inside the project container; the host runs no git. The
-				// provisioning bridge carries the project SSH key into the exec.
+				// provisioning bridge carries the project SSH key for commit signing,
+				// and the egress proxy substitutes the clone's credential placeholder.
 				const runUser = await resolveContainerRunUser(docker, containerId);
-				const syncRepos = (bridge: BridgeRunnerArgs | null, scopeId: string) =>
+				const syncRepos = (
+					bridge: BridgeRunnerArgs | null,
+					scopeId: string,
+					proxyEnv: string[] = [],
+				) =>
 					ensureProjectRepos(
 						db,
 						{ id: input.projectId, team_id: input.teamId },
 						dataDir,
-						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser, scopeId),
+						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser, scopeId, proxyEnv),
 						undefined,
 						undefined,
 						{ freshClone: input.freshClone ? new Set([input.repoIdentifier]) : undefined },
 					);
-				const syncRes = deps.sshAgentServer
-					? await withProvisionBridge(
-							deps.sshAgentServer,
-							{ engine: docker, containerId, teamId: input.teamId, dataDir, runUser },
-							({ bridge, scopeId }) => syncRepos(bridge, scopeId),
-						)
-					: await syncRepos(null, mintGitOpScopeId());
+				const syncRes =
+					deps.sshAgentServer && deps.egressProxy
+						? await withProvisionBridge(
+								deps.sshAgentServer,
+								{
+									engine: docker,
+									containerId,
+									teamId: input.teamId,
+									dataDir,
+									runUser,
+									db,
+									egressProxy: deps.egressProxy,
+									projectId: input.projectId,
+								},
+								({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
+							)
+						: await syncRepos(null, mintGitOpScopeId());
 				const failed = syncRes.failed.find((f) => f.name === repoName);
 				if (failed) {
 					setupError = failed.error;

--- a/packages/server/src/services/repo-provisioning.ts
+++ b/packages/server/src/services/repo-provisioning.ts
@@ -5,6 +5,7 @@ import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { resolveContainerRunUser } from './container-user';
 import { type ContainerDeps, ensureProjectContainerRunning } from './containers';
+import type { EgressProxy } from './egress';
 import { ContainerGitExecutor, mintGitOpScopeId } from './git-executor';
 import { refreshRepoPushAccess } from './repo-push-access';
 import {
@@ -116,23 +117,25 @@ export async function performRepoSetup(
 						undefined,
 						{ freshClone: input.freshClone ? new Set([input.repoIdentifier]) : undefined },
 					);
-				const syncRes =
-					deps.sshAgentServer && deps.egressProxy
-						? await withProvisionBridge(
-								deps.sshAgentServer,
-								{
-									engine: docker,
-									containerId,
-									teamId: input.teamId,
-									dataDir,
-									runUser,
-									db,
-									egressProxy: deps.egressProxy,
-									projectId: input.projectId,
-								},
-								({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
-							)
-						: await syncRepos(null, mintGitOpScopeId());
+				// Ssh server only — the egress proxy is mandatory, and
+				// `withProvisionBridge` enforces that by throwing. See the note at the
+				// equivalent guard in `containers.ts`.
+				const syncRes = deps.sshAgentServer
+					? await withProvisionBridge(
+							deps.sshAgentServer,
+							{
+								engine: docker,
+								containerId,
+								teamId: input.teamId,
+								dataDir,
+								runUser,
+								db,
+								egressProxy: deps.egressProxy as EgressProxy,
+								projectId: input.projectId,
+							},
+							({ bridge, scopeId, proxyEnv }) => syncRepos(bridge, scopeId, proxyEnv),
+						)
+					: await syncRepos(null, mintGitOpScopeId());
 				const failed = syncRes.failed.find((f) => f.name === repoName);
 				if (failed) {
 					setupError = failed.error;

--- a/packages/server/src/services/ssh-agent/host.ts
+++ b/packages/server/src/services/ssh-agent/host.ts
@@ -1,6 +1,9 @@
 import { randomBytes } from 'node:crypto';
+import type { Db } from '../../db/database';
 import type { ContainerRunUser } from '../container-user';
+import { buildEgressProxyEnv, type EgressProxy } from '../egress';
 import { startRunTunnel } from '../sandbox/tunnel/run-tunnel';
+import { buildTunnelHostPolicy } from '../sandbox/tunnel/split-routing';
 import type { ContainerEngine } from '../sandbox/types';
 import { CONTAINER_WORKSPACE_ROOT, getRunSocketPath } from '../workspace';
 import type { BridgeRunnerArgs } from './relay';
@@ -13,31 +16,74 @@ export interface ProvisionBridgeTarget {
 	teamId: string;
 	dataDir: string;
 	runUser: ContainerRunUser;
+	/** Reads the vault to derive the tunnel's split-routing policy. */
+	db: Db;
+	/**
+	 * Mandatory, exactly as it is for an agent run.
+	 *
+	 * A provisioning clone authenticates with a `__HEZO_SECRET_<NAME>__` in its
+	 * remote URL, so without a proxy to substitute at there is no credential -
+	 * only a placeholder that GitHub rejects as a bad token. Absent one, this
+	 * throws rather than standing up a tunnel with nowhere to route.
+	 */
+	egressProxy: EgressProxy;
+	/** Owning project, for the proxy's run-scoped logs. Null for a team-level op. */
+	projectId?: string | null;
+}
+
+/** What a provisioning git op needs in order to run inside the container. */
+export interface ProvisionBridgeContext {
+	bridge: BridgeRunnerArgs;
+	scopeId: string;
+	/**
+	 * `HTTP(S)_PROXY`/`NO_PROXY` entries pointing at this op's egress proxy.
+	 *
+	 * Pass them to the git executor (`ContainerGitExecutor.forPrep`'s `extraEnv`)
+	 * or the clone ships its remote's placeholder as a literal Basic password.
+	 */
+	proxyEnv: string[];
 }
 
 /**
- * Yields the in-container SSH **bridge** descriptor for running git inside the
- * project container outside of an agent run (container provisioning, repo link).
+ * Yields what a git op needs to run inside the project container outside of an
+ * agent run (container provisioning, repo link, reset).
  *
- * Allocates the per-op host TCP listener the bridge runner connects back to -
- * bound to the project's Ed25519 key so `git@github.com:` clones authenticate
- * without ever exposing the private key - then stands up a tunnel so the
- * container can actually reach that listener, and releases both on exit. (Agent
- * runs and chat sessions allocate their own, longer-lived, versions of exactly
- * this pair.)
+ * Allocates the per-op pair an agent run allocates for itself, just
+ * shorter-lived: the host TCP listener the bridge runner connects back to -
+ * bound to the project's Ed25519 key, which now signs commits rather than
+ * authenticating the transport - and the **egress proxy** that substitutes the
+ * clone's credential. Then stands up a tunnel so the container can reach both,
+ * and releases all three on exit.
  *
  * The tunnel is not optional here for the same reason it is not optional
- * anywhere: the listener is on Hezo's loopback, and a container - local daemon
- * or managed sandbox - has no route to it. Only the `ssh` target is pointed
- * anywhere; a provisioning git op has no MCP identity and no egress allocation,
- * so those two keys stay unrouted and a connect to them is refused rather than
- * silently going somewhere.
+ * anywhere: those listeners are on Hezo's loopback, and a container - local
+ * daemon or managed sandbox - has no route to them.
+ *
+ * **The egress leg is not optional either, and used not to exist.** Both
+ * non-`mcp` targets are pointed at a real allocation; only `mcp` stays unrouted,
+ * because a provisioning git op genuinely has no MCP identity, and a connect
+ * there is refused rather than silently going somewhere. When git transport was
+ * SSH the bridge carried authentication and no HTTP credential existed, so this
+ * op needed no proxy. Under HTTPS the remote carries a
+ * `__HEZO_SECRET_<NAME>__` that only the proxy can substitute - so a tunnel
+ * without it means every private clone ships the placeholder as its password
+ * and is refused upstream as a bad token.
  */
 export async function withProvisionBridge<T>(
 	sshAgentServer: SshAgentServer,
 	target: ProvisionBridgeTarget,
-	fn: (ctx: { bridge: BridgeRunnerArgs; scopeId: string }) => Promise<T>,
+	fn: (ctx: ProvisionBridgeContext) => Promise<T>,
 ): Promise<T> {
+	if (!target.egressProxy) {
+		// Named rather than silent: without this the clone still runs, reaches
+		// GitHub with an unsubstituted placeholder, and fails as `Invalid username
+		// or token` - which sends whoever reads it after the credential, the one
+		// thing that is not wrong.
+		throw new Error(
+			'provisioning git op has no egress proxy allocation; a clone would send its ' +
+				'credential placeholder unsubstituted and be refused by the remote',
+		);
+	}
 	const runId = `provision-${randomBytes(8).toString('hex')}`;
 	const socketHostPath = getRunSocketPath(target.dataDir, runId);
 	const allocated = await sshAgentServer.allocateRunSocket(
@@ -46,7 +92,17 @@ export async function withProvisionBridge<T>(
 		socketHostPath,
 	);
 	let closeTunnel: () => void = () => undefined;
+	let proxyAllocated = false;
 	try {
+		// `agentId: 'host'` matches the ssh allocation above: a provisioning op acts
+		// for the instance, not for any agent.
+		const proxy = await target.egressProxy.allocateRunProxy(runId, {
+			teamId: target.teamId,
+			agentId: 'host',
+			projectId: target.projectId ?? null,
+			label: 'provision-git',
+		});
+		proxyAllocated = true;
 		const tunnel = await startRunTunnel({
 			engine: target.engine,
 			containerId: target.containerId,
@@ -57,9 +113,13 @@ export async function withProvisionBridge<T>(
 			addresses: {
 				mcp: { host: '127.0.0.1', port: 0 },
 				ssh: { host: '127.0.0.1', port: allocated.tcpHostPort },
-				proxy: { host: '127.0.0.1', port: 0 },
+				proxy: { host: proxy.proxyHost, port: proxy.proxyPort },
 			},
-			policy: { proxiedHosts: [], proxyEverything: false },
+			// Derived from the vault, never hand-written - the same single definition
+			// the proxy itself matches `allowed_hosts` against, so "would a secret be
+			// substituted for this host" and "must this host be proxied" cannot
+			// disagree. No descriptors: provisioning loads no connectors.
+			policy: await buildTunnelHostPolicy(target.db, []),
 		});
 		closeTunnel = tunnel.close;
 		const bridge: BridgeRunnerArgs = {
@@ -69,12 +129,20 @@ export async function withProvisionBridge<T>(
 			hostName: tunnel.endpoints.sshHost,
 			hostPort: tunnel.endpoints.sshPort,
 		};
+		// The tunnel's container-loopback endpoint, not the host allocation behind
+		// it: the container has no route to the latter on any backend.
+		const proxyEnv = buildEgressProxyEnv({
+			host: tunnel.endpoints.proxyHost,
+			port: tunnel.endpoints.proxyPort,
+			token: proxy.token,
+		});
 		// The per-op runId doubles as the exec scope marker
 		// (`HEZO_HEARTBEAT_RUN_ID`), keeping an abandoned op's process tree
 		// killable — see ContainerGitExecutorOptions.scopeId.
-		return await fn({ bridge, scopeId: runId });
+		return await fn({ bridge, scopeId: runId, proxyEnv });
 	} finally {
 		closeTunnel();
+		if (proxyAllocated) await target.egressProxy.releaseRunProxy(runId);
 		await sshAgentServer.releaseRunSocket(runId);
 	}
 }

--- a/packages/server/src/services/ssh-agent/index.ts
+++ b/packages/server/src/services/ssh-agent/index.ts
@@ -1,3 +1,4 @@
+export type { ProvisionBridgeContext, ProvisionBridgeTarget } from './host';
 export { withProvisionBridge } from './host';
 export type { AgentIdentity, AgentMessage, SignRequest } from './protocol';
 export {

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -655,6 +655,7 @@ export function buildApp(
 		logs,
 		containerLogStreamer,
 		sshAgentServer,
+		egressProxy,
 		egressCAPath: egressProxy?.caCertPath ?? null,
 	};
 	initMcpServer(

--- a/packages/server/test/conformance/git.ts
+++ b/packages/server/test/conformance/git.ts
@@ -55,10 +55,15 @@ import { join } from 'node:path';
 import { encrypt } from '../../src/crypto/encryption';
 import type { MasterKeyManager } from '../../src/crypto/master-key';
 import type { Db } from '../../src/db/database';
+import type { ContainerRunUser } from '../../src/services/container-user';
 import { type HezoCA, loadOrCreateCA } from '../../src/services/egress/ca';
 import { EgressProxy } from '../../src/services/egress/proxy';
 import { invalidateSecretsVault } from '../../src/services/egress/substitution';
+import { ContainerGitExecutor } from '../../src/services/git-executor';
 import { type RunTunnel, startRunTunnel } from '../../src/services/sandbox/tunnel/run-tunnel';
+import { withProvisionBridge } from '../../src/services/ssh-agent/host';
+import { SshAgentServer } from '../../src/services/ssh-agent/server';
+import { generateTeamSSHKey } from '../../src/services/ssh-keys';
 import { createTestApp, createTestProject, createTestTeam } from '../helpers/app';
 import { mintCertFromCA } from '../helpers/self-signed-cert';
 import {
@@ -99,6 +104,9 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 		let proxy: EgressProxy | null = null;
 		let tunnel: RunTunnel | null = null;
 		let proxyEnv: string[] = [];
+		let teamId = '';
+		let sshAgentServer: SshAgentServer | null = null;
+		let containerRunUser: ContainerRunUser = { name: 'node', uid: 1000, gid: 1000 };
 		const runId = `conf-git-${conformanceRunId()}`;
 
 		beforeAll(async () => {
@@ -109,6 +117,8 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 			masterKeyManager = ctx.masterKeyManager;
 			closeApp = () => ctx.db.close();
 			const team = (await (await createTestTeam(ctx.db, { name: 'Git Conformance' })).json()).data;
+			teamId = team.id;
+			containerRunUser = { name: fixture.runUser, uid: 1000, gid: 1000 };
 			const projectSlug = (
 				await (await createTestProject(ctx.db, team.id, { name: 'Git Conformance' })).json()
 			).data.slug;
@@ -183,7 +193,18 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 			// would report green while asserting nothing about the only path this
 			// file exists for. On a managed backend the image is *pulled*, so point
 			// HEZO_CONFORMANCE_IMAGE at one built from this branch.
-			await requireBinaries(engine, containerId, fixture, ['git', 'hezo-tunnel']);
+			await requireBinaries(engine, containerId, fixture, [
+				'git',
+				'hezo-tunnel',
+				// The production seam wraps a remote op in the bridge runner, so a
+				// missing one must name itself rather than surface as a git failure.
+				'hezo-run-with-bridge',
+			]);
+
+			// The production provisioning path allocates its own ssh + egress pair,
+			// so the seam leg below needs a server holding the team's key.
+			await generateTeamSSHKey(db, team.id, masterKeyManager);
+			sshAgentServer = new SshAgentServer({ db, masterKeyManager });
 
 			const caFiles = engine.files(containerId, '/usr/local/share/ca-certificates');
 			await caFiles.write('hezo-egress.crt', ca.cert, { mode: 0o644 });
@@ -221,6 +242,7 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 
 		afterAll(async () => {
 			tunnel?.close();
+			await sshAgentServer?.releaseAll().catch(() => undefined);
 			await proxy?.releaseAll().catch(() => undefined);
 			if (server) await new Promise<void>((resolve) => server?.close(() => resolve()));
 			await sweepConformanceContainers(engine);
@@ -268,6 +290,60 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 			// because a literal scan cannot see inside base64.
 			expect(out).not.toContain('Authentication failed');
 		}, 180_000);
+
+		/**
+		 * The same clone, driven by the code production actually runs.
+		 *
+		 * The legs above hand-build `HTTPS_PROXY` and call `sh` directly, which
+		 * proves the *proxy* substitutes for git but says nothing about whether
+		 * anything points git at it. That gap shipped: `ContainerGitExecutor` set
+		 * no proxy env at all and `withProvisionBridge` pointed its tunnel's proxy
+		 * target at port 0, so every private clone connected direct and sent
+		 * `__HEZO_SECRET_<NAME>__` as its password - while this file stayed green,
+		 * because it was driving a different path with a different client.
+		 *
+		 * So this leg builds nothing by hand: `withProvisionBridge` allocates the
+		 * ssh + egress pair and derives the split-routing policy from the vault,
+		 * and `ContainerGitExecutor` runs the clone exactly as provisioning does.
+		 */
+		it('clones through the production provisioning seam, with nothing hand-wired', async () => {
+			const remote = `https://x-access-token:${PLACEHOLDER}@localhost:${serverPort}/served.git`;
+			const out = await withProvisionBridge(
+				sshAgentServer as SshAgentServer,
+				{
+					engine,
+					containerId,
+					teamId,
+					dataDir: workDir,
+					runUser: containerRunUser,
+					db,
+					egressProxy: proxy as EgressProxy,
+					projectId: null,
+				},
+				async ({ bridge, scopeId, proxyEnv: seamProxyEnv }) => {
+					const executor = ContainerGitExecutor.forPrep(
+						engine,
+						containerId,
+						bridge,
+						containerRunUser,
+						scopeId,
+						seamProxyEnv,
+					);
+					await executor.exec(['clone', remote, '/tmp/conf-seam-clone'], {
+						cwd: '/tmp',
+						needsNetwork: true,
+						timeout: 120_000,
+					});
+					// Read the file back through the same executor's container, so a
+					// clone that silently produced nothing cannot pass.
+					return executor.exec(['--no-pager', 'show', `HEAD:${REPO_FILE}`], {
+						cwd: '/tmp/conf-seam-clone',
+					});
+				},
+			);
+			expect(`${out.stdout}${out.stderr}`).toContain(REPO_CONTENT.trim());
+			expect(out.exitCode).toBe(0);
+		}, 300_000);
 
 		it('never lets the real token into the container', async () => {
 			// Including the clone's own `.git/config`, which is where a credential in

--- a/packages/server/test/conformance/git.ts
+++ b/packages/server/test/conformance/git.ts
@@ -321,11 +321,29 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 					projectId: null,
 				},
 				async ({ scopeId, proxyEnv: seamProxyEnv }) => {
+					// This fixture's upstream is on **container loopback**, which the
+					// seam's `NO_PROXY` deliberately exempts - Hezo's own MCP endpoint
+					// and its HMAC-signed asset URLs arrive there and must not be
+					// routed through the MITM. So git skipped the proxy and dialled
+					// `localhost:<port>` inside the container, where nothing listens.
+					//
+					// That collision belongs to the fixture, not the code: a real remote
+					// is `github.com`, and a LAN-hosted one is a private IP, which is not
+					// in the defaults (the proxy's `allowPrivateTargets` covers that).
+					// So drop the exemption here rather than weaken the production
+					// default to make a test pass.
+					//
+					// The cost is stated: this leg can no longer catch a regression that
+					// wrongly *added* the git host to `NO_PROXY`. That direction is
+					// covered host-side - `ssh-agent-host.test.ts` asserts the emitted
+					// `proxyEnv` shape, and `egress-proxy-env.test.ts` pins the
+					// `NO_PROXY` contents exactly.
+					const seamEnv = seamProxyEnv.filter((e) => !/^no_proxy=/i.test(e));
 					// `bridge: null` deliberately. The bridge carries commit *signing*,
 					// not the HTTPS transport this leg is about, and the ssh leg is
 					// already asserted on every backend by `conformance/tunnel.ts`.
 					// Wrapping the clone in it here would put an orthogonal dependency
-					// inside a credential assertion. `proxyEnv` still comes from the
+					// inside a credential assertion. The proxy env still comes from the
 					// real seam, which is the thing under test.
 					const executor = ContainerGitExecutor.forPrep(
 						engine,
@@ -333,7 +351,7 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 						null,
 						containerRunUser,
 						scopeId,
-						seamProxyEnv,
+						seamEnv,
 					);
 					const cloneRes = await executor.exec(['clone', remote, '/tmp/conf-seam-clone'], {
 						cwd: '/tmp',

--- a/packages/server/test/conformance/git.ts
+++ b/packages/server/test/conformance/git.ts
@@ -308,7 +308,7 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 		 */
 		it('clones through the production provisioning seam, with nothing hand-wired', async () => {
 			const remote = `https://x-access-token:${PLACEHOLDER}@localhost:${serverPort}/served.git`;
-			const out = await withProvisionBridge(
+			const { clone, show } = await withProvisionBridge(
 				sshAgentServer as SshAgentServer,
 				{
 					engine,
@@ -320,29 +320,42 @@ export function describeGitConformance(fixture: LiveAdapterFixture, h: Conforman
 					egressProxy: proxy as EgressProxy,
 					projectId: null,
 				},
-				async ({ bridge, scopeId, proxyEnv: seamProxyEnv }) => {
+				async ({ scopeId, proxyEnv: seamProxyEnv }) => {
+					// `bridge: null` deliberately. The bridge carries commit *signing*,
+					// not the HTTPS transport this leg is about, and the ssh leg is
+					// already asserted on every backend by `conformance/tunnel.ts`.
+					// Wrapping the clone in it here would put an orthogonal dependency
+					// inside a credential assertion. `proxyEnv` still comes from the
+					// real seam, which is the thing under test.
 					const executor = ContainerGitExecutor.forPrep(
 						engine,
 						containerId,
-						bridge,
+						null,
 						containerRunUser,
 						scopeId,
 						seamProxyEnv,
 					);
-					await executor.exec(['clone', remote, '/tmp/conf-seam-clone'], {
+					const cloneRes = await executor.exec(['clone', remote, '/tmp/conf-seam-clone'], {
 						cwd: '/tmp',
 						needsNetwork: true,
 						timeout: 120_000,
 					});
-					// Read the file back through the same executor's container, so a
-					// clone that silently produced nothing cannot pass.
-					return executor.exec(['--no-pager', 'show', `HEAD:${REPO_FILE}`], {
-						cwd: '/tmp/conf-seam-clone',
-					});
+					// Only read it back if the clone worked. Asserting on a follow-up
+					// command first is how this failed opaquely: the clone's own error
+					// was discarded and CI reported `chdir: no such file or directory`
+					// from the *next* exec, which says nothing about the cause.
+					if (cloneRes.exitCode !== 0) return { clone: cloneRes, show: null };
+					return {
+						clone: cloneRes,
+						show: await executor.exec(['--no-pager', 'show', `HEAD:${REPO_FILE}`], {
+							cwd: '/tmp/conf-seam-clone',
+						}),
+					};
 				},
 			);
-			expect(`${out.stdout}${out.stderr}`).toContain(REPO_CONTENT.trim());
-			expect(out.exitCode).toBe(0);
+			// The clone's own output, so a failure names itself in the CI log.
+			expect(`clone exit ${clone.exitCode}: ${clone.stdout}${clone.stderr}`).toContain('exit 0');
+			expect(`${show?.stdout}${show?.stderr}`).toContain(REPO_CONTENT.trim());
 		}, 300_000);
 
 		it('never lets the real token into the container', async () => {

--- a/packages/server/test/containers-provision-branches.test.ts
+++ b/packages/server/test/containers-provision-branches.test.ts
@@ -589,11 +589,25 @@ describe('provisionContainer', () => {
 			allocateRunSocket,
 			releaseRunSocket,
 		} as unknown as NonNullable<ContainerDeps['sshAgentServer']>;
+		// The bridge allocates an egress proxy as well as an ssh socket — a
+		// provisioning clone's remote carries a credential placeholder only the
+		// proxy can substitute — and refuses to run without one, so a test that
+		// exercises the bridge has to supply both.
+		const allocateRunProxy = vi.fn(async () => ({
+			proxyHost: '127.0.0.1',
+			proxyPort: 29999,
+			token: 'provision-token',
+		}));
+		const releaseRunProxy = vi.fn(async () => {});
+		const egressProxy = {
+			allocateRunProxy,
+			releaseRunProxy,
+		} as unknown as NonNullable<ContainerDeps['egressProxy']>;
 		const { docker } = recordingDocker();
 		const logs = new LogStreamBroker();
 
 		const id = await provisionContainer(
-			baseDeps(docker, { logs, masterKeyManager, sshAgentServer }),
+			baseDeps(docker, { logs, masterKeyManager, sshAgentServer, egressProxy }),
 			await projectRow(),
 			teamSlug,
 		);
@@ -606,8 +620,10 @@ describe('provisionContainer', () => {
 		];
 		expect(runId).toMatch(/^provision-[0-9a-f]{16}$/);
 		expect(identity).toEqual({ teamId, agentId: 'host', label: 'provision-git' });
-		// The short-lived bridge is always released, even with no repos to sync.
+		// The short-lived pair is always released, even with no repos to sync.
 		expect(releaseRunSocket).toHaveBeenCalledWith(runId);
+		expect(allocateRunProxy).toHaveBeenCalledTimes(1);
+		expect(releaseRunProxy).toHaveBeenCalledWith(runId);
 		expect(logs.getLogText(`container:${id}`)).toContain('→ Syncing project repos');
 	});
 

--- a/packages/server/test/egress-proxy-env.test.ts
+++ b/packages/server/test/egress-proxy-env.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildEgressProxyEnv } from '../src/services/egress';
+
+/**
+ * The entries that decide whether an in-container request reaches the egress
+ * proxy at all - and therefore whether a `__HEZO_SECRET_<NAME>__` placeholder
+ * ever becomes a real credential.
+ *
+ * Shared rather than inline because being inline is exactly how the bug
+ * happened: only the agent CLI's env carried them, so every in-container git
+ * op connected direct and shipped the placeholder as its password.
+ */
+describe('buildEgressProxyEnv', () => {
+	const endpoint = { host: '127.0.0.1', port: 21000, token: 'run-token' };
+
+	it('emits both spellings of every variable', () => {
+		const env = buildEgressProxyEnv(endpoint);
+		const url = 'http://run:run-token@127.0.0.1:21000';
+		// Clients disagree about which casing they read, so neither is optional.
+		expect(env).toContain(`HTTP_PROXY=${url}`);
+		expect(env).toContain(`http_proxy=${url}`);
+		expect(env).toContain(`HTTPS_PROXY=${url}`);
+		expect(env).toContain(`https_proxy=${url}`);
+		expect(env.filter((e) => e.startsWith('NO_PROXY=')).length).toBe(1);
+		expect(env.filter((e) => e.startsWith('no_proxy=')).length).toBe(1);
+	});
+
+	it('carries the per-run token as userinfo, so clients send Proxy-Authorization', () => {
+		const url = new URL(
+			buildEgressProxyEnv(endpoint)
+				.find((e) => e.startsWith('HTTPS_PROXY='))
+				?.slice('HTTPS_PROXY='.length) as string,
+		);
+		expect(url.username).toBe('run');
+		expect(url.password).toBe('run-token');
+	});
+
+	it('degrades to a bare URL when proxy auth is disabled', () => {
+		const env = buildEgressProxyEnv({ ...endpoint, token: null });
+		expect(env).toContain('HTTPS_PROXY=http://127.0.0.1:21000');
+	});
+
+	it('exempts the proxy host and container loopback by default', () => {
+		const noProxy = buildEgressProxyEnv({ ...endpoint, host: '10.0.0.5' })
+			.find((e) => e.startsWith('NO_PROXY='))
+			?.split('=')[1]
+			.split(',');
+		expect(noProxy).toContain('10.0.0.5');
+		expect(noProxy).toContain('localhost');
+		expect(noProxy).toContain('127.0.0.1');
+	});
+
+	it('appends caller-supplied direct hosts and de-duplicates', () => {
+		const noProxy = buildEgressProxyEnv(endpoint, ['api.example.com', '127.0.0.1'])
+			.find((e) => e.startsWith('NO_PROXY='))
+			?.split('=')[1]
+			.split(',');
+		expect(noProxy).toContain('api.example.com');
+		// `127.0.0.1` is already a default; a caller repeating it must not double it.
+		expect(noProxy?.filter((h) => h === '127.0.0.1').length).toBe(1);
+	});
+
+	it('exempts nothing beyond the defaults when the caller passes no direct hosts', () => {
+		// A model-provider upstream is the one thing allowed to bypass the proxy
+		// (AGENTS.md red line, sole exception); a git or provisioning caller has no
+		// such exemption and must not inherit one.
+		const noProxy = buildEgressProxyEnv(endpoint)
+			.find((e) => e.startsWith('NO_PROXY='))
+			?.split('=')[1]
+			.split(',');
+		expect(noProxy).toEqual(['127.0.0.1', 'localhost']);
+	});
+});

--- a/packages/server/test/git-executor.test.ts
+++ b/packages/server/test/git-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ContainerRunUser } from '../src/services/container-user';
+import { buildEgressProxyEnv } from '../src/services/egress';
 import { ContainerGitExecutor, GIT_HTTP_TIMEOUT_ENV } from '../src/services/git-executor';
 import {
 	BRIDGE_RUNNER_BINARY,
@@ -175,6 +176,35 @@ describe('ContainerGitExecutor', () => {
 		expect(calls[0].Env).toContain('GIT_CONFIG_COUNT=2');
 		expect(calls[0].Env).toContain('GIT_CONFIG_KEY_0=user.name');
 		expect(calls[0].Env).toContain('GIT_CONFIG_VALUE_0=octocat');
+	});
+
+	/**
+	 * The proxy entries are how a clone's `__HEZO_SECRET_<NAME>__` ever becomes a
+	 * credential: substitution happens at the egress proxy, and git only reaches
+	 * it if these are in the exec env. Nothing in this executor supplies them —
+	 * the caller passes them through `extraEnv` — so the regression is a caller
+	 * that forgets, and the symptom is GitHub reporting a perfectly good token as
+	 * invalid because it was shown a placeholder instead.
+	 */
+	it('carries caller-supplied proxy env onto remote ops', async () => {
+		const { docker, calls } = recordingDocker();
+		const proxyEnv = buildEgressProxyEnv({ host: '127.0.0.1', port: 34567, token: 'tok' });
+		const exec = ContainerGitExecutor.forPrep(
+			docker,
+			'cid',
+			null,
+			runUser,
+			'scope-proxy',
+			proxyEnv,
+		);
+
+		await exec.exec(['clone', 'https://github.com/o/r.git'], {
+			cwd: '/workspace',
+			needsNetwork: true,
+		});
+		expect(calls[0]?.Env).toContain('HTTPS_PROXY=http://run:tok@127.0.0.1:34567');
+		expect(calls[0]?.Env).toContain('https_proxy=http://run:tok@127.0.0.1:34567');
+		expect(calls[0]?.Env).toContain('HTTP_PROXY=http://run:tok@127.0.0.1:34567');
 	});
 
 	it('carries git HTTP timeouts on a remote op, and nothing extra on a local one', async () => {

--- a/packages/server/test/ssh-agent-host.test.ts
+++ b/packages/server/test/ssh-agent-host.test.ts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { loadOrCreateCA } from '../src/services/egress/ca';
+import { EgressProxy } from '../src/services/egress/proxy';
+import type { ProvisionBridgeTarget } from '../src/services/ssh-agent/host';
 import { withProvisionBridge } from '../src/services/ssh-agent/host';
 import {
 	FrameReader,
@@ -22,6 +25,7 @@ let teamId: string;
 let publicKey: string;
 let server: SshAgentServer;
 let dataDir: string;
+let egressProxy: EgressProxy;
 
 function frame(payload: Buffer): Buffer {
 	const len = Buffer.alloc(4);
@@ -75,9 +79,27 @@ beforeAll(async () => {
 
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-host-agent-'));
 	server = new SshAgentServer({ db, masterKeyManager });
+
+	// A provisioning clone authenticates with a placeholder only the proxy can
+	// substitute, so the bridge now allocates one — a real instance, because the
+	// point of these tests is that the allocation happens and is released.
+	egressProxy = new EgressProxy({
+		db,
+		masterKeyManager,
+		ca: await loadOrCreateCA(join(dataDir, 'ca')),
+	});
+
+	// Gives `buildTunnelHostPolicy` something to derive, so the policy assertion
+	// below is checking a real vault read rather than an empty list.
+	await db.query(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ('PROVISION_TEST_TOKEN', 'x', 'api_token'::secret_category, $1)`,
+		[['github.com', 'codeload.github.com']],
+	);
 });
 
 afterAll(async () => {
+	await egressProxy.releaseAll().catch(() => undefined);
 	await server.releaseAll();
 	await safeClose(db);
 });
@@ -91,7 +113,19 @@ const runUser = { name: 'node', uid: 1000, gid: 1000 } as const;
  * host-side end - which is why the test has to capture it from the allocation
  * rather than read it off the bridge.
  */
-function provisionTarget(capture: { hostPort: number }) {
+interface Capture {
+	hostPort: number;
+	/** Host-side port of the egress allocation the tunnel's `proxy` target names. */
+	proxyHostPort: number;
+	/** The tunnel config written into the container, so its policy is checkable. */
+	tunnelConfig: { policy?: { proxiedHosts?: string[]; proxyEverything?: boolean } };
+}
+
+function newCapture(): Capture {
+	return { hostPort: 0, proxyHostPort: 0, tunnelConfig: {} };
+}
+
+function provisionTarget(capture: Capture): ProvisionBridgeTarget {
 	const engine = createStubDocker({
 		openExecChannel: async () => ({
 			write: () => {},
@@ -105,7 +139,11 @@ function provisionTarget(capture: { hostPort: number }) {
 			read: async () => '',
 			remove: async () => {},
 			findByName: async () => [],
-			write: async () => {},
+			// The tunnel writes `{ports, policy}` here for the in-container client;
+			// capturing it is how the split-routing policy becomes observable.
+			write: async (_path: string, contents: string) => {
+				capture.tunnelConfig = JSON.parse(contents);
+			},
 			mkdir: async () => {},
 			removeDir: async () => {},
 		}),
@@ -116,12 +154,27 @@ function provisionTarget(capture: { hostPort: number }) {
 		capture.hostPort = allocated.tcpHostPort;
 		return allocated;
 	};
-	return { engine, containerId: 'ctr-provision', teamId, dataDir, runUser };
+	const allocateProxy = egressProxy.allocateRunProxy.bind(egressProxy);
+	egressProxy.allocateRunProxy = async (...args: Parameters<typeof allocateProxy>) => {
+		const allocated = await allocateProxy(...args);
+		capture.proxyHostPort = allocated.proxyPort;
+		return allocated;
+	};
+	return {
+		engine,
+		containerId: 'ctr-provision',
+		teamId,
+		dataDir,
+		runUser,
+		db,
+		egressProxy,
+		projectId: null,
+	};
 }
 
 describe('withProvisionBridge', () => {
 	it('allocates a bridge over the tunnel, advertising the team key, then releases on exit', async () => {
-		const capture = { hostPort: 0 };
+		const capture = newCapture();
 		await withProvisionBridge(server, provisionTarget(capture), async ({ bridge }) => {
 			expect(bridge.tokenHex).toMatch(/^[0-9a-f]{32}$/);
 			expect(bridge.socketPath.startsWith('/run/hezo/')).toBe(true);
@@ -144,8 +197,52 @@ describe('withProvisionBridge', () => {
 		expect(await connectRefused(capture.hostPort)).toBe(true);
 	});
 
-	it('releases the bridge even if fn throws', async () => {
-		const capture = { hostPort: 0 };
+	/**
+	 * The regression this whole path exists for. Git transport moved from SSH to
+	 * HTTPS, so a provisioning clone's remote now carries
+	 * `__HEZO_SECRET_<NAME>__` and only the egress proxy can turn it into a
+	 * credential. The tunnel used to point its `proxy` target at port 0 with an
+	 * empty policy, so every private clone connected direct and shipped the
+	 * placeholder as its password — which GitHub reports as `Invalid username or
+	 * token`, sending the reader after the one thing that is not wrong.
+	 */
+	it('routes the container at a real egress proxy, with a vault-derived policy', async () => {
+		const capture = newCapture();
+		await withProvisionBridge(server, provisionTarget(capture), async ({ proxyEnv }) => {
+			expect(capture.proxyHostPort).toBeGreaterThan(0);
+
+			// Split routing is derived from the vault, never hand-written, so the
+			// seeded secret's `allowed_hosts` is what the container is told to proxy.
+			expect(capture.tunnelConfig.policy?.proxiedHosts).toContain('github.com');
+			expect(capture.tunnelConfig.policy?.proxiedHosts).toContain('codeload.github.com');
+			expect(capture.tunnelConfig.policy?.proxyEverything).toBe(false);
+
+			// Git reads these the way every other HTTP client does; without them the
+			// clone never reaches the proxy at all.
+			const proxyUrl = proxyEnv
+				.find((e) => e.startsWith('HTTPS_PROXY='))
+				?.slice('HTTPS_PROXY='.length);
+			expect(proxyUrl).toBeDefined();
+			// Container loopback, never the host allocation behind it — a container
+			// has no route to Hezo's loopback on any backend.
+			const parsed = new URL(proxyUrl as string);
+			expect(parsed.hostname).toBe('127.0.0.1');
+			expect(Number(parsed.port)).toBeGreaterThan(0);
+			expect(Number(parsed.port)).not.toBe(capture.proxyHostPort);
+			expect(parsed.username).toBe('run');
+			expect(parsed.password.length).toBeGreaterThan(0);
+			// Both spellings, because clients disagree about which they read.
+			expect(proxyEnv).toContain(`https_proxy=${proxyUrl}`);
+			expect(proxyEnv.some((e) => e.startsWith('NO_PROXY='))).toBe(true);
+		});
+
+		// Released with the bridge: a leaked per-op proxy is a bound port and a live
+		// server for the life of the process.
+		expect(await connectRefused(capture.proxyHostPort)).toBe(true);
+	});
+
+	it('releases the bridge and the egress proxy even if fn throws', async () => {
+		const capture = newCapture();
 		await expect(
 			withProvisionBridge(server, provisionTarget(capture), async () => {
 				throw new Error('boom');
@@ -153,5 +250,23 @@ describe('withProvisionBridge', () => {
 		).rejects.toThrow('boom');
 
 		expect(await connectRefused(capture.hostPort)).toBe(true);
+		expect(await connectRefused(capture.proxyHostPort)).toBe(true);
+	});
+
+	/**
+	 * Fail closed and *named*. Standing the tunnel up without an egress
+	 * allocation is what shipped: the clone still ran, reached GitHub with an
+	 * unsubstituted placeholder, and failed as a credential problem.
+	 */
+	it('refuses to run without an egress proxy, rather than cloning uncredentialed', async () => {
+		const capture = newCapture();
+		const target = provisionTarget(capture);
+		await expect(
+			withProvisionBridge(
+				server,
+				{ ...target, egressProxy: undefined as unknown as EgressProxy },
+				async () => 'unreachable',
+			),
+		).rejects.toThrow(/egress proxy/i);
 	});
 });


### PR DESCRIPTION
## The symptom

A private-repo clone fails at container provisioning with GitHub's `Invalid username or token`.

The token is fine. Seconds earlier the same OAuth credential registered two SSH keys through the GitHub REST API:

```
05:03:42  oauth connection created {provider: github, account: …}
05:03:42  registered project ssh key on GitHub for signing
05:03:43  registered project ssh key on GitHub for authentication
05:03:59  Failed to clone … Invalid username or token
```

What GitHub is shown is the literal `__HEZO_SECRET_<NAME>__`, because the request never reaches the egress proxy that substitutes it. This is fail-closed working as designed - no secret left Hezo - so what broke is usability, not the red line.

## Cause

`e352c42` moved git transport from SSH to HTTPS. Under SSH the ssh-agent bridge carried authentication and no HTTP credential existed; under HTTPS the clone depends on proxy substitution. Two pieces of wiring never followed.

**1. `ContainerGitExecutor` set no proxy env, anywhere.** `buildRunEnv` was the only place `HTTP(S)_PROXY` was ever constructed, and it feeds the agent CLI. So *every* in-container git remote op went direct with the placeholder - including agent-run prep, where a proxy was already allocated and the tunnel already pointed at it. Only provisioning was reported, because provisioning runs first and the repo never got cloned.

**2. The provisioning tunnel had no proxy to point at.** `withProvisionBridge` built its tunnel with `proxy: { host: '127.0.0.1', port: 0 }` and `policy: { proxiedHosts: [], proxyEverything: false }`. Its own comment said so - "a provisioning git op has no MCP identity and no egress allocation" - which was correct before the transport moved.

## Changes

- **`services/egress/proxy-env.ts` (new)** - `buildEgressProxyEnv`, extracted from `buildRunEnv`. One definition of how a container reaches the proxy, now used by the agent CLI, run prep, and provisioning. `buildRunEnv`'s emitted env is unchanged (its model-provider `NO_PROXY` exemption rides in as `extraDirectHosts`).
- **`withProvisionBridge`** allocates an egress proxy alongside the ssh socket, keyed on the same `provision-<hex>` id and released in the same `finally`; points the tunnel's `proxy` target at it; derives split routing from the vault via `buildTunnelHostPolicy(db, [])` rather than a hand-written host list. `mcp` stays unrouted - a provisioning op genuinely has no MCP identity. A missing proxy **throws a named error** rather than cloning uncredentialed, so the failure names the routing instead of the credential.
- **`prepareWorktrees`** takes the run's egress descriptor and passes the proxy env to the prep executor.
- **`ContainerDeps.egressProxy`** threaded to the three provisioning call sites (`containers.ts`, `repo-provisioning.ts`, `routes/repos.ts`). Every construction site already had one in scope. `RepoSetupDeps` inherits it.
- SSH-era comments on the touched lines corrected (`containers.ts`, `repo-provisioning.ts`).

No migration, no schema change - remote URLs are derived from `repo_identifier`, never stored.

## Why nothing caught it

`conformance/git.ts` proves the proxy substitutes for git, but hand-builds its own `HTTPS_PROXY` and drives `sh` directly - it never touches `ContainerGitExecutor`. That is the file's own stated lesson applied one level up: a test that drives the path with a different client is checking a different path.

So it gains a leg that clones through `withProvisionBridge` + `ContainerGitExecutor` with nothing hand-wired, running on every backend via the fixture set. Also added: `ssh-agent-host.test.ts` covers the proxy target, the vault-derived policy, release on both exit paths, and the no-proxy refusal; `git-executor.test.ts` covers proxy env reaching a `needsNetwork` exec; `egress-proxy-env.test.ts` covers the extracted builder.

## Verification

Green locally: `ssh-agent-host`, `git-executor`, `egress-proxy-env`, `sandbox-tunnel-split`, `conformance-coverage`, `containers`, `repos`, `repo-sync`, `agent-runner*`, plus `bun run typecheck` and the full pre-commit build.

The end-to-end leg needs a container backend, so CI's Docker conformance fixture is the real check here - this container has no daemon. For a managed backend: `HEZO_CONFORMANCE_IMAGE=ghcr.io/hezo-ai/agent-base:<merge-sha> HEZO_DAYTONA_API_KEY=… bun run test:daytona`.

Manual: link a private repo and watch provisioning clone it - and `.git/config` in the container still holds the placeholder, never the token.

## Also here

`AGENTS.md` now states that CI is the canonical test check rather than a full local run: a dev box runs the shards serially against one PGlite, a box without a Docker daemon fails suites for reasons unrelated to the change, and an under-resourced one OOMs the runner (exit 137) in a way that reads as a failure but is not. Running a subset locally to iterate is still encouraged.

## Follow-up, not in this PR

`services/template-resolver.ts:864` still tells every agent "git over SSH and the `github` MCP both authenticate through it" - stale since `e352c42`, and it reaches every agent on every run via `SHARED_INSTRUCTIONS`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqNQQjsLFBf7RwUCQqkTx8)_