### PR TITLE
fix(web): keep the task ID on one line in the task list

### DIFF
--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -25,7 +25,7 @@ import {
 import { remarkNormalizeInlineCode } from '../lib/remark-normalize-inline-code';
 import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
 import { useOpenPreview } from './task-detail/preview-context';
-import { TaskStatusBadge } from './task-status-badge';
+import { TaskMentionTooltipContent } from './task-mention-tooltip';
 import { Tooltip } from './ui/tooltip';
 
 type RemarkPlugin = Parameters<typeof Markdown>[0]['remarkPlugins'];
@@ -391,18 +391,11 @@ export function MarkdownProse({
 					return (
 						<Tooltip
 							content={
-								<span className="flex flex-col gap-1">
-									<span>
-										<strong>{taskIdentifier.toUpperCase()}:</strong> {taskTitle}
-									</span>
-									{taskStatus ? (
-										<TaskStatusBadge
-											status={taskStatus}
-											className="self-start"
-											testId="task-mention-status-pill"
-										/>
-									) : null}
-								</span>
+								<TaskMentionTooltipContent
+									identifier={taskIdentifier}
+									title={taskTitle}
+									status={taskStatus}
+								/>
 							}
 						>
 							<Link

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -22,6 +22,7 @@ import {
 import { AdminApprovalsBanner } from './admin-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
 import { InfiniteScrollSentinel } from './infinite-scroll-sentinel';
+import { TaskMentionTooltipContent } from './task-mention-tooltip';
 import { TaskPriorityBadge } from './task-priority-badge';
 import { TaskRunDot } from './task-run-dot';
 import { TaskStatusBadge } from './task-status-badge';
@@ -128,6 +129,51 @@ function TaskListSection({
 				rowClassName={faded ? () => 'opacity-60' : undefined}
 			/>
 		</section>
+	);
+}
+
+/**
+ * Title cell: the ID column claims its full width (it never wraps), so the title
+ * is what gives - it truncates with an ellipsis. A tooltip carrying the full ID
+ * and title (the same card the task @mention link shows) makes that lossless.
+ *
+ * The tooltip is driven as a controlled Radix root rather than conditionally
+ * wrapping the span: the `<Tooltip>` stays mounted either way, so the measured
+ * node's ref never detaches. Truncation is measured on hover intent inside
+ * `onOpenChange`, which keeps a long list free of per-row ResizeObservers.
+ */
+function TaskTitleCell({ row }: { row: TaskRow }) {
+	const textRef = useRef<HTMLSpanElement>(null);
+	const [open, setOpen] = useState(false);
+	return (
+		<Tooltip
+			open={open}
+			onOpenChange={(next) => {
+				const el = textRef.current;
+				// Only open when the title is actually clipped; a fully visible title
+				// has nothing to reveal.
+				if (next && (!el || el.scrollWidth <= el.clientWidth + 1)) return;
+				setOpen(next);
+			}}
+			content={
+				<TaskMentionTooltipContent
+					identifier={row.identifier}
+					title={row.title}
+					status={row.status}
+				/>
+			}
+		>
+			<span className="font-medium inline-flex items-center gap-1.5 min-w-0 max-w-full">
+				{row.depth > 0 && (
+					<span className="text-text-3 shrink-0" aria-hidden="true">
+						↳
+					</span>
+				)}
+				<span ref={textRef} className="truncate">
+					{row.title}
+				</span>
+			</span>
+		</Tooltip>
 	);
 }
 
@@ -343,7 +389,12 @@ export function TaskList({ projectId }: TaskListProps) {
 			key: 'id',
 			header: 'ID',
 			width: '88px',
-			className: 'font-mono text-text-2',
+			// `whitespace-nowrap` lands on the <td> (DataTable appends col.className
+			// last). It stops the identifier breaking at its hyphen, and — because the
+			// table uses auto layout, where `width` is only a hint — it also raises the
+			// column's min-content width to the real content width (dot + any badges +
+			// identifier), so the wide Title column can no longer starve it.
+			className: 'font-mono text-text-2 whitespace-nowrap',
 			render: (row) => {
 				const lastRunFailed = isLastRunFailed(row.has_active_run, row.last_run_status);
 				return (
@@ -371,7 +422,7 @@ export function TaskList({ projectId }: TaskListProps) {
 								/>
 							</Tooltip>
 						)}
-						{row.identifier}
+						<span data-testid="task-identifier">{row.identifier}</span>
 					</span>
 				);
 			},
@@ -379,16 +430,14 @@ export function TaskList({ projectId }: TaskListProps) {
 		{
 			key: 'title',
 			header: 'Title',
-			render: (row) => (
-				<span className="font-medium inline-flex items-center gap-1.5 min-w-0">
-					{row.depth > 0 && (
-						<span className="text-text-3 shrink-0" aria-hidden="true">
-							↳
-						</span>
-					)}
-					<span className="truncate">{row.title}</span>
-				</span>
-			),
+			// The table uses auto layout, where a cell's min-content width is its
+			// widest unbreakable content — so a `truncate` (nowrap) title made this
+			// column demand the full title width, overflowing the table and starving
+			// the fixed-width columns instead of ellipsising. `max-w-0` drops that
+			// contribution and `w-full` claims whatever the other columns leave, which
+			// is what actually lets the ellipsis engage.
+			className: 'max-w-0 w-full',
+			render: (row) => <TaskTitleCell row={row} />,
 		},
 		...(projectId
 			? []

--- a/packages/web/src/components/task-mention-tooltip.tsx
+++ b/packages/web/src/components/task-mention-tooltip.tsx
@@ -1,0 +1,27 @@
+import { TaskStatusBadge } from './task-status-badge';
+
+/**
+ * Tooltip body for a task reference: `<IDENTIFIER>: <title>` over an optional
+ * status pill. Shared by the markdown @mention link renderer and the task
+ * list's truncated titles, so both surfaces show the same card.
+ */
+export function TaskMentionTooltipContent({
+	identifier,
+	title,
+	status,
+}: {
+	identifier: string;
+	title: string;
+	status?: string;
+}) {
+	return (
+		<span className="flex flex-col gap-1">
+			<span>
+				<strong>{identifier.toUpperCase()}:</strong> {title}
+			</span>
+			{status ? (
+				<TaskStatusBadge status={status} className="self-start" testId="task-mention-status-pill" />
+			) : null}
+		</span>
+	);
+}

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -522,6 +522,26 @@ export function uniqueName(base: string): string {
 	return `${base} ${Math.random().toString(36).slice(2, 8)}`;
 }
 
+/** Assert an element renders on a single text line (nowrap + height ≤ ~1.5 lines). */
+export async function expectSingleLine(locator: Locator): Promise<void> {
+	const metrics = await locator.evaluate((el) => {
+		const style = getComputedStyle(el);
+		const lineHeightPx = Number.parseFloat(style.lineHeight);
+		const fontSizePx = Number.parseFloat(style.fontSize);
+		return {
+			whiteSpace: style.whiteSpace,
+			height: el.getBoundingClientRect().height,
+			// line-height: normal resolves to "normal" in Chromium getComputedStyle,
+			// so fall back to a generous multiple of the font size.
+			oneLine: Number.isNaN(lineHeightPx) ? fontSizePx * 1.6 : lineHeightPx,
+		};
+	});
+	// nowrap is the single-line guarantee; the height check confirms it isn't
+	// silently spilling onto a second line. Two wrapped lines roughly double it.
+	expect(metrics.whiteSpace).toBe('nowrap');
+	expect(metrics.height).toBeLessThan(metrics.oneLine * 1.5);
+}
+
 export type HttpMethod = 'GET' | 'PATCH' | 'POST' | 'DELETE' | 'PUT';
 
 export type ResponseMatcher = (url: URL, method: string) => boolean;

--- a/test/browser/task-assignee-truncation.spec.ts
+++ b/test/browser/task-assignee-truncation.spec.ts
@@ -6,29 +6,13 @@
 // that only a browser engine resolves (decision tree point 1), so it lives here
 // rather than in the component tier.
 
-import type { Locator } from '@playwright/test';
 import { expect, test } from './fixtures';
-import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
-
-/** Assert an element renders on a single text line (nowrap + height ≤ ~1.5 lines). */
-async function expectSingleLine(locator: Locator): Promise<void> {
-	const metrics = await locator.evaluate((el) => {
-		const style = getComputedStyle(el);
-		const lineHeightPx = Number.parseFloat(style.lineHeight);
-		const fontSizePx = Number.parseFloat(style.fontSize);
-		return {
-			whiteSpace: style.whiteSpace,
-			height: el.getBoundingClientRect().height,
-			// line-height: normal resolves to "normal" in Chromium getComputedStyle,
-			// so fall back to a generous multiple of the font size.
-			oneLine: Number.isNaN(lineHeightPx) ? fontSizePx * 1.6 : lineHeightPx,
-		};
-	});
-	// nowrap is the single-line guarantee; the height check confirms it isn't
-	// silently spilling onto a second line. Two wrapped lines roughly double it.
-	expect(metrics.whiteSpace).toBe('nowrap');
-	expect(metrics.height).toBeLessThan(metrics.oneLine * 1.5);
-}
+import {
+	createProjectAndClearPlanning,
+	expectSingleLine,
+	uniqueName,
+	waitForPageLoad,
+} from './helpers';
 
 test('long assignee names stay on one line in the task list and side panel', async ({
 	sharedPage: page,

--- a/test/browser/task-id-nowrap.spec.ts
+++ b/test/browser/task-id-nowrap.spec.ts
@@ -1,0 +1,145 @@
+// Real Chromium (decision tree #1 + #2): the task list's ID column used to wrap
+// "HM-279" onto two lines, and the fix is a layout one — the assertions read
+// computed `white-space` and laid-out element heights, plus the truncation gate on
+// the title tooltip compares scrollWidth against clientWidth. happy-dom reports
+// zeros for all of it. The mobile leg (375px) is where the ID column is under the
+// most width pressure, since Project/Priority/Assignee are `hidden md:table-cell`
+// while ID/Title/Status always render.
+
+import { expect, test } from './fixtures';
+import {
+	createProjectAndClearPlanning,
+	expectSingleLine,
+	uniqueName,
+	waitForPageLoad,
+} from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+async function createTaskViaApi(
+	page: Page,
+	projectSlug: string,
+	token: string,
+	data: { project_id: string; title: string },
+): Promise<{ id: string; identifier: string }> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	// A task requires an assignee; the Blank-templated project has a Captain.
+	const res = await page.request.post(`/api/projects/${projectSlug}/tasks`, {
+		headers,
+		data: { assignee_slug: 'captain', ...data },
+	});
+	if (!res.ok()) throw new Error(`createTaskViaApi failed — ${res.status()} ${await res.text()}`);
+	return ((await res.json()) as { data: { id: string; identifier: string } }).data;
+}
+
+test.describe('Task list — ID never wraps, truncated titles get a tooltip', () => {
+	test('the identifier stays on one line and a clipped title reveals the full ID + title on hover', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		const proj = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Task Id Nowrap'),
+			description: 'Task list ID wrapping spec.',
+		});
+
+		// Long enough to overflow the Title column at any viewport this spec uses, so
+		// the truncation gate on the tooltip is genuinely exercised.
+		const longTitle = uniqueName(
+			`Rework the deployment pipeline so every release candidate is promoted through staging with a full regression sweep, an approval gate, and a signed changelog before it reaches production`,
+		);
+		const shortTitle = uniqueName('Short one');
+
+		const longTask = await createTaskViaApi(page, proj.slug, token, {
+			project_id: proj.id,
+			title: longTitle,
+		});
+		const shortTask = await createTaskViaApi(page, proj.slug, token, {
+			project_id: proj.id,
+			title: shortTitle,
+		});
+
+		// A sub-task guards the other half of the Title cell's sizing: the depth
+		// indent is padding on the same <td> that now carries `max-w-0 w-full`.
+		const subTitle = uniqueName('Nested one');
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const subRes = await page.request.post(
+			`/api/projects/${proj.slug}/tasks/${shortTask.id}/sub-tasks`,
+			{ headers, data: { title: subTitle, assignee_slug: 'captain' } },
+		);
+		if (!subRes.ok()) throw new Error(`sub-task create failed — ${await subRes.text()}`);
+
+		await page.goto(`/projects/${proj.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		// Scope every locator to the task's own row — the list also carries Captain's
+		// background planning work, and the sections render identical cells.
+		const longRow = page.getByRole('row').filter({ hasText: longTitle });
+		const shortRow = page.getByRole('row').filter({ hasText: shortTitle });
+		await expect(longRow).toBeVisible({ timeout: 20_000 });
+		await expect(shortRow).toBeVisible({ timeout: 20_000 });
+
+		// --- The reported bug: "HM-279" split across two lines ---
+		for (const row of [longRow, shortRow]) {
+			const identifier = row.getByTestId('task-identifier');
+			await expect(identifier).toBeVisible();
+			await expectSingleLine(identifier);
+		}
+		// The whole identifier is present, so nowrap isn't hiding a clipped ID.
+		await expect(longRow.getByTestId('task-identifier')).toHaveText(longTask.identifier);
+		await expect(shortRow.getByTestId('task-identifier')).toHaveText(shortTask.identifier);
+
+		// --- A clipped title is truncated visually only, and hover reveals it ---
+		const longTitleText = longRow.getByText(longTitle, { exact: true });
+		await expectSingleLine(longTitleText);
+		// Truncation is CSS-only: the full title stays in the DOM.
+		await expect(longTitleText).toHaveText(longTitle);
+		const clipped = await longTitleText.evaluate((el) => el.scrollWidth > el.clientWidth + 1);
+		expect(clipped).toBe(true);
+
+		await longTitleText.hover();
+		// Scope to the role="tooltip" panel — Radix also renders a hidden aria
+		// duplicate of the content that carries the same testId.
+		const tooltip = page.getByRole('tooltip');
+		await expect(tooltip).toBeVisible({ timeout: 20_000 });
+		await expect(tooltip).toContainText(`${longTask.identifier.toUpperCase()}: ${longTitle}`);
+		await expect(tooltip.getByTestId('task-mention-status-pill')).toBeVisible();
+
+		// --- The depth indent still renders on the now `max-w-0` title cell ---
+		const subRow = page.getByRole('row').filter({ hasText: subTitle });
+		await expect(subRow).toBeVisible({ timeout: 20_000 });
+		const parentTitleLeft = await shortRow
+			.getByText(shortTitle, { exact: true })
+			.evaluate((el) => el.getBoundingClientRect().left);
+		const subTitleLeft = await subRow
+			.getByText(subTitle, { exact: true })
+			.evaluate((el) => el.getBoundingClientRect().left);
+		// pl-5 sm:pl-6 (20-24px) plus the ↳ marker and its gap.
+		expect(subTitleLeft).toBeGreaterThan(parentTitleLeft + 20);
+
+		// --- A title that fits gets no tooltip (the truncation gate) ---
+		// Radix keeps hoverable tooltip content open across a grace area between the
+		// trigger and the panel, so step the pointer to empty space well clear of
+		// both rather than jumping it.
+		await page.mouse.move(1270, 500, { steps: 10 });
+		await expect(page.getByRole('tooltip')).toHaveCount(0);
+
+		const shortTitleText = shortRow.getByText(shortTitle, { exact: true });
+		expect(await shortTitleText.evaluate((el) => el.scrollWidth > el.clientWidth + 1)).toBe(false);
+		await shortTitleText.hover();
+		// Well past the 150ms Radix open delay that the positive case above just
+		// proved fires — so a still-absent tooltip is the gate, not a slow open.
+		await page.waitForTimeout(1000);
+		await expect(page.getByRole('tooltip')).toHaveCount(0);
+
+		// --- Mobile: the ID column is squeezed hardest here ---
+		await page.mouse.move(1270, 500, { steps: 10 });
+		await page.setViewportSize({ width: 375, height: 800 });
+		await expect(longRow.getByTestId('task-identifier')).toBeVisible();
+		await expectSingleLine(longRow.getByTestId('task-identifier'));
+		await expect(longRow.getByTestId('task-identifier')).toHaveText(longTask.identifier);
+		await expectSingleLine(shortRow.getByTestId('task-identifier'));
+	});
+});


### PR DESCRIPTION
## The bug

The ID column in the project task list rendered identifiers like `HM-279` broken across two lines (`HM-` / `279`).

The table uses **auto** layout, so the ID column's `width: '88px'` is only a hint. The identifier was a bare text node with no `whitespace-nowrap`, free to break at its hyphen - which made the column's min-content width just `HM-`, so the browser handed the surplus to the Title column and squeezed the ID down. The run dot and the optional warning / unread-mention badges sharing that 88px made it worse.

## The fix

Two cell-level changes in `packages/web/src/components/task-list.tsx`. The shared `DataTable` primitive is untouched on purpose: its five other consumers declare no column widths at all, so switching the table to fixed layout would have given every one of their columns equal width - a broad regression for a one-cell bug.

- **ID cell gets `whitespace-nowrap`.** It lands on the `<td>` (DataTable appends `col.className` last). This both stops the break and raises the column's min-content width to its real content width (dot + any badges + identifier), so the Title column can no longer starve it.
- **Title cell gets `max-w-0 w-full`.** A `truncate` (nowrap) title contributes its full unbreakable width to the cell's min-content, so the table was overflowing horizontally rather than ellipsising - the fixed-width Status / Priority / Assignee columns were pushed off-screen entirely. `max-w-0` drops that contribution and `w-full` claims whatever the other columns leave, which is what actually engages the ellipsis.

## The tooltip

A truncated title is now lossless: hovering it opens the same card the task @mention link already shows (bold identifier, full title, status pill).

That tooltip body moved out of the inline JSX in `markdown-prose.tsx` into a shared `TaskMentionTooltipContent` now that it has two call sites. Truncation is measured on hover intent inside a controlled Radix root, so a long list pays no per-row `ResizeObserver`, the measured node's ref never detaches, and a title that fits shows nothing at all.

## Testing

New `test/browser/task-id-nowrap.spec.ts`. This is the browser tier because every assertion reads real layout (computed `white-space`, laid-out element heights, `scrollWidth` vs `clientWidth`) - decision-tree point 1, and happy-dom reports zeros for all of it. It covers:

- the identifier renders on a single line, with the whole identifier present (nowrap isn't hiding a clipped ID), at 1280px **and** at 375px where the column is squeezed hardest
- a clipped title truncates visually only (full text stays in the DOM) and hovering it opens a tooltip with `<ID>: <full title>` plus the status pill
- a title that fits opens no tooltip - the truncation gate
- the depth indent still renders on the now `max-w-0` title cell (sub-task title sits further right than its parent's)

`expectSingleLine` moved from `task-assignee-truncation.spec.ts` into the shared browser helpers rather than being copied.

Verified green: the new spec; `task-assignee-truncation`, `task-mention-status`, `task-crud`, `task-list-infinite-scroll`; the `responsive.mobile` / `app-header.mobile` / `new-task-button.mobile` projects; the `task-list`, `markdown-prose`, `mention` and `task-detail` component tiers; `typecheck` and `biome check`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvJ1Me2kyLUJtRBcLtCQjH)_