### PR TITLE
fix(git): stop a merged-and-deleted branch reading as stranded commits

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2430,18 +2430,59 @@ failure never fails the commit. *Uncommitted*
 changes are still not covered — the agent commits to preserve, and the role prompts frame frequent
 committing (not a manual end-of-run push) as the durability action.
 
+On the success arm the hook also records the accepted tip at `refs/hezo/pushed/<branch>`
+(`PUSHED_MARKER_PREFIX`) — never on the failure arm, or a branch delivered up to commit 3 would
+read as fully pushed. It runs in the task worktree, but `refs/hezo/*` is not per-worktree, so the
+ref lands in the common git dir where the clone-rooted scan below reads it.
+
 **Stranded commits (ref comparison, not the error log).** Reporting a failed push into the run log
 is not the same as noticing that work is about to be left behind, and the two questions have
 different answers: the error log is append-only within a run and cleared at prep, so a push that
 failed at commit 3 and succeeded at commit 5 leaves a non-empty log with **nothing** actually
 unpushed. At run completion the runner therefore asks the authoritative question directly —
 `findUnpushedWork` / `countUnpushedCommits` (`services/git.ts`) run
-`git rev-list --count refs/heads/hezo/<task> --not --remotes=origin` in each prepared clone, which
-counts commits reachable from the task branch but from no `origin` tracking ref. `git push` updates
-those tracking refs on success and prep fetches before the agent starts, so this is a **local**
-read: no network call, and it is correct for all four shapes (current, behind, merged to the default
-branch under another name, never pushed). What counts as durable is the `DURABLE_REMOTES` parameter
-rather than a hardcoded remote at each call site.
+`git rev-list --count refs/heads/hezo/<task> --not --remotes=origin --glob=refs/hezo/pushed/*` in
+each prepared clone, which counts commits reachable from the task branch but from neither an
+`origin` tracking ref nor the hook's accepted-tip markers. `git push` updates those tracking refs on
+success and prep fetches before the agent starts, so this is a **local** read: no network call.
+What counts as durable is the `DURABLE_REMOTES` parameter rather than a hardcoded remote at each
+call site, and `deliveredExclusions` builds the `--not` set once so the count and the bundle below
+cannot disagree about what is already delivered.
+
+The tracking refs alone are correct for four shapes (current, behind, merged to the default branch
+under another name, never pushed) and **wrong for a fifth**: pushed, and then the remote branch
+deleted or the work squash-merged. Deleting a remote branch prunes its tracking ref locally, and a
+squash puts the content on the default branch under a commit that shares no history with the
+originals — so re-fetching cannot recover the fact either. That read the whole branch as stranded
+and failed the run, firing hardest on the tidiest workflow: merge the pull request, delete the
+branch. The marker answers it, because "did `origin` ever accept this commit" is the durability
+question and a remote cannot retract the answer.
+
+**The merge guard.** What the marker cannot see on its own is the other way a branch leaves the
+remote: deleted *without* being merged, where the work really is gone from `origin` and this clone
+may hold the last copy. Locally the two are indistinguishable — a squash preserves no per-commit
+identity on the default branch to match against — so `countBranchDelivery` reports the state and
+`reviewRetractedWork` (`services/agent-runner.ts`) asks the git host to resolve it, before the
+stranded-commit scan runs. It splits a branch's undelivered commits two ways: `unpushed` (on no
+remote ref and covered by no marker) and `retracted` (accepted by `origin`, advertised by it no
+longer). Only a non-zero `retracted` reaches out, so the ordinary path — branch still on the
+remote, or its tip already merged into a fetched default branch — makes no call at all.
+
+The question is put through `checkRepoCommitMerged` (`services/repo-github.ts` → `checkCommitMerged`
+in `services/github.ts`), which reads the pull requests associated with the marker's commit: that
+association survives both the squash and the branch deletion. On `not_merged` the run
+`voidPushedMarker`s the branch — the delivery record is no longer true — and the ordinary scan
+below then reports, vaults and fails exactly as it would for work that never left, with no second
+case anywhere downstream. **Only a definite `not_merged` acts.** `unknown` (no connection, a locked
+vault, a 404, a rate limit, an unreachable host) reports into the run log and changes nothing,
+because the primary durability question already answered *yes* and turning "could not ask" into a
+failed run would reinstate the false positive the marker exists to remove.
+
+`services/repo-github.ts` is the home for host-side questions about a repo asked with its own
+connected credential, outside the egress proxy — `resolveRepoGitHub` resolves the row, parses the
+identifier and decrypts the token, and `repo-push-access.ts` uses the same seam. The AGENTS.md red
+line holds structurally: the host is the constant `getApiBaseUrl()`, only `parseGitHubUrl`-charset
+`owner`/`repo` segments vary, and every function returns a verdict rather than an upstream body.
 
 A positive finding does three things: the run fails, the commits are copied out to the bundle
 vault, and the container is pinned for as long as it still holds the only copy.
@@ -2483,9 +2524,11 @@ store, and `sandbox/recovery.ts` is the seam between them.
     instance.
   - It needs per-provider volume provisioning plus a Docker bind-mount equivalent: two
     implementations of one thing, against zero today.
-- **A delta, not a copy of the history.** `--not --remotes=origin` packs only what no durable remote
-  has, recording the remote tips as prerequisites — kilobytes for an ordinary task. A clone with no
-  remote to exclude against produces a bundle of the whole branch, which is what
+- **A delta, not a copy of the history.** The same `deliveredExclusions` set the count uses packs
+  only what no durable remote and no accepted-tip marker already covers, recording those tips as
+  prerequisites — kilobytes for an ordinary task. Sharing the set is what stops the bundle carrying
+  commits the count already treats as safe. A clone with nothing to exclude against produces a
+  bundle of the whole branch, which is what
   `MAX_RECOVERY_BUNDLE_BYTES` (64 MiB, checked via `SandboxFiles.size` *before* the read buffers it)
   refuses rather than moving.
 - **Restored in run prep, strictly after the origin fetch** (`restoreRecoveryBundle`), because the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | An in-container script or its parser | `services/sandbox/proc-scripts.ts` - never an adapter |
 | What a container was provisioned with | `container_pool_members` (`memory_bytes`, `disk_ceiling_bytes`) - never re-read from the setting |
 | A chat platform | `ChatChannelAdapter` (`services/chat-channels/`) |
+| A host-side call to a repo's git host, with that repo's own credential | `resolveRepoGitHub` (`services/repo-github.ts`) - returns a verdict, never an upstream body |
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |
 | Paging (lists and large content) | `mcp/paging.ts` |
 | Shared enums, constants, validation run on both sides | `@hezo/shared` (`types/common.ts`) |

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -24,6 +24,7 @@ import {
 import { ContainerGitExecutor, mintGitOpScopeId } from '../services/git-executor';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
+import { loadConnectionAccessToken } from '../services/repo-github';
 import { performRepoSetup } from '../services/repo-provisioning';
 import { refreshRepoPushAccess } from '../services/repo-push-access';
 import { removeRepoFromWorkspace } from '../services/repo-sync';
@@ -118,7 +119,7 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		return err(c, 'INVALID_REQUEST', 'oauth connection is not for GitHub', 400);
 	}
 
-	const accessToken = await loadOAuthAccessToken(db, masterKeyManager, conn.id);
+	const accessToken = await loadConnectionAccessToken({ db, masterKeyManager }, conn.id);
 	if (!accessToken) {
 		return err(c, 'OAUTH_TOKEN_UNAVAILABLE', 'master key locked or token missing', 503);
 	}
@@ -643,7 +644,7 @@ reposRoutes.get('/projects/:projectId/oauth-connections/:id/orgs', async (c) => 
 	)
 		return err(c, 'NOT_FOUND', 'github connection not found', 404);
 
-	const token = await loadOAuthAccessToken(db, masterKeyManager, conn.id);
+	const token = await loadConnectionAccessToken({ db, masterKeyManager }, conn.id);
 	if (!token) return err(c, 'OAUTH_TOKEN_UNAVAILABLE', 'token unavailable', 503);
 
 	const { listUserOrgs } = await import('../services/github');
@@ -665,32 +666,13 @@ reposRoutes.get('/projects/:projectId/oauth-connections/:id/repos', async (c) =>
 		(conn.projectId !== null && conn.projectId !== projectId)
 	)
 		return err(c, 'NOT_FOUND', 'github connection not found', 404);
-	const token = await loadOAuthAccessToken(db, masterKeyManager, conn.id);
+	const token = await loadConnectionAccessToken({ db, masterKeyManager }, conn.id);
 	if (!token) return err(c, 'OAUTH_TOKEN_UNAVAILABLE', 'token unavailable', 503);
 
 	const { listAccessibleRepos } = await import('../services/github');
 	const repos = await listAccessibleRepos(owner, query, token);
 	return ok(c, repos);
 });
-
-async function loadOAuthAccessToken(
-	db: import('../db/database').Db,
-	masterKeyManager: import('../crypto/master-key').MasterKeyManager,
-	oauthConnectionId: string,
-): Promise<string | null> {
-	const key = masterKeyManager.getKey();
-	if (!key) return null;
-	const result = await db.query<{ encrypted_value: string }>(
-		`SELECT s.encrypted_value
-		 FROM oauth_connections oc
-		 JOIN secrets s ON s.id = oc.access_token_secret_id
-		 WHERE oc.id = $1`,
-		[oauthConnectionId],
-	);
-	if (result.rows.length === 0) return null;
-	const { decrypt } = await import('../crypto/encryption');
-	return decrypt(result.rows[0].encrypted_value, key);
-}
 
 interface RepoGitTarget {
 	repoId: string;

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -78,6 +78,7 @@ import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } fr
 import { buildEgressProxyEnv, type EgressProxy } from './egress';
 import {
 	clearPushErrors,
+	countBranchDelivery,
 	describeUnpushedWork,
 	ensurePushHook,
 	ensureTaskWorktreeWithRetry,
@@ -89,8 +90,10 @@ import {
 	mergeDefaultIntoWorktree,
 	type RepoLoc,
 	readPushErrors,
+	readPushedMarker,
 	seedInitialCommitIfEmpty,
 	type UnpushedWorkScan,
+	voidPushedMarker,
 	type WorktreeLoc,
 	worktreeChangedPaths,
 	worktreeHasChanges,
@@ -109,6 +112,7 @@ import { retryOrEscalateLostRun } from './orphan-detector';
 import type { PricingService } from './pricing';
 import type { ProgressActivityCandidates } from './project-activity';
 import { loadReactionsForTask, type ReactionGroup } from './reactions';
+import { checkRepoCommitMerged } from './repo-github';
 import { ensureProjectRepos } from './repo-sync';
 import { projectContainerMemoryGb } from './run-concurrency';
 import {
@@ -239,6 +243,17 @@ interface RepoRow {
 	id: string;
 	repo_identifier: string;
 }
+
+/**
+ * A prepared clone, carrying the `repos` row it came from.
+ *
+ * The id rides along rather than being looked up again at finalize because the one
+ * check that needs it - asking the git host what became of a branch the remote no
+ * longer advertises - has only a container path to go on otherwise, and matching a
+ * path back to a row by name is a second source of truth for something already known
+ * here. Structurally still a {@link RepoLoc}, so every existing consumer is unchanged.
+ */
+type CloneRef = RepoLoc & { repoId: string };
 
 /**
  * Build the env-var entries for a given provider/auth method. Composed from the
@@ -1642,7 +1657,7 @@ export async function runAgent(
 						workingDir: '/workspace',
 						designatedRepo: null as RepoRow | null,
 						worktrees: [] as WorktreeRef[],
-						clones: [] as RepoLoc[],
+						clones: [] as CloneRef[],
 						branch: null as string | null,
 						executor: null as GitExecutor | null,
 						recoveryFailed: new Set<string>(),
@@ -1713,6 +1728,14 @@ export async function runAgent(
 						`to this repository.\n${pushErrors}\n`,
 				);
 			}
+
+			// Before the scan: a branch `origin` accepted and no longer advertises is
+			// either a merged pull request tidied up after, or work deleted off the remote.
+			// Only the git host can tell those apart, and the scan below reads both as
+			// safe - so ask, and drop the delivery record when the answer is that nothing
+			// merged it. That turns the branch back into ordinary undelivered work, with
+			// nothing downstream needing a second case for it.
+			await reviewRetractedWork(deps, prep, emit);
 
 			// Whether committed work is about to be left behind in this container only.
 			//
@@ -2247,6 +2270,66 @@ async function anyWorktreeChanged(
 }
 
 /**
+ * Decide what became of commits `origin` accepted and no longer advertises, and
+ * void the delivery record for the ones nothing merged.
+ *
+ * The accepted-tip marker exists so that merging a pull request and deleting its
+ * branch - the workflow the role prompts ask for - is not reported as stranded work.
+ * The cost of that is one thing it cannot see on its own: a branch pushed and then
+ * deleted **without** being merged looks locally identical, and its commits really
+ * have left the remote. Git has nothing left to distinguish them by, because a
+ * squash merge preserves no per-commit identity on the default branch, so this asks
+ * the git host the one question refs cannot answer.
+ *
+ * **Only a definite `not_merged` acts.** `unknown` - no connection, a locked vault,
+ * a throttled or unreachable host - reports and leaves everything alone, because the
+ * primary durability question already answered *yes* (the commits did reach the
+ * remote), and turning "we could not ask" into a failed run would reinstate the
+ * false positive the marker was added to remove.
+ *
+ * The host call is reached at all only when a clone is in that state, which on the
+ * ordinary path (branch still on the remote, or its tip already merged into a
+ * fetched default branch) is never - so a run pays nothing for this until there is
+ * something to ask about.
+ */
+async function reviewRetractedWork(
+	deps: RunnerDeps,
+	prep: { executor: GitExecutor | null; clones: CloneRef[]; branch: string | null },
+	emit: (stream: 'stdout' | 'stderr', text: string) => void,
+): Promise<void> {
+	const { executor, branch } = prep;
+	if (!executor || !branch) return;
+
+	for (const clone of prep.clones) {
+		const delivery = await countBranchDelivery(executor, clone, branch);
+		if (!delivery?.retracted) continue;
+
+		const sha = await readPushedMarker(executor, clone, branch);
+		if (!sha) continue;
+
+		const repoName = basename(clone.containerPath);
+		const verdict = await checkRepoCommitMerged(deps, clone.repoId, sha);
+		if (verdict === 'merged') continue;
+		if (verdict === 'unknown') {
+			emit(
+				'stderr',
+				`[system] ${repoName}: ${branch} is no longer on origin and it could not be ` +
+					`confirmed whether its work was merged — treating the ${delivery.retracted} ` +
+					`commit(s) origin accepted as delivered.\n`,
+			);
+			continue;
+		}
+
+		await voidPushedMarker(executor, clone, branch);
+		emit(
+			'stderr',
+			`[system] ${repoName}: ${branch} was deleted from origin without being merged — ` +
+				`its ${delivery.retracted} commit(s) are no longer on the remote.\n`,
+		);
+	}
+}
+
+/**
  * Copy a run's undelivered commits into the bundle vault, and drop stored bundles
  * whose work has since reached the remote.
  *
@@ -2267,7 +2350,7 @@ async function vaultUnpushedWork(
 	unpushed: UnpushedWorkScan,
 	prep: {
 		executor: GitExecutor | null;
-		clones: RepoLoc[];
+		clones: CloneRef[];
 		branch: string | null;
 		recoveryFailed: Set<string>;
 	},
@@ -2353,7 +2436,7 @@ async function prepareWorktrees(
 	designatedRepo: RepoRow | null;
 	worktrees: WorktreeRef[];
 	/** Each prepared repo's clone — where the auto-push hook records failed pushes. */
-	clones: RepoLoc[];
+	clones: CloneRef[];
 	/** The task branch every prepared worktree is on, or null when no repo was prepared. */
 	branch: string | null;
 	executor: GitExecutor | null;
@@ -2627,14 +2710,14 @@ async function prepareWorktrees(
 		// Capture each prepared worktree's location + pre-run commit so the completion
 		// path can detect whether the run produced any code change.
 		const worktrees: WorktreeRef[] = [];
-		const clones: RepoLoc[] = [];
+		const clones: CloneRef[] = [];
 		for (const repo of repos.rows) {
 			if (worktreeErrors.has(repo.id)) continue;
 			const repoName = repoNameFromIdentifier(repo.repo_identifier);
 			const loc = wtLocOf(repoName);
 			if (!(await loc.files.exists('.git'))) continue;
 			worktrees.push({ loc, headBefore: await getWorktreeHead(executor, loc) });
-			clones.push(repoLocOf(repoName));
+			clones.push({ ...repoLocOf(repoName), repoId: repo.id });
 		}
 
 		// Reclaim the worktrees of finished tasks before the agent starts. Worktrees

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -1109,6 +1109,23 @@ export async function resetCloneToOrigin(
 export const PUSH_ERROR_LOG_NAME = 'hezo-push-errors.log';
 
 /**
+ * Ref namespace recording, per branch, the tip `origin` last accepted from this clone.
+ * Written by {@link POST_COMMIT_PUSH_HOOK} after a push succeeds and read back by
+ * {@link countUnpushedCommits}.
+ *
+ * It exists because a remote-tracking ref answers "is this on the remote **now**", and
+ * the durability question is "did this ever reach the remote at all" — once `origin`
+ * has accepted a commit, this container is no longer its only home, whatever becomes of
+ * the branch it arrived on. The two answers diverge on the tidiest possible workflow:
+ * an agent that merges its pull request and deletes the remote branch also prunes
+ * `refs/remotes/origin/<branch>` locally, and a squash merge leaves the original
+ * commits reachable from no remote ref at any point, so no amount of fetching recovers
+ * the fact. Sitting outside `refs/remotes/`, this ref is touched by no push, fetch or
+ * prune, and it keeps those commits reachable even once the branch itself is gone.
+ */
+export const PUSHED_MARKER_PREFIX = 'refs/hezo/pushed/';
+
+/**
  * `post-commit` hook installed into every clone so committed work survives an aborted
  * or timed-out run. The per-task worktree is ephemeral and the run's hard time limit
  * discards it on abort, so a commit that only lives in the worktree is lost; pushing
@@ -1135,6 +1152,11 @@ export const PUSH_ERROR_LOG_NAME = 'hezo-push-errors.log';
  * - `--no-verify` — this is a durability checkpoint, not a reviewed push, so it skips
  *   any pre-push test/lint hook; a WIP commit whose tests are still red must reach the
  *   remote all the same.
+ * - {@link PUSHED_MARKER_PREFIX} on the success arm only — records the accepted tip in a
+ *   ref the remote cannot retract. A failed push must leave the marker where it was, or
+ *   a branch pushed up to commit 3 would read as fully delivered. The hook runs in the
+ *   task worktree, but `refs/hezo/*` is not per-worktree, so the ref lands in the common
+ *   git dir, which is where the clone-rooted scan looks for it.
  * - `exit 0` unconditionally — reporting a failure is not the same as failing the commit.
  */
 export const POST_COMMIT_PUSH_HOOK = `#!/bin/sh
@@ -1145,9 +1167,16 @@ export const POST_COMMIT_PUSH_HOOK = `#!/bin/sh
 [ -S "$SSH_AUTH_SOCK" ] || exit 0
 git remote get-url origin >/dev/null 2>&1 || exit 0
 
-hezo_push_out=$(git push --no-verify origin HEAD 2>&1) && exit 0
-
 hezo_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+
+# Record the accepted tip on success only: a remote branch that is later deleted or
+# squash-merged takes its tracking ref with it, and this is what still says the work
+# reached origin.
+if hezo_push_out=$(git push --no-verify origin HEAD 2>&1); then
+  git update-ref "${PUSHED_MARKER_PREFIX}$hezo_branch" HEAD 2>/dev/null || true
+  exit 0
+fi
+
 hezo_remote=$(git remote get-url origin 2>/dev/null || echo origin)
 hezo_log="$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/${PUSH_ERROR_LOG_NAME}"
 {
@@ -1228,6 +1257,23 @@ export async function readPushErrors(clone: RepoLoc, maxLines = 40): Promise<str
 export const DURABLE_REMOTES = ['origin'] as const;
 
 /**
+ * The `--not` arguments naming everything a clone has already delivered: the durable
+ * remotes' tracking refs, plus every {@link PUSHED_MARKER_PREFIX} ref, which covers the
+ * commits whose tracking ref has since been pruned.
+ *
+ * Shared by {@link countUnpushedCommits} and {@link createRecoveryBundle} because the
+ * two must agree exactly - the count says how much is undelivered and the bundle packs
+ * it, so a bundle built against a wider exclusion set would re-pack commits the count
+ * already treats as safe.
+ *
+ * `--glob` over a namespace with no refs in it contributes nothing rather than failing,
+ * so a clone whose pushes have all been denied needs no special case.
+ */
+function deliveredExclusions(remotes: readonly string[]): string[] {
+	return [...remotes.map((r) => `--remotes=${r}`), `--glob=${PUSHED_MARKER_PREFIX}*`];
+}
+
+/**
  * Commits on a clone's task branch that reached none of {@link DURABLE_REMOTES}.
  *
  * **This is a ref comparison, deliberately, and not a read of
@@ -1242,11 +1288,16 @@ export const DURABLE_REMOTES = ['origin'] as const;
  * run prep fetches before the agent starts, so the tracking refs are a faithful
  * local record of what the remote holds - no network call is needed or made.
  *
- * `--not --remotes=<name>` excludes everything reachable from that remote's
- * tracking refs, which answers all four shapes uniformly: pushed and current (0),
- * pushed but behind (the delta), never pushed but already merged into the default
- * branch (0, correctly - the commits are on the remote), and never pushed at all
- * (the whole branch).
+ * Excluding everything reachable from those tracking refs answers four shapes
+ * uniformly: pushed and current (0), pushed but behind (the delta), never pushed but
+ * already merged into the default branch (0, correctly - the commits are on the
+ * remote), and never pushed at all (the whole branch). {@link PUSHED_MARKER_PREFIX}
+ * answers the fifth, which the tracking refs cannot: pushed, and then the remote
+ * branch deleted or the work squash-merged, where deleting the branch prunes its
+ * tracking ref and a squash leaves the originals reachable from nothing on the
+ * remote. Without the marker that reads as the entire branch being stranded, so
+ * merging a pull request and tidying up after it - the workflow the role prompts ask
+ * for - would fail its own run.
  *
  * Returns 0 for a definite all-clear (including "the branch was never created", so
  * the agent committed nothing), and **null when the question could not be answered**
@@ -1259,6 +1310,32 @@ export async function countUnpushedCommits(
 	branch: string,
 	remotes: readonly string[] = DURABLE_REMOTES,
 ): Promise<number | null> {
+	return (await countBranchDelivery(executor, repo, branch, remotes))?.unpushed ?? null;
+}
+
+/**
+ * How much of a branch a durable remote has, split by the two ways it can fail to
+ * have it.
+ *
+ * `retracted` is the state the marker introduces and the tracking refs alone cannot
+ * express: commits `origin` demonstrably accepted, which it no longer advertises
+ * under any ref. Almost always that is a merged pull request tidied up after -
+ * a squash puts the content on the default branch under a new commit and deleting
+ * the branch prunes its tracking ref - and it is then entirely benign. But it is
+ * the *same* local picture as a branch deleted without ever being merged, where the
+ * work really has left the remote and this clone may hold the last copy. Git cannot
+ * tell those apart (a squash preserves no per-commit identity to match on), so this
+ * only reports the state; deciding which one it is takes a question to the git host.
+ *
+ * Counted as the difference between excluding the markers and not, which is exact by
+ * construction. Both reads are local.
+ */
+export async function countBranchDelivery(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	branch: string,
+	remotes: readonly string[] = DURABLE_REMOTES,
+): Promise<{ unpushed: number; retracted: number } | null> {
 	if (!(await repo.files.exists('.git'))) return null;
 	const localRef = `refs/heads/${branch}`;
 	const exists = await executor.exec(['rev-parse', '--verify', '--quiet', localRef], {
@@ -1267,15 +1344,68 @@ export async function countUnpushedCommits(
 	});
 	// No branch is a definite absence of unpushed work, not an unanswered question:
 	// the agent committed nothing on this task's branch in this clone.
-	if (exists.exitCode !== 0) return 0;
+	if (exists.exitCode !== 0) return { unpushed: 0, retracted: 0 };
 
+	const count = async (args: string[]): Promise<number | null> => {
+		const { exitCode, stdout } = await executor.exec(
+			['rev-list', '--count', localRef, '--not', ...args],
+			{ cwd: repo.containerPath, timeout: 30_000 },
+		);
+		if (exitCode !== 0) return null;
+		const n = Number.parseInt(stdout.trim(), 10);
+		return Number.isFinite(n) ? n : null;
+	};
+
+	const remoteArgs = remotes.map((r) => `--remotes=${r}`);
+	const onNoRemote = await count(remoteArgs);
+	if (onNoRemote === null) return null;
+	// Nothing off the remotes means nothing to attribute either way, so the second
+	// read is skipped rather than paid for on the overwhelmingly common path.
+	if (onNoRemote === 0) return { unpushed: 0, retracted: 0 };
+
+	const unpushed = await count(deliveredExclusions(remotes));
+	if (unpushed === null) return null;
+	return { unpushed, retracted: Math.max(0, onNoRemote - unpushed) };
+}
+
+/**
+ * The tip a durable remote last accepted for this branch, or null when none was
+ * recorded or the ref could not be read. This is the commit a git host is asked
+ * about when {@link countBranchDelivery} reports retracted work.
+ */
+export async function readPushedMarker(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	branch: string,
+): Promise<string | null> {
 	const { exitCode, stdout } = await executor.exec(
-		['rev-list', '--count', localRef, '--not', ...remotes.map((r) => `--remotes=${r}`)],
-		{ cwd: repo.containerPath, timeout: 30_000 },
+		['rev-parse', '--verify', '--quiet', `${PUSHED_MARKER_PREFIX}${branch}`],
+		{ cwd: repo.containerPath, timeout: 10_000 },
 	);
-	if (exitCode !== 0) return null;
-	const count = Number.parseInt(stdout.trim(), 10);
-	return Number.isFinite(count) ? count : null;
+	const sha = stdout.trim();
+	return exitCode === 0 && sha.length > 0 ? sha : null;
+}
+
+/**
+ * Forget that a durable remote ever accepted this branch.
+ *
+ * Called only once a git host has confirmed the work is not on the remote any
+ * more and was never merged - at which point the marker is a record of something
+ * that is no longer true, and leaving it would go on suppressing a report of
+ * commits this container may be the last holder of. Dropping it restores the
+ * ordinary undelivered-work path whole: the count, the recovery bundle and the run
+ * error all follow from the same refs, with nothing downstream needing a second
+ * case for it.
+ */
+export async function voidPushedMarker(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	branch: string,
+): Promise<void> {
+	await executor.exec(['update-ref', '-d', `${PUSHED_MARKER_PREFIX}${branch}`], {
+		cwd: repo.containerPath,
+		timeout: 10_000,
+	});
 }
 
 /** A clone left holding commits that reached no durable remote. */
@@ -1372,13 +1502,16 @@ export const RECOVERY_REMOTE = 'hezo-recovery';
 /**
  * Pack a branch's undelivered commits into a bundle inside the container.
  *
- * `--not --remotes=<durable>` makes this a **delta**: the bundle carries only what
- * no durable remote already has, recording the remote tips as prerequisites. That
- * is what keeps it kilobytes for an ordinary task rather than a copy of the whole
- * history, and it is why a container restoring it must have fetched origin first
- * (run prep always has, before it restores). A clone with no remote at all has no
- * prerequisites to exclude, so its bundle is the entire branch - correct, and the
- * case the vault's size cap exists for.
+ * Excluding what the clone has already delivered makes this a **delta**: the bundle
+ * carries only what no durable remote already has, recording the remote tips as
+ * prerequisites. That is what keeps it kilobytes for an ordinary task rather than a
+ * copy of the whole history, and it is why a container restoring it must have
+ * fetched origin first (run prep always has, before it restores). A clone with no
+ * remote at all has no prerequisites to exclude, so its bundle is the entire branch -
+ * correct, and the case the vault's size cap exists for.
+ *
+ * The exclusion set comes from {@link deliveredExclusions}, the same one the count
+ * uses, so the bundle packs exactly the commits the count reported.
  *
  * Never throws: this runs at run finalize, where the run is already being failed
  * for the unpushed work, and a broken bundle must not mask that.
@@ -1396,7 +1529,7 @@ export async function createRecoveryBundle(
 			RECOVERY_BUNDLE_REL_PATH,
 			`refs/heads/${branch}`,
 			'--not',
-			...remotes.map((r) => `--remotes=${r}`),
+			...deliveredExclusions(remotes),
 		],
 		{ cwd: repo.containerPath, timeout: 120_000 },
 	);

--- a/packages/server/src/services/github.ts
+++ b/packages/server/src/services/github.ts
@@ -299,6 +299,67 @@ export type AuthKeyResult =
 	| { status: 'already_exists' };
 
 /**
+ * Whether a commit's work landed on the repo.
+ *
+ * `unknown` is a first-class answer, not an error: the caller decides whether a
+ * container may be released on the strength of this, so "could not tell" must never
+ * be collapsed into either of the definitive answers.
+ */
+export type CommitMergeVerdict = 'merged' | 'not_merged' | 'unknown';
+
+/**
+ * Ask whether a commit was merged, via the pull requests associated with it.
+ *
+ * This is the question a ref comparison inside the clone cannot answer. Once a
+ * branch is deleted from the remote, the local refs look identical whether the work
+ * was squash-merged first or thrown away - and a squash rewrites the commits, so
+ * there is no per-commit identity left on the default branch to match against. The
+ * association GitHub keeps between a commit and the pull request that carried it
+ * survives both the squash and the branch deletion, which is what makes it the right
+ * thing to ask.
+ *
+ * **Only a 200 is definitive.** A 404, a rate limit, a 5xx or an unreadable body all
+ * report `unknown`, because the caller turns `not_merged` into a failed run and a
+ * renamed repo or a throttled minute is no evidence that anyone lost any work.
+ *
+ * Returns a verdict and nothing else - no upstream body, no status text - so nothing
+ * derived from the credential this call carries can reach a run log.
+ */
+export async function checkCommitMerged(
+	owner: string,
+	repo: string,
+	sha: string,
+	accessToken: string,
+	fetchFn: FetchFn = globalThis.fetch,
+): Promise<CommitMergeVerdict> {
+	let res: Response;
+	try {
+		res = await fetchFn(`${getApiBaseUrl()}/repos/${owner}/${repo}/commits/${sha}/pulls`, {
+			headers: authHeaders(accessToken),
+		});
+	} catch (e) {
+		log.warn(`merge check for ${owner}/${repo}@${sha} failed:`, (e as Error).message);
+		return 'unknown';
+	}
+	if (res.status !== 200) {
+		log.warn(`merge check for ${owner}/${repo}@${sha} was inconclusive (${res.status})`);
+		return 'unknown';
+	}
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		return 'unknown';
+	}
+	if (!Array.isArray(body)) return 'unknown';
+	// An empty list is a definite "no pull request ever carried this commit", which
+	// is exactly the shape of a branch pushed and then thrown away.
+	return body.some((pr) => (pr as { merged_at?: unknown } | null)?.merged_at != null)
+		? 'merged'
+		: 'not_merged';
+}
+
+/**
  * Fetch the authenticated user's full identity — used when establishing an
  * OAuth connection (account id keys the `oauth_connections` row; email/avatar
  * populate its metadata).

--- a/packages/server/src/services/repo-github.ts
+++ b/packages/server/src/services/repo-github.ts
@@ -1,0 +1,102 @@
+import type { MasterKeyManager } from '../crypto/master-key';
+import type { Db } from '../db/database';
+import { type CommitMergeVerdict, checkCommitMerged, type FetchFn, parseGitHubUrl } from './github';
+
+/**
+ * Asking a repo's git host something from the server side, with the repo's own
+ * connected credential.
+ *
+ * These calls run **outside the egress proxy** - Hezo makes them itself rather than
+ * an agent making them through the substituting proxy - so the rule in AGENTS.md
+ * applies in full: the destination may not be agent-influenceable, and nothing
+ * derived from the credential may be returned. Both hold structurally here. The host
+ * is `getApiBaseUrl()`, a constant; only `owner`/`repo` path segments vary, and they
+ * come from `parseGitHubUrl`, whose charset admits no host or path escape. Every
+ * function returns a verdict, never an upstream body.
+ */
+export interface RepoGitHubDeps {
+	db: Db;
+	/** Optional so a deployment shape without a vault simply skips the call. */
+	masterKeyManager?: MasterKeyManager;
+}
+
+/** A repo resolved to everything one host-side API call needs. */
+export interface RepoGitHubTarget {
+	owner: string;
+	repo: string;
+	token: string;
+	fetchFn: FetchFn;
+}
+
+/**
+ * These calls are always a convenience, never a dependency - callers run them on
+ * paths a user or a finishing run is waiting behind. A host that hangs must surface
+ * as "unknown, keep what we had" within seconds rather than stalling the caller on
+ * the default socket timeout.
+ */
+export const GITHUB_CHECK_TIMEOUT_MS = 10_000;
+
+export const timeBoundedFetch: FetchFn = (input, init) =>
+	fetch(input, { ...init, signal: AbortSignal.timeout(GITHUB_CHECK_TIMEOUT_MS) });
+
+/**
+ * Resolve a repo row to a callable target, or null when the call cannot be made at
+ * all: no linked connection, an identifier that is not a GitHub repo, a locked
+ * vault, or a connection whose secret is gone. Null is "did not ask", which every
+ * caller must keep distinct from anything the host actually said.
+ */
+export async function resolveRepoGitHub(
+	deps: RepoGitHubDeps,
+	repoId: string,
+): Promise<RepoGitHubTarget | null> {
+	const res = await deps.db.query<{
+		repo_identifier: string;
+		oauth_connection_id: string | null;
+	}>('SELECT repo_identifier, oauth_connection_id FROM repos WHERE id = $1', [repoId]);
+	const row = res.rows[0];
+	if (!row?.oauth_connection_id) return null;
+
+	const parsed = parseGitHubUrl(row.repo_identifier);
+	if (!parsed) return null;
+
+	const token = await loadConnectionAccessToken(deps, row.oauth_connection_id);
+	if (!token) return null;
+
+	return { owner: parsed.owner, repo: parsed.repo, token, fetchFn: timeBoundedFetch };
+}
+
+/**
+ * Whether a commit this instance pushed was merged into the repo.
+ *
+ * Answers `unknown` for every reason the question could not be put - no connection,
+ * a locked vault, a host that would not say - so a caller can never read "we did not
+ * ask" as "nobody merged it".
+ */
+export async function checkRepoCommitMerged(
+	deps: RepoGitHubDeps,
+	repoId: string,
+	sha: string,
+): Promise<CommitMergeVerdict> {
+	const target = await resolveRepoGitHub(deps, repoId);
+	if (!target) return 'unknown';
+	return checkCommitMerged(target.owner, target.repo, sha, target.token, target.fetchFn);
+}
+
+/** Decrypt an OAuth connection's access token. Null when the vault is locked or the row is gone. */
+export async function loadConnectionAccessToken(
+	deps: RepoGitHubDeps,
+	oauthConnectionId: string,
+): Promise<string | null> {
+	const key = deps.masterKeyManager?.getKey();
+	if (!key) return null;
+	const result = await deps.db.query<{ encrypted_value: string }>(
+		`SELECT s.encrypted_value
+		 FROM oauth_connections oc
+		 JOIN secrets s ON s.id = oc.access_token_secret_id
+		 WHERE oc.id = $1`,
+		[oauthConnectionId],
+	);
+	if (result.rows.length === 0) return null;
+	const { decrypt } = await import('../crypto/encryption');
+	return decrypt(result.rows[0].encrypted_value, key);
+}

--- a/packages/server/src/services/repo-push-access.ts
+++ b/packages/server/src/services/repo-push-access.ts
@@ -1,15 +1,10 @@
-import type { MasterKeyManager } from '../crypto/master-key';
-import type { Db } from '../db/database';
 import { logger } from '../logger';
-import { type FetchFn, parseGitHubUrl, validateRepoAccess } from './github';
+import { validateRepoAccess } from './github';
+import { type RepoGitHubDeps, resolveRepoGitHub } from './repo-github';
 
 const log = logger.child('repo-push-access');
 
-export interface PushAccessDeps {
-	db: Db;
-	/** Optional so a deployment shape without a vault simply skips the check. */
-	masterKeyManager?: MasterKeyManager;
-}
+export type PushAccessDeps = RepoGitHubDeps;
 
 /**
  * Re-check whether the repo's connected GitHub account can push to it, and
@@ -36,28 +31,27 @@ export async function refreshRepoPushAccess(
 	deps: PushAccessDeps,
 	repoId: string,
 ): Promise<boolean | null> {
-	const { db, masterKeyManager } = deps;
+	const { db } = deps;
 
-	const repoRes = await db.query<{
-		repo_identifier: string;
-		oauth_connection_id: string | null;
-		can_push: boolean | null;
-	}>('SELECT repo_identifier, oauth_connection_id, can_push FROM repos WHERE id = $1', [repoId]);
-	const repo = repoRes.rows[0];
-	if (!repo) return null;
+	const repoRes = await db.query<{ can_push: boolean | null }>(
+		'SELECT can_push FROM repos WHERE id = $1',
+		[repoId],
+	);
+	if (repoRes.rows.length === 0) return null;
+	const stored = repoRes.rows[0].can_push;
 
-	const stored = repo.can_push;
-	if (!repo.oauth_connection_id) return stored;
-
-	const parsed = parseGitHubUrl(repo.repo_identifier);
-	if (!parsed) return stored;
-
-	const token = await loadConnectionAccessToken(deps, repo.oauth_connection_id);
-	if (!token) return stored;
+	const target = await resolveRepoGitHub(deps, repoId);
+	if (!target) return stored;
+	const name = `${target.owner}/${target.repo}`;
 
 	let canPush: boolean | null;
 	try {
-		const access = await validateRepoAccess(parsed.owner, parsed.repo, token, timeBoundedFetch);
+		const access = await validateRepoAccess(
+			target.owner,
+			target.repo,
+			target.token,
+			target.fetchFn,
+		);
 		if (access.accessible) {
 			canPush = access.canPush;
 		} else if (access.status === 403 || access.status === 404) {
@@ -68,42 +62,13 @@ export async function refreshRepoPushAccess(
 			return stored;
 		}
 	} catch (e) {
-		log.warn(`push-access check for ${repo.repo_identifier} failed`, (e as Error).message);
+		log.warn(`push-access check for ${name} failed`, (e as Error).message);
 		return stored;
 	}
 
 	if (canPush === null || canPush === stored) return stored;
 
 	await db.query('UPDATE repos SET can_push = $1 WHERE id = $2', [canPush, repoId]);
-	log.info(`push access for ${repo.repo_identifier}: ${canPush ? 'write' : 'read-only'}`);
+	log.info(`push access for ${name}: ${canPush ? 'write' : 'read-only'}`);
 	return canPush;
-}
-
-/**
- * This check is a convenience, never a dependency — callers run it on paths a user
- * or an agent is waiting behind. A GitHub that hangs must surface as "unknown, keep
- * what we had" within seconds, not stall the caller on the default socket timeout.
- */
-const PUSH_ACCESS_CHECK_TIMEOUT_MS = 10_000;
-
-const timeBoundedFetch: FetchFn = (input, init) =>
-	fetch(input, { ...init, signal: AbortSignal.timeout(PUSH_ACCESS_CHECK_TIMEOUT_MS) });
-
-/** Decrypt an OAuth connection's access token. Null when the vault is locked or the row is gone. */
-async function loadConnectionAccessToken(
-	deps: PushAccessDeps,
-	oauthConnectionId: string,
-): Promise<string | null> {
-	const key = deps.masterKeyManager?.getKey();
-	if (!key) return null;
-	const result = await deps.db.query<{ encrypted_value: string }>(
-		`SELECT s.encrypted_value
-		 FROM oauth_connections oc
-		 JOIN secrets s ON s.id = oc.access_token_secret_id
-		 WHERE oc.id = $1`,
-		[oauthConnectionId],
-	);
-	if (result.rows.length === 0) return null;
-	const { decrypt } = await import('../crypto/encryption');
-	return decrypt(result.rows[0].encrypted_value, key);
 }

--- a/packages/server/test/git-push-hook.test.ts
+++ b/packages/server/test/git-push-hook.test.ts
@@ -9,6 +9,7 @@ import {
 	ensurePushHook,
 	localGitLoc,
 	POST_COMMIT_PUSH_HOOK,
+	PUSHED_MARKER_PREFIX,
 	type RepoLoc,
 	readPushErrors,
 } from '../src/services/git';
@@ -38,6 +39,24 @@ function configure(dir: string) {
 	run('git config user.name tester', dir);
 	run('git config user.email tester@test.com', dir);
 	run('git config commit.gpgsign false', dir);
+}
+/**
+ * The tip the hook recorded as accepted by origin, or null if it recorded none. This
+ * is the half of the durability check that outlives the remote branch: deleting the
+ * branch (or squash-merging it) prunes the tracking ref, and this ref is what still
+ * says the commits were delivered.
+ */
+function markerSha(clone: string, branch: string): string | null {
+	try {
+		return execSync(`git rev-parse --verify ${PUSHED_MARKER_PREFIX}${branch}`, {
+			cwd: clone,
+			stdio: 'pipe',
+		})
+			.toString()
+			.trim();
+	} catch {
+		return null;
+	}
 }
 function remoteHasRef(bare: string, branch: string): boolean {
 	try {
@@ -108,10 +127,13 @@ describe('post-commit auto-push', () => {
 
 		expect(remoteHasRef(bare, branch)).toBe(true);
 		expect(sha(bare, branch)).toBe(sha(clone, 'HEAD'));
+		// The accepted tip is recorded where no later delete or squash can retract it.
+		expect(markerSha(clone, branch)).toBe(sha(clone, 'HEAD'));
 
 		// A second commit fast-forwards the remote branch to the new tip.
 		run('git commit --allow-empty -m second', clone, { ...process.env, SSH_AUTH_SOCK: sock });
 		expect(sha(bare, branch)).toBe(sha(clone, 'HEAD'));
+		expect(markerSha(clone, branch)).toBe(sha(clone, 'HEAD'));
 	});
 
 	it('does not push (but the commit still succeeds) when there is no live SSH socket', async () => {
@@ -123,6 +145,7 @@ describe('post-commit auto-push', () => {
 
 		expect(sha(clone, 'HEAD')).toBeTruthy(); // commit landed locally
 		expect(remoteHasRef(bare, branch)).toBe(false); // nothing pushed
+		expect(markerSha(clone, branch)).toBeNull(); // and nothing claimed as delivered
 	});
 
 	it('is a no-op (commit still succeeds) when the repo has no origin remote', async () => {
@@ -171,6 +194,9 @@ describe('post-commit auto-push failure reporting', () => {
 		expect(sha(clone, 'HEAD')).not.toBe(before);
 		expect(output).toContain('auto-push');
 		expect(output).toContain('local only');
+		// Nothing reached origin, so nothing may be recorded as having done so — a
+		// marker written here would report a stranded branch as safely delivered.
+		expect(markerSha(clone, 'hezo/AUTO-4')).toBeNull();
 	});
 
 	it('records the git error in the push-error log for the runner to surface', async () => {

--- a/packages/server/test/git-recovery-bundle.test.ts
+++ b/packages/server/test/git-recovery-bundle.test.ts
@@ -9,6 +9,7 @@ import {
 	fastForwardFromRecovery,
 	fetchRecoveryBundle,
 	localGitLoc,
+	PUSHED_MARKER_PREFIX,
 	RECOVERY_BUNDLE_REL_PATH,
 	RECOVERY_REMOTE,
 	type RepoLoc,
@@ -214,6 +215,26 @@ describe('recovery bundle hygiene', () => {
 		// already have - proof this is a delta against origin rather than a copy.
 		const verified = run(`git bundle verify ${RECOVERY_BUNDLE_REL_PATH} 2>&1 || true`, clone);
 		expect(verified).toMatch(/requires these \d+ ref|is okay/);
+	});
+
+	it('excludes commits the accepted-tip marker already covers', async () => {
+		// The count and the bundle read the same exclusion set, so a branch whose
+		// remote ref is gone (deleted after a merge) bundles only what came after the
+		// last accepted push - never a second copy of delivered work.
+		const { clone } = setup('marker-delta');
+		run('git commit --allow-empty -m delivered', clone);
+		run(`git push origin HEAD:${BRANCH}`, clone);
+		run(`git update-ref ${PUSHED_MARKER_PREFIX}${BRANCH} refs/heads/${BRANCH}`, clone);
+		const delivered = run('git rev-parse HEAD', clone).trim();
+		run(`git push origin --delete ${BRANCH}`, clone);
+		run('git commit --allow-empty -m stranded', clone);
+
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(1);
+		expect((await createRecoveryBundle(exec, repoLoc(clone), BRANCH)).ok).toBe(true);
+		// The delivered commit is named as a prerequisite the reader must already
+		// have, not carried — which is what makes this a delta and not a second copy.
+		const verified = run(`git bundle verify ${RECOVERY_BUNDLE_REL_PATH} 2>&1 || true`, clone);
+		expect(verified).toContain(delivered);
 	});
 
 	it('drops a stored bundle once the work reached origin', async () => {

--- a/packages/server/test/git-unpushed-commits.test.ts
+++ b/packages/server/test/git-unpushed-commits.test.ts
@@ -4,11 +4,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
+	countBranchDelivery,
 	countUnpushedCommits,
 	describeUnpushedWork,
 	findUnpushedWork,
 	localGitLoc,
+	PUSHED_MARKER_PREFIX,
 	type RepoLoc,
+	readPushedMarker,
+	voidPushedMarker,
 } from '../src/services/git';
 import { type GitExecutor, HostGitExecutor } from '../src/services/git-executor';
 import { hostSandboxFiles } from '../src/services/sandbox/files';
@@ -38,6 +42,17 @@ function run(cmd: string, cwd?: string): string {
 
 function commit(clone: string, message: string) {
 	run(`git commit --allow-empty -m ${JSON.stringify(message)}`, clone);
+}
+
+/**
+ * Push the branch and record the accepted tip, which is what the `post-commit` hook
+ * does on every successful push (`git-push-hook.test.ts` covers the hook itself). The
+ * marker ref is spelled from the exported constant so the hook's shell-side name and
+ * the scan's git-side name cannot drift apart unnoticed.
+ */
+function pushAndMark(clone: string, branch: string) {
+	run(`git push origin ${branch}`, clone);
+	run(`git update-ref ${PUSHED_MARKER_PREFIX}${branch} refs/heads/${branch}`, clone);
 }
 
 /** A clone on a fresh `hezo/<task>` branch pointed at a bare origin with one commit. */
@@ -103,6 +118,55 @@ describe('countUnpushedCommits', () => {
 		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(0);
 	});
 
+	it('reports 0 after the branch was merged and deleted on the remote', async () => {
+		// The shape that failed in production: the agent pushed every commit, merged its
+		// pull request, then deleted the remote branch - which prunes the local tracking
+		// ref, leaving already-delivered commits reachable from no `origin` ref at all.
+		const { clone } = setupClone('merged-deleted', BRANCH);
+		commit(clone, 'one');
+		commit(clone, 'two');
+		pushAndMark(clone, BRANCH);
+		run(`git push origin --delete ${BRANCH}`, clone);
+
+		// Asserted, not assumed: without the prune this case would pass for the wrong
+		// reason and stop testing anything.
+		expect(() => run(`git rev-parse --verify refs/remotes/origin/${BRANCH}`, clone)).toThrow();
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(0);
+	});
+
+	it('reports 0 when the work was squash-merged and the branch deleted', async () => {
+		// A squash merge puts the *content* on the default branch under a brand-new
+		// commit sharing no history with the branch tip, so the originals are reachable
+		// from no remote ref however current the clone's fetch is. Fetching harder
+		// cannot answer this one; only a record of what origin accepted can.
+		const { clone } = setupClone('squashed', BRANCH);
+		commit(clone, 'one');
+		commit(clone, 'two');
+		pushAndMark(clone, BRANCH);
+
+		run('git checkout main', clone);
+		run(`git merge --squash ${BRANCH}`, clone);
+		run('git commit --allow-empty -m squashed', clone);
+		run('git push origin main', clone);
+		run(`git push origin --delete ${BRANCH}`, clone);
+		run('git fetch origin', clone);
+
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(0);
+	});
+
+	it('still counts the commits made after the last accepted push', async () => {
+		// The marker clears only what origin actually took. A branch pushed up to its
+		// first commit and then committed on twice more is genuinely stranded by two,
+		// deleted remote branch or not.
+		const { clone } = setupClone('marked-partial', BRANCH);
+		commit(clone, 'landed');
+		pushAndMark(clone, BRANCH);
+		commit(clone, 'stranded one');
+		commit(clone, 'stranded two');
+		run(`git push origin --delete ${BRANCH}`, clone);
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(2);
+	});
+
 	it('reports 0 when the task branch was never created', async () => {
 		// A definite absence of unpushed work, not an unanswered question: the agent
 		// committed nothing on this task's branch.
@@ -150,6 +214,106 @@ describe('countUnpushedCommits', () => {
 		run('git push backup HEAD', clone);
 		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(1);
 		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH, ['origin', 'backup'])).toBe(0);
+	});
+});
+
+describe('countBranchDelivery', () => {
+	// The split the git host is asked about. `retracted` is work origin took and no
+	// longer advertises, which is a merged-and-tidied branch or a deleted one, and
+	// git cannot say which - so the two are counted apart from work that never left.
+	it('attributes a vanished remote branch to retracted, not unpushed', async () => {
+		const { clone } = setupClone('delivery-retracted', BRANCH);
+		commit(clone, 'one');
+		commit(clone, 'two');
+		pushAndMark(clone, BRANCH);
+		run(`git push origin --delete ${BRANCH}`, clone);
+		expect(await countBranchDelivery(exec, repoLoc(clone), BRANCH)).toEqual({
+			unpushed: 0,
+			retracted: 2,
+		});
+	});
+
+	it('separates the two when a branch has both', async () => {
+		const { clone } = setupClone('delivery-mixed', BRANCH);
+		commit(clone, 'delivered');
+		pushAndMark(clone, BRANCH);
+		run(`git push origin --delete ${BRANCH}`, clone);
+		commit(clone, 'never left');
+		expect(await countBranchDelivery(exec, repoLoc(clone), BRANCH)).toEqual({
+			unpushed: 1,
+			retracted: 1,
+		});
+	});
+
+	it('reports nothing retracted while the remote still has the branch', async () => {
+		// The ordinary path, and the one that must never reach out to a git host.
+		const { clone } = setupClone('delivery-current', BRANCH);
+		commit(clone, 'work');
+		pushAndMark(clone, BRANCH);
+		expect(await countBranchDelivery(exec, repoLoc(clone), BRANCH)).toEqual({
+			unpushed: 0,
+			retracted: 0,
+		});
+	});
+
+	it('attributes work that never reached origin to unpushed alone', async () => {
+		const { clone } = setupClone('delivery-unpushed', BRANCH);
+		commit(clone, 'one');
+		commit(clone, 'two');
+		expect(await countBranchDelivery(exec, repoLoc(clone), BRANCH)).toEqual({
+			unpushed: 2,
+			retracted: 0,
+		});
+	});
+});
+
+describe('the pushed marker', () => {
+	it('names the tip origin accepted, and nothing when none was recorded', async () => {
+		const { clone } = setupClone('marker-read', BRANCH);
+		commit(clone, 'work');
+		expect(await readPushedMarker(exec, repoLoc(clone), BRANCH)).toBeNull();
+		pushAndMark(clone, BRANCH);
+		expect(await readPushedMarker(exec, repoLoc(clone), BRANCH)).toBe(
+			run('git rev-parse HEAD', clone).trim(),
+		);
+	});
+
+	it('voiding it restores the full undelivered count', async () => {
+		// What the runner does once the git host confirms a branch was deleted
+		// without being merged: the delivery record is no longer true, so dropping it
+		// puts the branch back on the ordinary stranded-work path with no second case
+		// anywhere downstream.
+		const { clone } = setupClone('marker-void', BRANCH);
+		commit(clone, 'one');
+		commit(clone, 'two');
+		pushAndMark(clone, BRANCH);
+		run(`git push origin --delete ${BRANCH}`, clone);
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(0);
+
+		await voidPushedMarker(exec, repoLoc(clone), BRANCH);
+		expect(await readPushedMarker(exec, repoLoc(clone), BRANCH)).toBeNull();
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(2);
+	});
+
+	it('voiding one branch leaves another branch delivered', async () => {
+		// Two task branches share a clone, so the marker namespace is shared too.
+		// Voiding one must not disturb the other's record. Branched off `main` rather
+		// than off each other, so neither carries commits the other delivered - which
+		// origin would legitimately have either way.
+		const { clone } = setupClone('marker-void-scope', BRANCH);
+		const other = 'hezo/hez-2';
+		commit(clone, 'work a');
+		commit(clone, 'work b');
+		pushAndMark(clone, BRANCH);
+		run(`git checkout -b ${other} main`, clone);
+		commit(clone, 'other work');
+		pushAndMark(clone, other);
+		run(`git push origin --delete ${BRANCH}`, clone);
+		run(`git push origin --delete ${other}`, clone);
+
+		await voidPushedMarker(exec, repoLoc(clone), BRANCH);
+		expect(await countUnpushedCommits(exec, repoLoc(clone), BRANCH)).toBe(2);
+		expect(await countUnpushedCommits(exec, repoLoc(clone), other)).toBe(0);
 	});
 });
 

--- a/packages/server/test/github-service-extended.test.ts
+++ b/packages/server/test/github-service-extended.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+	checkCommitMerged,
 	computeScopeStatus,
 	createGitHubRepo,
+	type FetchFn,
 	listAccessibleRepos,
 	listUserOrgs,
 	parseGitHubUrl,
@@ -308,5 +310,105 @@ describe('createGitHubRepo error path', () => {
 		await expect(createGitHubRepo('whoever', 'x', true, 'gho_bad_create')).rejects.toThrow(
 			/Failed to create GitHub repo \(401\)/,
 		);
+	});
+});
+
+/**
+ * The question a ref comparison inside the clone cannot answer: once a branch is
+ * gone from the remote, was its work merged first or thrown away? Driven with a stub
+ * `fetchFn` rather than the simulator because what is under test is the verdict
+ * mapping - and specifically which responses are allowed to be *definitive*. Anything
+ * short of a 200 must report `unknown`: the caller turns `not_merged` into a failed
+ * run, and a renamed repo or a throttled minute is no evidence anyone lost work.
+ */
+describe('checkCommitMerged', () => {
+	const stub =
+		(res: Partial<Response> | Error): FetchFn =>
+		async () => {
+			if (res instanceof Error) throw res;
+			return res as Response;
+		};
+	const ok = (body: unknown): FetchFn =>
+		stub({ status: 200, json: async () => body } as Partial<Response>);
+
+	it('is merged when any associated pull request has been merged', async () => {
+		const verdict = await checkCommitMerged(
+			'octo',
+			'repo',
+			'abc123',
+			'tok',
+			ok([{ number: 1, merged_at: '2026-08-08T04:53:02Z' }]),
+		);
+		expect(verdict).toBe('merged');
+	});
+
+	it('is not merged when the only associated pull requests are unmerged', async () => {
+		expect(
+			await checkCommitMerged(
+				'octo',
+				'repo',
+				'abc123',
+				'tok',
+				ok([{ number: 1, merged_at: null }]),
+			),
+		).toBe('not_merged');
+	});
+
+	it('is not merged when no pull request ever carried the commit', async () => {
+		// A branch pushed and then thrown away - the case the guard exists for.
+		expect(await checkCommitMerged('octo', 'repo', 'abc123', 'tok', ok([]))).toBe('not_merged');
+	});
+
+	it.each([404, 403, 429, 500])('is unknown on a %i, never not_merged', async (status) => {
+		expect(
+			await checkCommitMerged(
+				'octo',
+				'repo',
+				'abc123',
+				'tok',
+				stub({ status } as Partial<Response>),
+			),
+		).toBe('unknown');
+	});
+
+	it('is unknown when the host is unreachable', async () => {
+		expect(
+			await checkCommitMerged('octo', 'repo', 'abc123', 'tok', stub(new Error('ECONNRESET'))),
+		).toBe('unknown');
+	});
+
+	it('is unknown when the body is not a readable list', async () => {
+		expect(
+			await checkCommitMerged(
+				'octo',
+				'repo',
+				'abc123',
+				'tok',
+				stub({
+					status: 200,
+					json: async () => {
+						throw new Error('not json');
+					},
+				} as Partial<Response>),
+			),
+		).toBe('unknown');
+		expect(await checkCommitMerged('octo', 'repo', 'abc123', 'tok', ok({ message: 'nope' }))).toBe(
+			'unknown',
+		);
+	});
+
+	it('asks the commit-to-pull-request endpoint, bearing the repo credential', async () => {
+		const calls: Array<{ url: string; auth: string | undefined }> = [];
+		const spy: FetchFn = async (input, init) => {
+			calls.push({
+				url: String(input),
+				auth: (init?.headers as Record<string, string> | undefined)?.Authorization,
+			});
+			return { status: 200, json: async () => [] } as Response;
+		};
+		await checkCommitMerged('octo', 'repo', 'deadbee', 'gho_tok', spy);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toContain('/repos/octo/repo/commits/deadbee/pulls');
+		expect(calls[0].auth).toBe('Bearer gho_tok');
 	});
 });

--- a/packages/server/test/helpers/github-sim.ts
+++ b/packages/server/test/helpers/github-sim.ts
@@ -60,6 +60,12 @@ export interface GitHubSimState {
 	repos: GitHubSimRepo[];
 	signingKeys: SigningKey[];
 	authKeys: AuthKey[];
+	/**
+	 * Commit shas the repo treats as carried by a merged pull request. Drives the
+	 * commit-to-pull-request endpoint, which is how Hezo tells a branch that was
+	 * merged and tidied up from one that was deleted with the work still on it.
+	 */
+	mergedCommits: Set<string>;
 	deviceFlows: Map<string, DeviceFlowEntry>;
 	oauthCodes: Map<string, string>;
 }
@@ -81,6 +87,7 @@ export async function createGitHubSim(): Promise<GitHubSim> {
 		repos: [],
 		signingKeys: [],
 		authKeys: [],
+		mergedCommits: new Set(),
 		deviceFlows: new Map(),
 		oauthCodes: new Map(),
 	};
@@ -168,6 +175,20 @@ export async function createGitHubSim(): Promise<GitHubSim> {
 			permissions: { admin: true, push: true, pull: true },
 			...found,
 		});
+	});
+
+	app.get('/repos/:owner/:repo/commits/:sha/pulls', (c) => {
+		if (!isAuthed(c.req.header('Authorization'))) return c.json({ message: 'Unauthorized' }, 401);
+		const full = `${c.req.param('owner')}/${c.req.param('repo')}`;
+		if (!state.repos.some((r) => r.full_name === full))
+			return c.json({ message: 'Not Found' }, 404);
+		// An empty list is GitHub's answer for a commit no pull request ever carried,
+		// which is the shape of a branch pushed and then thrown away.
+		return c.json(
+			state.mergedCommits.has(c.req.param('sha'))
+				? [{ number: 7, state: 'closed', merged_at: '2026-08-08T04:53:02Z' }]
+				: [],
+		);
 	});
 
 	const repoNameAlreadyExistsResponse = () => ({

--- a/packages/server/test/repos-push-access.test.ts
+++ b/packages/server/test/repos-push-access.test.ts
@@ -6,6 +6,7 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
 import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
+import { checkRepoCommitMerged } from '../src/services/repo-github';
 import { performRepoSetup } from '../src/services/repo-provisioning';
 import { refreshRepoPushAccess } from '../src/services/repo-push-access';
 import { safeClose } from './helpers';
@@ -301,5 +302,87 @@ describe('GET /repos/:repoId/git-state', () => {
 		// The panel is the operator's way to notice access changed on GitHub, so it
 		// must answer without depending on a running container.
 		expect(body.data.can_push).toBe(false);
+	});
+});
+
+/**
+ * The host-side half of the stranded-commit guard. The accepted-tip marker stops a
+ * merged-and-deleted branch reading as stranded work, and the cost is that a branch
+ * deleted *without* being merged looks identical in the clone's refs. This is what
+ * tells the two apart, so what matters most is which answers it is willing to call
+ * definitive: anything it could not actually ask must come back `unknown`, because
+ * the caller turns `not_merged` into a failed run.
+ */
+describe('checkRepoCommitMerged', () => {
+	const seedLinkedRepo = async (identifier: string): Promise<string> => {
+		const res = await db.query<{ id: string }>(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+			 VALUES ($1, $2, 'github'::repo_host_type, $3) RETURNING id`,
+			[projectId, identifier, oauthConnectionId],
+		);
+		return res.rows[0].id;
+	};
+
+	it('reports merged for a commit a merged pull request carried', async () => {
+		const repoId = await seedLinkedRepo('other-org/merged-branch');
+		sim.state.repos.push(repo('other-org', 'merged-branch'));
+		sim.state.mergedCommits.add('cafebabe');
+		expect(await checkRepoCommitMerged({ db, masterKeyManager }, repoId, 'cafebabe')).toBe(
+			'merged',
+		);
+	});
+
+	it('reports not_merged when no pull request ever carried the commit', async () => {
+		// The branch was pushed and then deleted with the work still on it - the one
+		// case that puts a container back on the stranded-work path.
+		const repoId = await seedLinkedRepo('other-org/thrown-away');
+		sim.state.repos.push(repo('other-org', 'thrown-away'));
+		expect(await checkRepoCommitMerged({ db, masterKeyManager }, repoId, 'deadbeef')).toBe(
+			'not_merged',
+		);
+	});
+
+	it('is unknown for a repo with no OAuth connection', async () => {
+		const res = await db.query<{ id: string }>(
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'other-org/no-connection', 'github'::repo_host_type) RETURNING id`,
+			[projectId],
+		);
+		expect(await checkRepoCommitMerged({ db, masterKeyManager }, res.rows[0].id, 'abc')).toBe(
+			'unknown',
+		);
+	});
+
+	it('is unknown for a repo row that is gone', async () => {
+		expect(
+			await checkRepoCommitMerged(
+				{ db, masterKeyManager },
+				'00000000-0000-0000-0000-000000000000',
+				'abc',
+			),
+		).toBe('unknown');
+	});
+
+	it('is unknown when the vault is locked, never not_merged', async () => {
+		// No key means the token cannot be decrypted, so the question was never put.
+		// Reading that as "nobody merged it" would fail a run over a check that never
+		// ran.
+		const repoId = await seedLinkedRepo('other-org/locked-vault');
+		sim.state.repos.push(repo('other-org', 'locked-vault'));
+		expect(await checkRepoCommitMerged({ db }, repoId, 'cafebabe')).toBe('unknown');
+	});
+
+	it('is unknown when the host cannot be reached', async () => {
+		const repoId = await seedLinkedRepo('other-org/offline-host');
+		sim.state.repos.push(repo('other-org', 'offline-host'));
+		const prev = process.env.GITHUB_API_BASE_URL;
+		process.env.GITHUB_API_BASE_URL = 'http://127.0.0.1:1';
+		try {
+			expect(await checkRepoCommitMerged({ db, masterKeyManager }, repoId, 'cafebabe')).toBe(
+				'unknown',
+			);
+		} finally {
+			process.env.GITHUB_API_BASE_URL = prev;
+		}
 	});
 });


### PR DESCRIPTION
The end-of-run scan asked `git rev-list <branch> --not --remotes=origin`, which is only correct while the remote-tracking ref is a faithful record of what the remote holds. Deleting a branch after merging its pull request - the workflow the role prompts ask for - prunes that ref locally, and a squash merge leaves the original commits reachable from nothing on the remote, so a run that merged and tidied up reported its whole branch as stranded: a failed run row and a recovery bundle vaulted for a branch that no longer exists.

The post-commit hook now records each accepted tip at `refs/hezo/pushed/<branch>`, outside `refs/remotes/` where no push, fetch or prune touches it, and the scan excludes it through the same exclusion set the recovery bundle uses. That answers the durability question as asked - did origin ever accept this commit - rather than whether the remote advertises it right now.

Closing the false negative that opens takes a question git cannot answer, because a branch deleted *without* being merged looks locally identical. countBranchDelivery splits undelivered commits into unpushed and retracted, and reviewRetractedWork asks the git host which pull requests carried the marker's commit, before the scan runs and only when something is retracted. On a definite not_merged it voids the marker, putting the branch back on the ordinary stranded-work path with no second case downstream. Only a 200 is definitive - a 404, a rate limit, a locked vault or no connection report unknown and change nothing, since reinstating the false positive is worse than missing an abandoned branch.

Also folds three byte-identical copies of the OAuth token decrypt into services/repo-github.ts, the new home for host-side calls to a repo's git host with that repo's own credential.

Docs-Checked: .dev/architecture.md + AGENTS.md seam registry updated; no docs/ page covers this