### PR TITLE
fix(web): open dropdown panels above their anchor when there is no room below

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | Shared enums, constants, validation run on both sides | `@hezo/shared` (`types/common.ts`) |
 | An instance setting | `routes/instance-settings.ts` + the `system-meta` helpers |
 | Date formatting | `packages/web/src/lib/format-date.ts` |
+| A dropdown panel's vertical side + height clamp | `usePanelPlacement` (`hooks/use-panel-placement.ts`), pure math in `lib/panel-placement.ts` |
 | An optimistic mutation | `useOptimisticMutation` (`hooks/use-optimistic-mutation.ts`) |
 | A server test context | `createTestContext()` (`test/helpers/context.ts`) |
 | A migration test | `createDataPreservationHarness()` (`test/helpers/migrate.ts`) |

--- a/packages/web/src/components/document-review/add-to-task-picker.tsx
+++ b/packages/web/src/components/document-review/add-to-task-picker.tsx
@@ -1,8 +1,16 @@
 import { Hash, Loader2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePanelPlacement } from '../../hooks/use-panel-placement';
 import { useTasks } from '../../hooks/use-tasks';
 import { Button } from '../ui/button';
 import type { ReviewTaskContext } from './action-review-dialog';
+
+/**
+ * Filter input plus the former `max-h-56` list, now the whole panel's design
+ * cap: the panel is the scroll container (the filter row sticks to its top), so
+ * `usePanelPlacement` can read a content height its own clamp doesn't move.
+ */
+const PANEL_MAX_HEIGHT_PX = 264;
 
 interface TaskRow {
 	/** Lowercase identifier — the `:taskId` API path segment. */
@@ -31,8 +39,9 @@ interface AddToTaskPickerProps {
  * "Add to task": a filterable dropdown of the project's tasks, opened from the
  * action-review dialog's footer. Hand-rolled absolute panel (MentionPicker
  * style) rather than a body-portaled popover — the trigger already sits inside
- * a modal dialog, and the panel opens upward so it never crosses the dialog's
- * scroll edge. Selecting a row posts the handoff to that task immediately.
+ * a modal dialog. `usePanelPlacement` picks the side: it prefers upward, the
+ * trigger being a dialog-footer button, and drops below only when there is no
+ * room above. Selecting a row posts the handoff to that task immediately.
  */
 export function AddToTaskPicker({
 	projectId,
@@ -46,7 +55,7 @@ export function AddToTaskPicker({
 	const [query, setQuery] = useState('');
 	const [debouncedQuery, setDebouncedQuery] = useState('');
 	const [highlightedIndex, setHighlightedIndex] = useState(0);
-	const listRef = useRef<HTMLDivElement>(null);
+	const anchorRef = useRef<HTMLDivElement>(null);
 
 	// Fresh filter on every open.
 	useEffect(() => {
@@ -100,14 +109,23 @@ export function AddToTaskPicker({
 		return rest;
 	}, [data, currentTask, debouncedQuery]);
 
+	const { panelRef, side, sideClassName, style } = usePanelPlacement<HTMLDivElement>(anchorRef, {
+		open,
+		prefer: 'top',
+		preferredMaxHeight: PANEL_MAX_HEIGHT_PX,
+		deps: [rows, isFetching],
+	});
+
 	useEffect(() => {
 		if (highlightedIndex >= rows.length) setHighlightedIndex(0);
 	}, [rows, highlightedIndex]);
 
 	useEffect(() => {
-		const el = listRef.current?.querySelector<HTMLElement>(`[data-task-idx="${highlightedIndex}"]`);
+		const el = panelRef.current?.querySelector<HTMLElement>(
+			`[data-task-idx="${highlightedIndex}"]`,
+		);
 		if (el) el.scrollIntoView({ block: 'nearest' });
-	}, [highlightedIndex]);
+	}, [highlightedIndex, panelRef]);
 
 	// Tracks the blur-close timer so we can cancel it on unmount. Without this
 	// the timer fires after the component is gone — in happy-dom teardown that
@@ -152,7 +170,7 @@ export function AddToTaskPicker({
 	}
 
 	return (
-		<div className="relative">
+		<div ref={anchorRef} className="relative">
 			<Button
 				size="sm"
 				onClick={() => onOpenChange(!open)}
@@ -167,7 +185,10 @@ export function AddToTaskPicker({
 			</Button>
 			{open && (
 				<div
-					className="absolute bottom-full right-0 z-10 mb-1 w-72 max-w-[calc(100vw-3rem)] rounded-md border border-border bg-surface shadow-md"
+					ref={panelRef}
+					className={`absolute right-0 z-10 ${sideClassName} w-72 max-w-[calc(100vw-3rem)] overflow-y-auto rounded-md border border-border bg-surface shadow-md`}
+					style={style}
+					data-placement={side}
 					data-testid="add-to-task-picker"
 				>
 					<input
@@ -180,9 +201,9 @@ export function AddToTaskPicker({
 						placeholder="Filter tasks…"
 						aria-label="Filter tasks"
 						data-testid="add-to-task-filter"
-						className="w-full border-b border-border bg-transparent px-3 py-2 text-[13px] text-text-1 outline-none placeholder:text-text-3"
+						className="sticky top-0 z-10 w-full border-b border-border bg-surface px-3 py-2 text-[13px] text-text-1 outline-none placeholder:text-text-3"
 					/>
-					<div ref={listRef} role="listbox" className="max-h-56 overflow-y-auto p-1">
+					<div role="listbox" className="p-1">
 						{isFetching && rows.length === 0 && (
 							<div className="px-3 py-2 text-xs text-text-2">Searching…</div>
 						)}

--- a/packages/web/src/components/mention-picker.tsx
+++ b/packages/web/src/components/mention-picker.tsx
@@ -1,6 +1,7 @@
 import { AtSign, FileText, Hash, UserRound } from 'lucide-react';
-import { useEffect, useMemo, useRef } from 'react';
+import { type RefObject, useEffect, useMemo } from 'react';
 import type { MentionKind, MentionSearchResult } from '../hooks/use-mentions';
+import { usePanelPlacement } from '../hooks/use-panel-placement';
 
 const KIND_ICON: Record<MentionKind, React.ComponentType<{ className?: string }>> = {
 	agent: UserRound,
@@ -16,6 +17,13 @@ const KIND_LABEL: Record<MentionKind, string> = {
 	doc: 'Project doc',
 };
 
+/** Everything but the vertical side, which `usePanelPlacement` decides per open. */
+const PANEL_BASE =
+	'absolute left-0 right-0 z-40 rounded-md border border-border bg-surface shadow-md';
+
+/** The former `max-h-64`, now the design cap the placement clamp works against. */
+const PANEL_MAX_HEIGHT_PX = 256;
+
 interface MentionPickerProps {
 	query: string;
 	results: MentionSearchResult[];
@@ -23,6 +31,8 @@ interface MentionPickerProps {
 	highlightedIndex: number;
 	onHoverIndex: (index: number) => void;
 	onSelect: (result: MentionSearchResult) => void;
+	/** The textarea's positioning wrapper — what the picker is measured against. */
+	anchorRef: RefObject<HTMLElement | null>;
 }
 
 export function MentionPicker({
@@ -32,21 +42,34 @@ export function MentionPicker({
 	highlightedIndex,
 	onHoverIndex,
 	onSelect,
+	anchorRef,
 }: MentionPickerProps) {
-	const listRef = useRef<HTMLDivElement>(null);
+	// The picker only mounts while open, so `open` is unconditionally true here.
+	// One ref serves both jobs: the panel is the scroll container, so it is what
+	// gets measured and what the highlighted row scrolls within.
+	const { panelRef, side, sideClassName, style } = usePanelPlacement<HTMLDivElement>(anchorRef, {
+		open: true,
+		preferredMaxHeight: PANEL_MAX_HEIGHT_PX,
+		deps: [results, loading, query],
+	});
 
 	const grouped = useMemo(() => results, [results]);
 
 	useEffect(() => {
-		const el = listRef.current?.querySelector<HTMLElement>(
+		const el = panelRef.current?.querySelector<HTMLElement>(
 			`[data-mention-idx="${highlightedIndex}"]`,
 		);
 		if (el) el.scrollIntoView({ block: 'nearest' });
-	}, [highlightedIndex]);
+	}, [highlightedIndex, panelRef]);
 
 	if (!loading && results.length === 0) {
 		return (
-			<div className="absolute left-0 right-0 top-full z-40 mt-1 rounded-md border border-border bg-surface shadow-md">
+			<div
+				ref={panelRef}
+				className={`${PANEL_BASE} ${sideClassName}`}
+				style={style}
+				data-placement={side}
+			>
 				<div className="px-3 py-2 text-xs text-text-2">
 					{query ? `No matches for @${query}` : 'Type to search'}
 				</div>
@@ -56,8 +79,10 @@ export function MentionPicker({
 
 	return (
 		<div
-			ref={listRef}
-			className="absolute left-0 right-0 top-full z-40 mt-1 max-h-64 overflow-y-auto rounded-md border border-border bg-surface shadow-md"
+			ref={panelRef}
+			className={`${PANEL_BASE} ${sideClassName} overflow-y-auto`}
+			style={style}
+			data-placement={side}
 			data-testid="mention-picker"
 		>
 			{loading && <div className="px-3 py-2 text-xs text-text-2">Searching…</div>}

--- a/packages/web/src/components/mention-textarea.tsx
+++ b/packages/web/src/components/mention-textarea.tsx
@@ -31,6 +31,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
 		},
 		forwardedRef,
 	) {
+		const wrapperRef = useRef<HTMLDivElement>(null);
 		const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 		const setTextareaRef = useCallback(
 			(el: HTMLTextAreaElement | null) => {
@@ -193,7 +194,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
 		);
 
 		return (
-			<div className={containerClassName}>
+			<div ref={wrapperRef} className={containerClassName}>
 				<Textarea
 					{...rest}
 					ref={setTextareaRef}
@@ -210,6 +211,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
 						highlightedIndex={highlightedIndex}
 						onHoverIndex={setHighlightedIndex}
 						onSelect={handleSelect}
+						anchorRef={wrapperRef}
 					/>
 				)}
 			</div>

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { Agent } from '../../hooks/use-agents';
 import type { CommentSkeleton } from '../../hooks/use-comments';
 import type { ExecutionLockState } from '../../hooks/use-execution-locks';
+import { usePanelPlacement } from '../../hooks/use-panel-placement';
 import { useQueuedWakeups } from '../../hooks/use-queued-wakeups';
 import { type Task, useTaskAncestors, type useUpdateTask } from '../../hooks/use-tasks';
 import { TASK_RUN_STATUS_META } from '../../lib/status-meta';
@@ -36,6 +37,9 @@ const EFFORT_LEVELS: { value: AgentEffort; label: string }[] = [
 	{ value: AgentEffort.High, label: 'High' },
 	{ value: AgentEffort.Max, label: 'Max (ultrathink)' },
 ];
+
+/** The assignee dropdown's former `max-h-48`, now the placement clamp's design cap. */
+const ASSIGNEE_PANEL_MAX_HEIGHT_PX = 192;
 
 interface TaskSidebarProps {
 	task: Task;
@@ -100,6 +104,17 @@ export function TaskSidebar({
 	const assigneeOptions = agents
 		?.filter((a) => a.admin_status !== 'disabled')
 		.filter((a) => !isInternalProject || a.slug === CAPTAIN_AGENT_SLUG);
+
+	const {
+		panelRef: assigneePanelRef,
+		side: assigneeSide,
+		sideClassName: assigneeSideClass,
+		style: assigneePanelStyle,
+	} = usePanelPlacement<HTMLDivElement>(assigneeRef, {
+		open: assigneeOpen,
+		preferredMaxHeight: ASSIGNEE_PANEL_MAX_HEIGHT_PX,
+		deps: [assigneeOptions],
+	});
 
 	// Reassignment is blocked whenever the task carries any non-terminal run —
 	// that mirrors the server, which 409s on a queued run just as it does on a
@@ -241,7 +256,12 @@ export function TaskSidebar({
 								</button>
 							</div>
 							{assigneeOpen && (
-								<div className="absolute left-0 right-0 top-full mt-1 z-20 rounded-md border border-border bg-surface shadow-md max-h-48 overflow-y-auto">
+								<div
+									ref={assigneePanelRef}
+									className={`absolute left-0 right-0 z-20 ${assigneeSideClass} rounded-md border border-border bg-surface shadow-md overflow-y-auto`}
+									style={assigneePanelStyle}
+									data-placement={assigneeSide}
+								>
 									{assigneeOptions?.map((a) => (
 										<button
 											type="button"

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { AlertTriangle, AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
+import { usePanelPlacement } from '../hooks/use-panel-placement';
 import { type Task, useInfiniteTasks, useTasks } from '../hooks/use-tasks';
 import { useI18n } from '../lib/i18n';
 import { nestTasksForDisplay } from '../lib/nest-tasks-for-display';
@@ -193,6 +194,16 @@ export function TaskList({ projectId }: TaskListProps) {
 	const [sortField, setSortField] = useState<SortField>(stored?.sortField ?? 'work_order');
 	const [sortDir, setSortDir] = useState<SortDir>(stored?.sortDir ?? 'asc');
 	const [createOpen, setCreateOpen] = useState(false);
+
+	const filterBarRef = useRef<HTMLDivElement>(null);
+	// No design cap: the panel is a wrap-around form, so it stays exactly as tall
+	// as its content wherever there is room and only clamps on a short viewport.
+	const {
+		panelRef: filterPanelRef,
+		side: filterSide,
+		sideClassName: filterSideClass,
+		style: filterPanelStyle,
+	} = usePanelPlacement<HTMLDivElement>(filterBarRef, { open: expanded });
 
 	useEffect(() => {
 		const handle = setTimeout(() => {
@@ -493,7 +504,7 @@ export function TaskList({ projectId }: TaskListProps) {
 	);
 
 	const filterBar = (
-		<div className="relative flex-1 min-w-0 h-10" data-testid="task-filter-bar">
+		<div ref={filterBarRef} className="relative flex-1 min-w-0 h-10" data-testid="task-filter-bar">
 			<div className="h-full rounded-md border border-border bg-surface">
 				<button
 					type="button"
@@ -512,8 +523,11 @@ export function TaskList({ projectId }: TaskListProps) {
 			</div>
 			{expanded && (
 				<div
+					ref={filterPanelRef}
 					data-testid="task-filter-panel"
-					className="absolute left-0 right-0 top-full z-20 mt-1 rounded-md border border-border bg-surface shadow-md px-3 py-3 flex flex-wrap items-end gap-3"
+					data-placement={filterSide}
+					style={filterPanelStyle}
+					className={`absolute left-0 right-0 z-20 ${filterSideClass} rounded-md border border-border bg-surface shadow-md overflow-y-auto px-3 py-3 flex flex-wrap items-end gap-3`}
 				>
 					<label className="flex flex-col gap-1 flex-1 min-w-0 sm:min-w-[180px]">
 						<span className="text-[11px] uppercase tracking-wider text-text-3">Search</span>

--- a/packages/web/src/hooks/use-panel-placement.ts
+++ b/packages/web/src/hooks/use-panel-placement.ts
@@ -1,0 +1,184 @@
+import {
+	type CSSProperties,
+	type DependencyList,
+	type RefObject,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react';
+import { PANEL_SIDE_CLASS, type PanelSide, resolvePanelPlacement } from '../lib/panel-placement';
+
+export interface PanelPlacementOptions {
+	/** Measure and listen only while the panel is up. */
+	open: boolean;
+	prefer?: PanelSide;
+	/** The panel's design cap in px (its former `max-h-*`). */
+	preferredMaxHeight?: number;
+	/** Values that change the panel's content height — results, rows, a loading flag. */
+	deps?: DependencyList;
+}
+
+export interface PanelPlacementResult<P extends HTMLElement> {
+	/** Attach to the panel element: it is both measured and observed. */
+	panelRef: RefObject<P | null>;
+	side: PanelSide;
+	/** The vertical position classes — concatenate with the caller's own horizontal ones. */
+	sideClassName: string;
+	/** Spread onto the panel's `style` to apply the height cap. */
+	style: CSSProperties;
+}
+
+/** A clipping scroll ancestor, resolved once per open so the walk stays off the scroll path. */
+interface ClipAncestor {
+	el: HTMLElement;
+	borderTop: number;
+	borderBottom: number;
+}
+
+/**
+ * Nearest ancestor that clips its overflow vertically — the real ceiling on how
+ * tall a panel can be, since an absolutely-positioned element is cut off at its
+ * scroll container's padding box however much viewport is left.
+ *
+ * Returns `null` where the answer can't be trusted: no `getComputedStyle`, or a
+ * zero-height rect, which is what a layout-less environment (happy-dom) reports
+ * for everything. Falling back to the viewport band there keeps the hook inert
+ * rather than wrong.
+ */
+function resolveClipAncestor(from: HTMLElement): ClipAncestor | null {
+	if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') return null;
+	let el = from.parentElement;
+	while (el && el !== document.body) {
+		const style = window.getComputedStyle(el);
+		// An empty string is happy-dom's "no cascade resolved", not `visible`.
+		if (style.overflowY && style.overflowY !== 'visible') {
+			const rect = el.getBoundingClientRect();
+			if (rect.height === 0) return null;
+			return {
+				el,
+				borderTop: Number.parseFloat(style.borderTopWidth) || 0,
+				borderBottom: Number.parseFloat(style.borderBottomWidth) || 0,
+			};
+		}
+		el = el.parentElement;
+	}
+	return null;
+}
+
+/** The band the panel must stay inside: the visual viewport, narrowed by any clipping ancestor. */
+function resolveBand(clip: ClipAncestor | null): { top: number; bottom: number } {
+	// `visualViewport` is the part of the page actually on screen, so the band
+	// shrinks when a mobile soft keyboard covers the bottom of the window.
+	// Desktop Chromium has no soft keyboard, so that leg is code-reviewed only.
+	const vv = typeof window === 'undefined' ? null : window.visualViewport;
+	const top = vv?.offsetTop ?? 0;
+	const bottom = top + (vv?.height ?? window.innerHeight);
+	if (!clip) return { top, bottom };
+	const rect = clip.el.getBoundingClientRect();
+	return {
+		top: Math.max(top, rect.top + clip.borderTop),
+		bottom: Math.min(bottom, rect.bottom - clip.borderBottom),
+	};
+}
+
+/**
+ * Opens a dropdown panel on whichever side of its anchor has room, shrinking it
+ * to fit rather than letting it cross the viewport edge: above the anchor near
+ * the bottom of the screen, below it near the top, scrolling internally when
+ * neither side can hold it whole.
+ *
+ * Measurement runs in a layout effect, so the resolved side lands in the same
+ * frame the panel mounts and there is no visible flash of a wrongly-placed
+ * panel. It re-measures on `deps`, on window and visual-viewport resize, on any
+ * ancestor scroll (capture phase, so no scroll-parent hunting), and through a
+ * ResizeObserver on both anchor and panel — the anchor half being what tracks
+ * the comment composer's textarea auto-growing as it is typed into.
+ *
+ * **The panel must be its own scroll container.** Content height is read from
+ * `panel.scrollHeight`, which reports the full content independently of the
+ * `max-height` written here only while the panel itself scrolls. Wrap it in a
+ * flex shell around an inner scroller instead and flex will shrink that child
+ * to the cap, so `scrollHeight` reports the cap straight back and the panel can
+ * never grow again once space reopens.
+ *
+ * That same property is what stops the re-measure looping: the cap cannot move
+ * the measured content height, the anchor is unaffected because the panel is out
+ * of flow, and the state write is skipped when nothing changed.
+ */
+export function usePanelPlacement<P extends HTMLElement>(
+	anchorRef: RefObject<HTMLElement | null>,
+	{ open, prefer = 'bottom', preferredMaxHeight, deps = [] }: PanelPlacementOptions,
+): PanelPlacementResult<P> {
+	const panelRef = useRef<P | null>(null);
+	const clipRef = useRef<ClipAncestor | null>(null);
+	const [placement, setPlacement] = useState<{ side: PanelSide; maxHeight: number | undefined }>(
+		() => ({ side: prefer, maxHeight: undefined }),
+	);
+
+	const measure = useCallback(() => {
+		const anchor = anchorRef.current;
+		if (!anchor) return;
+		const rect = anchor.getBoundingClientRect();
+		const band = resolveBand(clipRef.current);
+		const next = resolvePanelPlacement({
+			anchorTop: rect.top,
+			anchorBottom: rect.bottom,
+			viewportTop: band.top,
+			viewportBottom: band.bottom,
+			contentHeight: panelRef.current?.scrollHeight ?? 0,
+			prefer,
+			preferredMaxHeight,
+		});
+		setPlacement((prev) =>
+			prev.side === next.side && prev.maxHeight === next.maxHeight ? prev : next,
+		);
+	}, [anchorRef, prefer, preferredMaxHeight]);
+
+	// Listeners live exactly as long as the panel does. The clipping ancestor is
+	// resolved here rather than per measure — an ancestor's overflow can't change
+	// while the panel is up, so scroll handling never walks the tree.
+	useLayoutEffect(() => {
+		if (!open) return;
+		const anchor = anchorRef.current;
+		if (!anchor) return;
+		clipRef.current = resolveClipAncestor(anchor);
+		measure();
+
+		window.addEventListener('resize', measure);
+		document.addEventListener('scroll', measure, { capture: true, passive: true });
+		const vv = window.visualViewport;
+		vv?.addEventListener('resize', measure);
+		vv?.addEventListener('scroll', measure);
+
+		let ro: ResizeObserver | undefined;
+		if (typeof ResizeObserver !== 'undefined') {
+			ro = new ResizeObserver(measure);
+			ro.observe(anchor);
+			if (panelRef.current) ro.observe(panelRef.current);
+		}
+
+		return () => {
+			window.removeEventListener('resize', measure);
+			document.removeEventListener('scroll', measure, { capture: true });
+			vv?.removeEventListener('resize', measure);
+			vv?.removeEventListener('scroll', measure);
+			ro?.disconnect();
+			clipRef.current = null;
+		};
+	}, [open, anchorRef, measure]);
+
+	// Content-height signals from the caller. Separate from the effect above so a
+	// keystroke re-measures without tearing down and re-adding every listener.
+	useLayoutEffect(() => {
+		if (!open) return;
+		measure();
+	}, [open, measure, ...deps]);
+
+	return {
+		panelRef,
+		side: placement.side,
+		sideClassName: PANEL_SIDE_CLASS[placement.side],
+		style: { maxHeight: placement.maxHeight },
+	};
+}

--- a/packages/web/src/lib/panel-placement.ts
+++ b/packages/web/src/lib/panel-placement.ts
@@ -1,0 +1,113 @@
+/**
+ * Vertical placement for a dropdown panel anchored to a trigger: which side of
+ * the anchor it opens on, and how tall it is allowed to be there.
+ *
+ * Pure arithmetic over rectangles so it unit-tests in the component tier
+ * (happy-dom has no layout engine); the DOM measurement and the
+ * resize/scroll wiring live in `hooks/use-panel-placement.ts`.
+ *
+ * Horizontal anchoring is deliberately not modelled here. The call sites
+ * disagree — three panels are full-width `left-0 right-0`, one is `right-0 w-72`
+ * — so the horizontal classes stay with the caller and only the vertical side
+ * and the height cap are shared.
+ *
+ * The band the panel must stay inside is passed as an explicit top/bottom pair
+ * rather than a height, so a caller can hand in the *visual* viewport (soft
+ * keyboard up) or its intersection with a clipping scroll ancestor without this
+ * file knowing either exists.
+ */
+
+export type PanelSide = 'bottom' | 'top';
+
+/** The vertical half of a panel's position classes, keyed by side. */
+export const PANEL_SIDE_CLASS: Record<PanelSide, string> = {
+	bottom: 'top-full mt-1',
+	top: 'bottom-full mb-1',
+};
+
+/** Gap kept between the panel and the band edge. Matches the `mt-1`/`mb-1` offset. */
+export const PANEL_EDGE_PADDING_PX = 8;
+
+/**
+ * A panel's cap is never squeezed below this. On a band too short to hold it,
+ * a slight overhang is better than an unusable sliver — and since the cap is a
+ * `max-height`, a panel whose content is shorter still renders short.
+ */
+export const PANEL_MIN_HEIGHT_PX = 96;
+
+export interface PanelPlacementInput {
+	/** Anchor edges in client coordinates (`getBoundingClientRect()`). */
+	anchorTop: number;
+	anchorBottom: number;
+	/** The band the panel must stay inside, in the same coordinates. */
+	viewportTop: number;
+	viewportBottom: number;
+	/**
+	 * The panel's natural, unclamped content height (`panel.scrollHeight`). Only
+	 * decides the side — never the cap, so a sub-pixel content height can't
+	 * produce a cap that scrolls its own content by a fraction of a pixel. `0`
+	 * before the first measurement, which resolves to `prefer` unflipped.
+	 */
+	contentHeight: number;
+	/** The side to use whenever it can hold the panel. Defaults to `'bottom'`. */
+	prefer?: PanelSide;
+	/** The panel's design cap in px (its former `max-h-*`). Omit for "as tall as it fits". */
+	preferredMaxHeight?: number;
+	padding?: number;
+	minHeight?: number;
+}
+
+export interface PanelPlacement {
+	side: PanelSide;
+	/** px cap for the panel box: never past the band, never below `minHeight`. */
+	maxHeight: number;
+}
+
+/**
+ * Choose the side of the anchor with room for the panel, and the height cap
+ * that keeps it inside the band.
+ *
+ * The preferred side wins whenever it can hold the panel whole, so a panel only
+ * moves when staying put would clip it; when neither side fits, the roomier one
+ * takes it and the panel scrolls internally. Ties keep the preferred side, so a
+ * panel centred in its band never oscillates between the two.
+ */
+export function resolvePanelPlacement({
+	anchorTop,
+	anchorBottom,
+	viewportTop,
+	viewportBottom,
+	contentHeight,
+	prefer = 'bottom',
+	preferredMaxHeight,
+	padding = PANEL_EDGE_PADDING_PX,
+	minHeight = PANEL_MIN_HEIGHT_PX,
+}: PanelPlacementInput): PanelPlacement {
+	const space: Record<PanelSide, number> = {
+		bottom: Math.max(0, viewportBottom - anchorBottom - padding),
+		top: Math.max(0, anchorTop - viewportTop - padding),
+	};
+	const other: PanelSide = prefer === 'bottom' ? 'top' : 'bottom';
+
+	// What the panel would like to occupy: its content, never more than its
+	// design cap.
+	const desired =
+		preferredMaxHeight === undefined ? contentHeight : Math.min(contentHeight, preferredMaxHeight);
+
+	let side: PanelSide;
+	if (space[prefer] >= desired) side = prefer;
+	else if (space[other] >= desired) side = other;
+	else side = space[other] > space[prefer] ? other : prefer;
+
+	// The cap comes from the design cap and the room on the chosen side — not
+	// from the content. `max-height` doesn't stretch a short panel, so capping
+	// at the available space leaves a two-row picker two rows tall.
+	const bandCap = Math.max(0, viewportBottom - viewportTop - 2 * padding);
+	const fromSpace = Math.min(preferredMaxHeight ?? space[side], space[side]);
+	// The band wins over the floor: a band genuinely shorter than `minHeight`
+	// cannot hold `minHeight`, and overflowing it is what this function exists
+	// to prevent.
+	const maxHeight = Math.min(Math.max(fromSpace, minHeight), bandCap);
+
+	return { side, maxHeight };
+}

--- a/packages/web/test/mention-autocomplete.test.tsx
+++ b/packages/web/test/mention-autocomplete.test.tsx
@@ -6,6 +6,11 @@
 // matches" empty state, and the not-a-trigger case. Component tier — no real
 // layout / viewport / WebSocket (the picker's scrollIntoView is a no-op in
 // happy-dom but the surrounding logic is fully reachable).
+//
+// The picker's flip-above-when-near-the-bottom placement is only reachable here
+// as the `data-placement` attribute — happy-dom reports a zero box for
+// everything, so which side it actually resolves to is covered by
+// test/browser/dropdown-flip-placement.mobile.spec.ts.
 
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
@@ -47,6 +52,18 @@ test('typing "@" opens the picker and shows the searching/results state, with ag
 	expect(option.textContent).toContain('@');
 	// The kind label is shown on the right.
 	expect(option.textContent?.toLowerCase()).toContain('agent');
+});
+
+test('the open picker carries a resolved placement, defaulting below the composer', async () => {
+	const { composer, findByTestId, user } = await setupComposer();
+
+	await user.type(composer, '@cap');
+
+	const picker = await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+	// The placement hook ran and committed a side. With no layout engine there is
+	// always room below, so this is the unflipped default every composer had before.
+	expect(picker.getAttribute('data-placement')).toBe('bottom');
+	expect(picker.className).toContain('top-full');
 });
 
 test('selecting an agent option with a mouse inserts "@slug " into the textarea', async () => {

--- a/packages/web/test/panel-placement.test.ts
+++ b/packages/web/test/panel-placement.test.ts
@@ -1,0 +1,153 @@
+// Unit tests for the dropdown-panel placement math: which side of the anchor a
+// panel opens on, and the height cap that keeps it inside its band. This is the
+// tier that can actually assert the geometry — happy-dom has no layout, so the
+// hook and component tiers only see zero-sized rects. Real pixels are covered by
+// test/browser/dropdown-flip-placement.mobile.spec.ts.
+import { describe, expect, test } from 'vitest';
+import {
+	PANEL_EDGE_PADDING_PX,
+	PANEL_MIN_HEIGHT_PX,
+	PANEL_SIDE_CLASS,
+	type PanelPlacementInput,
+	resolvePanelPlacement,
+} from '../src/lib/panel-placement';
+
+/** A tall band with the anchor near its top — the "plenty of room below" base case. */
+function base(overrides: Partial<PanelPlacementInput> = {}): PanelPlacementInput {
+	return {
+		anchorTop: 100,
+		anchorBottom: 140,
+		viewportTop: 0,
+		viewportBottom: 800,
+		contentHeight: 300,
+		preferredMaxHeight: 256,
+		...overrides,
+	};
+}
+
+describe('side selection', () => {
+	test('stays below the anchor when the panel fits there', () => {
+		const { side, maxHeight } = resolvePanelPlacement(base());
+		expect(side).toBe('bottom');
+		// Room to spare, so the design cap governs rather than the viewport.
+		expect(maxHeight).toBe(256);
+	});
+
+	test('flips above the anchor when it no longer fits below', () => {
+		// 800 - 640 - 8 = 152px below, well short of the 256px the panel wants.
+		const { side, maxHeight } = resolvePanelPlacement(base({ anchorTop: 600, anchorBottom: 640 }));
+		expect(side).toBe('top');
+		expect(maxHeight).toBe(256);
+	});
+
+	test('takes the roomier side and shrinks to it when neither side fits', () => {
+		// 400px band: 102px below the anchor, 242px above. Neither holds 256.
+		const { side, maxHeight } = resolvePanelPlacement(
+			base({ anchorTop: 250, anchorBottom: 290, viewportBottom: 400 }),
+		);
+		expect(side).toBe('top');
+		expect(maxHeight).toBe(242);
+	});
+
+	test('keeps the preferred side on an exact tie', () => {
+		// A zero-height anchor centred in the band: 192px either way, neither enough.
+		const tie = base({ anchorTop: 200, anchorBottom: 200, viewportBottom: 400 });
+		expect(resolvePanelPlacement(tie).side).toBe('bottom');
+		expect(resolvePanelPlacement({ ...tie, prefer: 'top' }).side).toBe('top');
+	});
+
+	test('prefer: top holds above while it fits and drops below when it does not', () => {
+		expect(
+			resolvePanelPlacement(base({ anchorTop: 600, anchorBottom: 640, prefer: 'top' })).side,
+		).toBe('top');
+		// Anchor near the band top: only 92px above, but 652px below.
+		expect(resolvePanelPlacement(base({ prefer: 'top' })).side).toBe('bottom');
+	});
+
+	test('does not flip before the first measurement', () => {
+		// contentHeight 0 is the pre-measure state: nothing is known to overflow
+		// yet, so the panel must not jump to a side it may not need.
+		const { side } = resolvePanelPlacement(
+			base({ anchorTop: 600, anchorBottom: 640, contentHeight: 0 }),
+		);
+		expect(side).toBe('bottom');
+	});
+
+	test('is decided against the band, not the anchor alone', () => {
+		const geometry = base({ anchorTop: 250, anchorBottom: 290, viewportBottom: 400 });
+		// 242px above vs 102px below -> above.
+		expect(resolvePanelPlacement(geometry).side).toBe('top');
+		// The same anchor with the band starting at 200 leaves only 42px above,
+		// so the roomier side is now below.
+		expect(resolvePanelPlacement({ ...geometry, viewportTop: 200 }).side).toBe('bottom');
+	});
+});
+
+describe('height cap', () => {
+	test('the design cap wins when there is room for it', () => {
+		expect(resolvePanelPlacement(base({ contentHeight: 5000 })).maxHeight).toBe(256);
+	});
+
+	test('without a design cap the cap is the space on the chosen side', () => {
+		// 800 - 140 - 8 = 652.
+		const { maxHeight } = resolvePanelPlacement(
+			base({ preferredMaxHeight: undefined, contentHeight: 300 }),
+		);
+		expect(maxHeight).toBe(652);
+	});
+
+	test('short content is not padded out to the cap', () => {
+		// The cap is a `max-height`, so a two-row picker still renders two rows
+		// tall. Content height only decides the side, never the cap — capping at
+		// a fractional content height would scroll the panel against itself.
+		expect(resolvePanelPlacement(base({ contentHeight: 40 })).maxHeight).toBe(256);
+	});
+
+	test('subtracts the edge padding from both sides', () => {
+		const tight = base({ preferredMaxHeight: undefined, contentHeight: 5000, viewportBottom: 400 });
+		expect(resolvePanelPlacement(tight).maxHeight).toBe(252);
+		expect(resolvePanelPlacement({ ...tight, padding: 0 }).maxHeight).toBe(260);
+	});
+
+	test('floors at the minimum height rather than a sliver', () => {
+		// 400 - 396 - 8 clamps to 0 below; 4px above. Both unusable.
+		const { maxHeight } = resolvePanelPlacement(
+			base({ anchorTop: 12, anchorBottom: 396, viewportBottom: 400 }),
+		);
+		expect(maxHeight).toBe(PANEL_MIN_HEIGHT_PX);
+	});
+
+	test('an anchor filling the whole band still resolves to a usable cap', () => {
+		// The fullscreen composer: the anchor is the entire flex column, so both
+		// sides clamp to 0. The panel scrolls internally instead of vanishing.
+		const { side, maxHeight } = resolvePanelPlacement(base({ anchorTop: 0, anchorBottom: 800 }));
+		expect(side).toBe('bottom');
+		expect(maxHeight).toBe(PANEL_MIN_HEIGHT_PX);
+	});
+
+	test('a band shorter than the minimum height wins over the floor', () => {
+		// Nothing can be 96px tall inside a 24px band; overflowing it is the one
+		// thing this function exists to prevent.
+		const { maxHeight } = resolvePanelPlacement(
+			base({ anchorTop: 20, anchorBottom: 30, viewportBottom: 40 }),
+		);
+		expect(maxHeight).toBe(24);
+		expect(maxHeight).toBeGreaterThanOrEqual(0);
+	});
+
+	test('never returns a negative cap for an anchor scrolled out of the band', () => {
+		const { maxHeight } = resolvePanelPlacement(base({ anchorTop: 900, anchorBottom: 940 }));
+		expect(maxHeight).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe('constants', () => {
+	test('each side maps to its own vertical position classes', () => {
+		expect(PANEL_SIDE_CLASS.bottom).toBe('top-full mt-1');
+		expect(PANEL_SIDE_CLASS.top).toBe('bottom-full mb-1');
+	});
+
+	test('the default padding matches the mt-1/mb-1 offset', () => {
+		expect(PANEL_EDGE_PADDING_PX).toBe(8);
+	});
+});

--- a/packages/web/test/use-panel-placement.test.tsx
+++ b/packages/web/test/use-panel-placement.test.tsx
@@ -1,0 +1,144 @@
+// Unit tests for usePanelPlacement: the wiring around the placement math —
+// which side it reports, that it stays inert (and un-thrashed) in a layout-less
+// environment, that it survives a missing ResizeObserver, and that every
+// listener it adds is removed on close and unmount.
+//
+// happy-dom has no layout, so every rect is zero and the resolved side is
+// deterministic here; the arithmetic itself is covered in panel-placement.test.ts
+// and real pixels in test/browser/dropdown-flip-placement.mobile.spec.ts.
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { usePanelPlacement } from '../src/hooks/use-panel-placement';
+import type { PanelSide } from '../src/lib/panel-placement';
+
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+interface HarnessProps {
+	open?: boolean;
+	prefer?: PanelSide;
+	preferredMaxHeight?: number;
+	/** Mutated in the render body so a test can count renders. */
+	renders?: { count: number };
+}
+
+function Harness({ open = true, prefer, preferredMaxHeight, renders }: HarnessProps) {
+	const anchorRef = useRef<HTMLDivElement>(null);
+	const { panelRef, side, sideClassName, style } = usePanelPlacement<HTMLDivElement>(anchorRef, {
+		open,
+		prefer,
+		preferredMaxHeight,
+	});
+	if (renders) renders.count += 1;
+	return (
+		<div ref={anchorRef} data-testid="anchor">
+			{open && (
+				<div
+					ref={panelRef}
+					data-testid="panel"
+					data-placement={side}
+					className={sideClassName}
+					style={style}
+				/>
+			)}
+		</div>
+	);
+}
+
+describe('resolved side', () => {
+	test('defaults to below the anchor', () => {
+		// The pre-existing behaviour of every panel this hook replaces: with no
+		// layout to contradict it, nothing moves.
+		const { getByTestId } = render(<Harness />);
+		const panel = getByTestId('panel');
+		expect(panel.getAttribute('data-placement')).toBe('bottom');
+		expect(panel.className).toBe('top-full mt-1');
+	});
+
+	test('honours a preferred side of top', () => {
+		const { getByTestId } = render(<Harness prefer="top" />);
+		const panel = getByTestId('panel');
+		expect(panel.getAttribute('data-placement')).toBe('top');
+		expect(panel.className).toBe('bottom-full mb-1');
+	});
+
+	test('applies a height cap as an inline style', () => {
+		const { getByTestId } = render(<Harness />);
+		expect(getByTestId('panel').style.maxHeight).not.toBe('');
+	});
+});
+
+describe('measurement wiring', () => {
+	test('does not throw when ResizeObserver is unavailable', () => {
+		// The guard is load-bearing: the web test setup stubs IntersectionObserver
+		// but not ResizeObserver, and older mobile browsers can lack it too.
+		const globals = globalThis as { ResizeObserver?: typeof ResizeObserver };
+		const original = globals.ResizeObserver;
+		globals.ResizeObserver = undefined;
+		try {
+			expect(() => render(<Harness />)).not.toThrow();
+		} finally {
+			globals.ResizeObserver = original;
+		}
+	});
+
+	test('stays stable across repeated resize and scroll events', () => {
+		// Re-measuring must converge, not oscillate: the cap the hook writes can't
+		// move the content height it reads back, so identical geometry has to
+		// produce an identical placement however many times it is measured. A
+		// regression here shows up as a panel flickering between sides on scroll.
+		const renders = { count: 0 };
+		const { getByTestId } = render(<Harness renders={renders} />);
+		const panel = getByTestId('panel');
+		const side = panel.getAttribute('data-placement');
+		const cap = panel.style.maxHeight;
+		const before = renders.count;
+
+		for (let i = 0; i < 5; i += 1) {
+			fireEvent(window, new Event('resize'));
+			fireEvent(document, new Event('scroll'));
+		}
+
+		expect(panel.getAttribute('data-placement')).toBe(side);
+		expect(panel.style.maxHeight).toBe(cap);
+		// React may re-render once per bail-out, but never more than once per event.
+		expect(renders.count - before).toBeLessThanOrEqual(10);
+	});
+
+	test('attaches no listeners while closed', () => {
+		const onWindow = vi.spyOn(window, 'addEventListener');
+		const onDocument = vi.spyOn(document, 'addEventListener');
+		render(<Harness open={false} />);
+		expect(onWindow).not.toHaveBeenCalledWith('resize', expect.anything());
+		expect(onDocument).not.toHaveBeenCalledWith('scroll', expect.anything(), expect.anything());
+	});
+
+	test('removes every listener it added on unmount', () => {
+		const addWindow = vi.spyOn(window, 'addEventListener');
+		const removeWindow = vi.spyOn(window, 'removeEventListener');
+		const addDocument = vi.spyOn(document, 'addEventListener');
+		const removeDocument = vi.spyOn(document, 'removeEventListener');
+
+		const { unmount } = render(<Harness />);
+		const resize = addWindow.mock.calls.find(([type]) => type === 'resize');
+		const scroll = addDocument.mock.calls.find(([type]) => type === 'scroll');
+		expect(resize).toBeDefined();
+		expect(scroll).toBeDefined();
+
+		unmount();
+		// Same handler identity, or the listener outlives the panel.
+		expect(removeWindow).toHaveBeenCalledWith('resize', resize?.[1]);
+		expect(removeDocument).toHaveBeenCalledWith('scroll', scroll?.[1], { capture: true });
+	});
+
+	test('removes its listeners when the panel closes without unmounting', () => {
+		const removeWindow = vi.spyOn(window, 'removeEventListener');
+		const { rerender } = render(<Harness />);
+		removeWindow.mockClear();
+		rerender(<Harness open={false} />);
+		expect(removeWindow).toHaveBeenCalledWith('resize', expect.anything());
+	});
+});

--- a/test/browser/dropdown-flip-placement.mobile.spec.ts
+++ b/test/browser/dropdown-flip-placement.mobile.spec.ts
@@ -1,0 +1,187 @@
+// These tests stay in Playwright because they exercise behavior happy-dom
+// doesn't model (see AGENTS.md decision tree):
+//   1. Real CSS layout — which side a dropdown panel opens on is decided from
+//      live client rects (`getBoundingClientRect` against the viewport and the
+//      panel's clipping scroll ancestor), and the assertion is that the panel
+//      does not cross the viewport edge. happy-dom reports 0 for every box, so
+//      the placement there always resolves to the same side; the arithmetic
+//      itself is covered by packages/web/test/panel-placement.test.ts.
+//   2. Viewport-conditional layout — the `mobile` project runs *.mobile.spec.ts
+//      at 390x844, the viewport where a composer pinned to the bottom of the
+//      page has the least room below it.
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import {
+	createProjectAndClearPlanning,
+	uniqueName,
+	waitForPageLoad,
+	waitForStableBox,
+} from './helpers';
+
+/** The mention picker's design cap (`PANEL_MAX_HEIGHT_PX` in mention-picker.tsx). */
+const PICKER_MAX_HEIGHT = 256;
+
+type CreatedProject = { id: string; slug: string; team_id: string };
+type CreatedTask = { id: string; identifier: string };
+
+async function createProjectWithTalkativeTask(page: Page, token: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	const projectRes = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Dropdown Placement'),
+		description: 'Dropdown flip placement test.',
+	});
+	const project = ((await projectRes.json()) as { data: CreatedProject }).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const agent = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Placement Test Task', assignee_id: agent.id },
+	});
+	const task = ((await taskRes.json()) as { data: CreatedTask }).data;
+
+	// Enough comments to push the composer to the bottom of a scrolling page —
+	// which is the condition the flip exists for. The guard assertion in the test
+	// fails loudly if this ever stops being enough.
+	await Promise.all(
+		Array.from({ length: 12 }, (_, i) =>
+			page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+				headers,
+				data: { content_type: 'text', content: { text: `placement filler comment ${i}` } },
+			}),
+		),
+	);
+
+	return { project, task };
+}
+
+test.describe('Dropdown panels flip to the side with room — mobile (390x844)', () => {
+	test('the mention picker opens above the composer when it sits near the bottom', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { project, task } = await createProjectWithTalkativeTask(page, freshWorkspace.token);
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+		await waitForPageLoad(page);
+
+		const composer = page.getByPlaceholder('Add a comment...');
+		await expect(composer).toBeVisible({ timeout: 20000 });
+
+		const viewport = page.viewportSize();
+		if (!viewport) throw new Error('no viewport size');
+
+		await composer.click();
+		await composer.pressSequentially('@cap');
+
+		const picker = page.getByTestId('mention-picker');
+		await expect(picker).toBeVisible({ timeout: 20000 });
+
+		// The comment list above the composer is virtualized, and Virtuoso keeps
+		// correcting the scroll position as it swaps estimated row heights for real
+		// ones. Two separate boundingBox() calls can therefore straddle a
+		// correction and disagree, so read every rect in one evaluate: the whole
+		// snapshot is then internally consistent whatever the list does next.
+		const snapshot = () =>
+			page.evaluate(() => {
+				const anchor = document.querySelector<HTMLElement>(
+					'textarea[placeholder="Add a comment..."]',
+				);
+				const panel = document.querySelector<HTMLElement>('[data-testid="mention-picker"]');
+				if (!anchor || !panel) return null;
+				const a = anchor.getBoundingClientRect();
+				const p = panel.getBoundingClientRect();
+				return {
+					gapBelow: window.innerHeight - a.bottom,
+					placement: panel.getAttribute('data-placement'),
+					anchorTop: a.top,
+					panelTop: p.top,
+					panelBottom: p.bottom,
+					viewportHeight: window.innerHeight,
+				};
+			});
+
+		// Park the composer hard against the bottom of the viewport — the position
+		// the flip exists for — and wait for the picker to have resolved upward
+		// from there. Scrolling with the picker already open also exercises the
+		// hook's scroll-driven re-measure. The poll returns a label rather than a
+		// boolean so a failure says which precondition never held.
+		let settled: Awaited<ReturnType<typeof snapshot>> = null;
+		await expect
+			.poll(
+				async () => {
+					await page
+						.locator('main')
+						.first()
+						.evaluate((el) => {
+							el.scrollTo({ top: el.scrollHeight });
+						});
+					const s = await snapshot();
+					if (!s) return 'composer-or-picker-missing';
+					if (s.gapBelow < 0 || s.gapBelow >= PICKER_MAX_HEIGHT) {
+						return `composer-not-near-bottom:${Math.round(s.gapBelow)}`;
+					}
+					settled = s;
+					return s.placement ?? 'no-placement-attribute';
+				},
+				{ timeout: 30000 },
+			)
+			.toBe('top');
+
+		if (!settled) throw new Error('no settled snapshot captured');
+		const { anchorTop, panelTop, panelBottom, viewportHeight } = settled;
+		// Entirely above the composer. The tolerance absorbs sub-pixel rounding
+		// only — the regression this guards against put the whole panel (256px)
+		// on the wrong side.
+		expect(panelBottom).toBeLessThanOrEqual(anchorTop + 0.5);
+		// And inside the viewport on both edges, which is the shrink-to-fit clamp.
+		expect(panelTop).toBeGreaterThanOrEqual(-0.5);
+		expect(panelBottom).toBeLessThanOrEqual(viewportHeight + 0.5);
+	});
+
+	test('a panel near the top opens downward, and clamps instead of overflowing a short viewport', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const projectRes = await createProjectAndClearPlanning(page, '', freshWorkspace.token, {
+			name: uniqueName('Filter Placement'),
+			description: 'Filter panel placement test.',
+		});
+		const project = ((await projectRes.json()) as { data: CreatedProject }).data;
+
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		const toggle = page.getByTestId('task-filter-toggle');
+		await expect(toggle).toBeVisible({ timeout: 20000 });
+		await toggle.click();
+
+		const panel = page.getByTestId('task-filter-panel');
+		await expect(panel).toBeVisible({ timeout: 20000 });
+		// The filter bar is the first row of <main>, so there is room below it.
+		await expect(panel).toHaveAttribute('data-placement', 'bottom');
+
+		const viewport = page.viewportSize();
+		if (!viewport) throw new Error('no viewport size');
+		const barBox = await waitForStableBox(page.getByTestId('task-filter-bar'));
+		const panelBox = await waitForStableBox(panel);
+
+		expect(panelBox.y).toBeGreaterThanOrEqual(barBox.y + barBox.height - 0.5);
+		expect(panelBox.y + panelBox.height).toBeLessThanOrEqual(viewport.height + 0.5);
+
+		// Shrink the viewport to less than the panel's natural height. Flipping
+		// alone cannot save it here — only the height clamp can — so this is what
+		// proves the panel shrinks rather than running off the screen.
+		const shortHeight = 380;
+		await page.setViewportSize({ width: 390, height: shortHeight });
+		await expect(panel).toBeVisible();
+
+		const clampedBox = await waitForStableBox(panel);
+		expect(clampedBox.y).toBeGreaterThanOrEqual(-0.5);
+		expect(clampedBox.y + clampedBox.height).toBeLessThanOrEqual(shortHeight + 0.5);
+	});
+});


### PR DESCRIPTION
## What

Typing `@` in a comment composer that sits at the bottom of the scrolling task page opened the mention picker **downward**, past the viewport edge, so the agent list was cut off.

Three sibling panels shared the same shape and the same defect in one direction or the other, so all four are fixed together:

| Panel | Was | Now |
|---|---|---|
| Mention picker (`mention-picker.tsx`) | pinned down | flips |
| Assignee dropdown (`task-sidebar.tsx`) | pinned down | flips |
| Task filter panel (`task-list.tsx`) | pinned down | flips |
| Add-to-task picker (`add-to-task-picker.tsx`) | pinned up | flips, still prefers up |

Each panel now measures the room above and below its anchor when it opens, takes the side that fits, and clamps its own `max-height` to the space actually available - so it scrolls internally instead of crossing the edge.

The mention picker alone reaches 12 composers (task comments, task create, docs, skills, agent settings, the hire form, ...).

## How

Mirrors the existing `lib/fab-position.ts` + `hooks/use-draggable-fab.ts` split:

- **`packages/web/src/lib/panel-placement.ts`** - pure arithmetic over rectangles. The preferred side wins whenever it can hold the panel whole, so a panel only moves when staying put would clip it; when neither side fits, the roomier one takes it. Ties keep the preferred side, so a panel centred in its band can't oscillate.
- **`packages/web/src/hooks/use-panel-placement.ts`** - the DOM half. Measures in a layout effect (so the side is resolved before paint - no flash of a wrongly-placed panel) and re-measures on content changes, window and visual-viewport resize, ancestor scroll (capture phase), and a `ResizeObserver` on both anchor and panel. That last one is what tracks the comment composer's textarea auto-growing as you type.

The band a panel must stay inside is the visual viewport intersected with the nearest clipping scroll ancestor, so the fullscreen composer dialog and `<main>` are respected rather than approximated. The clipping ancestor is resolved once per open, so scroll handling never walks the tree.

Horizontal anchoring stays with each caller - three panels are `left-0 right-0`, one is `right-0 w-72` - and only the vertical side and the height cap are shared.

### One constraint worth flagging for review

The hook reads content height from `panel.scrollHeight`, which is independent of the cap it writes **only while the panel is its own scroll container**. A flex shell around an inner `flex-1 min-h-0` scroller would have flex shrink that child to the cap, so `scrollHeight` reports the cap straight back and the panel can never grow again once space reopens. The add-to-task picker was that shape, so it is restructured: the panel scrolls and its filter row is now `sticky top-0`. The rule is stated in the hook's doc comment.

### Not in scope

In the **expanded fullscreen composer** the anchor is the whole tall flex column, so both sides are tight and the panel resolves to a floor-height internally-scrolling list. That is better than today (where `top-full` puts it below the column entirely) but not good. Making it genuinely good means anchoring to the caret line, which needs caret-coordinate measurement - a separate change.

## Testing

- **`packages/web/test/panel-placement.test.ts`** (17 tests) - the geometry, in the tier that can actually assert it: flip either way, tie behaviour, `prefer: 'top'`, the design cap vs the viewport, the min-height floor, a band shorter than the floor, an anchor filling the band, an anchor scrolled out of the band, and the pre-measure state not flipping.
- **`packages/web/test/use-panel-placement.test.tsx`** (8 tests) - resolved side and classes, the `ResizeObserver`-undefined guard (happy-dom has no stub, so it is load-bearing), stability across repeated resize/scroll, and every listener removed on close and on unmount.
- **`packages/web/test/mention-autocomplete.test.tsx`** - one added test asserting `data-placement`. All 9 existing tests pass unchanged.
- **`test/browser/dropdown-flip-placement.mobile.spec.ts`** - real Chromium at 390x844: the picker opens above a bottom-parked composer and stays inside the viewport; the filter panel near the top opens downward and then *clamps* rather than overflowing when the viewport shrinks to 380px. Verified non-vacuous by temporarily disabling the flip, which fails it with `Expected "top", Received "bottom"`.

Every measurement in the first browser test is read in a single `evaluate`. Separate `boundingBox()` calls straddle Virtuoso's scroll corrections and disagree, which made an earlier draft flaky 1-in-3; the atomic snapshot passed 8/8 across repeats.

Also run green locally: `task-list`, `task-list-filter-persistence`, `task-crud`, `task-assignee-status`, `agent-links`, `markdown-editor`, `action-review-add-to-task`, `task-preview-action-review`, plus the browser specs for the composer, comments, assignee and passive mentions (21 tests). `typecheck` and `biome` clean.

## Also

One row added to the seam registry in `AGENTS.md` - four call sites clears the "two call sites means extract" bar.

Panels expose their resolved side as `data-placement`, which is the only part of this reachable without a layout engine and is what the component tier asserts.


---
_Generated by [Claude Code](https://claude.ai/code/session_015As5iXTkCqzChfZXonTGTZ)_