### PR TITLE
feat(web): remove the All tasks links from the progress columns

### DIFF
--- a/packages/web/src/components/progress/recent-task-columns.tsx
+++ b/packages/web/src/components/progress/recent-task-columns.tsx
@@ -122,18 +122,9 @@ export function RecentTaskColumns({
 			<div className="hidden gap-4 md:grid md:grid-cols-3">
 				{PROGRESS_ACTIVITY_KINDS.map((kind) => (
 					<div key={kind} data-testid={`progress-column-${kind}`}>
-						<div className="mb-1.5 flex items-center justify-between gap-2 px-0.5">
-							<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-3">
-								{t(COLUMN_LABELS[kind].heading)}
-							</h2>
-							<Link
-								to="/projects/$projectId/tasks"
-								params={{ projectId }}
-								className="text-[11px] text-text-3 transition-colors hover:text-text-1 hover:underline"
-							>
-								{t('progress.columns.allTasks')}
-							</Link>
-						</div>
+						<h2 className="mb-1.5 px-0.5 text-[11px] font-medium uppercase tracking-wider text-text-3">
+							{t(COLUMN_LABELS[kind].heading)}
+						</h2>
 						<ColumnBody
 							projectId={projectId}
 							entries={activity[kind] ?? []}

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Erstellt",
 	"progress.tabs.closed": "Abgeschlossen",
 	"progress.columns.tabsLabel": "Zuletzt bearbeitete Aufgaben",
-	"progress.columns.allTasks": "Alle Aufgaben",
 	"progress.columns.empty": "Noch nichts vorhanden.",
 	"progress.columns.awaitingRun": "Der Captain füllt dies bei einer Fortschrittsaktualisierung aus.",
 	"progress.runs.heading": "Fortschrittsaktualisierungen",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Created",
 	"progress.tabs.closed": "Closed",
 	"progress.columns.tabsLabel": "Recent task activity",
-	"progress.columns.allTasks": "All tasks",
 	"progress.columns.empty": "Nothing here yet.",
 	"progress.columns.awaitingRun": "The Captain fills these in during a progress update.",
 	"progress.runs.heading": "Progress update runs",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Creadas",
 	"progress.tabs.closed": "Completadas",
 	"progress.columns.tabsLabel": "Actividad reciente de tareas",
-	"progress.columns.allTasks": "Todas las tareas",
 	"progress.columns.empty": "Aún no hay nada.",
 	"progress.columns.awaitingRun": "El Captain las completa durante una actualización de progreso.",
 	"progress.runs.heading": "Ejecuciones de actualización de progreso",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Créées",
 	"progress.tabs.closed": "Terminées",
 	"progress.columns.tabsLabel": "Activité récente des tâches",
-	"progress.columns.allTasks": "Toutes les tâches",
 	"progress.columns.empty": "Rien pour l'instant.",
 	"progress.columns.awaitingRun": "Le Captain les remplit lors d'une mise à jour de progression.",
 	"progress.runs.heading": "Exécutions de mise à jour",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Create",
 	"progress.tabs.closed": "Completate",
 	"progress.columns.tabsLabel": "Attività recenti del progetto",
-	"progress.columns.allTasks": "Tutte le attività",
 	"progress.columns.empty": "Ancora nulla.",
 	"progress.columns.awaitingRun": "Il Captain le compila durante un aggiornamento di avanzamento.",
 	"progress.runs.heading": "Esecuzioni di aggiornamento",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "作成",
 	"progress.tabs.closed": "完了",
 	"progress.columns.tabsLabel": "最近のタスクの動き",
-	"progress.columns.allTasks": "すべてのタスク",
 	"progress.columns.empty": "まだ何もありません。",
 	"progress.columns.awaitingRun": "進捗更新の際に Captain が記入します。",
 	"progress.runs.heading": "進捗更新の実行",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "생성",
 	"progress.tabs.closed": "완료",
 	"progress.columns.tabsLabel": "최근 태스크 활동",
-	"progress.columns.allTasks": "모든 태스크",
 	"progress.columns.empty": "아직 아무것도 없습니다.",
 	"progress.columns.awaitingRun": "진행 업데이트 때 Captain이 채웁니다.",
 	"progress.runs.heading": "진행 업데이트 실행",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Aangemaakt",
 	"progress.tabs.closed": "Afgerond",
 	"progress.columns.tabsLabel": "Recente taakactiviteit",
-	"progress.columns.allTasks": "Alle taken",
 	"progress.columns.empty": "Nog niets.",
 	"progress.columns.awaitingRun": "De Captain vult dit in tijdens een voortgangsupdate.",
 	"progress.runs.heading": "Voortgangsupdate-runs",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Utworzone",
 	"progress.tabs.closed": "Zamknięte",
 	"progress.columns.tabsLabel": "Ostatnia aktywność zadań",
-	"progress.columns.allTasks": "Wszystkie zadania",
 	"progress.columns.empty": "Jeszcze nic tu nie ma.",
 	"progress.columns.awaitingRun": "Captain uzupełnia to podczas aktualizacji postępu.",
 	"progress.runs.heading": "Uruchomienia aktualizacji postępu",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Criadas",
 	"progress.tabs.closed": "Concluídas",
 	"progress.columns.tabsLabel": "Atividade recente de tarefas",
-	"progress.columns.allTasks": "Todas as tarefas",
 	"progress.columns.empty": "Ainda não há nada aqui.",
 	"progress.columns.awaitingRun": "O Captain preenche isto durante uma atualização de progresso.",
 	"progress.runs.heading": "Execuções de atualização de progresso",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "Skapade",
 	"progress.tabs.closed": "Avslutade",
 	"progress.columns.tabsLabel": "Senaste uppgiftsaktivitet",
-	"progress.columns.allTasks": "Alla uppgifter",
 	"progress.columns.empty": "Inget här än.",
 	"progress.columns.awaitingRun": "Captain fyller i detta vid en framstegsuppdatering.",
 	"progress.runs.heading": "Framstegsuppdateringar",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -69,7 +69,6 @@
 	"progress.tabs.created": "创建",
 	"progress.tabs.closed": "完成",
 	"progress.columns.tabsLabel": "最近的任务动态",
-	"progress.columns.allTasks": "全部任务",
 	"progress.columns.empty": "这里还没有内容。",
 	"progress.columns.awaitingRun": "Captain 会在进展更新时填写。",
 	"progress.runs.heading": "进展更新运行",


### PR DESCRIPTION
Removes the "All tasks" link that sat at the right edge of each of the three recent-activity column headings on the Progress page (RECENTLY ACTIONED / CREATED / CLOSED).

All three pointed at the same destination - `/projects/$projectId/tasks` - so the page carried the identical link three times in a row, in a header that only needs its label. The task list is already one click away in the project nav.

## Changes

- `packages/web/src/components/progress/recent-task-columns.tsx` - drop the three `<Link>`s. The `flex items-center justify-between` wrapper existed only to push the link right, so the `<h2>` absorbs the row's spacing classes and becomes the header row itself. The mobile tab strip never had these links and is untouched.
- `packages/web/src/lib/i18n/catalog/*.json` (all 12) - delete the now-orphaned `progress.columns.allTasks` key. Leaving it would trip `i18n-catalog.test.ts`, which fails on a key referenced nowhere in `packages/web/src/`.

## Testing

- `bunx vitest run test/i18n-catalog.test.ts test/progress-page.test.tsx` - 19 passed. The progress-page suite covers the columns, the task rows, and the per-task links, all of which still render.
- `bun run typecheck` and `bunx biome check` clean; the pre-commit hook's full `bun run build` passed.

No docs surface describes this link, and no user-facing string was added or reworded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGgBHdWbJTGBzRrb63DMK)_