### PR TITLE
feat(runner): count each MCP server's tools in the session banner

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1530,6 +1530,22 @@ cover the rest of the run:
   the first cut of this check - would have failed every Claude Code run on that CLI, and
   the live agent-CLI conformance suite is what caught it.
 
+  **The status does not say whether the tools arrived, so the count does.** `connected`
+  means the session came up, not that the server's tools reached the model, and that gap
+  is what made "connector X's tools are missing" unfalsifiable from a run log: the banner
+  read healthy either way. The session line therefore carries a per-server tool count next
+  to each status - `mcp: hezo=connected(73) typefully=connected(27)` - counted from the
+  `mcp__<server>__<tool>` namespace the injector builds. Counting matches against the
+  server names the event itself reports rather than splitting on `__`, so a connector whose
+  own name contains the separator still counts correctly. A server reporting `connected`
+  while contributing **zero** tools gets its own `[runner]` warning, because that is the
+  shape of every way the tools can fail to arrive (a list the runtime deferred behind its
+  own search tool, an empty catalogue, an allowlist that withheld everything) and none of
+  them show up in the status. The `tools` array is typed loosely by the CLI and Hezo had
+  only ever needed its length, so both plausible element shapes are accepted and anything
+  else is skipped; when no name parses, the counts are omitted entirely rather than
+  printing a misleading zero for every server.
+
 The runner also orders these: a signal kill outranks a captured terminal error, which in
 turn outranks "produced no output" on the run row - each is the cause of the one below it,
 and reporting the symptom first sends the reader after the wrong thing. A process a signal

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -481,6 +481,52 @@ function claudeHezoMcpFailure(servers: ClaudeMcpServerStatus[] | undefined): str
 	);
 }
 
+/**
+ * Tool names carried by an `init` event's `tools` array.
+ *
+ * The CLI types the array loosely and Hezo has only ever needed its length, so
+ * accept both plausible shapes (a bare name, or an object carrying one) and skip
+ * anything else. A partial read still answers the question this exists for, and a
+ * shape change must degrade to "no per-server counts", never to a broken session
+ * line.
+ */
+function initToolNames(tools: unknown[] | undefined): string[] {
+	if (!Array.isArray(tools)) return [];
+	const names: string[] = [];
+	for (const entry of tools) {
+		if (typeof entry === 'string') {
+			names.push(entry);
+			continue;
+		}
+		const name = (entry as { name?: unknown } | null)?.name;
+		if (typeof name === 'string') names.push(name);
+	}
+	return names;
+}
+
+/**
+ * How many tools each MCP server contributed, counted by the
+ * `mcp__<server>__<tool>` namespace the injector builds (see
+ * `mcp-injectors/claude-code.ts`).
+ *
+ * Matched against the server names the event itself reports rather than by
+ * splitting on `__`, so a connector whose own name contains the separator is
+ * still counted correctly.
+ */
+function mcpToolCounts(
+	names: readonly string[],
+	servers: readonly ClaudeMcpServerStatus[],
+): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const server of servers) {
+		const serverName = server?.name;
+		if (!serverName) continue;
+		const prefix = `mcp__${serverName}__`;
+		counts.set(serverName, names.filter((n) => n.startsWith(prefix)).length);
+	}
+	return counts;
+}
+
 function createClaudeCodeParser(price: PriceModelFn): AgentStreamParser {
 	let usage: AgentRunUsage | null = null;
 	let modelId: string | undefined;
@@ -502,15 +548,40 @@ function createClaudeCodeParser(price: PriceModelFn): AgentStreamParser {
 		if (event.type === 'system' && event.subtype === 'init') {
 			const toolCount = Array.isArray(event.tools) ? event.tools.length : 0;
 			modelId = event.model ?? undefined;
+			const mcpServers = event.mcp_servers ?? [];
 			// The per-server states go in the session line too, so a log read after
 			// the fact answers "did it have its tools?" without needing the raw
 			// stream - the question a bare `tools=25` left the reader to guess at.
-			const servers = (event.mcp_servers ?? [])
-				.map((s) => `${s?.name ?? '?'}=${s?.status ?? '?'}`)
+			//
+			// The state alone does not answer it, though: `connected` means the
+			// session came up, not that the server's tools reached the model. So
+			// carry a per-server tool count alongside it, derived from the names.
+			// Omitted entirely when no name parsed, rather than printing a
+			// misleading zero for every server.
+			const toolNames = initToolNames(event.tools);
+			const counts = toolNames.length > 0 ? mcpToolCounts(toolNames, mcpServers) : null;
+			const servers = mcpServers
+				.map((s) => {
+					const count = s?.name === undefined ? undefined : counts?.get(s.name);
+					return `${s?.name ?? '?'}=${s?.status ?? '?'}${count === undefined ? '' : `(${count})`}`;
+				})
 				.join(' ');
 			out.push(
 				`[session] model=${modelId ?? 'unknown'} tools=${toolCount}${servers ? ` mcp: ${servers}` : ''}`,
 			);
+			// Connected but contributing nothing is the shape of a server whose tools
+			// never reached the model - a tool list the runtime deferred behind its
+			// own search tool, an empty catalogue, or an allowlist that withheld
+			// everything. The banner's status would read healthy, so say it outright.
+			for (const s of mcpServers) {
+				const name = s?.name;
+				if (!name || (s?.status ?? '').toLowerCase() !== 'connected') continue;
+				if (counts?.get(name) === 0) {
+					out.push(
+						`[runner] MCP server "${name}" connected but contributed no tools to this run, so the agent cannot call them.`,
+					);
+				}
+			}
 			const mcpFailure = claudeHezoMcpFailure(event.mcp_servers);
 			if (mcpFailure) {
 				// Recorded as the run's terminal error rather than just logged: it is

--- a/packages/server/test/agent-stream-parser-branches.test.ts
+++ b/packages/server/test/agent-stream-parser-branches.test.ts
@@ -186,6 +186,125 @@ describe('Claude Code — session/init fallback arms', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Claude Code — per-server tool counts in the session line
+// ---------------------------------------------------------------------------
+
+describe('Claude Code — per-server MCP tool counts', () => {
+	it("counts each server's tools from the mcp__<server>__<tool> namespace", () => {
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'm',
+				tools: [
+					'Bash',
+					'Read',
+					'mcp__hezo__list_tasks',
+					'mcp__hezo__create_comment',
+					'mcp__typefully__typefully_list_drafts',
+				],
+				mcp_servers: [
+					{ name: 'hezo', status: 'connected' },
+					{ name: 'typefully', status: 'connected' },
+				],
+			},
+		]);
+		expect(out).toContain('tools=5 mcp: hezo=connected(2) typefully=connected(1)');
+	});
+
+	it('warns when a server reports connected but contributed no tools', () => {
+		// The failure this exists to surface: the transport came up, so the status
+		// reads healthy, but the runtime deferred the tool list behind its own
+		// search tool and none of the server's tools reached the model.
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'deepseek-v4-pro',
+				tools: ['Bash', 'mcp__hezo__list_tasks'],
+				mcp_servers: [
+					{ name: 'hezo', status: 'connected' },
+					{ name: 'typefully', status: 'connected' },
+				],
+			},
+		]);
+		expect(out).toContain('typefully=connected(0)');
+		expect(out).toContain('MCP server "typefully" connected but contributed no tools');
+		// The server that did contribute is not warned about.
+		expect(out).not.toContain('"hezo" connected but contributed no tools');
+		// A discovery gap, not a run-ending one.
+		expect(parser.getTerminalError()).toBeNull();
+	});
+
+	it('does not warn about a server that has not finished connecting', () => {
+		// `pending` at init is what a healthy run reports - the servers connect
+		// asynchronously afterwards - so zero tools there means nothing yet.
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'm',
+				tools: ['Bash'],
+				mcp_servers: [{ name: 'typefully', status: 'pending' }],
+			},
+		]);
+		expect(out).toContain('typefully=pending(0)');
+		expect(out).not.toContain('contributed no tools');
+	});
+
+	it('omits the counts entirely when no tool name can be read', () => {
+		// A shape change in the CLI's `tools` array must degrade to "no per-server
+		// numbers", never to a misleading zero against every server.
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'm',
+				tools: [{ unexpected: 'shape' }, 42],
+				mcp_servers: [{ name: 'hezo', status: 'connected' }],
+			},
+		]);
+		expect(out).toContain('tools=2 mcp: hezo=connected');
+		expect(out).not.toContain('hezo=connected(');
+		expect(out).not.toContain('contributed no tools');
+	});
+
+	it('reads a name off an object entry as well as a bare string', () => {
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'm',
+				tools: [{ name: 'mcp__hezo__get_task' }, 'mcp__hezo__list_tasks'],
+				mcp_servers: [{ name: 'hezo', status: 'connected' }],
+			},
+		]);
+		expect(out).toContain('hezo=connected(2)');
+	});
+
+	it('counts correctly for a connector whose own name contains the separator', () => {
+		// Counting by the server names the event reports, rather than splitting on
+		// `__`, is what keeps this right.
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = feed(parser, [
+			{
+				type: 'system',
+				subtype: 'init',
+				model: 'm',
+				tools: ['mcp__od__d__alpha', 'mcp__od__d__beta'],
+				mcp_servers: [{ name: 'od__d', status: 'connected' }],
+			},
+		]);
+		expect(out).toContain('od__d=connected(2)');
+	});
+});
+
 describe('Claude Code — assistant usage edge arms', () => {
 	it('renders text without usage when message.usage is absent (mu falsy arm)', () => {
 		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);


### PR DESCRIPTION
## Why

An agent reported "Typefully MCP tools aren't surfacing in my tool list" while the connector showed **Connected**. The claim then propagated into a task's progress summary and repeated across several runs, and **nobody could check it** - because nothing in a run log distinguishes a server whose tools arrived from one whose tools did not.

`=connected` in the `[session]` banner only ever meant the server's session came up. It says nothing about whether the tools reached the model. So the banner read healthy either way, and the agent's report was neither confirmable nor refutable.

This makes that question answerable.

## What changed

The session line carries a per-server tool count beside each status, counted from the `mcp__<server>__<tool>` namespace the injector builds:

```
[session] model=… tools=334 mcp: hezo=connected(73) typefully=connected(27) …
```

A server reporting `connected` while contributing **zero** tools gets its own warning:

```
[runner] MCP server "typefully" connected but contributed no tools to this run, so the agent cannot call them.
```

Zero-with-connected is the shape of every way the tools can fail to arrive - a list the runtime deferred behind its own search tool, an empty catalogue, an allowlist that withheld everything - and none of them show up in the status.

## Correctness details

- **Only `connected` warns, never `pending`.** MCP servers connect asynchronously *after* `init` is emitted, so a healthy run legitimately reports `pending` with a built-ins-only tools array (the existing note at `agent-stream-parser.ts` records this, measured against Claude Code 2.1.220). Warning on `pending` would fire on every healthy run.
- **Counting matches against the server names the event reports** rather than splitting on `__`, so a connector whose own name contains the separator still counts correctly.
- **Unknown element shapes degrade to no counts, never a false zero.** The CLI types `tools` loosely and only its length was ever needed before, so both plausible shapes (a bare name, an object carrying one) are accepted and anything else is skipped. When no name parses, counts are omitted entirely.
- Claude Code only. Codex and Gemini hardcode `tools=0` because they get no such event, and are untouched.

## Scope

Diagnostic only - **no run behaviour changes**. This is deliberately split out from the tool-search fix it was originally bundled with (#928), because that fix rests on a root cause that has never been confirmed, and this is the instrument that confirms or refutes it. One DeepSeek run against a Typefully-connected project now settles it: `typefully=connected(0)` or `typefully=connected(27)`.

## Testing

`bun run typecheck` clean, `bunx biome check` clean.

`bun run test --package server --pattern agent-stream-parser` - 188 passed across 3 files (109 in `agent-stream-parser-branches`). New coverage: per-server counts, the separator-in-connector-name edge, the unknown-element-shape fallback, the connected-but-zero warning, and `pending` correctly not warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgyasGxRakBVVhg3B3UEzx)_