### PR TITLE
fix(containers): stop one project's idle containers starving every other

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -53,7 +53,7 @@ manager (agents bring their own models and runtimes).
 | Realtime | WebSocket row-change events → client invalidates React Query keys |
 | Agent interface | MCP (Streamable HTTP) at `POST /mcp` via `@modelcontextprotocol/sdk` |
 | Crypto | AES-256-GCM at rest; master key held in memory only |
-| Containers | Docker Engine API or a managed sandbox service, behind one `ContainerEngine` seam — a pool per project, one run per container, started on demand and retired after a fixed 2-minute idle window (15 for a live assistant chat) |
+| Containers | Docker Engine API or a managed sandbox service, behind one `ContainerEngine` seam — a pool per project, one run per container, started on demand and retired per member after a fixed 2-minute idle window (15 for a live assistant chat), or sooner when another project needs the memory |
 
 **Monorepo** — Bun workspaces + Turborepo. **Three** packages plus a root `agents/`
 tree:
@@ -1635,9 +1635,9 @@ removing them.
 **A container found stopped-but-present is a suspended member, not a lost one**, and this is
 the case a managed backend produces routinely: Daytona's `autoStopInterval` reclaims a sandbox
 that has seen no toolbox traffic for ten minutes, which is exactly what an idle pool member
-looks like. Hezo's own idle pass cannot pre-empt it - `stopIdleContainers` retires a pool only
-when the whole *project* is idle, so a busy project's unused members are reclaimed by the
-provider first. The member's writable layer is intact, so the repair is to record `suspended`
+looks like. Hezo's own idle pass narrows the window but does not close it - the surplus pass
+retires a working project's idle members on their own clock (below), but a member inside that
+window can still be reclaimed by the provider first. The member's writable layer is intact, so the repair is to record `suspended`
 and let the ladder resume it in place (about a second) rather than discard the row and pay to
 build a replacement while the sandbox lingers as an orphan. Three places converge on this:
 `syncContainerStatus`'s running→stopped branch, the memory-limit auto-stop, and the `reuse`
@@ -1654,6 +1654,50 @@ exists to remove, and it is not hypothetical - it is how an idle member being au
 killed a run executing in a healthy sibling container. Two sources emit transitions in this
 one shape: `syncAllContainerStatuses` answers for the container `projects.container_id` names,
 and `reconcilePoolMembers` answers for every other member, which that sync cannot see at all.
+
+**The memory budget is instance-wide, so no project may sit on a share of it that it is not
+using.** Two mechanisms enforce that, and both exist because a container is pinned to its
+project for life - `container_pool_members.project_id` is set once at provision and nothing
+reassigns it, since the container is built around that project's `/workspace` bind mount,
+clone and git identity. Unused memory therefore cannot be handed over; the container has to go
+and a fresh one be built.
+
+- **Surplus idle retirement** (`planSurplusIdleRetirement`, run by `JobManager` after the
+  whole-project pass). `findIdleContainerCandidates` asks a project-shaped question - "has
+  everything here gone quiet?" - and a project running two tasks alongside two idle
+  containers never answers yes, so those two were charged to the budget in full for as long
+  as the project kept working and no other project could reach them. That is a permanently
+  wedged instance, not a slow one. `findStaleIdleMembers` asks the member-shaped question
+  instead, clocked on `last_released_at` (made total and indexed by migration 053; the old
+  clock was `projects.container_last_started_at`, so starting any container reset the timer
+  for every idle sibling). It fires only for projects that have a `busy` member - a fully
+  idle project still belongs to the whole-project pass, which keeps one member suspended for
+  a warm restart.
+- **Cross-project reclaim** (`planCrossProjectReclaim`, the `reclaim` rung of
+  `selectPoolMember`). Closes the gap in between: rather than queue behind memory a
+  neighbour is demonstrably not using, a blocked acquire retires enough of other projects'
+  idle members to cover its shortfall. All-or-nothing (freeing part of the shortfall helps
+  nobody and has destroyed a warm container to do it), only as much as the shortfall,
+  hoarder-first then longest-idle, and floored at `CONTAINER_RECLAIM_MIN_IDLE_SEC` so a
+  project mid-burst is not stripped of a container it is about to reuse - which is also what
+  stops two starved projects reclaiming from each other in a loop.
+
+**Both dispatch gates count reclaimable memory as headroom, and must.** The gate runs *before*
+the pool, so leaving it out meant the run was skipped as `InstanceAtCapacity` and the reclaim
+rung never ran - dead code behind a closed door. `getActiveContainers` returns
+`reclaimableMemoryGbByProject`, read through `reclaimableForOthers`; keyed by project because
+the figure is only meaningful relative to who is asking, and a project's own idle members reach
+it through the reuse rung instead. `JobManager.isContainerCapacityBlocked` and
+`isContainerCapacityBlockedInDb` are a deliberate pair and must not drift.
+
+**Reclaim runs outside the requester's lifecycle lock.** `withContainerLifecycleLock` is keyed
+per project, and reclaim takes the *victims'* locks - so a requester holding its own while
+doing that is exactly the cycle two simultaneously-starved projects need to deadlock. Hence
+`acquireRunContainer` takes the lock **per attempt** rather than around its loop: the `reclaim`
+decision returns out of the locked section, reclaim runs between attempts under a single
+process-wide `reclaimLock`, and the loop re-decides against what was actually freed. The
+process-wide serialisation is the other half - two requesters reading the same idle containers
+as their headroom would each retire enough for themselves and take twice what either needed.
 
 **A member is reusable only if it was built to the cap it would be built to now.** The cap
 is a memory *guarantee* the run is sized, budgeted and enforced against, and no backend can
@@ -2540,8 +2584,8 @@ store, and `sandbox/recovery.ts` is the seam between them.
 
 **The pin and the run failure are decided by different things**, which is the point of the vault.
 `setPoolMemberUnpushedFlag` (`services/sandbox/pool-db.ts`) sets
-`container_pool_members.has_unpushed_commits`, which `planIdleShutdown` excludes from both suspend
-and destroy — but it is now set from whether the copy-out **failed**, not from whether the work
+`container_pool_members.has_unpushed_commits`, which `planIdleShutdown` excludes from destroy and
+*prefers* for suspend (suspending keeps the writable layer, so the pin costs no memory) — but it is now set from whether the copy-out **failed**, not from whether the work
 reached `origin`. A vaulted run releases its container (the work exists in two places) and still
 fails (it never reached the remote); a run whose bundle could not be built, was oversized, or could
 not be moved keeps the pin, failing closed. The scan still distinguishes "no unpushed work" from

--- a/docs/containers/local-docker.md
+++ b/docs/containers/local-docker.md
@@ -32,7 +32,8 @@ one container's worth reserved for the assistant chat.**
 Swap counts in full, because a container sits idle between runs rather than working
 continuously. The remainder is the budget all project containers share. A run whose
 container will not fit in what is left waits in the queue and starts as memory frees up;
-the assistant chat always starts.
+the assistant chat always starts. No project can hold a share of that budget it is not
+using - see [how the budget is shared](/docs/containers/overview#how-much-can-run-at-once).
 
 You can set the total explicitly in **Settings -> Containers** if you would rather keep
 more headroom, and a project that needs a bigger container than the 2 GB default can raise

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -48,6 +48,12 @@ containers. That window is fixed rather than configurable: its only job is to ke
 container warm between one run and the next in the same project. Because containers do not
 stay up between bursts, they are not a place to run a long-lived dev or preview server.
 
+**Each container is timed separately.** A project running several tasks at once holds one
+container per run, and any of them that finishes and then sits idle past the window is
+retired on its own - the project does not have to fall completely quiet first. So a busy
+project gives its unused memory back while it keeps working, rather than holding it until
+the last task ends.
+
 **An open assistant chat gets a longer window.** A pause between chat messages is you
 reading a reply, not an idle project, so a container serving a live chat session is kept
 up for about fifteen minutes after the last message rather than a couple of minutes. That
@@ -175,6 +181,15 @@ consume:
   and starts as memory frees up; the assistant chat always starts. There is no separate
   limit on the *number* of containers: how many fit follows from this budget and the cap
   below.
+
+  The budget is shared across every project, and no project can sit on a share of it that
+  it is not using. A container belongs to the project it was built for and is never handed
+  to another - it is built around that project's checkout - so when a run cannot fit,
+  Hezo retires an idle container belonging to some other project and builds a fresh one
+  for the waiting run. Containers that have only just gone idle are left alone, so a
+  project working through a burst of tasks keeps its containers warm between them. Where
+  more than one project is holding idle containers, the one holding the most gives one up
+  first.
 - **RAM cap per container** - the memory limit applied to every container (2 GB by
   default). A project that needs more can override it on its own Containers page. A
   container over its cap is stopped, or has its biggest process killed by the kernel,

--- a/docs/containers/remote/overview.md
+++ b/docs/containers/remote/overview.md
@@ -118,6 +118,16 @@ of the system is sized against that promise.
   suspended sandbox still counts against your provider account's memory and disk limits, so
   on a small plan a handful of idle projects can hold the whole allowance. If runs start
   failing to provision while nothing appears to be running, that is what to look at.
+
+  A container holding commits that have not reached the remote is always suspended rather
+  than destroyed, whichever of these retires it, so the work is never the thing that gets
+  thrown away.
+- **A waiting run can retire another project's idle sandbox.** Hezo's own budget is shared,
+  so when a run does not fit, an idle container elsewhere is retired and a fresh one built
+  for the waiting run. That costs a cold start on the project that gave one up, and on a
+  managed backend it is a sandbox destroyed and later recreated rather than resumed. If you
+  see more provisioning than you expect, the memory budget is set tighter than the work you
+  are asking the instance to do.
 - **The first container of a project is slower to start** than a local one, because the
   provider builds it. Later ones start in a few seconds.
 - **A local model provider is not reachable.** Pointing an AI provider at

--- a/packages/server/migrations/053_container_pool_idle_clock.sql
+++ b/packages/server/migrations/053_container_pool_idle_clock.sql
@@ -1,0 +1,45 @@
+-- Give each pool member its own idle clock, so idle capacity can be reclaimed
+-- without waiting for its whole project to fall quiet.
+--
+-- Idle retirement used to be decided per *project*: a project was a candidate
+-- only when it had no queued or running run, no recently finished run, no
+-- dispatchable wakeup and no live chat session. A project with two busy
+-- containers and two idle ones therefore never qualified, and those two idle
+-- containers held their full memory against the instance budget for as long as
+-- the project kept working - starving every other project, which saw only "at
+-- its active-container limit". The clock made it worse: it was
+-- `projects.container_last_started_at`, so starting any container reset the
+-- idle timer for every idle sibling.
+--
+-- `last_released_at` is already the right clock and is already written on every
+-- release (`releasePoolMember`) and on boot-time reclaim
+-- (`reclaimBusyPoolMembers`). What it was not is dependable - nullable, and
+-- absent on a member that was provisioned but never served a run. This makes it
+-- total, so the idle scan and the reclaim-candidate query can both read a plain
+-- column instead of a COALESCE expression that no index can serve.
+
+-- A member that never served a run has no release stamp. Its creation is the
+-- honest floor: it has been available since the moment it existed, which is
+-- exactly what the idle clock is asking. Done before the NOT NULL below, in the
+-- same transaction, so no row can fail the constraint.
+UPDATE container_pool_members
+   SET last_released_at = created_at
+ WHERE last_released_at IS NULL;
+
+-- New rows are inserted by `upsertPoolMember`, which does not name this column.
+-- The default is what keeps the constraint true for them without teaching every
+-- insert site about a field that only the release path has an opinion on.
+ALTER TABLE container_pool_members
+    ALTER COLUMN last_released_at SET DEFAULT now();
+
+ALTER TABLE container_pool_members
+    ALTER COLUMN last_released_at SET NOT NULL;
+
+-- Serves both new scans: the once-a-minute sweep for members idle past the
+-- window, and the reclaim-candidate query on the acquire path when a project's
+-- next container does not fit the budget. Both filter on state, order by
+-- `last_released_at` and skip the chat's pinned member - which is excluded from
+-- the instance memory budget anyway, so reclaiming one would free nothing.
+CREATE INDEX idx_container_pool_members_idle
+    ON container_pool_members (state, last_released_at)
+    WHERE NOT reserved_for_chat;

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
 	CHAT_IDLE_TIMEOUT_MIN,
+	CONTAINER_RECLAIM_MIN_IDLE_SEC,
 	ContainerStatus,
 	HeartbeatRunStatus,
 	TEST_CONTAINER_LABEL_KEY,
@@ -37,9 +38,14 @@ import { ContainerGitExecutor, mintGitOpScopeId } from './git-executor';
 import { resolveAgentBaseImage } from './image-registry';
 import type { LogStreamBroker } from './log-stream-broker';
 import { ensureProjectRepos } from './repo-sync';
-import { getActiveContainers, projectContainerMemoryGb } from './run-concurrency';
+import {
+	getActiveContainers,
+	projectContainerMemoryGb,
+	reclaimableForOthers,
+} from './run-concurrency';
 import { DOCKER_HOST_GATEWAY_ENTRY } from './sandbox/endpoints';
 import { INSTANCE_LABEL, PROJECT_LABEL, TEAM_LABEL } from './sandbox/labels';
+import { planCrossProjectReclaim } from './sandbox/pool';
 import {
 	type ContainerAllocation,
 	claimPoolMember,
@@ -865,11 +871,158 @@ export async function ensureProjectContainerRunning(
 export class PoolCapacityError extends Error {
 	constructor(projectId: string) {
 		super(
-			`no container available for project ${projectId} and its next container ` +
-				`does not fit the instance memory budget`,
+			`no container available for project ${projectId}: its next container does not fit ` +
+				`the instance memory budget, and no other project holds idle capacity to reclaim`,
 		);
 		this.name = 'PoolCapacityError';
 	}
+}
+
+/**
+ * Serializes cross-project reclaim across the whole process.
+ *
+ * Two starved projects deciding at the same instant would otherwise both read
+ * the same idle containers as their headroom and both retire enough for
+ * themselves, taking twice what either needed. One at a time, and the second
+ * re-decides against what the first actually left.
+ *
+ * Deliberately *not* the per-project lifecycle lock: this is held while taking
+ * the victims' locks, and a requester holding its own lock at the same time is
+ * how two reclaims in opposite directions deadlock. See {@link acquireRunContainer}
+ * for the other half of that arrangement.
+ */
+const reclaimLock = new Map<string, Promise<unknown>>();
+
+interface ReclaimCandidateRow {
+	container_id: string;
+	project_id: string;
+	slug: string;
+	team_id: string;
+	memory_bytes: string | number | null;
+	has_unpushed_commits: boolean;
+	idle_for_ms: string | number;
+}
+
+/**
+ * Retire other projects' idle containers until `needGb` is free, and say whether
+ * it worked.
+ *
+ * A container belongs to its project for life - it is built around that project's
+ * workspace mount, repo clone and git identity - so the only way one project's
+ * unused memory can serve another is for the container to go and a fresh one to
+ * be built. That is the whole reason this is a retirement and not a handover.
+ *
+ * Only ever reached from the `reclaim` rung of `selectPoolMember`, which is to
+ * say only when the alternative is a run that queues indefinitely. The choice of
+ * victims is {@link planCrossProjectReclaim}, which is pure and holds every rule
+ * about fairness, the idle floor and all-or-nothing.
+ */
+async function reclaimIdleCapacityForProject(
+	deps: ContainerDeps,
+	requestingProjectId: string,
+	requestingSlug: string,
+	needGb: number,
+): Promise<boolean> {
+	const { db } = deps;
+	return withKeyedLock(reclaimLock, 'global', async () => {
+		const rows = await db.query<ReclaimCandidateRow>(
+			// Served by `idx_container_pool_members_idle`. The requesting project is
+			// excluded: its own idle members are offered to it by the reuse rung long
+			// before this, so anything of its own still here is a member the ladder
+			// already refused.
+			`SELECT m.container_id, m.project_id, p.slug, p.team_id, m.memory_bytes,
+			        m.has_unpushed_commits,
+			        EXTRACT(EPOCH FROM (now() - m.last_released_at)) * 1000 AS idle_for_ms
+			   FROM container_pool_members m
+			   JOIN projects p ON p.id = m.project_id
+			  WHERE m.state = 'idle' AND NOT m.reserved_for_chat
+			    AND m.project_id <> $1
+			  ORDER BY m.last_released_at`,
+			[requestingProjectId],
+		);
+		if (rows.rows.length === 0) return false;
+
+		// One lookup per distinct project, not per member: the fallback only applies
+		// to a member whose allocation was never recorded, and the project set here
+		// is small.
+		const capGb = new Map<string, number>();
+		for (const row of rows.rows) {
+			if (row.memory_bytes === null && !capGb.has(row.project_id)) {
+				capGb.set(row.project_id, await projectContainerMemoryGb(db, row.project_id));
+			}
+		}
+
+		const plan = planCrossProjectReclaim(
+			rows.rows.map((row) => ({
+				containerId: row.container_id,
+				projectId: row.project_id,
+				memoryGb:
+					row.memory_bytes === null
+						? (capGb.get(row.project_id) ?? 0)
+						: Number(row.memory_bytes) / 1024 ** 3,
+				idleForMs: Number(row.idle_for_ms),
+				hasUnpushedCommits: row.has_unpushed_commits,
+			})),
+			needGb,
+			CONTAINER_RECLAIM_MIN_IDLE_SEC * 1000,
+		);
+		if (plan.freedGb === 0) return false;
+
+		const victims = new Map<string, ReclaimCandidateRow>();
+		for (const row of rows.rows) victims.set(row.container_id, row);
+		const byProject = new Map<string, { suspend: string[]; destroy: string[] }>();
+		const bucket = (projectId: string) => {
+			const existing = byProject.get(projectId);
+			if (existing) return existing;
+			const fresh = { suspend: [] as string[], destroy: [] as string[] };
+			byProject.set(projectId, fresh);
+			return fresh;
+		};
+		for (const c of plan.suspend) bucket(c.projectId).suspend.push(c.containerId);
+		for (const c of plan.destroy) bucket(c.projectId).destroy.push(c.containerId);
+
+		log.info(
+			`project ${ref(requestingSlug, requestingProjectId)} needs ${needGb.toFixed(1)} GB; ` +
+				`reclaiming ${plan.freedGb.toFixed(1)} GB from ${byProject.size} other project(s)`,
+		);
+
+		let reclaimedAny = false;
+		for (const [victimId, group] of byProject) {
+			const victim = victims.get([...group.suspend, ...group.destroy][0]);
+			if (!victim) continue;
+			try {
+				await withContainerLifecycleLock(victimId, async () => {
+					// Re-verify under the lock: a member claimed since the scan is serving a
+					// run now, and taking it would kill that run to start ours.
+					const live = await db.query<{ container_id: string }>(
+						`SELECT container_id FROM container_pool_members
+						  WHERE project_id = $1 AND state = 'idle' AND NOT reserved_for_chat
+						    AND container_id = ANY($2::text[])`,
+						[victimId, [...group.suspend, ...group.destroy]],
+					);
+					const stillIdle = new Set(live.rows.map((r) => r.container_id));
+					if (stillIdle.size === 0) return;
+					const retired = await executeRetirementPlan(
+						deps,
+						{ id: victimId, slug: victim.slug, team_id: victim.team_id },
+						{
+							suspend: group.suspend.filter((id) => stillIdle.has(id)),
+							destroy: group.destroy.filter((id) => stillIdle.has(id)),
+						},
+						{ reason: `reclaimed for ${ref(requestingSlug, requestingProjectId)}` },
+					);
+					if (retired > 0) reclaimedAny = true;
+				});
+			} catch (err) {
+				// One uncooperative victim must not sink the whole reclaim - the
+				// requester re-decides against whatever was actually freed.
+				log.warn(
+					`could not reclaim from project ${ref(victim.slug, victimId)}: ${(err as Error).message}`,
+				);
+			}
+		}
+		return reclaimedAny;
+	});
 }
 
 /** A container claimed for one run, and the handle that gives it back. */
@@ -934,34 +1087,47 @@ export async function acquireRunContainer(
 	workload: ContainerWorkload = 'task-run',
 ): Promise<AcquiredContainer> {
 	const { db, docker } = deps;
-	const containerId = await withContainerLifecycleLock(projectId, async () => {
-		// Adopt a container the project already names but the pool has no row for.
-		// `projects.container_*` stays authoritative until every lifecycle call site
-		// has moved over (migration 049 is additive), so during that window a live
-		// container can be recorded in one place and not the other. Reading only the
-		// pool would provision a second container beside a perfectly good one -
-		// which is not a fallback path but the two representations of one container
-		// being reconciled, the same UNION `getActiveContainers` already does.
-		await adoptUnpooledContainer(deps, projectId);
-		// A pin the chat already holds is its own rung, and it has to come before
-		// the ladder rather than inside it: `selectPoolMember` excludes reserved
-		// members by design, so a session reconnecting would otherwise be handed a
-		// *different* container from the one it parked on - losing the filesystem
-		// its conversation was built against, and pinning a second container beside
-		// the one it already holds.
-		if (workload === 'chat') {
-			const existing = await reusableChatMember(
-				deps,
-				projectId,
-				memoryLimitBytes(await projectContainerMemoryGb(db, projectId)),
-			);
-			if (existing) return existing;
-		}
-		// Bounded: each iteration either claims a member or removes one from
-		// contention (a lost race retries against a pool one member smaller, and a
-		// recycle pass clears every mismatched member at once), so this cannot spin.
-		// The cap is the pool's own size, not a timeout.
-		for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS; attempt++) {
+	let bootstrapped = false;
+
+	/**
+	 * One pass of the ladder, under the project's lifecycle lock.
+	 *
+	 * The lock is taken per attempt rather than around the loop so the `reclaim`
+	 * rung can act *outside* it. Reclaim takes other projects' lifecycle locks, and
+	 * a requester still holding its own while doing so is exactly the cycle two
+	 * simultaneously-starved projects need to deadlock each other.
+	 */
+	const attemptAcquire = async (): Promise<
+		| { kind: 'acquired'; containerId: string }
+		| { kind: 'retry' }
+		| { kind: 'reclaim'; needGb: number }
+	> =>
+		withContainerLifecycleLock(projectId, async () => {
+			if (!bootstrapped) {
+				bootstrapped = true;
+				// Adopt a container the project already names but the pool has no row for.
+				// `projects.container_*` stays authoritative until every lifecycle call site
+				// has moved over (migration 049 is additive), so during that window a live
+				// container can be recorded in one place and not the other. Reading only the
+				// pool would provision a second container beside a perfectly good one -
+				// which is not a fallback path but the two representations of one container
+				// being reconciled, the same UNION `getActiveContainers` already does.
+				await adoptUnpooledContainer(deps, projectId);
+				// A pin the chat already holds is its own rung, and it has to come before
+				// the ladder rather than inside it: `selectPoolMember` excludes reserved
+				// members by design, so a session reconnecting would otherwise be handed a
+				// *different* container from the one it parked on - losing the filesystem
+				// its conversation was built against, and pinning a second container beside
+				// the one it already holds.
+				if (workload === 'chat') {
+					const existing = await reusableChatMember(
+						deps,
+						projectId,
+						memoryLimitBytes(await projectContainerMemoryGb(db, projectId)),
+					);
+					if (existing) return { kind: 'acquired' as const, containerId: existing };
+				}
+			}
 			const [active, requestMemoryGb] = await Promise.all([
 				getActiveContainers(db, deps.docker),
 				projectContainerMemoryGb(db, projectId),
@@ -976,11 +1142,17 @@ export async function acquireRunContainer(
 				// reserve for the chat twice and refuse it on a small host. An
 				// unreachable ceiling states that here without a second ladder.
 				workload === 'chat'
-					? { usedMemoryGb: 0, budgetGb: Number.POSITIVE_INFINITY, requestMemoryGb: 0 }
+					? {
+							usedMemoryGb: 0,
+							budgetGb: Number.POSITIVE_INFINITY,
+							requestMemoryGb: 0,
+							reclaimableMemoryGb: 0,
+						}
 					: {
 							usedMemoryGb: active.usedMemoryGb,
 							budgetGb: active.budgetGb,
 							requestMemoryGb,
+							reclaimableMemoryGb: reclaimableForOthers(active, projectId),
 						},
 				// The cap every member must have been built to, stated for every
 				// workload - unlike the budget figure above, which chat zeroes out.
@@ -988,6 +1160,8 @@ export async function acquireRunContainer(
 			);
 
 			if (decision.kind === 'queue') throw new PoolCapacityError(projectId);
+			// Handled by the caller, outside this lock. See `attemptAcquire`.
+			if (decision.kind === 'reclaim') return { kind: 'reclaim' as const, needGb: decision.needGb };
 
 			if (decision.kind === 'recycle') {
 				const proj = await loadProjectRow(db, projectId);
@@ -1001,14 +1175,16 @@ export async function acquireRunContainer(
 					);
 					await destroyContainer(deps, projectId, proj.slug, proj.team_id, stale.id);
 				}
-				continue;
+				return { kind: 'retry' as const };
 			}
 
 			if (decision.kind === 'create') {
 				const proj = await loadProjectRow(db, projectId);
 				const id = await provisionContainer(deps, proj, proj.team_slug);
-				if (await takeMember(deps, projectId, id, taskId, workload)) return id;
-				continue;
+				if (await takeMember(deps, projectId, id, taskId, workload)) {
+					return { kind: 'acquired' as const, containerId: id };
+				}
+				return { kind: 'retry' as const };
 			}
 
 			const member = decision.member;
@@ -1026,7 +1202,7 @@ export async function acquireRunContainer(
 				const info = await docker.inspectContainer(member.id);
 				if (info === null) {
 					await removePoolMember(db, member.id);
-					continue;
+					return { kind: 'retry' as const };
 				}
 				if (!info.State.Running) {
 					// Present but not up: a suspended member, not a lost one. Recording
@@ -1034,7 +1210,7 @@ export async function acquireRunContainer(
 					// in place - about a second, against discarding a warm filesystem
 					// and paying to build a replacement.
 					await setPoolMemberState(db, member.id, 'suspended');
-					continue;
+					return { kind: 'retry' as const };
 				}
 			}
 			if (decision.kind === 'resume') {
@@ -1046,15 +1222,37 @@ export async function acquireRunContainer(
 					// The container is gone from under the row. Drop it and re-decide
 					// rather than handing a run an id the engine no longer knows.
 					await removePoolMember(db, member.id);
-					continue;
+					return { kind: 'retry' as const };
 				}
 				await setPoolMemberState(db, member.id, 'idle');
 				await markProjectContainerStarted(deps, projectId, member.id);
 			}
-			if (await takeMember(deps, projectId, member.id, taskId, workload)) return member.id;
+			if (await takeMember(deps, projectId, member.id, taskId, workload)) {
+				return { kind: 'acquired' as const, containerId: member.id };
+			}
+			return { kind: 'retry' as const };
+		});
+
+	// Bounded: each iteration either claims a member, removes one from contention
+	// (a lost race retries against a pool one member smaller, and a recycle pass
+	// clears every mismatched member at once) or frees memory elsewhere, so this
+	// cannot spin. The cap is the pool's own size, not a timeout.
+	let containerId: string | null = null;
+	for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS && containerId === null; attempt++) {
+		const step = await attemptAcquire();
+		if (step.kind === 'acquired') {
+			containerId = step.containerId;
+		} else if (step.kind === 'reclaim') {
+			const proj = await loadProjectRow(db, projectId);
+			// Nothing reclaimable after all - another requester got there first, or
+			// every candidate was claimed between the decision and the lock. Queue
+			// rather than spin: the dispatcher requeues and the next tick re-decides.
+			if (!(await reclaimIdleCapacityForProject(deps, projectId, proj.slug, step.needGb))) {
+				throw new PoolCapacityError(projectId);
+			}
 		}
-		throw new PoolCapacityError(projectId);
-	});
+	}
+	if (containerId === null) throw new PoolCapacityError(projectId);
 
 	let released = false;
 	return {
@@ -1551,6 +1749,147 @@ export async function isProjectIdleForContainerStop(
 		projectId,
 	]);
 	return res.rows.length > 0;
+}
+
+/**
+ * Idle members of projects that are *working*, on each member's own clock.
+ *
+ * The query above asks a project-shaped question - "has everything here gone
+ * quiet?" - and a project with two busy containers and two idle ones never
+ * answers yes, so its idle members were charged to the instance memory budget in
+ * full for as long as it kept working and no other project could reach that
+ * memory. This asks the member-shaped question instead, which is the one that
+ * bounds the budget.
+ *
+ * The `EXISTS` restricts it to working projects on purpose: a fully idle project
+ * belongs to {@link findIdleContainerCandidates}, which retires its pool as a
+ * unit and keeps one member suspended for a warm restart. Overlapping the two
+ * would take that warm member away.
+ *
+ * The chat's pinned member is excluded - it is not counted against the budget, so
+ * retiring it frees nothing. Served by `idx_container_pool_members_idle`.
+ */
+const STALE_IDLE_MEMBER_SQL = (extraSql: string, limitSql: string) => `
+	SELECT m.container_id, m.project_id, p.slug, p.team_id
+	  FROM container_pool_members m
+	  JOIN projects p ON p.id = m.project_id
+	 WHERE m.state = 'idle'
+	   AND NOT m.reserved_for_chat
+	   AND m.last_released_at < now() - ($1 * interval '1 minute')
+	   AND EXISTS (
+	     SELECT 1 FROM container_pool_members b
+	      WHERE b.project_id = m.project_id AND b.state = 'busy'
+	   )
+	   ${extraSql}
+	 ORDER BY m.last_released_at
+	 ${limitSql}
+`;
+
+export interface StaleIdleMember {
+	container_id: string;
+	project_id: string;
+	slug: string;
+	team_id: string;
+}
+
+/** Surplus idle members across the instance, oldest first. */
+export async function findStaleIdleMembers(
+	db: Db,
+	timeoutMin: number,
+	limit: number,
+): Promise<StaleIdleMember[]> {
+	const res = await db.query<StaleIdleMember>(STALE_IDLE_MEMBER_SQL('', 'LIMIT $2'), [
+		timeoutMin,
+		limit,
+	]);
+	return res.rows;
+}
+
+/**
+ * Re-run the scan for one project immediately before retiring anything, under
+ * that project's lifecycle lock. A member claimed and released again between the
+ * batch scan and the lock is idle once more but no longer *stale*, and retiring
+ * it there would take a container the project is actively cycling through.
+ */
+export async function findStaleIdleMembersInProject(
+	db: Db,
+	projectId: string,
+	timeoutMin: number,
+): Promise<StaleIdleMember[]> {
+	const res = await db.query<StaleIdleMember>(STALE_IDLE_MEMBER_SQL('AND m.project_id = $2', ''), [
+		timeoutMin,
+		projectId,
+	]);
+	return res.rows;
+}
+
+/**
+ * Carry out a retirement plan against one project's containers: suspend some,
+ * destroy the rest.
+ *
+ * The single executor behind all three callers - the whole-project idle pass, the
+ * surplus-member pass, and cross-project reclaim on the acquire path. They differ
+ * only in how the plan was chosen; what it takes to retire a container safely
+ * (park any live chat session first, clear a project row still naming a destroyed
+ * container) is identical, and duplicating it is how one of them would quietly
+ * stop parking sessions.
+ *
+ * Returns how many containers were actually retired, for the caller's log line.
+ */
+export async function executeRetirementPlan(
+	deps: ContainerDeps,
+	project: { id: string; slug: string; team_id: string },
+	plan: { suspend: readonly string[]; destroy: readonly string[] },
+	opts: {
+		/** Why, for the log line: `idle`, `surplus idle`, `reclaimed for another project`. */
+		reason: string;
+		/** Park a live assistant session before its container goes. Omitted where none can exist. */
+		parkSession?: (containerId: string) => Promise<void>;
+	},
+): Promise<number> {
+	const { db, docker } = deps;
+
+	// Park any live assistant session on these containers *first*, while they
+	// are still up: closing the tunnel deliberately deletes the provider's PTY
+	// session on a reachable sandbox and skips the tunnel's unrequested-death
+	// path, so the session ends up `suspended` (resumable in place) instead of
+	// `crashed`. Best-effort - a park that fails must not strand the pool.
+	for (const containerId of [...plan.destroy, ...plan.suspend]) {
+		await opts.parkSession?.(containerId).catch((e) => {
+			log.warn(
+				`could not park the assistant session on ${ref(project.slug, containerId.slice(0, 12))} before retiring it: ${(e as Error).message}`,
+			);
+		});
+	}
+
+	let retired = 0;
+	for (const containerId of plan.destroy) {
+		// Destroyed, not stopped: its filesystem is reproducible from the git
+		// remote, and a container kept beyond the one suspended member is
+		// storage nobody asked for.
+		log.info(
+			`project ${ref(project.slug, project.id)} retiring ${opts.reason} container ${ref(project.slug, containerId.slice(0, 12))}`,
+		);
+		await docker.removeContainer(containerId, true).catch(() => undefined);
+		await removePoolMember(db, containerId);
+		// The project row may still name this container - `provisionContainer`
+		// points `container_id` at the newest one, which is exactly the surplus
+		// the plan destroys first. Left behind, the row names a container that
+		// no longer exists, and the next status sync reads that as the
+		// project's container having died: a spurious error on a project whose
+		// remaining containers are perfectly healthy.
+		await clearProjectContainerIfNamed(db, project.id, containerId);
+		retired++;
+	}
+
+	for (const containerId of plan.suspend) {
+		log.info(
+			`project ${ref(project.slug, project.id)} ${opts.reason} — suspending container ${ref(project.slug, containerId.slice(0, 12))}`,
+		);
+		await stopContainerGracefully(deps, project.id, project.slug, project.team_id, containerId);
+		retired++;
+	}
+	return retired;
 }
 
 /**

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -930,6 +930,15 @@ async function reclaimIdleCapacityForProject(
 			// excluded: its own idle members are offered to it by the reuse rung long
 			// before this, so anything of its own still here is a member the ladder
 			// already refused.
+			//
+			// Deliberately no LIMIT. The row count is already bounded by the memory
+			// budget itself - every row here is a *running* container, so there can
+			// never be more than `max_container_memory_gb` divided by the smallest
+			// per-container cap, which is tens at the outside and three on a default
+			// host. A LIMIT could only truncate below that, and truncating is the one
+			// thing that would break the all-or-nothing rule silently: the plan would
+			// read as "cannot cover the shortfall" while the memory to cover it was
+			// sitting outside the window.
 			`SELECT m.container_id, m.project_id, p.slug, p.team_id, m.memory_bytes,
 			        m.has_unpushed_commits,
 			        EXTRACT(EPOCH FROM (now() - m.last_released_at)) * 1000 AS idle_for_ms

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -54,11 +54,15 @@ import {
 	type ContainerTransition,
 	destroyContainer,
 	ensureProjectContainerRunning,
+	executeRetirementPlan,
 	failProjectRuns,
 	findIdleContainerCandidates,
+	findStaleIdleMembers,
+	findStaleIdleMembersInProject,
 	isProjectIdleForContainerStop,
 	provisionContainer,
 	reconcilePoolMembers,
+	type StaleIdleMember,
 	stopContainerGracefully,
 	syncAllContainerStatuses,
 	verifyContainerWorkspace,
@@ -79,6 +83,7 @@ import {
 	getActiveContainers,
 	isTaskBusyInDb,
 	projectContainerMemoryGb,
+	reclaimableForOthers,
 	sumProjectContainerMemoryGb,
 } from './run-concurrency';
 import { reclaimBusyPoolMembers } from './sandbox/pool-db';
@@ -1436,10 +1441,8 @@ export class JobManager {
 	 * exceeded.
 	 */
 	private async isContainerCapacityBlocked(projectId: string | null): Promise<CapacityVerdict> {
-		const { budgetGb, usedMemoryGb, projectsWithSpareContainer } = await getActiveContainers(
-			this.deps.db,
-			this.deps.docker,
-		);
+		const active = await getActiveContainers(this.deps.db, this.deps.docker);
+		const { budgetGb, usedMemoryGb, projectsWithSpareContainer } = active;
 		// Returned alongside the verdict, not just consumed here: the dispatch that
 		// follows has to know whether it is about to *create* a container, and it
 		// used to answer that from `projects.container_status` instead. Those two
@@ -1467,7 +1470,14 @@ export class JobManager {
 		const requestGb = projectId
 			? await projectContainerMemoryGb(this.deps.db, projectId)
 			: await getDefaultRamCapPerContainerGb(this.deps.db);
-		return { blocked: usedMemoryGb + pendingGb + requestGb > budgetGb, hasSpareContainer };
+		// Idle containers held by *other* projects are headroom, because the acquire
+		// path can retire them to make room. Leaving them out here is what stopped a
+		// starved run ever reaching that path: the dispatch was skipped as
+		// `InstanceAtCapacity` and the reclaim rung never ran. The same figure is
+		// added in `isContainerCapacityBlockedInDb`, which is this check's stateless
+		// twin and must not drift from it.
+		const headroomGb = budgetGb + reclaimableForOthers(active, projectId);
+		return { blocked: usedMemoryGb + pendingGb + requestGb > headroomGb, hasSpareContainer };
 	}
 
 	private acquirePendingContainerStart(projectId: string): void {
@@ -3261,6 +3271,11 @@ export class JobManager {
 		if (candidates.length > 0) {
 			log.debug(`Idle-container pass: ${stopped}/${candidates.length} candidate(s) stopped`);
 		}
+
+		// After the whole-project pass, not before: a project that has gone
+		// entirely quiet should be retired as a unit, keeping one member suspended
+		// for a warm restart, rather than having its members picked off first.
+		await this.retireSurplusIdleContainers();
 	}
 
 	/**
@@ -3286,11 +3301,9 @@ export class JobManager {
 		team_id: string;
 		container_id: string;
 	}): Promise<number> {
-		const { db, docker } = this.deps;
+		const { db } = this.deps;
 		const { planIdleShutdown } = await import('./sandbox/pool');
-		const { clearProjectContainerIfNamed, loadPoolMembers, removePoolMember } = await import(
-			'./sandbox/pool-db'
-		);
+		const { loadPoolMembers } = await import('./sandbox/pool-db');
 
 		const members = await loadPoolMembers(db, candidate.id);
 		// A project whose pool has no row yet (nothing has provisioned through the
@@ -3299,65 +3312,90 @@ export class JobManager {
 		const plan =
 			members.length > 0
 				? planIdleShutdown(members)
-				: {
-						suspend: {
-							id: candidate.container_id,
-							state: 'idle' as const,
-							lastTaskId: null,
-							hasUnpushedCommits: false,
-							atDiskCeiling: false,
-							reservedForChat: false,
-						},
-						destroy: [],
-					};
+				: { suspend: [{ id: candidate.container_id }], destroy: [] };
 
-		// Park any live assistant session on these containers *first*, while they
-		// are still up: closing the tunnel deliberately deletes the provider's PTY
-		// session on a reachable sandbox and skips the tunnel's unrequested-death
-		// path, so the session ends up `suspended` (resumable in place) instead of
-		// `crashed`. Best-effort - a park that fails must not strand the pool.
-		for (const member of [...plan.destroy, ...(plan.suspend ? [plan.suspend] : [])]) {
-			await this.deps.chatSessions?.parkForContainerSuspend(member.id).catch((e) => {
-				log.warn(
-					`could not park the assistant session on ${ref(candidate.slug, member.id.slice(0, 12))} before retiring it: ${(e as Error).message}`,
-				);
-			});
+		return executeRetirementPlan(
+			this.buildContainerDeps(),
+			{ id: candidate.id, slug: candidate.slug, team_id: candidate.team_id },
+			{
+				suspend: plan.suspend.map((m) => m.id),
+				destroy: plan.destroy.map((m) => m.id),
+			},
+			{ reason: 'idle', parkSession: (id) => this.parkChatSession(id) },
+		);
+	}
+
+	/** Best-effort park of any assistant session pinned to a container about to go. */
+	private async parkChatSession(containerId: string): Promise<void> {
+		await this.deps.chatSessions?.parkForContainerSuspend(containerId);
+	}
+
+	/**
+	 * Retire idle containers held by projects that are still working.
+	 *
+	 * {@link stopIdleContainers} only ever looks at projects that have gone
+	 * *entirely* quiet, which left the instance's worst capacity failure
+	 * unaddressed: a project running two tasks alongside two idle containers is
+	 * never quiet, so those two were charged to the memory budget in full and no
+	 * other project could reach them. An operator saw four containers, two of them
+	 * doing nothing, and every other project stuck at "at its active-container
+	 * limit" - not for the idle window, but until that project finished
+	 * everything it had.
+	 *
+	 * Deliberately no keep-one-warm rule, unlike the whole-project pass: this
+	 * project's busy containers are about to become idle themselves, so the next
+	 * run's warm start is already covered.
+	 */
+	private async retireSurplusIdleContainers(): Promise<void> {
+		const { db, docker } = this.deps;
+		const timeoutMin = CONTAINER_IDLE_TIMEOUT_MIN;
+		if (!(await docker.ping())) return;
+
+		const { planSurplusIdleRetirement } = await import('./sandbox/pool');
+		const { loadPoolMembers } = await import('./sandbox/pool-db');
+
+		const stale = await findStaleIdleMembers(db, timeoutMin, IDLE_STOP_BATCH_LIMIT);
+		const byProject = new Map<string, StaleIdleMember[]>();
+		for (const row of stale) {
+			const group = byProject.get(row.project_id);
+			if (group) group.push(row);
+			else byProject.set(row.project_id, [row]);
 		}
 
 		let retired = 0;
-		for (const member of plan.destroy) {
-			// Destroyed, not stopped: its filesystem is reproducible from the git
-			// remote, and a container kept beyond the one suspended member is
-			// storage nobody asked for.
-			log.info(
-				`project ${ref(candidate.slug, candidate.id)} retiring surplus idle container ${ref(candidate.slug, member.id.slice(0, 12))}`,
-			);
-			await docker.removeContainer(member.id, true).catch(() => undefined);
-			await removePoolMember(db, member.id);
-			// The project row may still name this container - `provisionContainer`
-			// points `container_id` at the newest one, which is exactly the surplus
-			// the plan destroys first. Left behind, the row names a container that
-			// no longer exists, and the next status sync reads that as the
-			// project's container having died: a spurious error on a project whose
-			// remaining containers are perfectly healthy.
-			await clearProjectContainerIfNamed(db, candidate.id, member.id);
-			retired++;
-		}
+		for (const [projectId, group] of byProject) {
+			try {
+				await withContainerLifecycleLock(projectId, async () => {
+					// A lazy start in flight has no DB row yet, so the members below could
+					// be claimed the moment this lock is released. Same guard the
+					// whole-project pass uses, and for the same reason.
+					if (this.pendingContainerStarts.has(projectId)) return;
+					// Re-run the scan under the lock: a member claimed and released again
+					// since the batch scan is idle but no longer stale.
+					const fresh = await findStaleIdleMembersInProject(db, projectId, timeoutMin);
+					const staleIds = new Set(fresh.map((r) => r.container_id));
+					if (staleIds.size === 0) return;
 
-		if (plan.suspend) {
-			log.info(
-				`project ${ref(candidate.slug, candidate.id)} idle — suspending container ${ref(candidate.slug, plan.suspend.id.slice(0, 12))}`,
-			);
-			await stopContainerGracefully(
-				this.buildContainerDeps(),
-				candidate.id,
-				candidate.slug,
-				candidate.team_id,
-				plan.suspend.id,
-			);
-			retired++;
+					const plan = planSurplusIdleRetirement(await loadPoolMembers(db, projectId), staleIds);
+					if (plan.suspend.length === 0 && plan.destroy.length === 0) return;
+
+					retired += await executeRetirementPlan(
+						this.buildContainerDeps(),
+						{ id: projectId, slug: group[0].slug, team_id: group[0].team_id },
+						{
+							suspend: plan.suspend.map((m) => m.id),
+							destroy: plan.destroy.map((m) => m.id),
+						},
+						{ reason: 'surplus idle', parkSession: (id) => this.parkChatSession(id) },
+					);
+				});
+			} catch (err) {
+				log.error(`Surplus idle retirement failed for project ${ref('', projectId)}:`, err);
+			}
 		}
-		return retired;
+		if (retired > 0) {
+			log.debug(`Surplus idle pass: retired ${retired} container(s) held by working projects`);
+		}
 	}
 
 	/**

--- a/packages/server/src/services/run-concurrency.ts
+++ b/packages/server/src/services/run-concurrency.ts
@@ -1,4 +1,4 @@
-import { ContainerStatus, HeartbeatRunStatus } from '@hezo/shared';
+import { CONTAINER_RECLAIM_MIN_IDLE_SEC, ContainerStatus, HeartbeatRunStatus } from '@hezo/shared';
 import type { Db } from '../db/database';
 import { getDefaultRamCapPerContainerGb, getMaxContainerMemoryGb } from '../lib/system-meta';
 
@@ -6,11 +6,12 @@ import type { ContainerEngine } from './sandbox/types';
 
 /**
  * DB-backed concurrency checks — the single source of truth for the two run
- * rules: at most one active (queued/running) agent run per task, and at most
- * `max_active_containers` (system_meta; default from the engine's own memory
- * answer) simultaneously RUNNING project containers across the instance. The container
- * cap is the memory guarantee: every container is memory-capped, so total
- * demand never exceeds `N × cap` no matter how many runs share a container.
+ * rules: at most one active (queued/running) agent run per task, and no more
+ * simultaneously RUNNING container memory across the instance than
+ * `max_container_memory_gb` (system_meta; default derived from the engine's own
+ * memory answer). A budget rather than a container count, because
+ * `projects.memory_limit_gib` exists so containers are not all the same size —
+ * see {@link ActiveContainers.usedMemoryGb}.
  * Shared by the scheduler (`JobManager`, which layers its in-memory dispatch
  * guards on top) and the stateless run-now route.
  *
@@ -64,6 +65,34 @@ export interface ActiveContainers {
 	 * a second one and must be gated like any other new start.
 	 */
 	projectsWithSpareContainer: Set<string>;
+	/**
+	 * Per project, how much of {@link usedMemoryGb} is held by idle members that
+	 * have sat idle long enough for another project to reclaim them, in GB.
+	 *
+	 * Keyed by project rather than summed because the figure is only meaningful
+	 * relative to who is asking: a project cannot reclaim from itself, and its own
+	 * idle members are already offered to it through the pool's reuse rung. Read it
+	 * with {@link reclaimableForOthers}.
+	 *
+	 * A container is pinned to its project for life - it is built around that
+	 * project's workspace mount, clone and git identity - so this memory is
+	 * reachable only by retiring the container, never by handing it over. Charging
+	 * it as free would over-subscribe the host; ignoring it entirely wedges the
+	 * instance, which is what it used to do.
+	 */
+	reclaimableMemoryGbByProject: Map<string, number>;
+}
+
+/** What {@link ActiveContainers.reclaimableMemoryGbByProject} offers a project other than its own. */
+export function reclaimableForOthers(
+	active: Pick<ActiveContainers, 'reclaimableMemoryGbByProject'>,
+	projectId: string | null,
+): number {
+	let total = 0;
+	for (const [id, gb] of active.reclaimableMemoryGbByProject) {
+		if (id !== projectId) total += gb;
+	}
+	return total;
 }
 
 /**
@@ -80,7 +109,7 @@ export async function getActiveContainers(
 	db: Db,
 	engine: Pick<ContainerEngine, 'containerHostMemory'>,
 ): Promise<ActiveContainers> {
-	const [budgetGb, defaultCapGb, running, spare] = await Promise.all([
+	const [budgetGb, defaultCapGb, running, spare, reclaimable] = await Promise.all([
 		getMaxContainerMemoryGb(db, engine),
 		getDefaultRamCapPerContainerGb(db),
 		db.query<{ project_id: string; memory_bytes: string | number | null }>(
@@ -132,11 +161,30 @@ export async function getActiveContainers(
 			    )`,
 			[ContainerStatus.Running],
 		),
+		db.query<{ project_id: string; memory_bytes: string | number | null }>(
+			// The subset of the running count that another project could get back by
+			// retiring it. Pool members only: the legacy `projects.container_*` arm
+			// records no state, so a container known only there cannot be shown to be
+			// idle, and retiring one on a guess would kill a live run.
+			//
+			// The chat's pinned member is excluded here as it is above - it is not in
+			// `usedMemoryGb`, so retiring it frees nothing against the budget and only
+			// interrupts somebody's session.
+			//
+			// Served by `idx_container_pool_members_idle`.
+			`SELECT project_id, memory_bytes FROM container_pool_members
+			  WHERE state = 'idle' AND NOT reserved_for_chat
+			    AND last_released_at <= now() - ($1 * interval '1 second')`,
+			[CONTAINER_RECLAIM_MIN_IDLE_SEC],
+		),
 	]);
 	// One query for the overrides rather than one per container: the set of
 	// distinct projects here is small, and a per-row lookup would make this gate
 	// cost grow with the fleet it is gating.
-	const overrides = await loadProjectMemoryCaps(db, new Set(running.rows.map((r) => r.project_id)));
+	const overrides = await loadProjectMemoryCaps(
+		db,
+		new Set([...running.rows, ...reclaimable.rows].map((r) => r.project_id)),
+	);
 	let usedMemoryGb = 0;
 	for (const row of running.rows) {
 		// What the container was actually built to hold, where that is recorded. A
@@ -151,10 +199,26 @@ export async function getActiveContainers(
 				? (overrides.get(row.project_id) ?? defaultCapGb)
 				: Number(row.memory_bytes) / 1024 ** 3;
 	}
+	// Resolved exactly as `usedMemoryGb` above, and it has to be: this is a subset
+	// of that figure, so a different fallback would let a project reclaim more or
+	// less than retiring the container actually gives back.
+	const reclaimableMemoryGbByProject = new Map<string, number>();
+	for (const row of reclaimable.rows) {
+		const gb =
+			row.memory_bytes === null
+				? (overrides.get(row.project_id) ?? defaultCapGb)
+				: Number(row.memory_bytes) / 1024 ** 3;
+		reclaimableMemoryGbByProject.set(
+			row.project_id,
+			(reclaimableMemoryGbByProject.get(row.project_id) ?? 0) + gb,
+		);
+	}
+
 	return {
 		budgetGb,
 		usedMemoryGb,
 		projectsWithSpareContainer: new Set(spare.rows.map((r) => r.project_id)),
+		reclaimableMemoryGbByProject,
 	};
 }
 
@@ -223,18 +287,22 @@ export async function projectContainerMemoryGb(db: Db, projectId: string): Promi
  * would let concurrent runs in one project walk straight past the cap. What
  * replaces it is the narrower and still-correct claim that a project with a
  * container genuinely free to take the run consumes no new slot.
+ *
+ * Reclaimable memory counts as headroom here, and must: the acquire path can now
+ * retire another project's idle container to make room, but it never gets the
+ * chance if this gate skips the dispatch first. Gating on the raw budget alone is
+ * what let one busy project's idle containers wedge every other project on the
+ * instance.
  */
 export async function isContainerCapacityBlockedInDb(
 	db: Db,
 	engine: Pick<ContainerEngine, 'containerHostMemory'>,
 	projectId: string,
 ): Promise<boolean> {
-	const { budgetGb, usedMemoryGb, projectsWithSpareContainer } = await getActiveContainers(
-		db,
-		engine,
-	);
-	if (projectsWithSpareContainer.has(projectId)) return false;
-	return usedMemoryGb + (await projectContainerMemoryGb(db, projectId)) > budgetGb;
+	const active = await getActiveContainers(db, engine);
+	if (active.projectsWithSpareContainer.has(projectId)) return false;
+	const headroomGb = active.budgetGb + reclaimableForOthers(active, projectId);
+	return active.usedMemoryGb + (await projectContainerMemoryGb(db, projectId)) > headroomGb;
 }
 
 /**

--- a/packages/server/src/services/sandbox/pool.ts
+++ b/packages/server/src/services/sandbox/pool.ts
@@ -60,6 +60,11 @@ export type PoolDecision =
 	/** Destroy these, then decide again. See {@link selectPoolMember}. */
 	| { kind: 'recycle'; members: PoolMember[] }
 	| { kind: 'create' }
+	/**
+	 * Free `needGb` by retiring idle members of *other* projects, then decide
+	 * again. See {@link planCrossProjectReclaim}.
+	 */
+	| { kind: 'reclaim'; needGb: number }
 	| { kind: 'queue' };
 
 export interface PoolCapacity {
@@ -69,6 +74,16 @@ export interface PoolCapacity {
 	budgetGb: number;
 	/** What one more container in *this* project would consume, in GB. */
 	requestMemoryGb: number;
+	/**
+	 * Of {@link usedMemoryGb}, how much is held by idle members of **other**
+	 * projects that reclaim could free right now, in GB.
+	 *
+	 * Separate from the used figure rather than subtracted from it because the
+	 * memory is genuinely spoken for until something retires those containers -
+	 * charging the budget as though it were already free would over-subscribe the
+	 * host in the window between deciding and retiring.
+	 */
+	reclaimableMemoryGb: number;
 }
 
 /**
@@ -98,7 +113,14 @@ export interface PoolCapacity {
  * 2. **Any warm idle container.** Nothing to start, cold worktree.
  * 3. **A suspended container.** Resume costs about a second.
  * 4. **Create**, if under the cap.
- * 5. **Queue** on the cap.
+ * 5. **Reclaim**, if the cap is full but idle containers in *other* projects hold
+ *    enough memory to cover the request. A container is pinned to its project for
+ *    its whole life - it is built around that project's workspace mount, clone and
+ *    git identity - so the only way one project's idle capacity can serve another
+ *    is to retire it and build afresh. Without this rung an instance can sit
+ *    permanently wedged: a busy project's idle members are charged to the budget
+ *    in full, and nothing else can touch them.
+ * 6. **Queue**, when even that would not free enough.
  *
  * Note what is *not* here: no rung ever returns a busy container, and no busy
  * container is ever recycled. That is the one-run-per-container rule, and it is
@@ -140,6 +162,11 @@ export function selectPoolMember(
 	if (suspended && fitsBudget(capacity)) return { kind: 'resume', member: suspended };
 
 	if (fitsBudget(capacity)) return { kind: 'create' };
+
+	// The shortfall, not the request: reclaiming more than the request needs
+	// destroys warm containers for nothing.
+	const needGb = capacity.usedMemoryGb + capacity.requestMemoryGb - capacity.budgetGb;
+	if (needGb <= capacity.reclaimableMemoryGb) return { kind: 'reclaim', needGb };
 	return { kind: 'queue' };
 }
 
@@ -191,10 +218,14 @@ function fitsBudget(capacity: PoolCapacity): boolean {
  * clone, it is paid only by genuinely concurrent runs, and it buys back a bound
  * that would otherwise have to be designed, tuned and tested.
  */
-export function planIdleShutdown(members: readonly PoolMember[]): {
-	suspend: PoolMember | null;
+export interface IdleRetirementPlan {
+	/** Stopped in place - the container survives, its writable layer intact. */
+	suspend: PoolMember[];
+	/** Removed outright; the filesystem is reproducible from the git remote. */
 	destroy: PoolMember[];
-} {
+}
+
+export function planIdleShutdown(members: readonly PoolMember[]): IdleRetirementPlan {
 	// Deliberately *not* filtered by `reservedForChat`. The reservation means "no
 	// task run may take this container" - it does not mean "never stop it". By the
 	// time this runs the project has already been judged idle by a predicate that
@@ -204,7 +235,7 @@ export function planIdleShutdown(members: readonly PoolMember[]): {
 	// parks, and resume starts it again with a fresh host-side half. Treating the
 	// reservation as a pin here would keep the container running forever.
 	const idle = members.filter((m) => m.state === 'idle');
-	const alreadySuspended = members.some((m) => m.state === 'suspended');
+	if (idle.length === 0) return { suspend: [], destroy: [] };
 
 	// A container holding work that reached no durable remote is pinned against
 	// **destroy** - that is what would lose the only copy, and nothing downstream
@@ -218,17 +249,135 @@ export function planIdleShutdown(members: readonly PoolMember[]): {
 	// project never comes. A handful of such projects would consume the whole
 	// budget and queue every run on the instance forever.
 	//
-	// So a pinned member is the *preferred* suspend candidate: it is the one that
-	// must not be destroyed, and suspending is how it stops costing memory while
-	// still holding the work.
+	// So **every** pinned member is suspended, not just one. The single-suspend
+	// rule below is a storage-economy bound on containers kept purely for warmth,
+	// and applying it to pinned members instead left the surplus ones running -
+	// which is the exact budget leak the paragraph above rules out, reached by a
+	// different route.
 	const pinned = idle.filter((m) => m.hasUnpushedCommits);
 	const disposable = idle.filter((m) => !m.hasUnpushedCommits);
-	if (idle.length === 0) return { suspend: null, destroy: [] };
+	if (pinned.length > 0) return { suspend: pinned, destroy: disposable };
 
-	if (alreadySuspended) return { suspend: null, destroy: disposable };
-	// Prefer a pinned member for the single suspend slot; the rest that may be
-	// destroyed are only ever the unpinned ones.
-	if (pinned.length > 0) return { suspend: pinned[0], destroy: disposable };
+	const alreadySuspended = members.some((m) => m.state === 'suspended');
+	if (alreadySuspended) return { suspend: [], destroy: disposable };
 	const [first, ...rest] = disposable;
-	return { suspend: first ?? null, destroy: rest };
+	return { suspend: first ? [first] : [], destroy: rest };
+}
+
+/**
+ * Which of a **working** project's idle containers to retire, judged on each
+ * member's own idle clock rather than on the project falling quiet.
+ *
+ * {@link planIdleShutdown} answers "this whole project has gone idle, retire its
+ * pool". That is the only question the sweeper used to ask, and it left a gap
+ * wide enough to wedge an instance: a project with two busy containers and two
+ * idle ones is never quiet, so its idle members were never candidates, while
+ * being charged to the instance memory budget in full for as long as the project
+ * kept working. Every other project saw a budget it could not reach and queued
+ * indefinitely.
+ *
+ * So a project that is *working* has its idle members judged individually. There
+ * is no keep-one-warm rule here, unlike the whole-project plan: the busy members
+ * are about to become idle themselves, so warmth for the next run is already
+ * accounted for, and holding a second container against that is what the caller
+ * is trying to stop.
+ *
+ * `staleMemberIds` are the members the caller has established sat idle past the
+ * window - the clock lives in SQL, where it can be indexed, so this stays pure.
+ * The chat's pinned member is never touched: it is excluded from the memory
+ * budget already, so retiring it frees nothing and only interrupts a session.
+ */
+export function planSurplusIdleRetirement(
+	members: readonly PoolMember[],
+	staleMemberIds: ReadonlySet<string>,
+): IdleRetirementPlan {
+	// Not a working project - either fully idle, in which case the whole-project
+	// pass owns it and its warm-start guarantees, or holding nothing at all.
+	if (!members.some((m) => m.state === 'busy')) return { suspend: [], destroy: [] };
+
+	const stale = members.filter(
+		(m) => m.state === 'idle' && !m.reservedForChat && staleMemberIds.has(m.id),
+	);
+	return {
+		suspend: stale.filter((m) => m.hasUnpushedCommits),
+		destroy: stale.filter((m) => !m.hasUnpushedCommits),
+	};
+}
+
+/** An idle container in some *other* project, offered up to cover a blocked run. */
+export interface ReclaimCandidate {
+	containerId: string;
+	projectId: string;
+	/** What retiring it gives back to the instance budget, in GB. */
+	memoryGb: number;
+	/** How long it has sat idle. The caller supplies the clock; this stays pure. */
+	idleForMs: number;
+	hasUnpushedCommits: boolean;
+}
+
+export interface ReclaimPlan {
+	suspend: ReclaimCandidate[];
+	destroy: ReclaimCandidate[];
+	/** What executing this plan gives back, in GB. Zero for an empty plan. */
+	freedGb: number;
+}
+
+/**
+ * Which of other projects' idle containers to retire so a blocked run fits.
+ *
+ * Reached only from the `reclaim` rung of {@link selectPoolMember}, which is to
+ * say only when a run would otherwise queue. Idle containers are *useful* while
+ * nobody else wants the memory - that is the whole point of keeping them warm -
+ * so nothing here runs speculatively.
+ *
+ * Four rules, each closing a way this could do harm:
+ *
+ * - **All or nothing.** If the eligible candidates together cannot cover
+ *   `needGb`, the plan is empty. Freeing three of the four GB a run needs helps
+ *   nobody and has destroyed two warm containers to achieve it.
+ * - **Only as much as `needGb`.** Retiring past the shortfall is the same waste
+ *   in smaller units.
+ * - **The project holding the most idle containers loses first**, and only then
+ *   longest-idle first. Ordering by idle time alone takes a quiet project's one
+ *   warm container while a hoarder keeps three, which is the fairness question
+ *   inverted; the tie-break on container id after that keeps the plan
+ *   deterministic for a given input, so a test can pin it.
+ * - **`minIdleMs` floors eligibility.** A project releasing a container between
+ *   two runs seconds apart is mid-burst, not idle, and stripping it there makes
+ *   both runs pay a cold start to hand memory to a third project that would lose
+ *   it the same way. This is what stops two starved projects reclaiming from each
+ *   other in a loop.
+ *
+ * Unpushed commits are suspended rather than destroyed, for the reason
+ * {@link planIdleShutdown} sets out at length: suspend frees the memory and keeps
+ * the only copy of the work.
+ */
+export function planCrossProjectReclaim(
+	candidates: readonly ReclaimCandidate[],
+	needGb: number,
+	minIdleMs: number,
+): ReclaimPlan {
+	const empty: ReclaimPlan = { suspend: [], destroy: [], freedGb: 0 };
+	if (needGb <= 0) return empty;
+
+	const eligible = candidates.filter((c) => c.idleForMs >= minIdleMs);
+	if (eligible.reduce((sum, c) => sum + c.memoryGb, 0) < needGb) return empty;
+
+	const heldBy = new Map<string, number>();
+	for (const c of eligible) heldBy.set(c.projectId, (heldBy.get(c.projectId) ?? 0) + 1);
+
+	const ordered = [...eligible].sort((a, b) => {
+		const byHoard = (heldBy.get(b.projectId) ?? 0) - (heldBy.get(a.projectId) ?? 0);
+		if (byHoard !== 0) return byHoard;
+		if (b.idleForMs !== a.idleForMs) return b.idleForMs - a.idleForMs;
+		return a.containerId.localeCompare(b.containerId);
+	});
+
+	const plan: ReclaimPlan = { suspend: [], destroy: [], freedGb: 0 };
+	for (const candidate of ordered) {
+		if (plan.freedGb >= needGb) break;
+		(candidate.hasUnpushedCommits ? plan.suspend : plan.destroy).push(candidate);
+		plan.freedGb += candidate.memoryGb;
+	}
+	return plan;
 }

--- a/packages/server/test/containers-pool-acquire.test.ts
+++ b/packages/server/test/containers-pool-acquire.test.ts
@@ -261,9 +261,11 @@ describe('acquireRunContainer', () => {
 		// a warm idle container is correctly *not* blocked, because reusing a
 		// container already running consumes no new budget. The budget only bites
 		// when the pool has nothing left to give.
-		await db.query(`UPDATE container_pool_members SET state = 'busy' WHERE project_id = $1`, [
-			projectId,
-		]);
+		//
+		// Instance-wide rather than for this project alone, because an idle member
+		// anywhere is now headroom - the acquire path reclaims it rather than
+		// queueing. This case is the one where there is genuinely nothing to take.
+		await db.query(`UPDATE container_pool_members SET state = 'busy'`);
 		await setMaxContainerMemoryGb(db, 1);
 		try {
 			await expect(
@@ -271,9 +273,139 @@ describe('acquireRunContainer', () => {
 			).rejects.toBeInstanceOf(PoolCapacityError);
 		} finally {
 			await setMaxContainerMemoryGb(db, 40);
-			await db.query(`UPDATE container_pool_members SET state = 'idle' WHERE project_id = $1`, [
-				projectId,
-			]);
+			await db.query(`UPDATE container_pool_members SET state = 'idle'`);
+		}
+	});
+});
+
+/**
+ * The other half of the reported failure. Retiring a working project's surplus
+ * containers on the idle cron frees the budget within a minute; this is what
+ * closes the gap in between, when a run would otherwise sit queued behind memory
+ * its neighbour is demonstrably not using.
+ *
+ * A container belongs to its project for life - it is built around that project's
+ * workspace mount, repo clone and git identity - so the only way that memory can
+ * serve another project is for the container to go and a fresh one to be built.
+ */
+describe('acquireRunContainer reclaiming from another project', () => {
+	const TASK_STARVED = randomUUID();
+	const CAP_BYTES = 2 * 1024 ** 3;
+	let removed: string[];
+	let stopped: string[];
+
+	function reclaimingDocker(): ContainerEngine {
+		return createStubDocker({
+			createContainer: vi.fn(async () => ({ Id: `reclaim-cid-${seq++}`, Warnings: [] })),
+			startContainer: vi.fn(async () => {}),
+			execCreate: vi.fn(async () => 'exec-x'),
+			execStart: vi.fn(async () => ({ stdout: '', stderr: '' })),
+			execInspect: vi.fn(async () => ({ ExitCode: 0, Running: false, Pid: 0 })),
+			inspectContainer: vi.fn(async (id: string) => ({
+				Id: id,
+				State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+				Config: { Image: 'stub' },
+			})),
+			removeContainer: vi.fn(async (id: string) => {
+				removed.push(id);
+			}),
+			stopContainer: vi.fn(async (id: string) => {
+				stopped.push(id);
+			}),
+		});
+	}
+
+	/** Start from an empty fleet so the budget arithmetic is exactly what each case states. */
+	async function emptyFleet(): Promise<void> {
+		await db.query('DELETE FROM container_pool_members');
+		await db.query('UPDATE projects SET container_id = NULL, container_status = NULL');
+		removed = [];
+		stopped = [];
+	}
+
+	async function seedIdle(
+		project: string,
+		containerId: string,
+		over: { idleMin?: number; unpushed?: boolean } = {},
+	): Promise<void> {
+		await db.query(
+			`INSERT INTO container_pool_members
+			   (project_id, container_id, state, memory_bytes, has_unpushed_commits, last_released_at)
+			 VALUES ($1, $2, 'idle', $3, $4, now() - ($5 || ' minutes')::interval)`,
+			[project, containerId, CAP_BYTES, over.unpushed ?? false, over.idleMin ?? 10],
+		);
+	}
+
+	it('retires another project’s long-idle container rather than queueing', async () => {
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Donor');
+		const starved = await freshProject('Reclaim Starved');
+		await seedIdle(donor, 'donor-idle');
+		// Room for exactly one container, which the donor is holding.
+		await setMaxContainerMemoryGb(db, 2);
+		try {
+			const acquired = await acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED);
+			expect(removed).toContain('donor-idle');
+			expect(acquired.containerId).not.toBe('donor-idle');
+			// The donor's row goes with the container - it is destroyed, never handed over.
+			const left = await db.query<{ container_id: string }>(
+				'SELECT container_id FROM container_pool_members WHERE project_id = $1',
+				[donor],
+			);
+			expect(left.rows).toEqual([]);
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
+		}
+	});
+
+	it('suspends rather than destroys a donor container holding unpushed commits', async () => {
+		// Suspending frees the memory and keeps the only copy of the work.
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Risky Donor');
+		const starved = await freshProject('Reclaim Risky Starved');
+		await seedIdle(donor, 'donor-risky', { unpushed: true });
+		await setMaxContainerMemoryGb(db, 2);
+		try {
+			await acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED);
+			expect(stopped).toContain('donor-risky');
+			expect(removed).not.toContain('donor-risky');
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
+		}
+	});
+
+	it('never reclaims a container that has only just gone idle', async () => {
+		// A project releasing a container between two runs seconds apart is
+		// mid-burst. Stripping it there makes both runs pay a cold start to hand
+		// memory to a third project that would lose it the same way.
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Fresh Donor');
+		const starved = await freshProject('Reclaim Fresh Starved');
+		await seedIdle(donor, 'donor-fresh', { idleMin: 0 });
+		await setMaxContainerMemoryGb(db, 2);
+		try {
+			await expect(
+				acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED),
+			).rejects.toBeInstanceOf(PoolCapacityError);
+			expect(removed).toEqual([]);
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
+		}
+	});
+
+	it('reuses its own warm container rather than reclaiming somebody else’s', async () => {
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Untouched Donor');
+		const mine = await freshProject('Reclaim Self Server');
+		await seedIdle(donor, 'donor-untouched');
+		await seedIdle(mine, 'my-warm');
+		await setMaxContainerMemoryGb(db, 2);
+		try {
+			const acquired = await acquireRunContainer(deps(reclaimingDocker()), mine, TASK_STARVED);
+			expect(acquired.containerId).toBe('my-warm');
+			expect(removed).toEqual([]);
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
 		}
 	});
 });

--- a/packages/server/test/containers-provision-branches.test.ts
+++ b/packages/server/test/containers-provision-branches.test.ts
@@ -378,7 +378,7 @@ describe('provisionContainer', () => {
 					// allocatable and suspendable. A container with no CA trusted and
 					// no repos must be neither.
 					usable: members.length,
-					suspendable: planIdleShutdown(members).suspend === null ? 0 : 1,
+					suspendable: planIdleShutdown(members).suspend.length,
 				});
 			},
 		});

--- a/packages/server/test/job-manager-idle-stop.test.ts
+++ b/packages/server/test/job-manager-idle-stop.test.ts
@@ -396,3 +396,130 @@ describe('container-idle-stop', () => {
 		await db.query(`DELETE FROM container_pool_members WHERE project_id = $1`, [projectId]);
 	});
 });
+
+/**
+ * The reported failure: four containers on one project, two running tasks and two
+ * doing nothing, and every *other* project stuck at "at its active-container
+ * limit". The idle pass above only ever looks at projects that have gone entirely
+ * quiet, and a project running two tasks never is - so those two idle containers
+ * were charged to the instance memory budget in full for as long as the project
+ * kept working, and nothing on the instance could reach that memory.
+ */
+describe('surplus idle containers in a working project', () => {
+	const CAP_BYTES = 2 * 1024 ** 3;
+
+	const seedMember = async (
+		containerId: string,
+		state: 'idle' | 'busy' | 'suspended',
+		over: { unpushed?: boolean; chat?: boolean; idleMin?: number } = {},
+	): Promise<void> => {
+		await db.query(
+			`INSERT INTO container_pool_members
+			   (project_id, container_id, state, memory_bytes, has_unpushed_commits,
+			    reserved_for_chat, last_released_at)
+			 VALUES ($1, $2, $3::container_pool_state, $4, $5, $6,
+			         now() - ($7 || ' minutes')::interval)`,
+			[
+				projectId,
+				containerId,
+				state,
+				CAP_BYTES,
+				over.unpushed ?? false,
+				over.chat ?? false,
+				over.idleMin ?? 60,
+			],
+		);
+	};
+
+	/** An active run, which is what makes the whole-project predicate call this project busy. */
+	const startRun = () =>
+		db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+			[agentId, teamId, taskId],
+		);
+
+	const sweep = async (): Promise<{ stops: string[]; removes: string[] }> => {
+		const stops: string[] = [];
+		const removes: string[] = [];
+		const manager = createManager(stops, removes);
+		await (manager as unknown as { stopIdleContainers(): Promise<void> }).stopIdleContainers();
+		manager.shutdown();
+		return { stops, removes };
+	};
+
+	const remaining = async (): Promise<string[]> => {
+		const r = await db.query<{ container_id: string }>(
+			`SELECT container_id FROM container_pool_members WHERE project_id = $1
+			  ORDER BY container_id`,
+			[projectId],
+		);
+		return r.rows.map((row) => row.container_id);
+	};
+
+	beforeEach(async () => {
+		await db.query('DELETE FROM container_pool_members WHERE project_id = $1', [projectId]);
+	});
+
+	it('retires the idle containers of a project that is still running tasks', async () => {
+		await seedMember('busy-1', 'busy');
+		await seedMember('busy-2', 'busy');
+		await seedMember('idle-1', 'idle');
+		await seedMember('idle-2', 'idle');
+		await startRun();
+
+		const { stops, removes } = await sweep();
+
+		// The whole-project pass correctly declines - the project is busy - and the
+		// surplus pass is what frees the memory.
+		expect(removes.sort()).toEqual(['idle-1', 'idle-2']);
+		expect(stops).toEqual([]);
+		expect(await remaining()).toEqual(['busy-1', 'busy-2']);
+	});
+
+	it('leaves an idle container that has not yet reached the window', async () => {
+		await seedMember('busy-1', 'busy');
+		await seedMember('fresh', 'idle', { idleMin: 0 });
+		await startRun();
+
+		const { removes } = await sweep();
+		expect(removes).toEqual([]);
+		expect(await remaining()).toEqual(['busy-1', 'fresh']);
+	});
+
+	it('suspends rather than destroys a surplus container holding unpushed commits', async () => {
+		// Destroying it loses the only copy of the work; suspending frees the memory
+		// and keeps the writable layer.
+		await seedMember('busy-1', 'busy');
+		await seedMember('risky', 'idle', { unpushed: true });
+		await startRun();
+
+		const { stops, removes } = await sweep();
+		expect(stops).toEqual(['risky']);
+		expect(removes).toEqual([]);
+	});
+
+	it('never touches the assistant’s pinned container', async () => {
+		// It is excluded from the memory budget already, so retiring it frees
+		// nothing and only interrupts somebody's session.
+		await seedMember('busy-1', 'busy');
+		await seedMember('chat', 'idle', { chat: true });
+		await startRun();
+
+		const { stops, removes } = await sweep();
+		expect(stops).toEqual([]);
+		expect(removes).toEqual([]);
+		expect(await remaining()).toEqual(['busy-1', 'chat']);
+	});
+
+	it('leaves a fully idle project to the whole-project pass, which keeps one warm', async () => {
+		// No busy member, so this is not a working project: the pass above owns it
+		// and suspends one member for a warm restart rather than picking them off.
+		await seedMember('a', 'idle');
+		await seedMember('b', 'idle');
+
+		const { stops, removes } = await sweep();
+		expect(stops).toEqual(['a']);
+		expect(removes).toEqual(['b']);
+	});
+});

--- a/packages/server/test/migrate-053-container-pool-idle-clock.test.ts
+++ b/packages/server/test/migrate-053-container-pool-idle-clock.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '053_container_pool_idle_clock.sql';
+
+interface Seeded {
+	projectId: string;
+	/** Released a while ago - the ordinary case, and the one that must not be rewritten. */
+	released: string;
+	/** Provisioned but never released, so its stamp is NULL and has to be invented. */
+	neverReleased: string;
+}
+
+/**
+ * The migration exists to make `last_released_at` a dependable clock. Two things
+ * have to be true afterwards and neither is "the column changed": a member that
+ * already carried a release stamp must still carry *that* stamp (the clock is
+ * what decides which container gets retired, so silently resetting one would
+ * hand the idle sweeper a wrong answer), and a member that never carried one
+ * must come out with a usable figure rather than a NULL the new scans cannot
+ * index.
+ */
+describe('053_container_pool_idle_clock migration', () => {
+	let h: DataPreservationHarness;
+	let seeded: Seeded;
+	let releasedAt: Date;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ($1, $1) RETURNING id`,
+			['team-idle-clock'],
+		);
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, $2, $2, $3) RETURNING id`,
+			[team.rows[0].id, 'idle-clock', 'IDL'],
+		);
+		const projectId = project.rows[0].id;
+
+		releasedAt = new Date(Date.now() - 90 * 60 * 1000);
+		const member = async (
+			containerId: string,
+			state: string,
+			lastReleasedAt: Date | null,
+		): Promise<string> => {
+			const res = await h.db.query<{ id: string }>(
+				`INSERT INTO container_pool_members (project_id, container_id, state, last_released_at)
+				 VALUES ($1, $2, $3::container_pool_state, $4) RETURNING id`,
+				[projectId, containerId, state, lastReleasedAt],
+			);
+			return res.rows[0].id;
+		};
+
+		seeded = {
+			projectId,
+			released: await member('ctr-released', 'idle', releasedAt),
+			neverReleased: await member('ctr-never-released', 'idle', null),
+		};
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('preserves both pre-existing members and the release stamp one already had', async () => {
+		const rows = await h.db.query<{ id: string; container_id: string; last_released_at: Date }>(
+			`SELECT id, container_id, last_released_at FROM container_pool_members
+			  WHERE project_id = $1 ORDER BY container_id`,
+			[seeded.projectId],
+		);
+		expect(rows.rows.map((r) => r.container_id)).toEqual(['ctr-never-released', 'ctr-released']);
+
+		const released = rows.rows.find((r) => r.id === seeded.released);
+		expect(released).toBeDefined();
+		// To the second: the column is TIMESTAMPTZ and the driver round-trips it,
+		// but the point of the assertion is that the backfill did not touch a row
+		// that already had a stamp.
+		expect(new Date(released?.last_released_at ?? 0).getTime()).toBeCloseTo(
+			releasedAt.getTime(),
+			-3,
+		);
+	});
+
+	it('backfills a missing stamp from the member creation time', async () => {
+		const row = await h.db.query<{ last_released_at: Date; created_at: Date }>(
+			`SELECT last_released_at, created_at FROM container_pool_members WHERE id = $1`,
+			[seeded.neverReleased],
+		);
+		const { last_released_at, created_at } = row.rows[0];
+		expect(last_released_at).not.toBeNull();
+		expect(new Date(last_released_at).getTime()).toBe(new Date(created_at).getTime());
+	});
+
+	it('makes the clock total, so the idle scans never meet a NULL', async () => {
+		const nullable = await h.db.query<{ is_nullable: string; column_default: string | null }>(
+			`SELECT is_nullable, column_default FROM information_schema.columns
+			  WHERE table_name = 'container_pool_members' AND column_name = 'last_released_at'`,
+		);
+		expect(nullable.rows[0].is_nullable).toBe('NO');
+		expect(nullable.rows[0].column_default).toContain('now()');
+
+		// A new member inserted the way `upsertPoolMember` does - without naming
+		// the column - still satisfies the constraint.
+		const inserted = await h.db.query<{ last_released_at: Date }>(
+			`INSERT INTO container_pool_members (project_id, container_id, state)
+			 VALUES ($1, $2, 'creating'::container_pool_state) RETURNING last_released_at`,
+			[seeded.projectId, 'ctr-fresh'],
+		);
+		expect(inserted.rows[0].last_released_at).not.toBeNull();
+	});
+
+	it('indexes the columns the idle sweep and the reclaim scan actually order by', async () => {
+		const idx = await h.db.query<{ indexdef: string }>(
+			`SELECT indexdef FROM pg_indexes
+			  WHERE tablename = 'container_pool_members'
+			    AND indexname = 'idx_container_pool_members_idle'`,
+		);
+		expect(idx.rows).toHaveLength(1);
+		expect(idx.rows[0].indexdef).toContain('state');
+		expect(idx.rows[0].indexdef).toContain('last_released_at');
+		expect(idx.rows[0].indexdef).toContain('reserved_for_chat');
+	});
+});

--- a/packages/server/test/run-concurrency-capacity.test.ts
+++ b/packages/server/test/run-concurrency-capacity.test.ts
@@ -12,6 +12,7 @@ import { MAX_CONTAINER_MEMORY_GB_KEY, setSystemMeta } from '../src/lib/system-me
 import {
 	getActiveContainers,
 	isContainerCapacityBlockedInDb,
+	reclaimableForOthers,
 } from '../src/services/run-concurrency';
 import { createStubDocker } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
@@ -67,13 +68,20 @@ describe('container capacity', () => {
 			disk_used_bytes: number;
 			disk_ceiling_bytes: number;
 			memory_bytes: number | null;
+			/**
+			 * How long ago this member was released. Defaults to *now*, so a member is
+			 * not reclaimable unless a case says so - the idle floor is a rule these
+			 * tests should have to opt into, not one they trip over.
+			 */
+			idle_for_min: number;
 		}> = {},
 	): Promise<void> {
 		await db.query(
 			`INSERT INTO container_pool_members
 			   (project_id, container_id, state, reserved_for_chat, disk_used_bytes,
-			    disk_ceiling_bytes, memory_bytes)
-			 VALUES ($1, $2, $3::container_pool_state, $4, $5, $6, $7)`,
+			    disk_ceiling_bytes, memory_bytes, last_released_at)
+			 VALUES ($1, $2, $3::container_pool_state, $4, $5, $6, $7,
+			         now() - ($8 || ' minutes')::interval)`,
 			[
 				projectId,
 				containerId,
@@ -82,6 +90,7 @@ describe('container capacity', () => {
 				over.disk_used_bytes ?? 0,
 				over.disk_ceiling_bytes ?? poolDiskCeilingBytes(DEFAULT_CONTAINER_DISK_GB),
 				over.memory_bytes === undefined ? 2 * 1024 ** 3 : over.memory_bytes,
+				over.idle_for_min ?? 0,
 			],
 		);
 	}
@@ -269,6 +278,73 @@ describe('container capacity', () => {
 		// …while a default-sized container fits in the same remaining 2 GB.
 		const normal = await seedProject();
 		expect(await isContainerCapacityBlockedInDb(db, engine, normal)).toBe(false);
+	});
+
+	/**
+	 * The gate runs *before* the pool, so it decides whether a run ever reaches the
+	 * acquire path at all. Leaving reclaimable memory out of it is what let one busy
+	 * project's idle containers wedge every other project on the instance: the
+	 * dispatch was skipped as `InstanceAtCapacity` and the reclaim rung never ran.
+	 */
+	describe('reclaimable headroom', () => {
+		it('does not block a run that another project’s idle container can cover', async () => {
+			const hoarder = await seedProject();
+			await addMember(hoarder, 'ctr-busy', { state: 'busy' });
+			await addMember(hoarder, 'ctr-idle', { idle_for_min: 10 });
+			// The budget is full: two 2 GB containers against a 4 GB ceiling.
+			expect((await getActiveContainers(db, engine)).usedMemoryGb).toBe(4);
+
+			const starved = await seedProject();
+			expect(await isContainerCapacityBlockedInDb(db, engine, starved)).toBe(false);
+		});
+
+		it('still blocks when every container elsewhere is busy', async () => {
+			const hoarder = await seedProject();
+			await addMember(hoarder, 'ctr-busy-a', { state: 'busy' });
+			await addMember(hoarder, 'ctr-busy-b', { state: 'busy' });
+
+			const starved = await seedProject();
+			expect(await isContainerCapacityBlockedInDb(db, engine, starved)).toBe(true);
+		});
+
+		it('still blocks while the idle container is inside the reclaim floor', async () => {
+			// A project mid-burst is not idle capacity.
+			const hoarder = await seedProject();
+			await addMember(hoarder, 'ctr-busy', { state: 'busy' });
+			await addMember(hoarder, 'ctr-fresh');
+
+			const starved = await seedProject();
+			expect(await isContainerCapacityBlockedInDb(db, engine, starved)).toBe(true);
+		});
+
+		it('does not count the chat’s pinned container as reclaimable', async () => {
+			// It is excluded from `usedMemoryGb` already, so retiring it frees nothing
+			// against the budget - counting it as headroom would over-subscribe.
+			const hoarder = await seedProject();
+			await addMember(hoarder, 'ctr-busy-a', { state: 'busy' });
+			await addMember(hoarder, 'ctr-busy-b', { state: 'busy' });
+			await addMember(hoarder, 'ctr-chat', { reserved_for_chat: true, idle_for_min: 10 });
+
+			const starved = await seedProject();
+			expect(await isContainerCapacityBlockedInDb(db, engine, starved)).toBe(true);
+		});
+
+		it('does not offer a project its own idle container as reclaimable headroom', async () => {
+			// Its own idle member reaches it through the pool's reuse rung, which
+			// consumes no new budget. Counting it here as well would let the project
+			// start a second container it has no room for.
+			const other = await seedProject();
+			await addMember(other, 'ctr-busy-a', { state: 'busy' });
+			const mine = await seedProject();
+			await addMember(mine, 'ctr-mine-busy', { state: 'busy' });
+			await addMember(mine, 'ctr-mine-idle', { idle_for_min: 10 });
+
+			const active = await getActiveContainers(db, engine);
+			expect(reclaimableForOthers(active, mine)).toBe(0);
+			// And the project is not blocked - but on the spare-container rung, not
+			// on headroom it does not have.
+			expect(active.projectsWithSpareContainer.has(mine)).toBe(true);
+		});
 	});
 });
 

--- a/packages/server/test/sandbox-pool.test.ts
+++ b/packages/server/test/sandbox-pool.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	type PoolCapacity,
 	type PoolMember,
+	planCrossProjectReclaim,
 	planIdleShutdown,
+	planSurplusIdleRetirement,
+	type ReclaimCandidate,
 	selectPoolMember,
 } from '../src/services/sandbox/pool';
 
@@ -26,8 +29,21 @@ function member(id: string, over: Partial<PoolMember> = {}): PoolMember {
 
 // Capacity is a memory budget, so "room" and "full" are stated in GB. A default
 // container asks for 2 GB: ROOM has 8 GB of a 10 GB budget free, FULL has none.
-const ROOM: PoolCapacity = { usedMemoryGb: 2, budgetGb: 10, requestMemoryGb: 2 };
-const FULL: PoolCapacity = { usedMemoryGb: 10, budgetGb: 10, requestMemoryGb: 2 };
+// Both state nothing reclaimable, so the rungs under test are the ones exercised;
+// FULL_RECLAIMABLE is the same wall with another project's idle container behind it.
+const ROOM: PoolCapacity = {
+	usedMemoryGb: 2,
+	budgetGb: 10,
+	requestMemoryGb: 2,
+	reclaimableMemoryGb: 0,
+};
+const FULL: PoolCapacity = {
+	usedMemoryGb: 10,
+	budgetGb: 10,
+	requestMemoryGb: 2,
+	reclaimableMemoryGb: 0,
+};
+const FULL_RECLAIMABLE: PoolCapacity = { ...FULL, reclaimableMemoryGb: 2 };
 
 describe('selectPoolMember ladder', () => {
 	it('prefers a warm container that last served this task', () => {
@@ -80,6 +96,44 @@ describe('selectPoolMember ladder', () => {
 		expect(selectPoolMember(null, [member('warm', { lastTaskId: 'other' })], ROOM, CAP).kind).toBe(
 			'reuse',
 		);
+	});
+
+	it('reclaims from other projects rather than queueing when the budget is full', () => {
+		// A container belongs to its project for life, so the only way another
+		// project's unused memory can serve this one is for that container to go.
+		// Without this rung one busy project's idle containers wedge the instance:
+		// they are charged to the budget in full and nothing can reach them.
+		expect(selectPoolMember('t', [], FULL_RECLAIMABLE, CAP)).toEqual({
+			kind: 'reclaim',
+			needGb: 2,
+		});
+	});
+
+	it('asks only for the shortfall, not for the whole request', () => {
+		const capacity: PoolCapacity = {
+			usedMemoryGb: 9,
+			budgetGb: 10,
+			requestMemoryGb: 2,
+			reclaimableMemoryGb: 4,
+		};
+		expect(selectPoolMember('t', [], capacity, CAP)).toEqual({ kind: 'reclaim', needGb: 1 });
+	});
+
+	it('queues when reclaim could not free enough either', () => {
+		const capacity: PoolCapacity = { ...FULL, requestMemoryGb: 8, reclaimableMemoryGb: 2 };
+		expect(selectPoolMember('t', [], capacity, CAP)).toEqual({ kind: 'queue' });
+	});
+
+	it('creates rather than reclaiming while the budget still has room', () => {
+		// Idle containers elsewhere are useful while nobody needs the memory; this
+		// rung never runs speculatively.
+		expect(selectPoolMember('t', [], { ...ROOM, reclaimableMemoryGb: 8 }, CAP)).toEqual({
+			kind: 'create',
+		});
+	});
+
+	it('reuses its own warm container rather than reclaiming another project’s', () => {
+		expect(selectPoolMember('t', [member('warm')], FULL_RECLAIMABLE, CAP).kind).toBe('reuse');
 	});
 });
 
@@ -221,13 +275,13 @@ describe('planIdleShutdown', () => {
 		// cardinality - which removes the need for a retention cap or a reap
 		// horizon entirely.
 		const plan = planIdleShutdown([member('a'), member('b'), member('c')]);
-		expect(plan.suspend?.id).toBe('a');
+		expect(plan.suspend.map((m) => m.id)).toEqual(['a']);
 		expect(plan.destroy.map((m) => m.id)).toEqual(['b', 'c']);
 	});
 
 	it('destroys all of them when one is already suspended', () => {
 		const plan = planIdleShutdown([member('kept', { state: 'suspended' }), member('a')]);
-		expect(plan.suspend).toBeNull();
+		expect(plan.suspend).toEqual([]);
 		expect(plan.destroy.map((m) => m.id)).toEqual(['a']);
 	});
 
@@ -238,7 +292,7 @@ describe('planIdleShutdown', () => {
 		// the one that takes the suspend slot rather than being left running.
 		const plan = planIdleShutdown([member('risky', { hasUnpushedCommits: true })]);
 		expect(plan.destroy).toEqual([]);
-		expect(plan.suspend?.id).toBe('risky');
+		expect(plan.suspend.map((m) => m.id)).toEqual(['risky']);
 	});
 
 	it('prefers the risky container for the suspend slot and destroys the safe one', () => {
@@ -246,17 +300,22 @@ describe('planIdleShutdown', () => {
 		// global budget forever - the flag is only cleared by a later run on that
 		// same container, which for a stuck project never comes.
 		const plan = planIdleShutdown([member('risky', { hasUnpushedCommits: true }), member('safe')]);
-		expect(plan.suspend?.id).toBe('risky');
+		expect(plan.suspend.map((m) => m.id)).toEqual(['risky']);
 		expect(plan.destroy.map((m) => m.id)).toEqual(['safe']);
 	});
 
-	it('never destroys the pinned member even when something is already suspended', () => {
+	it('suspends every pinned member, even when one is already suspended', () => {
+		// The single-suspend rule bounds containers kept purely for *warmth*.
+		// Applying it to a pinned member instead left that member running - holding
+		// its full RAM cap out of the budget forever, since nothing but a later run
+		// on that same container clears the flag. That is the leak the rule was
+		// written to prevent, reached from the other side.
 		const plan = planIdleShutdown([
 			member('parked', { state: 'suspended' }),
 			member('risky', { hasUnpushedCommits: true }),
 			member('safe'),
 		]);
-		expect(plan.suspend).toBeNull();
+		expect(plan.suspend.map((m) => m.id)).toEqual(['risky']);
 		expect(plan.destroy.map((m) => m.id)).toEqual(['safe']);
 	});
 
@@ -268,13 +327,177 @@ describe('planIdleShutdown', () => {
 		// belongs to a session that has gone quiet. Parking it is the point:
 		// otherwise the chat's container runs, and bills, forever.
 		const plan = planIdleShutdown([member('chat', { reservedForChat: true })]);
-		expect(plan.suspend?.id).toBe('chat');
+		expect(plan.suspend.map((m) => m.id)).toEqual(['chat']);
 		expect(plan.destroy).toEqual([]);
 	});
 
 	it('leaves busy containers alone', () => {
 		const plan = planIdleShutdown([member('busy', { state: 'busy' })]);
-		expect(plan.suspend).toBeNull();
+		expect(plan.suspend).toEqual([]);
 		expect(plan.destroy).toEqual([]);
+	});
+});
+
+/**
+ * The reported failure in one function: a project running two tasks alongside two
+ * idle containers is never "quiet", so nothing retired those two - while they were
+ * charged to the instance memory budget in full and no other project could reach
+ * that memory.
+ */
+describe('planSurplusIdleRetirement', () => {
+	const stale = (...ids: string[]) => new Set(ids);
+
+	it('retires a working project’s stale idle containers', () => {
+		const plan = planSurplusIdleRetirement(
+			[
+				member('busy-1', { state: 'busy' }),
+				member('busy-2', { state: 'busy' }),
+				member('idle-1'),
+				member('idle-2'),
+			],
+			stale('idle-1', 'idle-2'),
+		);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['idle-1', 'idle-2']);
+		expect(plan.suspend).toEqual([]);
+	});
+
+	it('leaves a fully idle project to the whole-project pass', () => {
+		// That pass keeps one member suspended for a warm restart; picking its
+		// members off individually here would take that away.
+		const plan = planSurplusIdleRetirement([member('a'), member('b')], stale('a', 'b'));
+		expect(plan).toEqual({ suspend: [], destroy: [] });
+	});
+
+	it('leaves an idle container that has not yet gone stale', () => {
+		const plan = planSurplusIdleRetirement(
+			[member('busy', { state: 'busy' }), member('fresh'), member('old')],
+			stale('old'),
+		);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['old']);
+	});
+
+	it('suspends rather than destroys a container holding unpushed commits', () => {
+		const plan = planSurplusIdleRetirement(
+			[member('busy', { state: 'busy' }), member('risky', { hasUnpushedCommits: true })],
+			stale('risky'),
+		);
+		expect(plan.suspend.map((m) => m.id)).toEqual(['risky']);
+		expect(plan.destroy).toEqual([]);
+	});
+
+	it('never touches the chat’s container or a busy one', () => {
+		// The chat's member is excluded from the memory budget already, so retiring
+		// it frees nothing and only interrupts a session.
+		const plan = planSurplusIdleRetirement(
+			[
+				member('busy', { state: 'busy' }),
+				member('chat', { reservedForChat: true }),
+				member('other-busy', { state: 'busy' }),
+			],
+			stale('chat', 'other-busy'),
+		);
+		expect(plan).toEqual({ suspend: [], destroy: [] });
+	});
+});
+
+describe('planCrossProjectReclaim', () => {
+	const MIN_IDLE = 30_000;
+	const candidate = (
+		containerId: string,
+		projectId: string,
+		over: Partial<ReclaimCandidate> = {},
+	): ReclaimCandidate => ({
+		containerId,
+		projectId,
+		memoryGb: 2,
+		idleForMs: 5 * 60_000,
+		hasUnpushedCommits: false,
+		...over,
+	});
+
+	it('frees exactly what the shortfall needs and no more', () => {
+		// Retiring past the shortfall destroys warm containers for nothing.
+		const plan = planCrossProjectReclaim(
+			[candidate('a', 'p1'), candidate('b', 'p1'), candidate('c', 'p1')],
+			2,
+			MIN_IDLE,
+		);
+		expect(plan.destroy).toHaveLength(1);
+		expect(plan.freedGb).toBe(2);
+	});
+
+	it('returns an empty plan when it cannot cover the shortfall', () => {
+		// All or nothing: freeing 2 of the 6 GB a run needs helps nobody, and has
+		// destroyed a warm container to achieve it.
+		const plan = planCrossProjectReclaim([candidate('a', 'p1')], 6, MIN_IDLE);
+		expect(plan).toEqual({ suspend: [], destroy: [], freedGb: 0 });
+	});
+
+	it('takes from the project holding the most idle containers first', () => {
+		// Ordering by idle time alone takes a quiet project's single warm container
+		// while a hoarder keeps three, which is the fairness question inverted.
+		const plan = planCrossProjectReclaim(
+			[
+				candidate('lonely', 'quiet', { idleForMs: 60 * 60_000 }),
+				candidate('h1', 'hoarder'),
+				candidate('h2', 'hoarder'),
+				candidate('h3', 'hoarder'),
+			],
+			2,
+			MIN_IDLE,
+		);
+		expect(plan.destroy.map((c) => c.projectId)).toEqual(['hoarder']);
+	});
+
+	it('takes the longest-idle container within one project', () => {
+		const plan = planCrossProjectReclaim(
+			[
+				candidate('recent', 'p1', { idleForMs: 60_000 }),
+				candidate('ancient', 'p1', { idleForMs: 60 * 60_000 }),
+			],
+			2,
+			MIN_IDLE,
+		);
+		expect(plan.destroy.map((c) => c.containerId)).toEqual(['ancient']);
+	});
+
+	it('ignores a container that has only just gone idle', () => {
+		// A project releasing a container between two runs seconds apart is
+		// mid-burst, not idle. This floor is what stops two starved projects
+		// reclaiming from each other in a loop.
+		const plan = planCrossProjectReclaim(
+			[candidate('justreleased', 'p1', { idleForMs: 1_000 })],
+			2,
+			MIN_IDLE,
+		);
+		expect(plan).toEqual({ suspend: [], destroy: [], freedGb: 0 });
+	});
+
+	it('suspends a container holding unpushed commits rather than destroying it', () => {
+		// Suspend frees the memory and keeps the only copy of the work.
+		const plan = planCrossProjectReclaim(
+			[candidate('risky', 'p1', { hasUnpushedCommits: true })],
+			2,
+			MIN_IDLE,
+		);
+		expect(plan.suspend.map((c) => c.containerId)).toEqual(['risky']);
+		expect(plan.destroy).toEqual([]);
+		expect(plan.freedGb).toBe(2);
+	});
+
+	it('accounts for containers of different sizes', () => {
+		// The budget is memory, not a container count, because
+		// `projects.memory_limit_gib` exists so containers are not all the same size.
+		const plan = planCrossProjectReclaim(
+			[candidate('big', 'p1', { memoryGb: 8 }), candidate('small', 'p2', { memoryGb: 1 })],
+			4,
+			MIN_IDLE,
+		);
+		expect(plan.destroy.map((c) => c.containerId)).toEqual(['big']);
+		expect(plan.freedGb).toBe(8);
+	});
+
+	it('asks for nothing when the shortfall is zero or negative', () => {
+		expect(planCrossProjectReclaim([candidate('a', 'p1')], 0, MIN_IDLE).freedGb).toBe(0);
 	});
 });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -355,6 +355,28 @@ export const CONTAINER_IDLE_TIMEOUT_MIN = 2;
 export const CHAT_IDLE_TIMEOUT_MIN = 15;
 
 /**
+ * How long a member must have sat idle before another **project** may reclaim it
+ * to fit its own container into the memory budget.
+ *
+ * Much shorter than {@link CONTAINER_IDLE_TIMEOUT_MIN} because it answers a
+ * different question. The idle window asks "is this container still worth
+ * keeping warm?", and the answer stays yes for a while because nothing else
+ * wants the memory. Reclaim only runs when something else demonstrably does: a
+ * run that is otherwise queued indefinitely. A starved project waiting two
+ * minutes for a container its neighbour is not using is the defect, not the
+ * remedy.
+ *
+ * It is not zero, and that is what stops the thrash. A project mid-burst
+ * releases a container between two runs seconds apart, and stripping it in that
+ * gap would make the pair of runs pay a cold start each to hand memory to a
+ * third project that would then lose it the same way. Thirty seconds is longer
+ * than the release-to-reacquire chain (comment insert, wakeup fire, 1 Hz
+ * dispatch cron, acquire) and short enough that a genuinely stranded run is not
+ * left waiting on a container nobody wants.
+ */
+export const CONTAINER_RECLAIM_MIN_IDLE_SEC = 30;
+
+/**
  * The "latest few" messages kept in the active window after a compaction flush.
  * Internal constant (not an operator setting): everything older than this tail
  * is summarized into long-term memory and dropped from the chatbox.


### PR DESCRIPTION
Four containers on one project - two running tasks, two idle - left every other project reporting **"Hezo is at its active-container limit"** indefinitely.

## Why it happened

Three things compound:

1. **Idle members are charged to the memory budget in full.** `getActiveContainers` sums `memory_bytes` over `state IN ('creating','idle','busy')`, so two idle containers hold their whole allocation.
2. **A container is pinned to its project for life.** `container_pool_members.project_id` is set once at provision and nothing reassigns it - correctly, since the container is built around that project's `/workspace` bind mount, clone and git identity. Unused memory cannot be handed over.
3. **The only thing that retired idle members asked a project-shaped question.** `IDLE_CANDIDATE_SQL` excludes any project matching `BUSY_PROJECTS_SQL`, whose first arm is "has a queued or running run". A project working through two tasks never qualifies, so its idle containers were held **until it finished everything it had** - not for the idle window.

Two secondary defects in the same query: the clock was `projects.container_last_started_at`, so starting any container reset the timer for every idle sibling, and the scan keyed off the legacy `projects.container_*` columns rather than pool-member rows.

## What changed

Everything here is above the `ContainerEngine` seam - no adapter, no conformance suite, no backend branch.

**Idle retirement becomes a property of the member.** `planSurplusIdleRetirement` retires a *working* project's idle members on their own `last_released_at` clock. A fully idle project still goes through the whole-project pass, which keeps one member suspended for a warm restart, so single-container projects behave exactly as before.

**`planCrossProjectReclaim` closes the gap in between.** Rather than queue behind memory a neighbour is demonstrably not using, a blocked acquire retires enough of other projects' idle members to cover its shortfall. All-or-nothing (freeing part of a shortfall helps nobody and has destroyed a warm container to do it), only as much as the shortfall, hoarder-first then longest-idle, and floored at `CONTAINER_RECLAIM_MIN_IDLE_SEC` (30s) so a project mid-burst keeps its containers - which is also what stops two starved projects reclaiming from each other in a loop.

**Both dispatch gates count reclaimable memory as headroom.** They run *before* the pool, so without this the run is skipped as `InstanceAtCapacity` and the reclaim rung never fires - dead code behind a closed door. `isContainerCapacityBlocked` and `isContainerCapacityBlockedInDb` are a deliberate pair and stay in step.

**Lock ordering.** `acquireRunContainer` now takes its lifecycle lock **per attempt** rather than around the loop, so reclaim - which takes the *victims'* locks - never runs while holding the requester's. A process-wide reclaim mutex stops two requesters counting the same idle containers as their headroom.

**A second leak in `planIdleShutdown`.** A pinned (`has_unpushed_commits`) member alongside an already-suspended one was neither suspended nor destroyed, so it kept its full RAM cap out of the budget forever - the flag is only cleared by a later run on that same container. Every pinned member is now suspended, which frees the memory and keeps the only copy of the work.

## Migration

`053_container_pool_idle_clock.sql` makes `last_released_at` a dependable clock: backfills NULLs from `created_at`, sets `DEFAULT now()` + `NOT NULL`, and adds `idx_container_pool_members_idle (state, last_released_at) WHERE NOT reserved_for_chat` - which serves both new scans. Data-preservation test asserts pre-existing stamps survive untouched, a missing stamp is backfilled to its `created_at`, and the column is total.

## Tests

- `sandbox-pool.test.ts` - the new `reclaim` rung, `planSurplusIdleRetirement`, and `planCrossProjectReclaim` (ordering, idle floor, all-or-nothing, suspend-vs-destroy, mixed container sizes). 45 tests.
- `job-manager-idle-stop.test.ts` - **the regression test for the report**: a project with two busy and two idle members has the idle two retired while the busy ones keep running; plus the fresh-member, unpushed-commits, chat-pinned and fully-idle cases.
- `containers-pool-acquire.test.ts` - a blocked project acquires by reclaiming; unpushed-commit donors are suspended not destroyed; a just-released donor is left alone; a project reuses its own warm container rather than taking somebody else's.
- `run-concurrency-capacity.test.ts` - the gate un-blocks on reclaimable headroom, and still blocks when everything elsewhere is busy, inside the floor, chat-pinned, or the project's own.
- `migrate-053-container-pool-idle-clock.test.ts` - data preservation.

`bun run typecheck` and `biome check` clean. Ran locally: `--pattern container` (240), `--pattern job-manager` (202), `--pattern migrate` (307), `--package shared` (263), plus the four suites above - all green. Four failures in `sandbox-open.test.ts` / `sandbox-backend-store.test.ts` are pre-existing in this environment (no Docker daemon) and reproduce on a clean tree.

## Risks

- **Warm-reuse hit rate falls** where memory is contended. The idle floor and "evict the minimum" rule bound it; longest-idle-first targets the least useful container.
- **On a managed backend** a reclaimed sandbox is destroyed and later recreated rather than resumed, so a tight budget will show more provisioning.
- **Lock ordering** is the one place a bug becomes a hang rather than a wrong answer - the per-attempt lock restructure in `acquireRunContainer` deserves the closest look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQf64LRpiCr6cgEscY1be4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQf64LRpiCr6cgEscY1be4)_