### PR TITLE
docs: realign container docs with the two-backend architecture, guard doc links at commit time

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3254,11 +3254,12 @@ tier. Full rationale: `AGENTS.md` › Bun-native runtime rules.
 
 ## 8. SSH signing & git
 
-Repo access is **SSH end to end**, keyed on one Ed25519 key per team (`team_ssh_keys`,
-`UNIQUE(team_id)`, encrypted on the team row and never in the secrets vault). The same key
-signs commits and authenticates the git transport, so a `Verified` badge on GitHub and a
-successful `git push` are the same credential. The OAuth token is never used for git - see
-§ 9, *Git vs API*.
+Commit signing is keyed on one Ed25519 key per team (`team_ssh_keys`, `UNIQUE(team_id)`,
+encrypted on the team row and never in the secrets vault). Git **transport is HTTPS on
+every backend** (§ Agent runtime - `buildGitRemoteUrl`), authenticated by the GitHub
+connection's access token as a placeholder the egress proxy substitutes; the key's
+remaining job is signing, which is what makes a `Verified` badge the mark of a commit
+that went through this instance. See § 9, *Git vs API*.
 
 The key never leaves Hezo. Everything that needs it reaches it through an **ssh-agent
 socket**, which is what lets a container sign and push without the private half ever
@@ -3624,10 +3625,12 @@ is withheld rather than absent. There is deliberately **no MCP write tool** for 
 allowlist: letting an agent widen its own access would be a privilege escalation, so the
 write side is human-only (`GET`/`PATCH`/`POST …/methods{,/refresh}`).
 
-**Git vs API.** Repo clone/fetch/push does **not** use the OAuth token — that's SSH with
-the project key (§ 8). The OAuth token is reserved for GitHub REST (listing/creating
-repos, registering keys) and the GitHub MCP tool surface. Full design: this section plus
-the route table in `services/oauth/` and `routes/oauth.ts`.
+**Git vs API.** Both surfaces now ride the OAuth token, differently delivered: GitHub
+REST (listing/creating repos, registering keys) and the GitHub MCP tool surface use it
+server-side, while repo clone/fetch/push carries it as the access-token secret's
+**placeholder** in the HTTPS remote URL, substituted at the egress proxy (§ 8). The
+project key signs commits and never authenticates transport. Full design: this section
+plus the route table in `services/oauth/` and `routes/oauth.ts`.
 
 ---
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,4 @@
 bunx commitlint --edit $1
 bun scripts/check-docs-ack.ts $1
 bun scripts/check-translations-ack.ts $1
+bun scripts/check-docs-links.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@
 | A user-facing string | the 11 non-English catalogs | `i18n-catalog.test.ts` |
 | A team prompt or `team.json` | committed `marketplace/teams/*.json` + `index.json` | `marketplace-build.test.ts` |
 | A docs page (add / remove / frontmatter) | the embedded docs bundle | `docs-bundle.test.ts` |
+| A link in a `docs/` page (another page, an anchor, a repo file, an external URL) | the target it names | `docs-links.test.ts` + the `check-docs-links.ts` hook |
 | A new conformance suite | `conformance/index.ts` | `conformance-coverage.test.ts` |
 | A new doc- or string-bearing path | `DOC_BEARING_PATTERNS` / `STRING_BEARING_PATTERNS` | its ack-hook test |
 | Container backend behaviour | `SANDBOX_AGENT_ENVIRONMENTS`, that provider's `docs/containers/remote/` page, the Containers settings UI | compile error, **new backend only** |
@@ -99,7 +100,9 @@
 
 **Verify, don't assume.** Generated surfaces have drift tests (`{mcp-reference,llms-txt,docs-bundle}.test.ts`); hand-written prose has one guard, `docs-terminology.test.ts`, checking punctuation only. Nothing checks whether prose is *true* — re-read the pages describing what you changed and confirm every concrete claim still matches the code.
 
-**Two husky hooks run on every commit.** `.husky/pre-commit`: `bunx biome check --diagnostic-level=error .`, `bun run typecheck`, `bun run build`. `.husky/commit-msg`: `bunx commitlint --edit`, `scripts/check-docs-ack.ts`, `scripts/check-translations-ack.ts`.
+**Two husky hooks run on every commit.** `.husky/pre-commit`: `bunx biome check --diagnostic-level=error .`, `bun run typecheck`, `bun run build`. `.husky/commit-msg`: `bunx commitlint --edit`, `scripts/check-docs-ack.ts`, `scripts/check-translations-ack.ts`, `scripts/check-docs-links.ts`.
+
+**`check-docs-links.ts` fails a commit staging any `docs/**/*.md` on a broken link.** Internal links (docs-to-docs incl. `#anchors`, relative paths, `github.com/hezo-ai/hezo/{blob,raw,tree}/main/<path>`) are checked across the whole tree - a rename or delete breaks *other* files' links. External URLs are probed for staged files only (7-day success cache in `.git/`); a definitive 404/410 blocks, network-shaped failures (403 bot walls, timeouts, DNS) only warn, so an offline commit passes. Fix the link, never bypass; `docs-links.test.ts` re-runs the internal check in CI.
 
 **`Docs-Checked:` is enforced at commit time.** Any commit staging doc-bearing code (`packages/*/src/`, `packages/*/migrations/`, `agents/`, `skills/`, `docker/`, `deploy/`, `marketplace/`, `scripts/`) is rejected without a `Docs-Checked:` trailer recording the pass you did across **both** `docs/` and `.dev/`. Bare values (`yes`, `n/a`, `done`, anything under 10 characters) are rejected:
 
@@ -155,7 +158,7 @@ All changes ship with tests exercising functionality, not "code runs without thr
 - Use `ctx.app` / `ctx.baseUrl` / `ctx.port` — never a shared singleton, never a hardcoded port. No mutable state shared between files.
 - Pure logic tests can call functions directly.
 - GitHub OAuth/repo/SSH-key tests use `test/helpers/github-sim.ts` — set `GITHUB_API_BASE_URL` and `GITHUB_OAUTH_BASE_URL` before the context boots.
-- `HEZO_SKIP_DOCKER=1` swaps in the in-process fake (`services/fake-docker.ts`). **Test/CI-only — never expose it to users.** A Docker-compatible runtime is a hard prerequisite, so it must not appear in CLI/preflight output, `docs/`, README or `--help`; `docker-preflight.test.ts` guards this. Code comments and `.dev/` may reference it.
+- `HEZO_SKIP_DOCKER=1` swaps in the in-process fake (`services/fake-docker.ts`). **Test/CI-only — never expose it to users.** The supported backends are the real ones (a local Docker-compatible runtime, or a managed sandbox service), so the fake must not appear in CLI/preflight output, `docs/`, README or `--help`; `docker-preflight.test.ts` guards this. Code comments and `.dev/` may reference it.
 
 ### Test-setup performance
 
@@ -503,7 +506,7 @@ Agents reference secrets by placeholder (`__HEZO_SECRET_<NAME>__`) in any header
 
 - Put the placeholder in the agent's container env, never the real value. The real value lives in `secrets` with `allowed_hosts` constraining which upstream hosts substitution may fire for.
 - To obtain a raw secret at runtime the agent calls `request_credential` and a human pastes the value via the task thread. The three HTTP-auth `CredentialKind`s (`api_key`, `oauth_token`, `github_pat`) MUST pass `allowed_hosts` — the tool rejects the request otherwise. The other three (`ssh_private_key`, `webhook_secret`, `other`) are exempt, never riding an outbound HTTP header. Agents request the narrowest scope and shortest expiry, and prefer a registered connector (`register_connector`) where one covers the provider.
-- For GitHub repo access, the human connects an OAuth account once via device flow on the project's Connections page. The OAuth token is for REST calls only (listing orgs/repos, creating repos); clone/fetch/push run over SSH authenticated by the project's Ed25519 key, which is also the commit-signing key. On first connect the public key is registered on the connecting user's account as both a signing and an authentication key. Host-side and in-container git both go through `SshAgentServer` — host via its Unix socket, container via the per-run socat bridge.
+- For GitHub repo access, the human connects an OAuth account once via device flow on the project's Connections page. The OAuth token authenticates REST calls and the git transport: clone/fetch/push run over HTTPS with the token as a `__HEZO_SECRET_*__` placeholder the egress proxy substitutes. The project's Ed25519 key signs commits only, reached through `SshAgentServer` over the per-run bridge; on first connect its public half is registered on the connecting user's account as a signing (and authentication) key.
 - For SaaS MCPs requiring OAuth, the operator starts the auth-code flow from the MCP-connection form; the resulting `oauth_connection_id` links to the `mcp_connections` row and the injector emits a placeholder Authorization header.
 
 The egress proxy does not audit substitution events. Secret values are never logged; substitution failures surface to the agent as explicit HTTP errors.

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -93,6 +93,12 @@ Use one of these instead:
 - `http://host.docker.internal:11434` - a server on the same machine as Hezo.
 - `http://192.168.1.50:11434` - a server elsewhere on your network, by its LAN address.
 
+Both only resolve while the container is on the same machine as the server - that is, on
+[local Docker](/docs/containers/local-docker), the default. On a
+[managed sandbox service](/docs/containers/remote/overview) the container runs on the
+provider's machines, where these addresses mean nothing - use a model endpoint reachable
+over the internet instead.
+
 Hezo warns you in the connect form if you enter a `localhost` address.
 
 ### Cost and model choice

--- a/docs/concepts/meta-harness.md
+++ b/docs/concepts/meta-harness.md
@@ -69,18 +69,19 @@ Everything runs from one self-contained server process:
   external Postgres is [optional](/docs/deployment/configuration)). Uploaded asset
   files live there too, or in any
   [S3-compatible bucket](/docs/deployment/configuration) if you configure one.
-- **Egress proxy** - the mandatory exit through which all agent network traffic
-  flows, where secret placeholders become real values for allowed hosts only.
-- **Docker orchestration** - provisions and manages the containers agents run in.
+- **Egress proxy** - the checkpoint every request that could carry a secret must pass,
+  where placeholders become real values for allowed hosts only.
+- **Container orchestration** - provisions and manages the containers agents run in, on
+  the local Docker daemon or a managed sandbox service.
 - **MCP server** - a built-in [Model Context Protocol](/docs/mcp/hezo-mcp-server)
   endpoint, so agents (Hezo's own and external clients) can manage your work.
 
 ### Where agents run
 
-Each project gets its own **container** - a private workspace with the project's
-code and tools. Agents execute inside it, never on your host directly. All their
-outbound traffic is forced through the egress proxy, and the keys used to sign commits
-or reach your model never enter the container. See
+Agents execute inside **containers** - private workspaces holding a project's code and
+tools - never on your host directly. A container serves one project, one run at a time.
+Outbound requests that could carry a secret pass through the egress proxy, and the keys
+used to sign commits never enter a container. See
 [Container isolation](/docs/security/container-isolation) for the security case, and
 [Containers](/docs/containers/overview) for where they run: your own Docker daemon by
 default, or a managed sandbox service, switchable at any time.

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -12,12 +12,13 @@ A **project** is the primary unit of work in Hezo, and every project owns exactl
 **team** - its roster of agents. The relationship is one-to-one: a team backs a single
 project. You don't manage teams separately; you reach a team through its project.
 
-This keeps things clean: a project's agents, tasks, budget, container, and connections
+This keeps things clean: a project's agents, tasks, budget, containers, and connections
 all belong to that project and nothing leaks between them.
 
-A project's container runs only while there is work: it starts automatically when an
-agent run or the assistant needs it and stops again after sitting idle, so projects you
-aren't actively using cost nothing.
+A project's containers run only while there is work: one starts automatically when an
+agent run or the assistant needs it - each run going at once gets a container of its own
+- and it stops again after sitting idle, so projects you aren't actively using cost
+nothing.
 
 ## Project icon
 

--- a/docs/concepts/team-structure.md
+++ b/docs/concepts/team-structure.md
@@ -33,7 +33,7 @@ A team's structure is more than a list of agents. It's:
 - **What the team shares** - its [skills](/docs/concepts/skills),
   [project documents and memory](/docs/concepts/documents-and-memory),
   connected [external services](/docs/mcp/connecting-mcp-servers), budgets, and the project
-  container they all work in.
+  workspace their containers work in.
 
 Change any of these and you've changed the team's structure.
 

--- a/docs/containers/local-docker.md
+++ b/docs/containers/local-docker.md
@@ -1,6 +1,6 @@
 ---
 title: Local Docker
-order: 25.2
+order: 17.6
 section: Containers
 ---
 
@@ -68,8 +68,12 @@ practical difference from a [remote service](/docs/containers/remote/overview), 
 provider may carry only some protocols - so if your agents need to reach something over
 SSH from inside the container, local Docker is the option that has it.
 
-HTTP and HTTPS still pass through Hezo's egress proxy either way. That is what substitutes
-credentials into agent requests, and it applies on every container service.
+Requests to hosts your credentials and connectors are scoped to still pass through Hezo's
+egress proxy - that is what substitutes credentials into agent requests, and it applies on
+every container service. Everything else connects straight out from the container. A
+request that reaches a credentialed host without the proxy carries an inert placeholder
+rather than a secret, so nothing rides on the container playing along - see
+[Secret protection](/docs/security/secret-protection).
 
 ## Startup
 

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Containers overview
-order: 25.1
+order: 17.5
 section: Containers
 ---
 
@@ -32,9 +32,11 @@ the container hold placeholders, never the actual credentials, and the proxy enf
 which hosts each secret may be sent to. Git signing and SSH keys stay outside the
 container too, so commits land verified without the private key ever being exposed.
 
-**Limits.** Each container runs with a memory cap, a process limit that stops fork bombs,
-and a reduced set of Linux capabilities, so a runaway agent cannot exhaust the machine it
-is on.
+**Limits.** Each container runs against a hard memory cap, and where it shares your own
+machine ([local Docker](/docs/containers/local-docker)) Hezo also applies a process limit
+that stops fork bombs and drops Linux capabilities to the few the workload needs, so a
+runaway agent cannot exhaust the machine it is on. On a managed service the equivalent
+guardrails between sandboxes are the provider's own.
 
 For the full security picture, including the honest note on where a container's boundary
 ends, see [Container isolation](/docs/security/container-isolation) and
@@ -137,9 +139,17 @@ HEZO_SANDBOX_BACKEND=daytona HEZO_DAYTONA_API_KEY=<key> hezo
 
 **This sets the service a brand-new instance starts on.** It is a convenience for
 provisioning an instance non-interactively, not a second way to configure a running one.
-Once a service has been chosen in Settings -> Containers, that stored choice wins and the
-flag and environment variable are ignored on later startups. To change a running
-instance, use Settings -> Containers.
+The first startup records the choice, and from then on the stored setting wins:
+restarting with a different flag or environment variable does not switch an existing
+instance - Hezo logs that it ignored the flag and stays where it is, so a stale launch
+script or leftover environment variable can never flip the substrate under your agents.
+To change an instance once it has booted - stopped or running - use Settings ->
+Containers.
+
+The provider key is the one flag that stays live: passing `--daytona-api-key` (or
+`HEZO_DAYTONA_API_KEY`) at a later startup rotates or supplies the credential for the
+backend already chosen - it never chooses a backend by itself. See
+[Restarting an instance on a managed service](#restarting-an-instance-on-a-managed-service).
 
 Selecting a managed service Hezo cannot reach is **fatal at startup**. Hezo reports the
 problem and exits rather than silently falling back to local Docker: an instance that

--- a/docs/containers/remote/daytona.md
+++ b/docs/containers/remote/daytona.md
@@ -1,6 +1,6 @@
 ---
 title: Daytona
-order: 25.4
+order: 17.8
 section: Containers
 ---
 

--- a/docs/containers/remote/overview.md
+++ b/docs/containers/remote/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Remote containers
-order: 25.3
+order: 17.7
 section: Containers
 ---
 
@@ -9,9 +9,10 @@ section: Containers
 Point Hezo at a managed sandbox service and agent containers run on the provider's
 machines instead of yours, while Hezo keeps doing all of the work that touches your data.
 
-Everything in [Containers](/docs/containers/overview) still holds: one container per
-project, started on demand, isolated from everything else, with secrets substituted at
-Hezo's own egress proxy. This page covers what is different.
+Everything in [Containers](/docs/containers/overview) still holds: containers belong to
+one project and serve one run at a time, start on demand, are isolated from everything
+else, and secrets are substituted at Hezo's own egress proxy. This page covers what is
+different.
 
 Hezo supports one managed provider today:
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -15,6 +15,16 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
 > HTTPS, systemd, and the firewall - on DigitalOcean, Hetzner, Vultr, Linode, or
 > Lightsail. This page covers the manual shape if you'd rather set it up yourself.
 
+> **Running agent containers on a
+> [managed sandbox service](/docs/containers/remote/overview) instead?** Then the server
+> needs no Docker at all, and a much smaller VPS will do - the containers' memory lives
+> with the provider, not on this host. Skip the Docker steps below and pass
+> `--sandbox-backend` on first start
+> ([configuration](/docs/deployment/configuration#running-agent-containers-on-a-managed-sandbox-service)),
+> or move an already-running instance over from **Settings -> Containers**
+> ([Switching at any time](/docs/containers/overview#switching-at-any-time)) - restarting
+> with different environment variables does not switch an existing instance.
+
 ## The shape of a cloud deployment
 
 1. **Provision a host with Docker** and install the `hezo` binary

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -225,14 +225,16 @@ while the server is stopped - `aws s3 sync /var/lib/hezo/assets/ s3://my-bucket/
 ## Running agent containers on a managed sandbox service
 
 Every agent run executes inside a container. By default that container runs on the local
-Docker daemon, which is why Docker is a prerequisite for a normal install. Setting
-These flags choose what a **brand-new** instance starts on. After that the setting in
-Settings -> Containers is what counts, and you can switch service (or switch back to local
-Docker) there at any time without restarting - see
-[Switching at any time](/docs/containers/overview#switching-at-any-time).
+Docker daemon, which is why a Docker-compatible runtime is a prerequisite for a normal
+install. `--sandbox-backend` (or `HEZO_SANDBOX_BACKEND`) starts a **brand-new** instance
+on a managed sandbox service instead, and Docker stops being required at all.
 
-`--sandbox-backend` (or `HEZO_SANDBOX_BACKEND`) moves those containers onto a managed
-sandbox service instead, and Docker stops being required at all.
+The flags only choose what a brand-new instance starts on. The first startup records the
+choice, and from then on the stored setting wins: the flags are ignored on later startups
+- Hezo logs that it ignored them if they disagree - so restarting with different
+environment variables never switches an existing instance. Switching, in either
+direction, is done from Settings -> Containers at any time, no restart needed. See
+[Switching at any time](/docs/containers/overview#switching-at-any-time).
 
 [Remote containers](/docs/containers/remote/overview) covers what changes when you do:
 how a container reaches your instance, what stays on your side, and what is not available
@@ -256,10 +258,13 @@ HEZO_DAYTONA_API_URL=https://app.daytona.io/api   # optional: a regional endpoin
 Add `--daytona-api-url` (or `HEZO_DAYTONA_API_URL`) only if you are pointed at a regional
 or self-hosted endpoint; it defaults to Daytona's public API.
 
-**All of it is deployment configuration**, set before the server starts - there is no
-setting for it in the web UI, and the API key does not go in the secrets vault. The
-General settings page shows which backend is in use, read-only, next to the database and
-asset backends.
+The provider API key is stored **encrypted in the secrets vault** and read only by Hezo
+itself to drive the provider's control plane - it never enters an agent container.
+Because it is encrypted, a restarted instance reconnects to the provider once you
+unlock; a key passed at startup is used straight away and saved once you unlock. The
+Containers settings page names the service in use and is also where you replace an
+expired or revoked key - see
+[Restarting an instance on a managed service](/docs/containers/overview#restarting-an-instance-on-a-managed-service).
 
 ### The agent image on a managed backend
 

--- a/docs/deployment/container-runtimes.md
+++ b/docs/deployment/container-runtimes.md
@@ -11,6 +11,12 @@ boundary**, not a packaging convenience - it keeps agents off your host so a bug
 compromised agent can't reach your files, credentials, or wider network (see
 [Container isolation](/docs/security/container-isolation)).
 
+This page is about the default setup, where containers run on **your own machine**. If
+the instance runs its agent containers on a
+[managed sandbox service](/docs/containers/remote/overview), there is no local runtime to
+install and nothing below applies. You choose - and can switch - between the two in
+**Settings -> Containers**.
+
 Hezo talks to the container runtime over the **Docker Engine API on a Unix socket**, so it
 works with any Docker-compatible runtime. You do not have to run Docker Desktop.
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -15,6 +15,10 @@ keys, and the spend.
 - A host that can run a **Docker-compatible container runtime** (your laptop,
   a home server, or a cloud VPS). Colima, Rancher Desktop, OrbStack, Lima and rootless
   Docker all work - see [Container runtimes](/docs/deployment/container-runtimes).
+  Running agent containers on a
+  [managed sandbox service](/docs/containers/remote/overview) instead? Then the host
+  needs no container runtime at all - and **Settings -> Containers** switches an
+  instance between the two at any time.
 - The **`hezo` binary** (see [Installation](/docs/getting-started/installation)).
 - Your **master key** (created on first run; see
   [First-run setup](/docs/getting-started/first-run)).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,8 @@ section: Getting started
 Hezo ships as a **single self-contained binary** - there's no runtime, language
 toolchain, or dependencies to install. Download it, run it, and you're up in seconds.
 The one thing to have in place first is a **Docker-compatible runtime**, which Hezo uses
-to run each project's agents in an isolated container.
+to run each project's agents in isolated containers on your machine - unless you point
+the instance at a managed sandbox service instead (below).
 
 ## Prerequisites
 
@@ -24,6 +25,15 @@ to run each project's agents in an isolated container.
   need.
 - A machine you're happy to leave running while agents work (a laptop is fine to
   start; a small always-on server is better for long-running teams).
+
+**Rather not run containers on this machine at all?** A brand-new instance can start its
+agent containers on a [managed sandbox service](/docs/containers/remote/overview) instead
+- `hezo --sandbox-backend daytona --daytona-api-key "<key>"` - and then no container
+runtime is needed here. See [Containers](/docs/containers/overview) for the trade-off.
+The choice stays live after install: **Settings -> Containers** switches an existing
+instance between local and remote containers at any time
+([Switching at any time](/docs/containers/overview#switching-at-any-time)) - the flag and
+environment variable only seed the first startup.
 
 ## Install the binary
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -36,8 +36,9 @@ agent can't hurt you. A few guarantees sit underneath everything:
   [Container isolation](/docs/security/container-isolation), and
   [Containers](/docs/containers/overview) for where those containers run (your own Docker
   daemon or a managed service).
-- **Agents work in real repos without holding the keys.** Git signing and SSH happen
-  on the host, so commits land **verified** while the key never enters the sandbox. See
+- **Agents work in real repos without holding the keys.** Commit signing and git
+  credentials stay on your instance, so commits land **verified** while nothing secret
+  enters the sandbox. See
   [Git & verified commits](/docs/security/git-and-verified-commits).
 
 ## What you can do with it

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,9 +17,11 @@ hezo [options]
 ```
 
 Boots the Hezo server and web app (default port 3100) against the data directory
-(default `~/.hezo/`). A Docker-compatible container runtime must be installed and running
-first - Hezo checks at startup and exits with install/start guidance if no
-daemon is reachable (see [Installation](/docs/getting-started/installation) and
+(default `~/.hezo/`). Unless the instance runs its containers on a
+[managed sandbox service](/docs/containers/remote/overview) (below), a Docker-compatible
+container runtime must be installed and running first - Hezo checks at startup and exits
+with install/start guidance if no daemon is reachable (see
+[Installation](/docs/getting-started/installation) and
 [Container runtimes](/docs/deployment/container-runtimes)). See the
 [Configuration reference](/docs/deployment/configuration) for the full table of flags and
 their environment-variable equivalents. The most common:

--- a/docs/security/container-isolation.md
+++ b/docs/security/container-isolation.md
@@ -7,97 +7,141 @@ section: Security
 # Container isolation
 
 Agents execute real, often AI-generated code. Hezo runs that code where it can't hurt
-you: **every project gets its own container, and agents only ever run inside it** - never
-on your host directly. Hezo drives that through any
-[Docker-compatible runtime](/docs/deployment/container-runtimes); the isolation described
-here is the same whichever you use.
+you: **agents only ever work inside a container - never on your host directly.** Where
+those containers live is your choice, made in **Settings -> Containers**: on your own
+machine through any [Docker-compatible runtime](/docs/deployment/container-runtimes) (the
+default), or on a [managed sandbox service](/docs/containers/remote/overview) such as
+[Daytona](/docs/containers/remote/daytona), so agent work does not touch your machine at
+all. The choice is not a commitment: the same settings page
+[switches a running instance](/docs/containers/overview#switching-at-any-time) between
+them at any time, in either direction.
 
-This page is the security case for that boundary. For where those containers run and how
-to choose - your own Docker daemon or a managed service - see
-[Containers](/docs/containers/overview). Every property described here holds on either.
+This page is the security case for that boundary, and it is one case, not two: the same
+container image, the same tunnel back to Hezo, the same egress proxy and the same key
+handling apply on either backend. The few properties that belong to one backend are
+called out as such. For where containers run, how they are sized and how to switch, see
+[Containers](/docs/containers/overview).
 
-## A sandbox per project
+## One project, one run, one container
 
-Each project's container is a private workspace holding that project's code and tools.
-Because the sandbox is per project, one project's agents can't see or touch another's
-work - the blast radius of anything going wrong is contained to a single project.
+A container belongs to **exactly one project**, and serves **one agent run at a time**. A
+project with two agents working at once holds two containers; between runs a container is
+kept briefly and reused for that project's next run; and a container is never shared or
+handed between projects.
+
+The blast radius of anything going wrong is therefore one run in one project. Another
+run's work - even in the same project - is in a different container, and another
+project's might as well be on a different machine. What runs in the same project do
+share is the project's work itself: the repositories they are collaborating on.
 
 ## Containers run only when there is work
 
-A container starts automatically the moment an agent run or an assistant chat needs it,
-and stops again after sitting idle (a couple of minutes). A quiet instance runs zero
-containers. Two global limits in **Settings > Containers** bound what a burst of agent
-activity can consume:
+A container starts the moment an agent run or an assistant chat needs one, and is
+retired after a couple of minutes idle (a live assistant chat keeps its container for
+about fifteen minutes, so a reply you take a moment to type does not pay a cold start). A
+quiet instance runs zero containers.
 
-- **Total container memory** - how much memory all project containers may use at once.
-  The assistant chat's container runs on top of it, so a chat turn never waits behind
-  background work. When unset, Hezo sizes it automatically, and how depends on where
-  containers run: on [local Docker](/docs/containers/local-docker) it is derived from the
-  machine's memory (RAM + swap, less 1 GB always kept free for the operating system and
-  Hezo itself, less one container's worth for the assistant chat; swap counts in full,
-  since a container sits idle between runs), while on a
-  [managed service](/docs/containers/remote/overview) the containers are not on your
-  machine at all and the default is a flat starting figure you raise deliberately. A run
-  whose container will not fit in what is left waits in the queue and starts as memory
-  frees up; the assistant chat always starts. There is no separate limit on the *number*
-  of containers: how many fit follows from this budget and the RAM cap below, and a
-  project that raises its own cap simply takes a larger share.
-- **RAM cap per container** - the memory limit applied to every container (2 GB by
-  default; projects that need more can override it on their own Containers page). A
-  container over its cap is stopped, or has its biggest process killed by the kernel,
-  instead of taking down the whole server.
+What a burst of agent activity can consume is bounded in **Settings -> Containers**, and
+every ceiling is enforced per container:
 
-A third setting on the same page, **Disk per container**, sizes each container's own
-filesystem where the container service allocates one - see
+- a **global memory budget** all project containers share - a run whose container will
+  not fit waits in the queue, while the assistant chat's container is reserved on top of
+  the budget so a chat always starts;
+- a **RAM cap per container** (2 GB by default, with a per-project override) - a
+  container at its cap is stopped, or has its biggest process killed, and the run reports
+  the cap by name rather than failing mysteriously;
+- a **disk allocation per container**, where the container service gives each container
+  its own filesystem.
+
+How the automatic defaults are derived - from your machine's memory locally, as a flat
+budget you raise deliberately on a managed service - and the sizing arithmetic live in
 [Containers](/docs/containers/overview#how-much-can-run-at-once).
 
-As a sizing rule of thumb, one working agent (its coding CLI plus the helper tools it
-spawns) typically uses 300-350 MB of memory, and the container cap bounds the total
-regardless of how many agents share it.
+## What a container cannot reach
 
-Containers stop a couple of minutes after a project's last activity and start again on
-demand, so a quiet instance runs none. That window is fixed rather than configurable -
-its only job is to keep a container warm between one run and the next in the same
-project, which takes seconds, and there is no setting an operator could tune better than
-that. Because containers do not stay up between bursts, they are not a place to run a
-long-lived dev or preview server.
+From inside the container, agents **cannot** reach your **host filesystem** (only the
+project's own workspace is available) or your **host processes and devices**. On a
+managed service this holds in the strongest possible sense: the container is not on your
+machine, so there is nothing of yours beside it to reach.
 
-From inside the container, agents **cannot** reach:
+Outbound network access is handled separately, through the tunnel and egress proxy below.
 
-- your **host filesystem** (only the project's own workspace is available), or
-- your **host processes or devices**.
+## The container reaches Hezo through a tunnel
 
-Outbound network access is handled separately, through Hezo's egress proxy (below).
+A run needs three things from Hezo: the MCP endpoint (its tools), the egress proxy
+(below), and the ssh-agent (commit signing). Hezo **reaches into the container** and runs
+a small tunnel client there; all three arrive on the container's own loopback. The
+mechanism is described in
+[Remote containers](/docs/containers/remote/overview#how-a-container-reaches-hezo), and
+it is identical on local Docker.
 
-## Outbound traffic goes through the egress proxy
+Two consequences matter for your security posture:
 
-Hezo points the container's outbound traffic at its **egress proxy** using the standard
-`HTTP(S)_PROXY` settings. That's what makes the
-[secret protection](/docs/security/secret-protection) guarantee hold: your real secrets
-are only ever materialised at the proxy - agents inside the container hold placeholders,
-never the actual values - and the proxy enforces which hosts each secret may be sent to.
-(Calls to your LLM provider are the one exception: they go direct, with the model
-credentials injected into the run.)
+- **Your instance exposes nothing.** The per-run endpoints on Hezo's side bind loopback
+  only, so there is no inbound port to open and no public hostname to have - not for
+  local containers, and not for remote ones.
+- **Each run's endpoints are its own**, guarded by per-run tokens, so one run cannot
+  drive another run's proxy or signer.
 
-Each run's proxy is scoped to that run with its own token, so one run can't route requests
-through another's proxy. A run that somehow reached the proxy without its token is simply
-turned away - it never gets a secret substituted, so the guarantee holds even then.
+## Secrets are substituted outside the container, at the egress proxy
+
+Agents hold **placeholders**, never secret values - see
+[Secret protection](/docs/security/secret-protection). A request to any host that one of
+your credentials or connectors is scoped to travels the tunnel to Hezo's **egress
+proxy**, which substitutes the real value at the last moment and enforces that secret's
+allowed hosts. Requests to everything else - package registries, documentation, a public
+API no credential is scoped to - go straight out from the container and never pass
+through your instance.
+
+Routing those directly loses nothing: a secret can only ever materialise at the proxy,
+so a request that reaches a credentialed host without the proxy carries the
+unsubstituted placeholder, which is inert and simply fails upstream. The proxy, not the
+route, is what the guarantee rests on.
+
+Two boundaries sit on the proxy itself:
+
+- **A per-run token.** Each run's proxy requires that run's own credential, so a process
+  that somehow reached it without one is turned away - and even then, the most it could
+  ever have shipped is a placeholder.
+- **A destination guard.** The proxy refuses to carry traffic to loopback, link-local or
+  private addresses, so it cannot be used as a tunnel to Hezo's own API, its database,
+  or anything else on your host or LAN.
+
+One exception, the same on every backend: the credential the coding CLI uses to reach
+its **AI model provider** is injected into the run and travels direct, because proxying
+breaks some model endpoints. It is the only secret that exists in plaintext inside a
+run.
 
 ## Resource and privilege limits
 
-Each container also runs with guardrails so a runaway or misbehaving agent can't exhaust the
-host: a **memory cap** (the global RAM cap per container, overridable per project, with
-the running total shown while an agent works), a
-**process limit** that stops fork bombs, and a **reduced set of Linux capabilities** (the
-container starts with all capabilities dropped and only the few the workload needs added
-back). A proper init process runs as PID 1 so exited helper processes are always cleaned up.
+Every container runs against a hard **memory ceiling**, and on a managed service a fixed
+**disk allocation** - a runaway run is stopped at its cap, with the cap named, rather
+than taking anything else down with it.
 
-One honest note on the boundary: a container shares your machine's Linux kernel, so it is a
-strong sandbox, not a virtual machine. On macOS and Windows the runtime already runs every
-container inside a lightweight VM (Docker Desktop, Colima, Rancher Desktop, OrbStack and
-Lima all work this way); on a server, the usual and recommended setup is to
-run Hezo on its own VM or host. If you're running untrusted work, keep Hezo on a dedicated
-machine or VM - that is the boundary that isolates it from everything else.
+On **local Docker**, where the container shares your machine, Hezo also hardens the
+container itself: a **process limit** that stops fork bombs, **all Linux capabilities
+dropped** with only the few the workload needs added back, and a proper init process as
+PID 1 so exited helpers are always cleaned up. On a **managed service** those knobs are
+the provider's: isolation between sandboxes is the provider's own, and what Hezo
+enforces there is the memory and disk contract above.
+
+## Where the boundary actually is
+
+One honest note per backend:
+
+- **On your own machine**, a container shares your kernel - a strong sandbox, not a
+  virtual machine. On macOS and Windows the runtime already runs every container inside
+  a lightweight VM (Docker Desktop, Colima, Rancher Desktop, OrbStack and Lima all work
+  this way); on a Linux server, the usual and recommended setup is to give Hezo its own
+  VM or host. If you run untrusted work, that dedicated machine or VM is the boundary
+  that isolates it from everything else.
+- **On a managed service**, nothing of the agent's work executes on your machine - the
+  container, its kernel and its neighbours are the provider's. The provider's machines
+  hold your project's checkout and the run's output while work happens, plus the one
+  plaintext credential noted above; they never hold your stored secrets, your keys or
+  your master key, which stay on your instance. See
+  [Remote containers](/docs/containers/remote/overview) for exactly what moves and what
+  does not.
 
 ## Keys never enter the container
 
@@ -106,15 +150,20 @@ them:
 
 - **Your secrets** are referenced by placeholder and substituted *outside* the
   container, at the proxy.
-- **Git signing and SSH keys** stay on the host. When an agent commits or pushes, the
-  signing happens host-side on its behalf - the private key is never exposed to the
-  agent. Commits land **verified**, signed by your project's key. See
+- **Your git credentials and signing key** stay on your instance. Clones and pushes
+  authenticate through a placeholder the proxy substitutes on the way out, and commit
+  signing happens instance-side on the agent's behalf - so commits land **verified**
+  while the private key never exists inside the container. See
   [Git & verified commits](/docs/security/git-and-verified-commits).
+- **Your master key** never leaves Hezo's own memory: it is not written to disk on your
+  instance, let alone into a container. See
+  [Master key & encryption](/docs/security/master-key).
 
 ## What this gives you
 
-Putting the three pillars together - placeholders + egress scoping, encryption at rest,
-and container isolation - a compromised agent is boxed in: it can't read your secrets
-(they're only ever materialised at the proxy, behind host allow-lists), can't reach your
-host, and can't escape its project. You get the upside of autonomous agents running real
-code without betting your system on every line of it being safe.
+Putting the pillars together - placeholders + egress scoping, encryption at rest, and
+container isolation - a compromised agent is boxed in: it can't read your secrets
+(they only ever materialise at the proxy, behind host allow-lists), can't reach your
+host, and can't escape its run's container or its project. You get the upside of
+autonomous agents running real code without betting your system on every line of it
+being safe.

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -14,8 +14,8 @@ agent's sandbox**, and so the commits your agents make land as **Verified** on G
 
 Each project has its **own [Ed25519](https://en.wikipedia.org/wiki/EdDSA) key**, used to
 sign the project's git commits. The private key is
-[encrypted at rest](/docs/security/master-key) and lives **on the host** - it is never
-written into the container where agent code runs.
+[encrypted at rest](/docs/security/master-key) and lives **on your Hezo instance** - it
+is never written into the container where agent code runs, wherever that container is.
 
 ## Connect GitHub once
 
@@ -81,8 +81,8 @@ Git transport runs over **HTTPS** (`https://github.com/owner/repo.git`), authent
 the token from the GitHub account you connected.
 
 **That token is never inside the container.** The remote carries a placeholder in place of
-the credential, and Hezo's egress proxy swaps in the real value as each request leaves the
-host - the same mechanism that protects every other secret an agent uses. A request that
+the credential, and Hezo's egress proxy swaps in the real value as each request leaves
+for GitHub - the same mechanism that protects every other secret an agent uses. A request that
 somehow avoided the proxy would carry the placeholder, which is not a valid credential, so
 it fails rather than leaking anything.
 
@@ -93,8 +93,8 @@ on your laptop but not in production is worse than one that works in both.
 
 ## Committed work is never lost
 
-Agent runs are time-limited, and each task works in a throwaway copy of the repository that
-is discarded when the run ends. So that committed work always survives - even if a run is
+Agent runs are time-limited, and each task works in a disposable working copy of the
+repository that does not outlive the task. So that committed work always survives - even if a run is
 cut short or reaches its time limit mid-way - Hezo **pushes every commit to the remote the
 moment it is made**. As soon as an agent commits, that commit is on the task's branch on
 GitHub, so nothing an agent has committed is ever lost with the run.

--- a/docs/security/secret-protection.md
+++ b/docs/security/secret-protection.md
@@ -24,8 +24,10 @@ the last possible moment.
 
 ## The egress proxy
 
-All of an agent's outbound network traffic is routed through Hezo's **egress proxy**.
-As a request leaves, the proxy:
+Any agent request that could carry one of your secrets - a request to a host that some
+credential or connector is scoped to - is routed through Hezo's **egress proxy**,
+wherever the [container runs](/docs/containers/overview). As such a request leaves, the
+proxy:
 
 1. **Looks for placeholders** in the request's headers and URL.
 2. **Checks the destination** against that secret's list of **allowed hosts**.
@@ -36,6 +38,13 @@ If a placeholder is used against a host it isn't allowed for, the proxy **blocks
 request**. So even if an agent is tricked or compromised into trying to send your
 Stripe key somewhere it shouldn't, the substitution simply never happens and the
 secret never leaves.
+
+Traffic with no security stake - an `npm install`, a documentation fetch, a request to a
+host no credential is scoped to - connects straight out from the container rather than
+round-tripping through your instance. Nothing is lost by that: a secret can only ever
+materialise at the proxy, so a request that goes out directly can carry at most a
+placeholder, which is inert and simply fails upstream. The proxy, not the route, is what
+the guarantee rests on.
 
 ### Credentials that go in the request body
 

--- a/packages/server/src/services/sandbox/agent-environment.ts
+++ b/packages/server/src/services/sandbox/agent-environment.ts
@@ -40,9 +40,10 @@ export const SANDBOX_AGENT_ENVIRONMENTS: Record<SandboxBackend, SandboxAgentEnvi
 		egress: [
 			'Outbound network is whatever that machine allows, so it is usually unrestricted - ' +
 				'HTTPS, SSH, and other TCP protocols all work unless the operator has a firewall of their own.',
-			"All HTTP and HTTPS traffic still passes through Hezo's egress proxy, which is what " +
-				'substitutes `__HEZO_SECRET_<NAME>__` placeholders. A request that bypasses the proxy ' +
-				'carries the unsubstituted placeholder and simply fails upstream.',
+			"Requests to hosts your credentials and connectors are scoped to pass through Hezo's " +
+				'egress proxy, which is what substitutes `__HEZO_SECRET_<NAME>__` placeholders; ' +
+				'everything else connects direct. A request that reaches a credentialed host without ' +
+				'the proxy carries the unsubstituted placeholder and simply fails upstream.',
 		],
 	},
 	[Backend.Daytona]: {

--- a/packages/server/test/docs-links.test.ts
+++ b/packages/server/test/docs-links.test.ts
@@ -1,0 +1,142 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+// Repo tooling under scripts/ — imported directly (pure functions, no DB/DOM),
+// same pattern as docs-ack-hook.test.ts.
+import {
+	checkDocsTree,
+	classifyExternalStatus,
+	docsPathToFile,
+	extractLinks,
+	headingAnchors,
+	isSkippedExternalUrl,
+	selfRepoPath,
+	slugifyHeading,
+	stripCode,
+} from '../../../scripts/check-docs-links';
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+
+describe('slugifyHeading', () => {
+	it('matches the GitHub slugger on the anchor shapes the docs actually link', () => {
+		expect(slugifyHeading('Managed database & asset storage')).toBe(
+			'managed-database--asset-storage',
+		);
+		expect(slugifyHeading('HQ - the home team')).toBe('hq---the-home-team');
+		expect(slugifyHeading('Connecting an OAuth API with the device flow (no callback)')).toBe(
+			'connecting-an-oauth-api-with-the-device-flow-no-callback',
+		);
+		expect(slugifyHeading('Switching at any time')).toBe('switching-at-any-time');
+	});
+
+	it('strips emphasis and code markers but keeps their text', () => {
+		expect(slugifyHeading('Using `--foo`')).toBe('using---foo');
+		expect(slugifyHeading('**Bold** heading')).toBe('bold-heading');
+	});
+});
+
+describe('headingAnchors', () => {
+	it('collects every heading level, suffixes duplicates, and skips fenced blocks', () => {
+		const anchors = headingAnchors(
+			['# Top', '## Same', '## Same', '```', '## Not a heading', '```'].join('\n'),
+		);
+		expect(anchors).toEqual(new Set(['top', 'same', 'same-1']));
+	});
+});
+
+describe('stripCode / extractLinks', () => {
+	it('ignores links inside fenced blocks and inline code, preserving line numbers', () => {
+		const md = [
+			'intro',
+			'```sh',
+			'curl [not a link](http://localhost:3100)',
+			'```',
+			'see `[also not](/docs/nope)` and [real](/docs/introduction).',
+		].join('\n');
+		expect(stripCode(md)).not.toContain('/docs/nope');
+		const links = extractLinks(md);
+		expect(links).toEqual([{ target: '/docs/introduction', line: 5 }]);
+	});
+
+	it('extracts images and multiple links per line', () => {
+		const links = extractLinks('![alt](../assets/x.png) then [a](/docs/a) and [b](/docs/b)');
+		expect(links.map((l) => l.target)).toEqual(['../assets/x.png', '/docs/a', '/docs/b']);
+	});
+});
+
+describe('target classification', () => {
+	it('maps /docs paths to markdown files', () => {
+		expect(docsPathToFile('/docs/containers/overview')).toBe('docs/containers/overview.md');
+		expect(docsPathToFile('/docs/containers/overview/')).toBe('docs/containers/overview.md');
+		expect(docsPathToFile('/docs')).toBe('docs/introduction.md');
+	});
+
+	it('recognises links into this repo', () => {
+		expect(selfRepoPath('https://github.com/hezo-ai/hezo/blob/main/agents/blank/captain.md')).toBe(
+			'agents/blank/captain.md',
+		);
+		expect(selfRepoPath('https://github.com/hezo-ai/hezo/blob/main/deploy/provision.sh#L3')).toBe(
+			'deploy/provision.sh',
+		);
+		expect(selfRepoPath('https://github.com/hezo-ai/hezo/releases/latest')).toBeNull();
+		expect(selfRepoPath('https://github.com/other/repo/blob/main/x.md')).toBeNull();
+	});
+
+	it('skips example hosts and blocks only on definitive statuses', () => {
+		expect(isSkippedExternalUrl('http://localhost:3100/SKILL.md')).toBe(true);
+		expect(isSkippedExternalUrl('http://host.docker.internal:11434')).toBe(true);
+		expect(isSkippedExternalUrl('https://api.example.com/x')).toBe(true);
+		expect(isSkippedExternalUrl('https://www.daytona.io')).toBe(false);
+		expect(classifyExternalStatus(404)).toBe('broken');
+		expect(classifyExternalStatus(410)).toBe('broken');
+		expect(classifyExternalStatus(200)).toBe('ok');
+		expect(classifyExternalStatus(302)).toBe('ok');
+		// A 403 can be a bot wall in front of a perfectly good page.
+		expect(classifyExternalStatus(403)).toBe('unreachable');
+		expect(classifyExternalStatus(503)).toBe('unreachable');
+	});
+});
+
+describe('checkDocsTree', () => {
+	const exists = () => false;
+
+	it('reports a link to a missing page, a bad anchor, and a bad relative path', () => {
+		const files = new Map<string, string>([
+			['docs/a.md', '# A\n\n## Real heading\n\n[gone](/docs/missing) [bad](/docs/b#nope)'],
+			['docs/b.md', '# B\n\n[img](../assets/nope.png) [ok self](#b)'],
+		]);
+		const problems = checkDocsTree(files, exists);
+		expect(problems).toHaveLength(3);
+		expect(problems[0]).toContain('docs/a.md:5');
+		expect(problems[0]).toContain('/docs/missing');
+		expect(problems[1]).toContain('broken anchor /docs/b#nope');
+		expect(problems[2]).toContain('broken relative link ../assets/nope.png');
+	});
+
+	it('accepts valid pages, anchors, same-file anchors and repo links that exist', () => {
+		const files = new Map<string, string>([
+			['docs/a.md', '# A\n\n[b](/docs/b#real-heading) [self](#a)'],
+			['docs/b.md', '# B\n\n## Real heading\n\ntext'],
+		]);
+		expect(checkDocsTree(files, () => true)).toEqual([]);
+	});
+});
+
+describe('the real docs tree', () => {
+	it('has no broken internal links, anchors, or repo-file links', () => {
+		const files = new Map<string, string>();
+		const walk = (dir: string) => {
+			for (const entry of readdirSync(join(repoRoot, dir), { withFileTypes: true })) {
+				const rel = `${dir}/${entry.name}`;
+				if (entry.isDirectory()) walk(rel);
+				else if (entry.name.endsWith('.md'))
+					files.set(rel, readFileSync(join(repoRoot, rel), 'utf8'));
+			}
+		};
+		walk('docs');
+		expect(files.size).toBeGreaterThan(40);
+		const problems = checkDocsTree(files, (p) => existsSync(join(repoRoot, p)));
+		expect(problems).toEqual([]);
+	});
+});

--- a/scripts/check-docs-links.ts
+++ b/scripts/check-docs-links.ts
@@ -1,0 +1,345 @@
+// Commit-msg guard: a commit staging any docs/**/*.md fails on a broken docs link.
+//
+// Internal links - docs-to-docs (including #anchors), same-file anchors, relative
+// paths, and github.com/hezo-ai/hezo/{blob,raw,tree}/main/<path> links into this
+// repo - are checked across the WHOLE tree, not just staged files, because a
+// deleted or renamed page breaks other files' links. These checks are
+// deterministic and always block.
+//
+// External URLs are probed only for the staged files (HEAD, then GET on servers
+// that refuse HEAD), with successes cached in .git/ for a week. Only a
+// definitive 404/410 blocks: a 403 can be a bot wall (console.x.ai answers 403
+// to a browser-UA GET while loading fine in a browser), and an offline machine
+// must warn, never wedge a commit - which is why there is no bypass env var.
+//
+// Pure functions here are unit-tested in packages/server/test/docs-links.test.ts,
+// which also runs the whole-tree internal check so CI catches what a bypassed
+// hook would have.
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, posix } from 'node:path';
+
+const DOCS_DIR = 'docs';
+const INTRO_FILE = 'docs/introduction.md';
+const SELF_REPO_RE = /^https:\/\/github\.com\/hezo-ai\/hezo\/(?:blob|raw|tree)\/main\/([^#?]+)/;
+/** Hosts that appear in docs as examples, never as real destinations. */
+const SKIP_HOSTS = new Set(['localhost', '127.0.0.1', 'host.docker.internal', 'example.com']);
+/** The only statuses that prove a link wrong; everything else could be the network. */
+const HARD_BROKEN_STATUSES = new Set([404, 410]);
+const CACHE_PATH = join('.git', 'hezo-docs-link-cache.json');
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_CONCURRENCY = 6;
+/** Some hosts 403 generic clients; a browser UA keeps false alarms down. */
+const LINK_CHECK_UA =
+	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36';
+
+export interface FoundLink {
+	target: string;
+	/** 1-based line in the source file. */
+	line: number;
+}
+
+/**
+ * Blank fenced code blocks, preserving line count so reported line numbers stay
+ * true. Inline code is left alone here - headings like `## Using \`--foo\``
+ * need their backticked text for slugging.
+ */
+export function stripFences(md: string): string {
+	let fence: string | null = null;
+	return md
+		.split('\n')
+		.map((line) => {
+			const marker = line.match(/^\s*(```|~~~)/);
+			if (fence !== null) {
+				if (marker && marker[1] === fence) fence = null;
+				return '';
+			}
+			if (marker) {
+				fence = marker[1];
+				return '';
+			}
+			return line;
+		})
+		.join('\n');
+}
+
+/** Blank fenced blocks and inline code spans - example links are not links. */
+export function stripCode(md: string): string {
+	return stripFences(md)
+		.split('\n')
+		.map((line) => line.replace(/`[^`]*`/g, (m) => ' '.repeat(m.length)))
+		.join('\n');
+}
+
+/** Every inline/image/autolink target with its line number, code stripped. */
+export function extractLinks(md: string): FoundLink[] {
+	const links: FoundLink[] = [];
+	const inline = /!?\[[^\]]*\]\(([^()\s]+(?:\([^()]*\)[^()\s]*)*)\)/g;
+	const auto = /<(https?:\/\/[^>\s]+)>/g;
+	stripCode(md)
+		.split('\n')
+		.forEach((line, i) => {
+			for (const m of line.matchAll(inline)) links.push({ target: m[1], line: i + 1 });
+			for (const m of line.matchAll(auto)) links.push({ target: m[1], line: i + 1 });
+		});
+	return links;
+}
+
+/** GitHub-slugger-compatible anchor for one heading's text. */
+export function slugifyHeading(heading: string): string {
+	return heading
+		.trim()
+		.toLowerCase()
+		.replace(/[*_`]/g, '')
+		.replace(/[^\p{L}\p{N}\s_-]/gu, '')
+		.replace(/\s/g, '-');
+}
+
+/** Anchors of every markdown heading, with GitHub's -1/-2 dedup suffixes. */
+export function headingAnchors(md: string): Set<string> {
+	const anchors = new Set<string>();
+	const seen = new Map<string, number>();
+	for (const m of stripFences(md).matchAll(/^#{1,6}\s+(.+?)\s*#*\s*$/gm)) {
+		const base = slugifyHeading(m[1]);
+		const n = seen.get(base) ?? 0;
+		seen.set(base, n + 1);
+		anchors.add(n === 0 ? base : `${base}-${n}`);
+	}
+	return anchors;
+}
+
+/** Map a site-absolute `/docs/...` link to its repo-relative markdown file. */
+export function docsPathToFile(sitePath: string): string {
+	const sub = sitePath.replace(/^\/docs\/?/, '').replace(/\/$/, '');
+	return sub === '' ? INTRO_FILE : posix.join(DOCS_DIR, `${sub}.md`);
+}
+
+/** Repo-relative path a github.com/hezo-ai/hezo blob/raw/tree link names, or null. */
+export function selfRepoPath(url: string): string | null {
+	const m = url.match(SELF_REPO_RE);
+	return m ? m[1].replace(/\/$/, '') : null;
+}
+
+/** External URLs that are doc examples rather than destinations. */
+export function isSkippedExternalUrl(url: string): boolean {
+	try {
+		const host = new URL(url).hostname.toLowerCase();
+		return SKIP_HOSTS.has(host) || host.endsWith('.example.com');
+	} catch {
+		return true;
+	}
+}
+
+export function classifyExternalStatus(status: number): 'ok' | 'broken' | 'unreachable' {
+	if (HARD_BROKEN_STATUSES.has(status)) return 'broken';
+	if (status >= 200 && status < 400) return 'ok';
+	return 'unreachable';
+}
+
+/**
+ * Validate every internal link in `files` (repo-relative path -> content).
+ * `exists` answers for targets outside the map: assets, self-repo file links.
+ * Returns one `file:line message` string per problem.
+ */
+export function checkDocsTree(
+	files: Map<string, string>,
+	exists: (repoRelativePath: string) => boolean,
+): string[] {
+	const problems: string[] = [];
+	const anchorsByFile = new Map<string, Set<string>>();
+	for (const [path, content] of files) anchorsByFile.set(path, headingAnchors(content));
+
+	const checkAnchor = (
+		from: string,
+		line: number,
+		target: string,
+		file: string,
+		anchor: string,
+	) => {
+		if (!anchorsByFile.get(file)?.has(anchor)) {
+			problems.push(`${from}:${line} broken anchor ${target} (no heading "#${anchor}" in ${file})`);
+		}
+	};
+
+	for (const [path, content] of files) {
+		for (const { target, line } of extractLinks(content)) {
+			if (/^https?:\/\//.test(target)) {
+				const repoPath = selfRepoPath(target);
+				if (repoPath !== null && !exists(repoPath)) {
+					problems.push(`${path}:${line} broken repo link ${target} (${repoPath} does not exist)`);
+				}
+				continue;
+			}
+			if (target.startsWith('mailto:')) continue;
+
+			const hash = target.indexOf('#');
+			const pathPart = hash === -1 ? target : target.slice(0, hash);
+			const anchor = hash === -1 ? null : target.slice(hash + 1);
+
+			if (pathPart === '') {
+				if (anchor !== null) checkAnchor(path, line, target, path, anchor);
+				continue;
+			}
+			if (pathPart.startsWith('/docs')) {
+				const file = docsPathToFile(pathPart);
+				if (!files.has(file)) {
+					problems.push(`${path}:${line} broken link ${target} (${file} does not exist)`);
+					continue;
+				}
+				if (anchor !== null) checkAnchor(path, line, target, file, anchor);
+				continue;
+			}
+			if (pathPart.startsWith('/')) {
+				problems.push(
+					`${path}:${line} absolute non-docs link ${target} - use /docs/... or a full URL`,
+				);
+				continue;
+			}
+			const resolved = posix.normalize(posix.join(posix.dirname(path), pathPart));
+			if (resolved.endsWith('.md') && files.has(resolved)) {
+				if (anchor !== null) checkAnchor(path, line, target, resolved, anchor);
+				continue;
+			}
+			if (!exists(resolved)) {
+				problems.push(
+					`${path}:${line} broken relative link ${target} (${resolved} does not exist)`,
+				);
+			}
+		}
+	}
+	return problems;
+}
+
+export interface ExternalProbe {
+	verdict: 'ok' | 'broken' | 'unreachable';
+	detail: string;
+}
+
+async function fetchStatus(url: string, method: 'HEAD' | 'GET'): Promise<number> {
+	const res = await fetch(url, {
+		method,
+		redirect: 'follow',
+		headers: { 'user-agent': LINK_CHECK_UA, accept: '*/*' },
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	});
+	// The status is the answer; never download the body.
+	await res.body?.cancel().catch(() => {});
+	return res.status;
+}
+
+/** HEAD, falling back to GET when the server refuses HEAD or the transport fails. */
+export async function probeExternalUrl(url: string): Promise<ExternalProbe> {
+	let headStatus: number | null = null;
+	try {
+		headStatus = await fetchStatus(url, 'HEAD');
+		if (classifyExternalStatus(headStatus) === 'ok')
+			return { verdict: 'ok', detail: `HEAD ${headStatus}` };
+	} catch {
+		// fall through to GET
+	}
+	try {
+		const status = await fetchStatus(url, 'GET');
+		return { verdict: classifyExternalStatus(status), detail: `GET ${status}` };
+	} catch (e) {
+		return { verdict: 'unreachable', detail: (e as Error).message };
+	}
+}
+
+function walkDocsFiles(root: string): Map<string, string> {
+	const files = new Map<string, string>();
+	const walk = (dir: string) => {
+		for (const entry of readdirSync(join(root, dir), { withFileTypes: true })) {
+			const rel = posix.join(dir, entry.name);
+			if (entry.isDirectory()) walk(rel);
+			else if (entry.name.endsWith('.md')) files.set(rel, readFileSync(join(root, rel), 'utf8'));
+		}
+	};
+	walk(DOCS_DIR);
+	return files;
+}
+
+function readCache(): Record<string, number> {
+	try {
+		return JSON.parse(readFileSync(CACHE_PATH, 'utf8')) as Record<string, number>;
+	} catch {
+		return {};
+	}
+}
+
+function writeCache(cache: Record<string, number>): void {
+	try {
+		mkdirSync(dirname(CACHE_PATH), { recursive: true });
+		writeFileSync(CACHE_PATH, JSON.stringify(cache));
+	} catch {
+		// Cache is an optimization; a worktree layout without .git/ just re-probes.
+	}
+}
+
+async function main(): Promise<void> {
+	const staged = execSync('git diff --cached --name-only', { encoding: 'utf8' })
+		.split('\n')
+		.filter(Boolean);
+	const stagedDocs = staged.filter((f) => /^docs\/.*\.md$/.test(f));
+	if (stagedDocs.length === 0) return;
+
+	const files = walkDocsFiles(process.cwd());
+	const problems = checkDocsTree(files, (p) => existsSync(join(process.cwd(), p)));
+	if (problems.length > 0) {
+		console.error(`\ncommit rejected: ${problems.length} broken docs link(s):\n`);
+		for (const p of problems) console.error(`  ${p}`);
+		console.error(
+			'\nFix the link or its target. Internal links are checked across the whole docs tree,',
+		);
+		console.error('so a renamed or deleted page must take its inbound links with it.\n');
+		process.exit(1);
+	}
+
+	// External URLs: staged files only, successes cached for a week.
+	const cache = readCache();
+	const now = Date.now();
+	const urls = new Map<string, string>();
+	for (const f of stagedDocs) {
+		const content = files.get(f);
+		if (!content) continue; // staged deletion
+		for (const { target, line } of extractLinks(content)) {
+			if (!/^https?:\/\//.test(target)) continue;
+			if (isSkippedExternalUrl(target) || selfRepoPath(target) !== null) continue;
+			if (now - (cache[target] ?? 0) < CACHE_TTL_MS) continue;
+			if (!urls.has(target)) urls.set(target, `${f}:${line}`);
+		}
+	}
+
+	const queue = [...urls.entries()];
+	const broken: string[] = [];
+	const warnings: string[] = [];
+	await Promise.all(
+		Array.from({ length: Math.min(FETCH_CONCURRENCY, queue.length) }, async () => {
+			for (let item = queue.shift(); item !== undefined; item = queue.shift()) {
+				const [url, where] = item;
+				const probe = await probeExternalUrl(url);
+				if (probe.verdict === 'ok') cache[url] = now;
+				else if (probe.verdict === 'broken') broken.push(`  ${where} ${url} (${probe.detail})`);
+				else warnings.push(`  ${where} ${url} (${probe.detail})`);
+			}
+		}),
+	);
+	writeCache(cache);
+
+	for (const w of warnings) {
+		console.error(`warn: could not verify external link (not blocking):\n${w}`);
+	}
+	if (broken.length > 0) {
+		console.error(`\ncommit rejected: ${broken.length} dead external link(s):\n`);
+		for (const b of broken) console.error(b);
+		console.error('\nA 404/410 means the URL is wrong or gone - fix or remove the link.\n');
+		process.exit(1);
+	}
+}
+
+if (import.meta.main) {
+	main().catch((e) => {
+		// The guard must never invent a failure of its own - report and pass.
+		console.error(`warn: check-docs-links failed to run (not blocking): ${(e as Error).message}`);
+	});
+}


### PR DESCRIPTION
## What this does

Two commits: a docs realignment for the two-backend container architecture, and a new commit-msg guard that fails commits on broken docs links.

### Containers become their own section, ahead of Security

The `docs/containers/` pages (overview, Local Docker, Remote containers, Daytona) move from orders 25.1-25.4 to 17.5-17.8, so the section renders between "Chat & messaging apps" and "Security". URLs are path-derived, so no link changes; `docs-bundle.test.ts`'s section-header-once guard stays green because every section's orders remain contiguous.

### Stale claims fixed, verified against the code

- **`docs/security/container-isolation.md` rewritten** for both backends: the per-project pool (one run per container, never shared across projects), the tunnel into the container, split routing at the egress proxy (per-run token + destination guard), per-backend hardening (pids-limit/cap-drop/init are the Docker adapter's; a managed service's inter-sandbox isolation is the provider's), and an honest boundary note per backend.
- **"All traffic goes through the egress proxy" corrected** on `secret-protection.md`, `local-docker.md`, `meta-harness.md`, and the agent-facing Docker entry in `SANDBOX_AGENT_ENVIRONMENTS` - only hosts a credential or connector is scoped to are proxied (`tunnel/split-routing.ts`), and routing the rest direct is fail-closed for secrets.
- **Docker prerequisite scoped to the local backend** on `installation.md`, `cli.md`, `configuration.md`, `self-hosting.md`, `cloud.md`, `container-runtimes.md` - with `--sandbox-backend daytona` no daemon is needed (`openSandboxBackend` only pings Docker on the Docker branch). Each page now names the Settings -> Containers switch, and `configuration.md`'s managed-sandbox section is repaired (garbled sentence; it claimed no runtime switch exists and that the key stays out of the vault - both contradicted by `sandbox/backend-store.ts`).
- **Env-var semantics stated precisely**: the flags seed a brand-new instance only; the first startup records the choice and later restarts warn-and-ignore a disagreeing flag (`resolveStartupBackend`), so `containers/overview.md`'s startup section no longer reads as if env vars switch an existing instance. The provider key is documented as the one flag that stays live (credential rotation, never selection).
- **Pool-model wording** on `projects-and-teams.md`, `team-structure.md`, `remote/overview.md`, `ai-models.md` (local model endpoints resolve on local Docker only), `introduction.md`, and three precision fixes on `git-and-verified-commits.md`.
- **Internal docs realigned**: `architecture.md` section 8's opener and section 9's "Git vs API" still described SSH git transport; both now match the HTTPS-with-placeholder transport (`buildGitRemoteUrl`). AGENTS.md's Credentials bullet and the stale Docker-prerequisite clause in its test rules likewise.

### New: `scripts/check-docs-links.ts` in `.husky/commit-msg`

Fires only when a commit stages `docs/**/*.md`:

- **Internal links block deterministically, checked across the whole tree** (a rename/delete breaks *other* files' links): `/docs/...` pages, `#anchors` (GitHub-slugger compatible, validated against the tree's real anchors), relative paths, and `github.com/hezo-ai/hezo/{blob,raw,tree}/main/<path>` links checked against the worktree - so renaming an `agents/` role doc can no longer strand a docs link.
- **External URLs are probed for staged files only** (browser UA, HEAD then GET, 7-day success cache in `.git/`). Only a definitive 404/410 blocks. Probing all 57 current URLs showed why: `console.x.ai` and `platform.openai.com/api-keys` answer 403 to any automated client while loading fine in a browser, and `platform.deepseek.com` refuses HEAD but answers GET - so bot walls, timeouts and offline machines warn instead of wedging the commit, and no bypass env var is needed.
- `packages/server/test/docs-links.test.ts` unit-tests the pure functions and re-runs the whole-tree internal check hermetically, so CI catches what a bypassed hook would have. AGENTS.md documents the hook and adds the mirrored-surfaces row.

## Verification

- `docs-links` (11), `docs-bundle` (4), `docs-terminology` (2), `docs-ack-hook` (11) tests pass; `bun run typecheck` and `biome check` clean; both commits went through the full pre-commit (biome, typecheck, build) and commit-msg (commitlint, ack hooks, link check) chain, with the link guard exercised for real on commit 1.
- The live hezo.ai pages refresh with the next release. One assumption to confirm on the website side: the site derives sidebar/section order from page `order` frontmatter as the embedded bundle does - if the website repo hardcodes its nav, it needs the matching one-line change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEzDk8aJfK81hZ2WB5Xbvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEzDk8aJfK81hZ2WB5Xbvj)_