### PR TITLE
feat(web): copy button on rendered markdown code blocks

### DIFF
--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../hooks/use-chat';
 import { useCloseOnRouteChange } from '../../hooks/use-close-on-route-change';
 import { useContainerHealth } from '../../hooks/use-container-health';
+import { useCopyFeedback } from '../../hooks/use-copy-feedback';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
 import { useFileAttachments } from '../../hooks/use-file-attachments';
 import { LONG_PRESS_MS, useLongPress } from '../../hooks/use-long-press';
@@ -996,21 +997,10 @@ function SentAttachments({
  * reachable. `group-hover` is itself auto-scoped to `(hover: hover)` by Tailwind.
  */
 function MessageCopyButton({ text, align }: { text: string; align: 'start' | 'end' }) {
-	const [copied, setCopied] = useState(false);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	useEffect(() => {
-		return () => {
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		};
-	}, []);
+	const { copied, copy } = useCopyFeedback();
 
 	const handleCopy = async () => {
-		if (await copyToClipboard(text)) {
-			setCopied(true);
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		}
+		await copy(text);
 	};
 
 	return (

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { AlignLeft, Check, Code, Copy, Maximize2, Minimize2, MoveVertical } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
-import { copyToClipboard } from '../lib/clipboard';
+import { useCopyFeedback } from '../hooks/use-copy-feedback';
 import type { CommentRefTask } from '../lib/remark-comment-refs';
 import { FormattedLogView } from './formatted-log-view';
 import { Button } from './ui/button';
@@ -51,13 +51,12 @@ export function LogViewer({
 	commentRefTask,
 }: LogViewerProps) {
 	const [autoScroll, setAutoScroll] = useState(true);
-	const [copied, setCopied] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [viewMode, setViewMode] = useState<'formatted' | 'raw'>(formattable ? 'formatted' : 'raw');
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const lastCountRef = useRef(0);
 	const pendingBottomOffsetRef = useRef<number | null>(null);
-	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const { copied, copy } = useCopyFeedback();
 
 	const attachScrollRef = useCallback((node: HTMLDivElement | null) => {
 		scrollRef.current = node;
@@ -92,19 +91,8 @@ export function LogViewer({
 		setIsExpanded((v) => !v);
 	};
 
-	useEffect(() => {
-		return () => {
-			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-		};
-	}, []);
-
 	const handleCopy = async () => {
-		const text = lines.map((l) => l.text).join('\n');
-		if (await copyToClipboard(text)) {
-			setCopied(true);
-			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-			copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		}
+		await copy(lines.map((l) => l.text).join('\n'));
 	};
 
 	const isFormatted = formattable && viewMode === 'formatted';

--- a/packages/web/src/components/markdown-code-block.tsx
+++ b/packages/web/src/components/markdown-code-block.tsx
@@ -1,0 +1,115 @@
+import { Check, Copy } from 'lucide-react';
+import type { ComponentProps } from 'react';
+import { useCopyFeedback } from '../hooks/use-copy-feedback';
+import { useI18n } from '../lib/i18n';
+
+/**
+ * Minimal shape of the hast nodes react-markdown hands a component override.
+ * Declared locally rather than imported from `hast` - the same idiom
+ * `lib/rehype-review-highlights.ts` uses, so this module takes no dependency on
+ * a type package that only arrives transitively through react-markdown.
+ */
+interface HastNodeLike {
+	type?: string;
+	value?: unknown;
+	children?: unknown;
+}
+
+/**
+ * The raw source of a fenced code block, read off its hast node.
+ *
+ * Reading hast rather than the rendered React children is what makes this
+ * exact: `rehype-review-highlights` splits the code's single text node into
+ * several, interleaved with `<mark>` elements, whenever a review comment's quote
+ * lands inside the fence - so the original string is only recoverable by walking
+ * the tree. `mdast-util-to-hast` appends one trailing newline when it builds the
+ * `<pre><code>` pair (a rendering artifact, not the author's code), so drop
+ * exactly one.
+ */
+export function codeBlockText(node: unknown): string {
+	const text = collectText(node);
+	return text.endsWith('\n') ? text.slice(0, -1) : text;
+}
+
+function collectText(node: unknown): string {
+	if (!node || typeof node !== 'object') return '';
+	const n = node as HastNodeLike;
+	if (n.type === 'text') return typeof n.value === 'string' ? n.value : '';
+	if (!Array.isArray(n.children)) return '';
+	let out = '';
+	for (const child of n.children) out += collectText(child);
+	return out;
+}
+
+/**
+ * A rendered markdown code block with a copy button overlaid on its bottom-right
+ * corner. Registered as MarkdownProse's `pre` override; inline `<code>` never
+ * reaches it (mdast only emits `<pre>` for fenced and indented blocks).
+ *
+ * Three pieces of this are load-bearing and invisible:
+ *
+ * 1. The button cannot live inside the `<pre>`. `.prose pre` is `overflow-x:
+ *    auto`, so an absolutely positioned child would be positioned against the
+ *    scroll container and slide out of view horizontally with the code. Hence
+ *    the wrapper.
+ *
+ * 2. The wrapper is deliberately bare - no padding, no border, no `overflow`,
+ *    no `flow-root`. `position: relative` does not establish a block formatting
+ *    context, so the pre's typography margins collapse *through* the wrapper and
+ *    the wrapper's border box ends up identical to the pre's. That is what puts
+ *    `bottom-2 right-2` inside the code block instead of out in the margin gap,
+ *    and what keeps the block's spacing identical to the unwrapped version.
+ *    Adding any of those properties silently drops the button below the block.
+ *
+ * 3. Wrapping costs the two typography resets: `.prose > :first-child` /
+ *    `:last-child` now land on the wrapper, whose own margin is already 0, and a
+ *    collapse takes the max - so the pre's margin would survive at the very top
+ *    or bottom of a prose block. The two arbitrary variants below re-apply the
+ *    resets to the pre itself.
+ *
+ * The button must also stay icon-only. `lib/doc-review-selection.ts` walks every
+ * text node under the prose container and that stream has to stay identical to
+ * the hast stream `rehype-review-highlights` anchors against; an SVG contributes
+ * no text nodes, but a visible label would, and would break review anchoring on
+ * every document and text-asset surface.
+ */
+export function MarkdownCodeBlock({
+	node,
+	children,
+	...preProps
+}: ComponentProps<'pre'> & { node?: unknown }) {
+	const { t } = useI18n();
+	const { copied, copy } = useCopyFeedback();
+
+	const handleCopy = async () => {
+		await copy(codeBlockText(node));
+	};
+
+	return (
+		<div
+			data-testid="markdown-code-block"
+			className="relative group/code-block [&:first-child_pre]:mt-0 [&:last-child_pre]:mb-0"
+		>
+			{/* `preProps` forwards whatever react-markdown put on the element (a
+			    className a rehype plugin added, for instance) so wrapping stays
+			    lossless; `node` is react-markdown's own extra prop and must not
+			    reach the DOM. */}
+			<pre {...preProps}>{children}</pre>
+			{/* Keyed on hover *capability*, not screen size (the same idiom as the chat
+			    message copy button): pointer devices reveal it on hover so it never
+			    sits over the code, touch devices keep it visible so it stays
+			    reachable. `pointer-events-none` while hidden matters here in a way it
+			    doesn't for the chat button - an opacity-0 overlay still hit-tests and
+			    would block text selection in the block's corner. */}
+			<button
+				type="button"
+				onClick={handleCopy}
+				aria-label={copied ? t('common.copied') : t('common.copy')}
+				data-testid="code-block-copy"
+				className="absolute bottom-2 right-2 z-10 flex h-6 w-6 items-center justify-center rounded-md border border-border bg-surface-3 text-text-3 shadow-xs transition-opacity hover:bg-surface-2 hover:text-text-1 focus-visible:opacity-100 group-hover/code-block:pointer-events-auto group-hover/code-block:opacity-100 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0"
+			>
+				{copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+			</button>
+		</div>
+	);
+}

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -24,6 +24,7 @@ import {
 } from '../lib/remark-mentions';
 import { remarkNormalizeInlineCode } from '../lib/remark-normalize-inline-code';
 import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
+import { MarkdownCodeBlock } from './markdown-code-block';
 import { useOpenPreview } from './task-detail/preview-context';
 import { TaskMentionTooltipContent } from './task-mention-tooltip';
 import { Tooltip } from './ui/tooltip';
@@ -467,6 +468,10 @@ export function MarkdownProse({
 					<table>{props.children}</table>
 				</div>
 			),
+			// A fenced code block renders inside a relative wrapper so its copy
+			// button can overlay the bottom-right corner without pushing the
+			// following content down. Inline `<code>` never reaches this override.
+			pre: MarkdownCodeBlock,
 		};
 	}, [projectId, instance, openPreview, activeReviewId, onReviewHighlightClick]);
 

--- a/packages/web/src/components/task-detail/comment-row.tsx
+++ b/packages/web/src/components/task-detail/comment-row.tsx
@@ -1,13 +1,12 @@
 import { CommentContentType } from '@hezo/shared';
 import { Check, Copy, CornerDownRight, Reply } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
 import {
 	type Comment,
 	type CommentSkeleton,
 	skeletonNeedsBody,
 	useCommentBody,
 } from '../../hooks/use-comments';
-import { copyToClipboard } from '../../lib/clipboard';
+import { useCopyFeedback } from '../../hooks/use-copy-feedback';
 import { defaultAvatarForSlug } from '../../lib/default-avatars';
 import { AgentLink } from '../agent-link';
 import {
@@ -28,21 +27,10 @@ import { Avatar, avatarColorFromString } from '../ui/avatar';
  * check for 1.5s as confirmation (mirrors the log-viewer copy affordance).
  */
 function CopyCommentButton({ text }: { text: string }) {
-	const [copied, setCopied] = useState(false);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	useEffect(() => {
-		return () => {
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		};
-	}, []);
+	const { copied, copy } = useCopyFeedback();
 
 	const handleCopy = async () => {
-		if (await copyToClipboard(text)) {
-			setCopied(true);
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		}
+		await copy(text);
 	};
 
 	return (

--- a/packages/web/src/hooks/use-copy-feedback.ts
+++ b/packages/web/src/hooks/use-copy-feedback.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '../lib/clipboard';
+
+/** How long the confirmation stays up before the icon reverts. */
+const DEFAULT_RESET_MS = 1500;
+
+/**
+ * Copy text to the clipboard and hold a transient "copied" flag.
+ *
+ * Every copy affordance in the app runs the same state machine: on a successful
+ * copy flip to the check icon, then revert after ~1.5s - and each needs the same
+ * timer bookkeeping (clear a pending timer on a re-copy so a fast double click
+ * doesn't revert early, and on unmount so the timeout never fires into an
+ * unmounted component). That is this hook.
+ *
+ * Callers keep their own markup: the affordances differ in size, label, tooltip
+ * and placement, and only the state is shared - which is why this is a hook and
+ * not a `<CopyButton>` carrying a prop for each of those differences.
+ */
+export function useCopyFeedback(resetMs: number = DEFAULT_RESET_MS) {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	const copy = useCallback(
+		async (text: string): Promise<boolean> => {
+			if (!(await copyToClipboard(text))) return false;
+			setCopied(true);
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+			timeoutRef.current = setTimeout(() => setCopied(false), resetMs);
+			return true;
+		},
+		[resetMs],
+	);
+
+	return { copied, copy };
+}

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -34,6 +34,8 @@
 	"common.delete": "Löschen",
 	"common.retry": "Erneut versuchen",
 	"common.back": "Zurück",
+	"common.copy": "Kopieren",
+	"common.copied": "Kopiert",
 	"nav.home": "Start",
 	"nav.settings": "Einstellungen",
 	"nav.projects": "Projekte",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -34,6 +34,8 @@
 	"common.delete": "Delete",
 	"common.retry": "Retry",
 	"common.back": "Back",
+	"common.copy": "Copy",
+	"common.copied": "Copied",
 	"nav.home": "Home",
 	"nav.settings": "Settings",
 	"nav.projects": "Projects",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -34,6 +34,8 @@
 	"common.delete": "Eliminar",
 	"common.retry": "Reintentar",
 	"common.back": "Atrás",
+	"common.copy": "Copiar",
+	"common.copied": "Copiado",
 	"nav.home": "Inicio",
 	"nav.settings": "Ajustes",
 	"nav.projects": "Proyectos",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -34,6 +34,8 @@
 	"common.delete": "Supprimer",
 	"common.retry": "Réessayer",
 	"common.back": "Retour",
+	"common.copy": "Copier",
+	"common.copied": "Copié",
 	"nav.home": "Accueil",
 	"nav.settings": "Réglages",
 	"nav.projects": "Projets",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -34,6 +34,8 @@
 	"common.delete": "Elimina",
 	"common.retry": "Riprova",
 	"common.back": "Indietro",
+	"common.copy": "Copia",
+	"common.copied": "Copiato",
 	"nav.home": "Home",
 	"nav.settings": "Impostazioni",
 	"nav.projects": "Progetti",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -34,6 +34,8 @@
 	"common.delete": "削除",
 	"common.retry": "再試行",
 	"common.back": "戻る",
+	"common.copy": "コピー",
+	"common.copied": "コピーしました",
 	"nav.home": "ホーム",
 	"nav.settings": "設定",
 	"nav.projects": "プロジェクト",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -34,6 +34,8 @@
 	"common.delete": "삭제",
 	"common.retry": "다시 시도",
 	"common.back": "뒤로",
+	"common.copy": "복사",
+	"common.copied": "복사됨",
 	"nav.home": "홈",
 	"nav.settings": "설정",
 	"nav.projects": "프로젝트",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -34,6 +34,8 @@
 	"common.delete": "Verwijderen",
 	"common.retry": "Opnieuw proberen",
 	"common.back": "Terug",
+	"common.copy": "Kopiëren",
+	"common.copied": "Gekopieerd",
 	"nav.home": "Start",
 	"nav.settings": "Instellingen",
 	"nav.projects": "Projecten",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -34,6 +34,8 @@
 	"common.delete": "Usuń",
 	"common.retry": "Spróbuj ponownie",
 	"common.back": "Wstecz",
+	"common.copy": "Kopiuj",
+	"common.copied": "Skopiowano",
 	"nav.home": "Start",
 	"nav.settings": "Ustawienia",
 	"nav.projects": "Projekty",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -34,6 +34,8 @@
 	"common.delete": "Excluir",
 	"common.retry": "Tentar novamente",
 	"common.back": "Voltar",
+	"common.copy": "Copiar",
+	"common.copied": "Copiado",
 	"nav.home": "Início",
 	"nav.settings": "Configurações",
 	"nav.projects": "Projetos",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -34,6 +34,8 @@
 	"common.delete": "Ta bort",
 	"common.retry": "Försök igen",
 	"common.back": "Tillbaka",
+	"common.copy": "Kopiera",
+	"common.copied": "Kopierad",
 	"nav.home": "Start",
 	"nav.settings": "Inställningar",
 	"nav.projects": "Projekt",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -34,6 +34,8 @@
 	"common.delete": "删除",
 	"common.retry": "重试",
 	"common.back": "返回",
+	"common.copy": "复制",
+	"common.copied": "已复制",
 	"nav.home": "主页",
 	"nav.settings": "设置",
 	"nav.projects": "项目",

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -44,6 +44,7 @@ import { EmptyState } from '../../../components/ui/empty-state';
 import { Input } from '../../../components/ui/input';
 import { RelativeTime } from '../../../components/ui/relative-time';
 import { Tooltip } from '../../../components/ui/tooltip';
+import { useCopyFeedback } from '../../../hooks/use-copy-feedback';
 import {
 	type ProjectAsset,
 	useArchiveProjectAsset,
@@ -61,7 +62,6 @@ import {
 	folderLeafName,
 	groupAssets,
 } from '../../../lib/asset-folders';
-import { copyToClipboard } from '../../../lib/clipboard';
 import { useI18n } from '../../../lib/i18n';
 
 interface AssetsSearch {
@@ -1008,21 +1008,10 @@ function MoveAssetDialog({
  * check for 1.5s as confirmation (mirrors the comment/log copy affordances).
  */
 function CopyReferenceButton({ reference }: { reference: string }) {
-	const [copied, setCopied] = useState(false);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	useEffect(() => {
-		return () => {
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		};
-	}, []);
+	const { copied, copy } = useCopyFeedback();
 
 	const handleCopy = async () => {
-		if (await copyToClipboard(reference)) {
-			setCopied(true);
-			if (timeoutRef.current) clearTimeout(timeoutRef.current);
-			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		}
+		await copy(reference);
 	};
 
 	return (

--- a/packages/web/test/markdown-code-block.test.tsx
+++ b/packages/web/test/markdown-code-block.test.tsx
@@ -1,0 +1,156 @@
+// The copy affordance on rendered markdown code blocks. Fully standalone: with
+// no projectId/instance every mention query in MarkdownProse is `enabled: false`
+// and useOpenPreview() returns null outside a provider, so these need no backend
+// and no router - just a QueryClient and the message catalog (the button's
+// aria-label resolves through t()).
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { codeBlockText } from '../src/components/markdown-code-block';
+import { MarkdownProse } from '../src/components/markdown-prose';
+import type { ReviewAnnotation } from '../src/lib/rehype-review-highlights';
+import { withI18n } from './helpers/i18n';
+
+function renderProse(markdown: string, reviewAnnotations?: ReviewAnnotation[]) {
+	return render(
+		withI18n(
+			<QueryClientProvider client={new QueryClient()}>
+				<MarkdownProse reviewAnnotations={reviewAnnotations} onReviewHighlightClick={() => {}}>
+					{markdown}
+				</MarkdownProse>
+			</QueryClientProvider>,
+		),
+	);
+}
+
+/**
+ * Swap in a recording clipboard for the duration of `fn`, restoring whatever
+ * happy-dom had defined. Mirrors the stub in task-comments.test.tsx.
+ */
+async function withClipboard(fn: (writes: string[]) => Promise<void>) {
+	const writes: string[] = [];
+	const originalDesc = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+	Object.defineProperty(navigator, 'clipboard', {
+		configurable: true,
+		value: {
+			writeText: async (t: string) => {
+				writes.push(t);
+			},
+		},
+	});
+	try {
+		await fn(writes);
+	} finally {
+		if (originalDesc) Object.defineProperty(navigator, 'clipboard', originalDesc);
+		else delete (navigator as { clipboard?: unknown }).clipboard;
+	}
+}
+
+test('a fenced block gets one copy button; inline code gets none', () => {
+	const { container, queryAllByTestId } = renderProse(
+		['Use `npm` inline.', '', '```sh', 'npm run build', '```', ''].join('\n'),
+	);
+
+	expect(queryAllByTestId('code-block-copy')).toHaveLength(1);
+
+	// The inline chip is a bare <code> in the paragraph - not wrapped, no button.
+	const inline = container.querySelector('p code');
+	expect(inline?.textContent).toBe('npm');
+	expect(inline?.closest('[data-testid="markdown-code-block"]')).toBeNull();
+
+	// The one <pre> is the wrapped one.
+	const pres = container.querySelectorAll('pre');
+	expect(pres).toHaveLength(1);
+	expect(pres[0].closest('[data-testid="markdown-code-block"]')).not.toBeNull();
+});
+
+test('clicking copies the exact fence contents, without the trailing newline', async () => {
+	const user = userEvent.setup();
+	const { getByTestId } = renderProse(
+		['Before.', '', '```ts', 'const a = 1;', 'const b = 2;', '```', '', 'After.'].join('\n'),
+	);
+
+	await withClipboard(async (writes) => {
+		await user.click(getByTestId('code-block-copy'));
+		// mdast-util-to-hast appends one newline building <pre><code>; it is a
+		// rendering artifact and must not land in the clipboard.
+		expect(writes).toEqual(['const a = 1;\nconst b = 2;']);
+	});
+});
+
+test('the button confirms the copy, then reverts', async () => {
+	const user = userEvent.setup();
+	const { getByTestId } = renderProse(['```', 'echo hi', '```'].join('\n'));
+
+	const btn = getByTestId('code-block-copy');
+	expect(btn.getAttribute('aria-label')).toBe('Copy');
+
+	await withClipboard(async () => {
+		await user.click(btn);
+		await waitFor(() => expect(btn.getAttribute('aria-label')).toBe('Copied'));
+	});
+});
+
+test('a review highlight inside a fence still copies the whole block', async () => {
+	const user = userEvent.setup();
+	const { getByTestId } = renderProse(['```sh', 'npm run build', '```'].join('\n'), [
+		{ id: 'r1', quote: 'run build', occurrence: 0 },
+	]);
+
+	// The highlight really is inside the code block - i.e. the code's single text
+	// node has been split, which is what defeats a naive textContent read.
+	const mark = getByTestId('review-highlight');
+	expect(mark.closest('pre')).not.toBeNull();
+
+	await withClipboard(async (writes) => {
+		await user.click(getByTestId('code-block-copy'));
+		expect(writes).toEqual(['npm run build']);
+	});
+});
+
+test('each code block tracks its own copied state', async () => {
+	const user = userEvent.setup();
+	const { getAllByTestId } = renderProse(
+		['```', 'first', '```', '', '```', 'second', '```'].join('\n'),
+	);
+
+	const [first, second] = getAllByTestId('code-block-copy');
+	await withClipboard(async (writes) => {
+		await user.click(second);
+		expect(writes).toEqual(['second']);
+		await waitFor(() => expect(second.getAttribute('aria-label')).toBe('Copied'));
+		expect(first.getAttribute('aria-label')).toBe('Copy');
+	});
+});
+
+test('codeBlockText walks nested nodes and drops one trailing newline', () => {
+	// The shape rehype-review-highlights produces: the code text split around a
+	// <mark>, with the to-hast trailing newline on the end.
+	const node = {
+		type: 'element',
+		tagName: 'pre',
+		children: [
+			{
+				type: 'element',
+				tagName: 'code',
+				children: [
+					{ type: 'text', value: 'npm ' },
+					{
+						type: 'element',
+						tagName: 'mark',
+						children: [{ type: 'text', value: 'run build' }],
+					},
+					{ type: 'text', value: '\n' },
+				],
+			},
+		],
+	};
+
+	expect(codeBlockText(node)).toBe('npm run build');
+	// Only one newline is an artifact; a deliberate blank final line survives.
+	expect(codeBlockText({ type: 'text', value: 'a\n\n' })).toBe('a\n');
+	expect(codeBlockText(undefined)).toBe('');
+	expect(codeBlockText({ type: 'element', tagName: 'pre' })).toBe('');
+});

--- a/test/browser/markdown-code-copy.spec.ts
+++ b/test/browser/markdown-code-copy.spec.ts
@@ -1,0 +1,154 @@
+// Real-CSS-layout assertions (testing decision tree, point 1): the copy button's
+// overlay depends on the code block's typography margins collapsing *through* its
+// relative wrapper, which is only observable via boundingBox() and
+// getComputedStyle() after a real layout pass - happy-dom computes neither.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+// A fence between two paragraphs: lets us compare the gap above the block to the
+// gap below it, which is what "the button doesn't push content down" means.
+const CODE_MID = [
+	'# Code doc',
+	'',
+	'Before the block.',
+	'',
+	'```sh',
+	'echo one',
+	'echo two',
+	'```',
+	'',
+	'After the block.',
+].join('\n');
+
+// A body that is *only* a fence, so the block is both the first and the last
+// child of the prose container - the case the wrapper's :first-child/:last-child
+// margin compensation exists for.
+const CODE_ONLY = ['```sh', 'echo hello', '```'].join('\n');
+
+async function openDoc(
+	page: import('@playwright/test').Page,
+	projectSlug: string,
+	token: string,
+	filename: string,
+	content: string,
+) {
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/${filename}`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content },
+	});
+	expect(res.ok()).toBe(true);
+	await page.goto(`/projects/${projectSlug}/documents?file=${filename}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: filename })).toBeVisible({ timeout: 20000 });
+}
+
+test('the code-block copy button overlays the block without shifting layout', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await openDoc(page, projectSlug, token, 'code-mid.md', CODE_MID);
+
+	const wrapper = page.getByTestId('markdown-code-block').first();
+	const pre = wrapper.locator('pre');
+	await expect(pre).toBeVisible();
+
+	// Collapse-through: with no padding/border/overflow on the wrapper, the pre's
+	// typography margins collapse past it, so the two boxes coincide. Adding
+	// `overflow-hidden` or padding to the wrapper fails right here.
+	const wrapperBox = await wrapper.boundingBox();
+	const preBox = await pre.boundingBox();
+	expect(wrapperBox).not.toBeNull();
+	expect(preBox).not.toBeNull();
+	if (!wrapperBox || !preBox) return;
+	expect(Math.abs(wrapperBox.x - preBox.x)).toBeLessThanOrEqual(1);
+	expect(Math.abs(wrapperBox.y - preBox.y)).toBeLessThanOrEqual(1);
+	expect(Math.abs(wrapperBox.width - preBox.width)).toBeLessThanOrEqual(1);
+	expect(Math.abs(wrapperBox.height - preBox.height)).toBeLessThanOrEqual(1);
+
+	// The button is hover-revealed on a pointer device, so hover before measuring.
+	await wrapper.hover();
+	const button = page.getByTestId('code-block-copy').first();
+	await expect(button).toBeVisible();
+
+	// Overlay: the button sits entirely inside the code block, so it occupies no
+	// layout of its own.
+	const btnBox = await button.boundingBox();
+	expect(btnBox).not.toBeNull();
+	if (!btnBox) return;
+	expect(btnBox.x).toBeGreaterThanOrEqual(preBox.x);
+	expect(btnBox.y).toBeGreaterThanOrEqual(preBox.y);
+	expect(btnBox.x + btnBox.width).toBeLessThanOrEqual(preBox.x + preBox.width + 1);
+	expect(btnBox.y + btnBox.height).toBeLessThanOrEqual(preBox.y + preBox.height + 1);
+
+	// …in the bottom-right corner specifically: both edges are inset by the
+	// `bottom-2 right-2` 8px (plus the pre's 1px border). Measured as a distance
+	// to the corner rather than "past the midpoint", which a short block fails
+	// for the wrong reason - a two-line fence is barely taller than the button.
+	expect(preBox.x + preBox.width - (btnBox.x + btnBox.width)).toBeLessThanOrEqual(12);
+	expect(preBox.y + preBox.height - (btnBox.y + btnBox.height)).toBeLessThanOrEqual(12);
+
+	// No pushdown: the gap the block leaves above itself equals the gap below, and
+	// the pre keeps its normal mid-document typography margins.
+	const beforeBox = await page.getByText('Before the block.').boundingBox();
+	const afterBox = await page.getByText('After the block.').boundingBox();
+	expect(beforeBox).not.toBeNull();
+	expect(afterBox).not.toBeNull();
+	if (!beforeBox || !afterBox) return;
+	const topGap = preBox.y - (beforeBox.y + beforeBox.height);
+	const bottomGap = afterBox.y - (preBox.y + preBox.height);
+	expect(Math.abs(topGap - bottomGap)).toBeLessThanOrEqual(1);
+	expect(bottomGap).toBeGreaterThan(10);
+
+	const margins = await pre.evaluate((el) => {
+		const s = getComputedStyle(el);
+		return { top: s.marginTop, bottom: s.marginBottom };
+	});
+	expect(margins.top).toBe(margins.bottom);
+	expect(Number.parseFloat(margins.top)).toBeGreaterThan(10);
+
+	// Mobile: same overlay guarantees at the narrow breakpoint.
+	await page.setViewportSize({ width: 375, height: 800 });
+	await expect(pre).toBeVisible();
+	const mWrapperBox = await wrapper.boundingBox();
+	const mPreBox = await pre.boundingBox();
+	expect(mWrapperBox).not.toBeNull();
+	expect(mPreBox).not.toBeNull();
+	if (!mWrapperBox || !mPreBox) return;
+	expect(Math.abs(mWrapperBox.height - mPreBox.height)).toBeLessThanOrEqual(1);
+
+	await wrapper.hover();
+	const mBtnBox = await button.boundingBox();
+	expect(mBtnBox).not.toBeNull();
+	if (!mBtnBox) return;
+	expect(mBtnBox.x).toBeGreaterThanOrEqual(mPreBox.x);
+	expect(mBtnBox.x + mBtnBox.width).toBeLessThanOrEqual(mPreBox.x + mPreBox.width + 1);
+	expect(mBtnBox.y + mBtnBox.height).toBeLessThanOrEqual(mPreBox.y + mPreBox.height + 1);
+});
+
+test('a document that is only a code block keeps the first/last margin resets', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await openDoc(page, projectSlug, token, 'code-only.md', CODE_ONLY);
+
+	const pre = page.getByTestId('markdown-code-block').first().locator('pre');
+	await expect(pre).toBeVisible();
+
+	// Wrapping the pre moves `.prose > :first-child`/`:last-child` onto the
+	// wrapper, whose margin is already 0 - and a collapse takes the max, so the
+	// pre's own margin would survive without the compensating variants.
+	// Computed style, not a bounding box: `.prose` has no padding, so an
+	// uncompensated margin would collapse straight out through it and a y-delta
+	// would read the same either way.
+	const margins = await pre.evaluate((el) => {
+		const s = getComputedStyle(el);
+		return { top: s.marginTop, bottom: s.marginBottom };
+	});
+	expect(margins.top).toBe('0px');
+	expect(margins.bottom).toBe('0px');
+});


### PR DESCRIPTION
Every fenced code block rendered through `MarkdownProse` now carries a small copy button in its bottom-right corner. That reaches every markdown surface at once: task descriptions and summaries, comments, CEO chat, the markdown text blocks in agent run logs, the docs viewer, goals, the skills dialog, and every markdown editor's preview tab.

Previously the only way to get code out of a block was to hand-select it inside a scrollable `<pre>`.

## Behaviour

- Same `Copy` -> `Check` affordance as every other copy control in the app, reverting after 1.5s.
- Hover-revealed on pointer devices so it never sits over the code; permanently visible on touch, where there is no hover. Keyed on `(hover: hover)` capability rather than screen size - the same idiom the chat message copy button uses.
- `pointer-events-none` while hidden, so the invisible overlay cannot swallow text selection in the block's corner.

## Overlaid, not in flow

The button costs no layout. The `<pre>` renders inside a bare `relative` wrapper whose typography margins collapse straight *through* it, making the wrapper's border box identical to the pre's - so `bottom-2 right-2` lands inside the code block rather than out in the margin gap, and the spacing around the block is unchanged.

Three things about that are load-bearing and commented in the source:

1. The button cannot live inside the `<pre>`. `.prose pre` is `overflow-x: auto`, so an absolutely positioned child would slide out of view horizontally with the code.
2. The wrapper must stay bare - no padding, border, `overflow` or `flow-root`. Any of those establishes a block formatting context, blocks the collapse, and drops the button below the block.
3. Wrapping moves the `.prose > :first-child` / `:last-child` margin resets onto the wrapper, whose margin is already 0 - and a collapse takes the max, so the pre's own margin would survive. Two arbitrary variants re-apply the resets to the pre.

## Copy text

Read off the hast `node` rather than the rendered React children: `rehype-review-highlights` splits the code's text node around `<mark>` elements when a review quote lands inside a fence, so the original string is only recoverable by walking the tree. The trailing newline `mdast-util-to-hast` appends is dropped.

The button stays icon-only deliberately - `doc-review-selection.ts` walks the prose text-node stream and it has to stay identical to the hast stream review anchors resolve against, so a visible label would shift them.

## Refactor

Extracts `useCopyFeedback` from the four copy buttons that already ran a byte-identical copied-state/timeout state machine (comment, chat message, asset reference, run log) rather than adding a fifth copy. Their markup, classNames, aria-labels and testids are unchanged, and their existing tests pass unedited - that is the proof the refactor is behaviour-preserving.

## Translations

`common.copy` / `common.copied` added to all 12 catalogs for the button's aria-label. No existing string reworded, renamed or removed.

## Tests

**`packages/web/test/markdown-code-block.test.tsx`** (new, 6 tests, ~140ms - fully standalone, no backend or router):
- a fenced block gets one button, inline code gets none
- clicking copies the exact fence contents with no trailing newline
- the aria-label confirms the copy
- a review highlight inside a fence still copies the whole block
- each block tracks its own copied state
- `codeBlockText` walks nested nodes and drops one trailing newline

**`test/browser/markdown-code-copy.spec.ts`** (new, 2 tests) - kept in Playwright by decision-tree point 1, real CSS layout:
- the wrapper's box equals the pre's box (the collapse-through guard - adding `overflow-hidden` fails here)
- the button is contained in the pre, inset at the bottom-right corner
- the gap above the block equals the gap below (the no-pushdown guard)
- a document that is only a code block keeps its first/last margin resets
- the same overlay guarantees at a 375px mobile viewport

## Verification

- `bun run test --package web`: 1512 passed. One unrelated flake in `agent-hire.test.tsx` under the loaded run, green in isolation.
- The new browser spec passes against real Chromium at both 1280px and 375px.
- Confirmed in the built CSS that all four arbitrary variants emit, and that the group-hover reveal at (0,2,0) beats the `(hover: hover)` hide at (0,1,0).
- `bun run typecheck` and `biome check` clean; the pre-commit build passes.

## Docs

No `docs/` change - per-element copy affordances are undocumented today (the comment and chat copy buttons ship without one, and the two clipboard mentions in `docs/concepts` are the asset-reference and review-handoff workflows, both unchanged). No `.dev/architecture.md` change - a component override adds no route, data flow or architecture element.

---
_Generated by [Claude Code](https://claude.ai/code/session_015vDGWhP6YbCEJmmCqG8m2N)_