### PR TITLE
fix(runtime): turn Claude Code tool search off on non-Anthropic endpoints

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2830,6 +2830,24 @@ below). Prime Agent is never a default. Ollama and LM Studio therefore offer exa
 each and the UI omits the picker for them — their Advanced disclosure holds only the optional
 API key.
 
+**Claude Code against a non-Anthropic endpoint turns tool search off.** `buildProviderEnv`
+stamps `CLAUDE_CODE_CUSTOM_ENDPOINT_ENV` (`ENABLE_TOOL_SEARCH=false`) whenever
+`claudeCodeProviderUsesCustomEndpoint` holds - DeepSeek, Z.ai, Moonshot-on-Claude-Code, Ollama
+and LM Studio. Left at the CLI default, a large tool surface is swapped for a search tool and
+the MCP tools are deferred: present to the session, absent from the list the model can see,
+which reads to an agent as a connector that is connected but has no tools. Anthropic is
+excluded deliberately - Claude drives the search tool reliably and pays no schema cost for
+tools it never loads. Applied centrally rather than per-binding `staticEnv` because the local
+runners carry no `staticEnv` at all, so a `staticEnv`-only rule would silently skip both.
+
+**This setting is not yet confirmed against the pinned Claude Code build.** `ENABLE_TOOL_SEARCH`
+came from Moonshot's vendor docs, and a wrong variable name fails silently. It also carries a
+real cost in the other direction: with search off, every tool schema is resident in context on
+every request, which does not scale indefinitely with the connector count. The per-server tool
+count in the `[session]` banner is what settles both questions from a run log - a non-zero
+count for a connector that previously reported zero is the confirmation; there is no other
+evidence that this took effect.
+
 **Because the runtime is per credential, it must be resolved from the credential row, never
 from the provider.** `buildProviderEnv` composes from `providerRuntimeBinding(provider,
 resolvedRuntime)` — reading the adapter's own fields would build the *default* runtime's env

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -4,6 +4,7 @@ import {
 	AgentRuntime,
 	AiAuthMethod,
 	type AiProvider,
+	CLAUDE_CODE_CUSTOM_ENDPOINT_ENV,
 	CLAUDE_CODE_QUIET_ENV,
 	CommentContentType,
 	ContainerStatus,
@@ -287,6 +288,15 @@ export function buildProviderEnv(
 	const out: string[] = [];
 	if (runtime === AgentRuntime.ClaudeCode) {
 		for (const [key, value] of Object.entries(CLAUDE_CODE_QUIET_ENV)) {
+			out.push(`${key}=${value}`);
+		}
+	}
+	// Claude Code against anything other than first-party Anthropic. Covers the
+	// third-party gateways and the local runners alike, which is why it keys off
+	// the predicate rather than the per-provider `staticEnv`: Ollama and LM Studio
+	// have no `staticEnv` to carry it.
+	if (claudeCodeProviderUsesCustomEndpoint(provider, runtime)) {
+		for (const [key, value] of Object.entries(CLAUDE_CODE_CUSTOM_ENDPOINT_ENV)) {
 			out.push(`${key}=${value}`);
 		}
 	}

--- a/packages/server/test/agent-runner-branches.test.ts
+++ b/packages/server/test/agent-runner-branches.test.ts
@@ -167,6 +167,47 @@ describe('buildProviderEnv', () => {
 		expect(env).toContain('ANTHROPIC_AUTH_TOKEN=ds-key');
 	});
 
+	it('disables Claude Code tool search on every non-Anthropic endpoint, and only there', () => {
+		// Left at the CLI default, a large tool surface is swapped for a search tool
+		// and the MCP tools are deferred out of the model's visible list - which
+		// reads to the agent as a connector that is connected but has no tools.
+		// Anthropic keeps tool search: Claude drives it reliably and pays no schema
+		// cost for the tools it never loads.
+		const envFor = (provider: AiProvider, baseUrl: string | null = null) =>
+			buildProviderEnv(provider, {
+				value: 'k',
+				authMethod: AiAuthMethod.ApiKey,
+				baseUrl,
+				runtime: null,
+			});
+
+		for (const provider of [AiProvider.DeepSeek, AiProvider.ZAi, AiProvider.Kimi]) {
+			expect(envFor(provider)).toContain('ENABLE_TOOL_SEARCH=false');
+		}
+		// The local runners carry no staticEnv at all - their endpoint rides on the
+		// credential - so a staticEnv-only rule would have silently skipped both.
+		for (const provider of [AiProvider.Ollama, AiProvider.LmStudio]) {
+			expect(envFor(provider, 'http://127.0.0.1:11434')).toContain('ENABLE_TOOL_SEARCH=false');
+		}
+
+		expect(envFor(AiProvider.Anthropic).some((e) => e.startsWith('ENABLE_TOOL_SEARCH='))).toBe(
+			false,
+		);
+	});
+
+	it('sets ENABLE_TOOL_SEARCH once for Moonshot, which used to carry its own copy', () => {
+		// The setting has one home now. Two would drift the moment one side moved.
+		const env = buildProviderEnv(AiProvider.Kimi, {
+			value: 'kimi-key',
+			authMethod: AiAuthMethod.ApiKey,
+			baseUrl: null,
+			runtime: null,
+		});
+		expect(env.filter((e) => e === 'ENABLE_TOOL_SEARCH=false')).toHaveLength(1);
+		// Moonshot's other documented setting stays on its own binding.
+		expect(env).toContain('CLAUDE_CODE_AUTO_COMPACT_WINDOW=262144');
+	});
+
 	it('emits the Moonshot staticEnv + quiet env for Kimi (Claude Code runtime)', () => {
 		const env = buildProviderEnv(AiProvider.Kimi, {
 			value: 'kimi-key',

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1602,6 +1602,28 @@ export const CLAUDE_CODE_QUIET_ENV = {
 } as const;
 
 /**
+ * Claude Code settings applied only when it runs against a **non-Anthropic**
+ * endpoint - the third-party Anthropic-compatible gateways (DeepSeek, Z.ai,
+ * Moonshot) and the local runners (Ollama, LM Studio). Membership is
+ * {@link claudeCodeProviderUsesCustomEndpoint}.
+ *
+ * `ENABLE_TOOL_SEARCH=false` keeps every tool in the model's tool list. Left at
+ * the CLI default, a large tool surface (Hezo's own ~81 plus every connector's)
+ * is swapped for a search tool and the MCP tools are deferred - present to the
+ * session, absent from the list the model can see. Claude uses that search tool
+ * reliably, so first-party Anthropic keeps it and pays no schema cost; the
+ * models behind these endpoints do not, and an agent that cannot see a
+ * connector's tools reports the connector as broken.
+ *
+ * Applied centrally rather than per-binding `staticEnv` because Ollama and
+ * LM Studio carry no `staticEnv` at all - their endpoint rides on the
+ * credential - so a `staticEnv`-only rule would silently skip both.
+ */
+export const CLAUDE_CODE_CUSTOM_ENDPOINT_ENV = {
+	ENABLE_TOOL_SEARCH: 'false',
+} as const;
+
+/**
  * The Gemini CLI refuses to run in an "untrusted" folder and silently downgrades
  * `--yolo` to manual tool approval, which hangs a headless run; Hezo agents run
  * headless in `/workspace`. Trusting the workspace is the documented headless
@@ -1627,9 +1649,12 @@ export const KIMI_DEFAULT_MODEL = 'kimi-k2.7-code';
 
 /**
  * Moonshot reached through Claude Code, against the Anthropic-compatible
- * gateway — the same pattern as DeepSeek/Z.ai. `ENABLE_TOOL_SEARCH` and
- * `CLAUDE_CODE_AUTO_COMPACT_WINDOW` are Moonshot's documented Claude Code
- * settings (https://platform.kimi.ai/docs/guide/agent-support).
+ * gateway — the same pattern as DeepSeek/Z.ai. `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
+ * is Moonshot's documented Claude Code setting
+ * (https://platform.kimi.ai/docs/guide/agent-support). Its documented
+ * `ENABLE_TOOL_SEARCH=false` is no longer set here: it now applies to every
+ * non-Anthropic endpoint via {@link CLAUDE_CODE_CUSTOM_ENDPOINT_ENV}, so
+ * keeping a copy would give the setting two homes.
  *
  * `kimi`'s default binding; `MOONSHOT_KIMI_CODE_BINDING` below is its alternate.
  * The point of the pair is that the same key reaches the same upstream either
@@ -1642,7 +1667,6 @@ const MOONSHOT_CLAUDE_CODE_BINDING: ProviderRuntimeBinding = {
 		ANTHROPIC_DEFAULT_SONNET_MODEL: KIMI_DEFAULT_MODEL,
 		ANTHROPIC_DEFAULT_HAIKU_MODEL: KIMI_DEFAULT_MODEL,
 		CLAUDE_CODE_SUBAGENT_MODEL: KIMI_DEFAULT_MODEL,
-		ENABLE_TOOL_SEARCH: 'false',
 		CLAUDE_CODE_AUTO_COMPACT_WINDOW: '262144',
 	},
 	credentialEnvByAuthMethod: { [AiAuthMethod.ApiKey]: 'ANTHROPIC_AUTH_TOKEN' },
@@ -1910,9 +1934,19 @@ export function claudeCodeModelArg(provider: AiProvider, model: string): string 
 /**
  * True for the providers that route Claude Code at a THIRD-PARTY
  * Anthropic-compatible endpoint (DeepSeek, Z.ai, Kimi) rather than Anthropic's
- * own API — identified by a `staticEnv.ANTHROPIC_BASE_URL` override.
+ * own API — identified by a `staticEnv.ANTHROPIC_BASE_URL` override — plus the
+ * local runners, which reach a custom endpoint carried on the credential.
  *
- * For these, the run's selected model is the single model that endpoint serves,
+ * In other words: Claude Code against anything that is not first-party
+ * Anthropic. Two consumers read it, and both want exactly that set.
+ *
+ * **Tool search.** {@link CLAUDE_CODE_CUSTOM_ENDPOINT_ENV} is applied to these
+ * runs so the full tool list stays visible rather than being deferred behind the
+ * CLI's search tool, which the models behind these endpoints do not drive
+ * reliably.
+ *
+ * **Derived models.** For these, the run's selected model is the single model
+ * that endpoint serves,
  * so the runtime's *derived* models — the Stop-hook completeness judge and the
  * Claude Code subagent default — should track the selected model instead of a
  * hardcoded constant. The constant goes stale the moment the provider ships a


### PR DESCRIPTION
> **Rewritten.** This PR originally bundled five changes behind one root cause that was never confirmed. It has been split so each part stands on its own evidence. This branch now carries **only** the tool-search change - the one that depends on the unconfirmed diagnosis. See [Split](#split) below.

## ⚠️ Do not merge yet - the root cause is unconfirmed

Everything below is a hypothesis. It is plausible and it has vendor corroboration, but nothing in this repo or in any run log has confirmed it.

## The hypothesis

An agent reported "Typefully MCP tools aren't surfacing in my tool list" while the connector showed **Connected**. Nothing in Hezo was filtering it: the card read `1 credential · all methods`, meaning `enabled_methods IS NULL`, so `toolRestrictionOf` returned `{}`, no `permissions.deny` entries were written, and the egress method guard never engaged.

The proposed explanation is Claude Code's **tool-search mode**: with 334 tools loaded across six MCP servers, the CLI swaps the full tool list for a search tool and defers the rest - present to the session, absent from the list the model can see. `MOONSHOT_CLAUDE_CODE_BINDING` already set `ENABLE_TOOL_SEARCH: 'false'`; DeepSeek and Z.ai did not, and Ollama/LM Studio carry no `staticEnv` at all.

## What argues against it

- **`tools=334` looks like the full list.** That is `event.tools.length` from the `init` event. Under tool search you would expect a small number plus a search tool, not roughly the whole inventory.
- **The agent never checked.** It never attempted a Typefully call, never called `list_connectors`, never called `test_connector`. Its claim traces to a line in its own progress summary from two days earlier that it repeated verbatim across several runs.
- **`ENABLE_TOOL_SEARCH` is unverified.** It appears in this repo only in the Moonshot binding, taken from [Moonshot's vendor docs](https://platform.kimi.ai/docs/guide/agent-support), not from anything checked against the pinned Claude Code build. A wrong variable name fails silently, so a merged no-op would look identical to a merged fix.

So there are two live hypotheses: the tools were deferred (this PR), or the tools were there all along and nobody looked.

## The cost of being wrong

Turning search off puts **every tool schema in context on every request**. On the one measured data point - Hezo's own 81 tools at 128,488 bytes - that is roughly 50-134k tokens at the 334-tool scale, paid per turn, forever, and growing with each connector added. If the second hypothesis is right, this buys nothing and costs that.

## The merge gate

#930 (merged) added a per-server tool count to the `[session]` banner. One DeepSeek run against a Typefully-connected project, **without** this branch applied, settles it:

| Banner reads | Meaning | Action |
|---|---|---|
| `typefully=connected(0)` | Tools were deferred. Hypothesis confirmed. | Merge this |
| `typefully=connected(27)` | Tools were present all along. | **Close this.** The real defect is agent-side verification |

## What changed

`buildProviderEnv` stamps `CLAUDE_CODE_CUSTOM_ENDPOINT_ENV` (`ENABLE_TOOL_SEARCH=false`) wherever `claudeCodeProviderUsesCustomEndpoint` holds - DeepSeek, Z.ai, Moonshot-on-Claude-Code, Ollama, LM Studio.

Applied centrally rather than per-binding `staticEnv` because the local runners carry no `staticEnv` at all - their endpoint rides on the credential - so a `staticEnv`-only rule would silently skip both. Moonshot's own copy is dropped so the setting has one home. Anthropic is excluded deliberately: Claude drives the search tool reliably and pays no schema cost for tools it never loads.

## Split

The other four changes were extracted, because none of them depend on this diagnosis being right:

| PR | Contents | Status |
|---|---|---|
| #930 | Per-server tool counts in the session banner | **Merged** - the instrument for the gate above |
| #931 | Vendor-namespace method classification + refusing an allowlist that enables nothing + over-long tool-name warning | Open, independently correct |
| #932 | Per-caller `tools/list` projection, drop the inert `$schema` (-22.7%) | Open, independently correct |
| **#928** | This - tool search off on custom endpoints | **Held** pending the banner reading |

## Testing

`bun run typecheck` clean, `bunx biome check` clean.

- `packages/server` - `agent-runner*`: 237 passed across 7 files, covering `buildProviderEnv` stamping the setting for each custom-endpoint provider and omitting it for Anthropic
- `packages/shared` - `common`: 37 passed