### PR TITLE
fix(connectors): classify vendor-namespaced MCP tools by their real verb

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3783,6 +3783,26 @@ otherwise a leading-word heuristic. An unrecognised name classifies as **write**
 heuristic can never widen access by accident. `summarizeMethodAccess` is the single source
 for every count the card, the dialog, and `list_connectors` show, so they can't disagree.
 
+`classifyMcpMethods` (the whole-catalog entry point) first detects a **vendor namespace** -
+a leading token every tool shares, as in `typefully_list_drafts` / `typefully_get_me` - and
+classifies on the word after it. Without that the vendor sits where the verb belongs and an
+entire server classifies as write. Detection is deliberately conservative: every tool must
+share the token, two tools minimum, and a token that is itself a read prefix is refused (a
+server whose tools are all `list_*` is naming them consistently, not namespacing them). A
+single tool can never imply a namespace, so `classifyMcpMethod` alone keeps its old behaviour.
+
+Because of that, an `access: 'read'` request can resolve to an allowlist of nothing when the
+classifier recognises no read method at all. `discoverConnectorMethods` **refuses to persist
+an empty allowlist**: `enabled_methods` stays NULL (unrestricted) and the miss is logged,
+because `[]` means restricted-to-nothing and would withhold every tool while the card still
+read Connected. The request stays pending, so a later refresh can still satisfy it.
+
+Discovery also warns when a fully-qualified `mcp__<server>__<tool>` name exceeds
+`MCP_TOOL_NAME_MAX_LENGTH` (64, the cap Anthropic and the OpenAI-compatible endpoints share).
+Advisory only - what happens past the limit is the provider's call, so the descriptor is
+unaffected - and the warning names the connector, since renaming it shortens every one of its
+tools at once.
+
 `discoverConnectorMethods` (`services/connectors/method-discovery.ts`) probes a connected
 `saas` connector over the MCP SDK's Streamable HTTP transport (SSE fallback) and caches the
 catalog. It decrypts the connector's own credential in-process (trusted server code — § 7's

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3787,9 +3787,13 @@ for every count the card, the dialog, and `list_connectors` show, so they can't 
 a leading token every tool shares, as in `typefully_list_drafts` / `typefully_get_me` - and
 classifies on the word after it. Without that the vendor sits where the verb belongs and an
 entire server classifies as write. Detection is deliberately conservative: every tool must
-share the token, two tools minimum, and a token that is itself a read prefix is refused (a
-server whose tools are all `list_*` is naming them consistently, not namespacing them). A
-single tool can never imply a namespace, so `classifyMcpMethod` alone keeps its old behaviour.
+share the token, and the token is refused when it is itself a read prefix (a server whose
+tools are all `list_*` is naming them consistently, not namespacing them) or a plain mutation
+verb (`WRITE_VERB_PREFIXES`). A single tool can imply a namespace; those two refusals are what
+make that safe, since they reject exactly the tokens a one-tool guess would get wrong -
+`update_view` keeps `update` as its verb rather than stripping to the read prefix `view`.
+`classifyMcpMethod` called directly on one tool, with no namespace passed, keeps its old
+behaviour.
 
 Because of that, an `access: 'read'` request can resolve to an allowlist of nothing when the
 classifier recognises no read method at all. `discoverConnectorMethods` **refuses to persist

--- a/packages/server/src/services/connectors/method-discovery.ts
+++ b/packages/server/src/services/connectors/method-discovery.ts
@@ -18,7 +18,9 @@
 import {
 	ConnectorTransport,
 	classifyMcpMethods,
+	MCP_TOOL_NAME_MAX_LENGTH,
 	type McpMethodInfo,
+	qualifiedMcpToolName,
 	readOnlyMethodNames,
 } from '@hezo/shared';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -295,11 +297,43 @@ export async function discoverConnectorMethods(
 
 	const methods = classifyMcpMethods(tools);
 
+	// Warned here, once per catalog refresh, rather than on every descriptor
+	// build: the condition is a property of the connector's name plus the server's
+	// tool names, so repeating it per run would be noise on a green log without
+	// telling an operator anything new. Not fatal - what an over-long name costs
+	// is decided upstream by the provider, so the run still gets the descriptor.
+	const overLong = methods
+		.map((m) => qualifiedMcpToolName(row.name, m.name))
+		.filter((n) => n.length > MCP_TOOL_NAME_MAX_LENGTH);
+	if (overLong.length > 0) {
+		log.warn('connector tool names exceed the provider tool-name limit', {
+			connectorId,
+			name: row.name,
+			limit: MCP_TOOL_NAME_MAX_LENGTH,
+			count: overLong.length,
+			examples: overLong.slice(0, 3),
+		});
+	}
+
 	// Apply a pending read-only request in the same statement that stores the
 	// catalog, so there is no window where the methods are known but the
 	// requested restriction has not been applied.
-	const applyReadOnly =
+	const readOnlyNames = readOnlyMethodNames(methods);
+	const wantsReadOnly =
 		row.requested_access === 'read' && !row.access_applied_at && row.enabled_methods === null;
+	// An allowlist that enables nothing is never what `access: 'read'` asked for -
+	// it means the classifier recognised no read method at all, which a server
+	// that names every tool after itself can produce for its whole catalog.
+	// Applying it would withhold every tool while the connector still reports
+	// Connected, so leave it unrestricted and make the miss visible instead.
+	const applyReadOnly = wantsReadOnly && readOnlyNames.length > 0;
+	if (wantsReadOnly && readOnlyNames.length === 0 && methods.length > 0) {
+		log.warn('connector read-access request not applied: no method classified read-only', {
+			connectorId,
+			name: row.name,
+			methodCount: methods.length,
+		});
+	}
 
 	if (applyReadOnly) {
 		await deps.db.query(
@@ -310,7 +344,7 @@ export async function discoverConnectorMethods(
 			     access_applied_at = now(),
 			     updated_at = now()
 			 WHERE id = $3 AND access_applied_at IS NULL AND enabled_methods IS NULL`,
-			[JSON.stringify(methods), JSON.stringify(readOnlyMethodNames(methods)), connectorId],
+			[JSON.stringify(methods), JSON.stringify(readOnlyNames), connectorId],
 		);
 	} else {
 		await deps.db.query(

--- a/packages/server/src/services/mcp-injectors/claude-code.ts
+++ b/packages/server/src/services/mcp-injectors/claude-code.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { AiProvider } from '@hezo/shared';
+import { AiProvider, qualifiedMcpToolName } from '@hezo/shared';
 import { buildDocWriteGuardScript, DOC_WRITE_GUARD_FILENAME } from '../doc-write-guard';
 import { buildClaudeCodeSettings } from '../stop-hook-prompt';
 import type {
@@ -61,7 +61,8 @@ export const claudeCodeAdapter: RuntimeMcpAdapter = {
 		// of the withheld tools, addressed by their fully-qualified names.
 		const deniedTools: string[] = [];
 		for (const d of descriptors) {
-			for (const tool of d.disabledTools ?? []) deniedTools.push(`mcp__${d.name}__${tool}`);
+			for (const tool of d.disabledTools ?? [])
+				deniedTools.push(qualifiedMcpToolName(d.name, tool));
 		}
 
 		// Blocking doc-write guard, emitted only when the project actually has docs

--- a/packages/server/test/connector-requested-access.test.ts
+++ b/packages/server/test/connector-requested-access.test.ts
@@ -315,6 +315,121 @@ describe('the request reaches discovery', () => {
 		expect(after.rows[0].enabled_methods.sort()).toEqual(['get_issue', 'list_issues']);
 		expect(after.rows[0].access_applied_at).not.toBeNull();
 	});
+
+	it('resolves a vendor-namespaced catalog to its real read methods', async () => {
+		// A server that names every tool after itself put the vendor where the verb
+		// belongs, so the whole catalog classified as write and `access: 'read'`
+		// resolved to an allowlist of nothing.
+		const vendor = await startTestMcpHttpServer({
+			tools: [
+				{ name: 'typefully_list_drafts' },
+				{ name: 'typefully_get_me' },
+				{ name: 'typefully_create_draft' },
+			],
+		});
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'typefully',
+				displayName: 'Typefully',
+				mcpUrl: `http://127.0.0.1:${vendor.port}/mcp`,
+				mcpTransport: 'http',
+				projectId,
+				requestedAccess: ConnectorAccess.Read,
+			});
+			await db.query(`UPDATE mcp_connections SET activated_at = now() WHERE id = $1`, [row.id]);
+
+			const result = await discoverConnectorMethods({ db, masterKeyManager }, row.id, 'connect');
+			expect(result.ok).toBe(true);
+
+			const after = await db.query<{ enabled_methods: string[] }>(
+				`SELECT enabled_methods FROM mcp_connections WHERE id = $1`,
+				[row.id],
+			);
+			expect(after.rows[0].enabled_methods.sort()).toEqual([
+				'typefully_get_me',
+				'typefully_list_drafts',
+			]);
+		} finally {
+			await vendor.close();
+		}
+	});
+
+	it('warns about tool names that cross the provider limit without withholding them', async () => {
+		// `mcp__<connector>__<tool>` has to fit in 64 characters. Past that the
+		// provider decides what happens to the tool, so this is diagnosable rather
+		// than silent - but it never costs the run the descriptor.
+		const long = await startTestMcpHttpServer({
+			tools: [
+				{ name: 'typefully_linkedin_resolve_linkedin_organization_from_url' },
+				{ name: 'typefully_get_me' },
+			],
+		});
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'typefully',
+				displayName: 'Typefully',
+				mcpUrl: `http://127.0.0.1:${long.port}/mcp`,
+				mcpTransport: 'http',
+				projectId,
+			});
+			await db.query(`UPDATE mcp_connections SET activated_at = now() WHERE id = $1`, [row.id]);
+
+			const result = await discoverConnectorMethods({ db, masterKeyManager }, row.id, 'connect');
+			expect(result.ok).toBe(true);
+
+			// Both tools are still catalogued - the warning is advisory.
+			const after = await db.query<{ discovered_methods: Array<{ name: string }> }>(
+				`SELECT discovered_methods FROM mcp_connections WHERE id = $1`,
+				[row.id],
+			);
+			expect(after.rows[0].discovered_methods.map((m) => m.name)).toEqual([
+				'typefully_linkedin_resolve_linkedin_organization_from_url',
+				'typefully_get_me',
+			]);
+		} finally {
+			await long.close();
+		}
+	});
+
+	it('leaves the connector unrestricted when no method classifies read-only', async () => {
+		// An allowlist enabling nothing would withhold every tool while the card
+		// still read Connected. NULL means unrestricted, `[]` means restricted to
+		// nothing, and keeping that distinction honest is the whole point.
+		const writeOnly = await startTestMcpHttpServer({
+			tools: [{ name: 'tracker_create_issue' }, { name: 'tracker_delete_issue' }],
+		});
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'tracker-write-only',
+				displayName: 'Tracker',
+				mcpUrl: `http://127.0.0.1:${writeOnly.port}/mcp`,
+				mcpTransport: 'http',
+				projectId,
+				requestedAccess: ConnectorAccess.Read,
+			});
+			await db.query(`UPDATE mcp_connections SET activated_at = now() WHERE id = $1`, [row.id]);
+
+			const result = await discoverConnectorMethods({ db, masterKeyManager }, row.id, 'connect');
+			expect(result.ok).toBe(true);
+
+			const after = await db.query<{
+				enabled_methods: string[] | null;
+				discovered_methods: unknown[] | null;
+				access_applied_at: string | null;
+			}>(
+				`SELECT enabled_methods, discovered_methods, access_applied_at::text AS access_applied_at
+				 FROM mcp_connections WHERE id = $1`,
+				[row.id],
+			);
+			// The catalog is still cached - only the narrowing was withheld.
+			expect(after.rows[0].discovered_methods).toHaveLength(2);
+			expect(after.rows[0].enabled_methods).toBeNull();
+			// The request stays pending, so a later refresh can still satisfy it.
+			expect(after.rows[0].access_applied_at).toBeNull();
+		} finally {
+			await writeOnly.close();
+		}
+	});
 });
 
 describe('list_connectors method_access', () => {

--- a/packages/shared/src/mcp/method-access.ts
+++ b/packages/shared/src/mcp/method-access.ts
@@ -74,20 +74,61 @@ const READ_ONLY_PREFIXES = [
  * casing convention in the wild: `list_issues`, `listIssues`, `list-issues`,
  * `ListIssues` all yield `['list', 'issues']`.
  */
-function leadingWord(name: string): string {
-	const spaced = name
+function splitWords(name: string): string[] {
+	return name
 		.replace(/[_\-.\s]+/g, ' ')
 		.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-		.trim();
-	const first = spaced.split(' ')[0] ?? '';
-	return first.toLowerCase();
+		.trim()
+		.split(' ')
+		.filter(Boolean)
+		.map((word) => word.toLowerCase());
+}
+
+/**
+ * The vendor namespace every tool in a catalog is prefixed with, or null when
+ * there is no such prefix.
+ *
+ * Many servers name every tool after themselves - `typefully_list_drafts`,
+ * `typefully_get_me` - which puts the vendor where the verb should be and makes
+ * the prefix table classify the whole server as write. Detecting the shared
+ * token here lets classification look at the word that actually carries the
+ * verb, and the whole-catalog view is what makes it safe: one tool cannot tell a
+ * namespace from a verb.
+ *
+ * Deliberately conservative. It requires **every** tool to share the token (a
+ * partial match is a coincidence, not a namespace), needs at least two tools,
+ * and refuses a token that is itself a read-only prefix - a server whose tools
+ * are all `list_*` is naming them consistently, and stripping that would discard
+ * the only signal the heuristic has.
+ */
+function sharedVendorPrefix(tools: readonly McpToolDescriptor[]): string | null {
+	if (tools.length < 2) return null;
+	let shared: string | null = null;
+	for (const tool of tools) {
+		const words = splitWords(tool.name);
+		// A single-word name has no room for a namespace plus a verb, so the
+		// catalog as a whole is not namespaced.
+		if (words.length < 2) return null;
+		const first = words[0] ?? '';
+		if (shared === null) shared = first;
+		else if (shared !== first) return null;
+	}
+	if (shared === null || READ_ONLY_PREFIXES.includes(shared)) return null;
+	return shared;
 }
 
 /**
  * Classify one advertised tool. The server's `readOnlyHint` wins whenever it is
  * set (either way); otherwise the leading word decides and `inferred` is set.
+ *
+ * `namespace`, when given, is a vendor prefix shared across the whole catalog
+ * (see {@link sharedVendorPrefix}); the word after it is what gets tested.
+ * Callers holding one tool omit it and get the historic behaviour.
  */
-export function classifyMcpMethod(tool: McpToolDescriptor): McpMethodInfo {
+export function classifyMcpMethod(
+	tool: McpToolDescriptor,
+	namespace?: string | null,
+): McpMethodInfo {
 	const declared = tool.annotations?.readOnlyHint;
 	if (typeof declared === 'boolean') {
 		return {
@@ -97,17 +138,20 @@ export function classifyMcpMethod(tool: McpToolDescriptor): McpMethodInfo {
 			inferred: false,
 		};
 	}
+	const words = splitWords(tool.name);
+	const verb = (namespace && words[0] === namespace ? words[1] : words[0]) ?? '';
 	return {
 		name: tool.name,
 		...(tool.description ? { description: tool.description } : {}),
-		readOnly: READ_ONLY_PREFIXES.includes(leadingWord(tool.name)),
+		readOnly: READ_ONLY_PREFIXES.includes(verb),
 		inferred: true,
 	};
 }
 
 /** Classify a whole `tools/list` payload, preserving the server's ordering. */
 export function classifyMcpMethods(tools: readonly McpToolDescriptor[]): McpMethodInfo[] {
-	return tools.map(classifyMcpMethod);
+	const namespace = sharedVendorPrefix(tools);
+	return tools.map((tool) => classifyMcpMethod(tool, namespace));
 }
 
 /** Whether a connector restricts its methods at all. */

--- a/packages/shared/src/mcp/method-access.ts
+++ b/packages/shared/src/mcp/method-access.ts
@@ -85,6 +85,46 @@ function splitWords(name: string): string[] {
 }
 
 /**
+ * Verbs that mark a shared token as the tool's own action rather than a vendor
+ * name. The mirror of the read-prefix refusal in {@link sharedVendorPrefix}.
+ *
+ * Load-bearing once a single tool can imply a namespace: with one tool there is
+ * nothing to cross-check the token against, so `update_view` would strip
+ * `update` and classify on `view` - a read prefix - marking a write tool
+ * read-only. That is the one direction this module promises never to fail in,
+ * so a token that is plainly a mutation is refused instead. A vendor genuinely
+ * called `post` or `run` loses its namespace and classifies as write, which is
+ * the safe way round.
+ */
+const WRITE_VERB_PREFIXES = [
+	'create',
+	'update',
+	'delete',
+	'remove',
+	'set',
+	'add',
+	'put',
+	'patch',
+	'post',
+	'write',
+	'send',
+	'reset',
+	'clear',
+	'drop',
+	'insert',
+	'upsert',
+	'move',
+	'rename',
+	'archive',
+	'publish',
+	'cancel',
+	'run',
+	'execute',
+	'start',
+	'stop',
+];
+
+/**
  * The vendor namespace every tool in a catalog is prefixed with, or null when
  * there is no such prefix.
  *
@@ -92,17 +132,21 @@ function splitWords(name: string): string[] {
  * `typefully_get_me` - which puts the vendor where the verb should be and makes
  * the prefix table classify the whole server as write. Detecting the shared
  * token here lets classification look at the word that actually carries the
- * verb, and the whole-catalog view is what makes it safe: one tool cannot tell a
- * namespace from a verb.
+ * verb.
  *
  * Deliberately conservative. It requires **every** tool to share the token (a
- * partial match is a coincidence, not a namespace), needs at least two tools,
- * and refuses a token that is itself a read-only prefix - a server whose tools
- * are all `list_*` is naming them consistently, and stripping that would discard
- * the only signal the heuristic has.
+ * partial match is a coincidence, not a namespace), and refuses a token that is
+ * itself a read-only prefix - a server whose tools are all `list_*` is naming
+ * them consistently, and stripping that would discard the only signal the
+ * heuristic has - or a plain mutation verb, per {@link WRITE_VERB_PREFIXES}.
+ *
+ * A single tool can imply a namespace. The whole-catalog view is weaker evidence
+ * at one tool than at ten, which is what the two refusals above are carrying:
+ * they reject the tokens where a one-tool guess would go wrong, and a vendor
+ * name is not among them.
  */
 function sharedVendorPrefix(tools: readonly McpToolDescriptor[]): string | null {
-	if (tools.length < 2) return null;
+	if (tools.length === 0) return null;
 	let shared: string | null = null;
 	for (const tool of tools) {
 		const words = splitWords(tool.name);
@@ -113,7 +157,9 @@ function sharedVendorPrefix(tools: readonly McpToolDescriptor[]): string | null 
 		if (shared === null) shared = first;
 		else if (shared !== first) return null;
 	}
-	if (shared === null || READ_ONLY_PREFIXES.includes(shared)) return null;
+	if (shared === null) return null;
+	if (READ_ONLY_PREFIXES.includes(shared)) return null;
+	if (WRITE_VERB_PREFIXES.includes(shared)) return null;
 	return shared;
 }
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -2241,6 +2241,23 @@ export const RUNTIME_SUPPORTS_MCP_TOOL_FILTER: Record<AgentRuntime, boolean> = {
 };
 
 /**
+ * The fully-qualified name a connector's tool is addressed by, and the ceiling
+ * that name has to fit inside.
+ *
+ * Anthropic's API and the OpenAI-compatible endpoints both cap a tool name at 64
+ * characters. The namespace spends `mcp__`, the connector's own name and `__`
+ * before the upstream tool name even begins, so a verbose connector name paired
+ * with a verbose tool name can cross it - and at that point the provider, not
+ * Hezo, decides what becomes of the tool. Renaming the connector shortens every
+ * one of its tools at once, which is why the warning names the connector.
+ */
+export const MCP_TOOL_NAME_MAX_LENGTH = 64;
+
+export function qualifiedMcpToolName(serverName: string, toolName: string): string {
+	return `mcp__${serverName}__${toolName}`;
+}
+
+/**
  * Flags that make each CLI emit structured per-turn events to stdout while
  * the run is in flight, so the run log shows tool calls, thinking, and
  * partial assistant text live instead of silence until the final result.

--- a/packages/shared/test/mcp-method-access.test.ts
+++ b/packages/shared/test/mcp-method-access.test.ts
@@ -79,6 +79,78 @@ describe('classifyMcpMethod', () => {
 	});
 });
 
+describe('classifyMcpMethods — vendor-namespaced catalogs', () => {
+	it('classifies on the verb after a namespace every tool shares', () => {
+		// The real shape that broke this: Typefully names every tool after itself,
+		// so the leading word is the vendor and the prefix table saw a catalog with
+		// no read method anywhere in it.
+		const out = classifyMcpMethods([
+			{ name: 'typefully_list_drafts' },
+			{ name: 'typefully_get_me' },
+			{ name: 'typefully_create_draft' },
+			{ name: 'typefully_delete_draft' },
+		]);
+		expect(out.map((m) => m.readOnly)).toEqual([true, true, false, false]);
+		// Still a guess, not a declaration.
+		expect(out.every((m) => m.inferred)).toBe(true);
+		expect(readOnlyMethodNames(out)).toEqual(['typefully_list_drafts', 'typefully_get_me']);
+	});
+
+	it('leaves the name untouched — only the classification changes', () => {
+		const [first] = classifyMcpMethods([
+			{ name: 'typefully_get_me', description: 'Who am I' },
+			{ name: 'typefully_create_draft' },
+		]);
+		expect(first).toEqual({
+			name: 'typefully_get_me',
+			description: 'Who am I',
+			readOnly: true,
+			inferred: true,
+		});
+	});
+
+	it('requires every tool to share the token, since a partial match is a coincidence', () => {
+		const out = classifyMcpMethods([{ name: 'typefully_list_drafts' }, { name: 'get_me' }]);
+		// No namespace inferred, so `typefully` is read as the verb and falls through
+		// to write - the historic, deliberately strict behaviour.
+		expect(out[0]?.readOnly).toBe(false);
+		expect(out[1]?.readOnly).toBe(true);
+	});
+
+	it('refuses to strip a shared token that is itself a read prefix', () => {
+		// A server whose tools are all `list_*` is naming them consistently, not
+		// namespacing them. Stripping `list` would leave `drafts`/`tags` and turn a
+		// wholly read-only catalog into a wholly write one.
+		const out = classifyMcpMethods([{ name: 'list_drafts' }, { name: 'list_tags' }]);
+		expect(out.map((m) => m.readOnly)).toEqual([true, true]);
+	});
+
+	it('cannot infer a namespace from a single tool', () => {
+		// One name gives no way to tell a vendor prefix from a verb, so it stays
+		// strict.
+		expect(classifyMcpMethods([{ name: 'typefully_get_me' }])[0]?.readOnly).toBe(false);
+	});
+
+	it('does not infer a namespace when any tool is a bare single word', () => {
+		const out = classifyMcpMethods([{ name: 'typefully' }, { name: 'typefully_get_me' }]);
+		expect(out.map((m) => m.readOnly)).toEqual([false, false]);
+	});
+
+	it("still lets the server's readOnlyHint override the namespace-aware guess", () => {
+		const out = classifyMcpMethods([
+			{ name: 'typefully_get_or_lock_draft', annotations: { readOnlyHint: false } },
+			{ name: 'typefully_create_draft' },
+		]);
+		expect(out[0]?.readOnly).toBe(false);
+		expect(out[0]?.inferred).toBe(false);
+	});
+
+	it('handles camelCase namespacing too', () => {
+		const out = classifyMcpMethods([{ name: 'typefullyListDrafts' }, { name: 'typefullyGetMe' }]);
+		expect(out.map((m) => m.readOnly)).toEqual([true, true]);
+	});
+});
+
 const CATALOG: McpMethodInfo[] = [
 	{ name: 'get_issue', readOnly: true, inferred: false },
 	{ name: 'list_issues', readOnly: true, inferred: false },

--- a/packages/shared/test/mcp-method-access.test.ts
+++ b/packages/shared/test/mcp-method-access.test.ts
@@ -125,10 +125,25 @@ describe('classifyMcpMethods — vendor-namespaced catalogs', () => {
 		expect(out.map((m) => m.readOnly)).toEqual([true, true]);
 	});
 
-	it('cannot infer a namespace from a single tool', () => {
-		// One name gives no way to tell a vendor prefix from a verb, so it stays
-		// strict.
-		expect(classifyMcpMethods([{ name: 'typefully_get_me' }])[0]?.readOnly).toBe(false);
+	it('infers a namespace from a single tool', () => {
+		// A one-tool catalog is still namespaced if it looks namespaced; the token
+		// refusals below are what keep a one-tool guess honest.
+		expect(classifyMcpMethods([{ name: 'typefully_get_me' }])[0]?.readOnly).toBe(true);
+	});
+
+	it('refuses a shared token that is a plain mutation verb', () => {
+		// The mirror of the read-prefix refusal, and the guard that makes a
+		// single-tool namespace safe: stripping `update` here would classify on
+		// `view` - a read prefix - and call a write tool read-only.
+		expect(classifyMcpMethods([{ name: 'update_view' }])[0]?.readOnly).toBe(false);
+		expect(classifyMcpMethods([{ name: 'delete_export' }])[0]?.readOnly).toBe(false);
+		const many = classifyMcpMethods([{ name: 'create_list' }, { name: 'create_preview' }]);
+		expect(many.map((m) => m.readOnly)).toEqual([false, false]);
+	});
+
+	it('keeps a single tool strict when its token carries no verb signal either way', () => {
+		// `typefully_create_draft` strips to `create`, which is not a read prefix.
+		expect(classifyMcpMethods([{ name: 'typefully_create_draft' }])[0]?.readOnly).toBe(false);
 	});
 
 	it('does not infer a namespace when any tool is a bare single word', () => {


### PR DESCRIPTION
## The bug

`leadingWord('typefully_list_drafts')` returns `typefully`. That is not in `READ_ONLY_PREFIXES`, so **every** tool of a vendor-namespaced MCP server classified as *write*. Servers that prefix each tool with their own name are common, and for all of them the classification was wrong across the board.

On its own that only mislabels the methods dialog. Combined with an `access: 'read'` request it silently mutes the entire server:

1. `readOnlyMethodNames` finds no read methods and resolves to `[]`.
2. `discoverConnectorMethods` persists `enabled_methods = []` - **restricted to nothing**, which is deliberately not the same as `NULL` (migration 044).
3. `toolRestrictionOf` puts every tool into `permissions.deny`.
4. The connector card still reads **Connected**, and no tools reach the model.

## The fixes

**Namespace-aware classification.** `classifyMcpMethods` (the whole-catalogue entry point) now detects a leading token every tool shares and classifies on the word after it.

The safety comes from two token refusals rather than from a tool-count minimum:

- **a token that is itself a read prefix is refused** - a server whose tools are all `list_*` is naming them consistently, not namespacing them, and stripping `list` would turn a wholly read-only catalogue into a wholly write one
- **a token that is a plain mutation verb is refused** (`WRITE_VERB_PREFIXES`) - without this, `update_view` would strip `update` and classify on `view`, a read prefix, marking a write tool read-only

**A single tool can imply a namespace.** A one-tool server is exactly the case with no other signal available, and refusing to look left `typefully_get_me` classified as write on a catalogue of one. The two refusals above reject precisely the tokens a one-tool guess would get wrong, and a vendor name is not among them.

The mutation-verb refusal closes a hole that existed at two tools as well - `create_list` / `create_preview` would have hit it - so it is not merely scaffolding for the single-tool case. A vendor genuinely called `post` or `run` loses its namespace and classifies as write, which is the safe way round.

`classifyMcpMethod` called directly on one tool with no namespace passed is unchanged, and a server-declared `readOnlyHint` still wins outright. The heuristic keeps its documented "can only ever be too strict, never too permissive" property.

**Refuse to persist an allowlist that enables nothing.** If the read-only resolution comes back empty against a non-empty catalogue, `enabled_methods` stays `NULL` and the miss is logged. An allowlist withholding every tool is never what `access: 'read'` asked for - it is a classification failure, and silently muting a server is the worst available outcome. The request stays pending so a later refresh can satisfy it.

**Warn on over-long tool names.** `mcp__typefully__typefully_linkedin_resolve_linkedin_organization_from_url` is 73 characters, over the 64-char cap Anthropic and the OpenAI-compatible endpoints share. Advisory only - what happens past the limit is the provider's call, so the descriptor is unaffected. The warning names the connector, since renaming it shortens every one of its tools at once.

## Context

Split out of #928, which bundled this behind a tool-search root cause. That root cause has since been **refuted** by measurement - a DeepSeek run reported `typefully=connected(25)`, so the tools were present all along and #928 is closed. This PR was split out precisely so it would not go down with that diagnosis: it is a live trap for any vendor-namespaced connector registered with read access, independent of what caused the original report.

Worth noting the Typefully connector in that report was *not* in this state - its card read "all methods", meaning `enabled_methods IS NULL`. This is the failure that was waiting to happen, not the one that did.

## Testing

`bun run typecheck` clean, `bunx biome check` clean.

- `packages/shared` - `mcp-method-access`: 28 passed
- `packages/server` - `connector-*`: 72 passed across 8 files (including `connector-requested-access` and `migrate-044-connector-method-access`)
- `packages/server` - `mcp-injectors`: 79 passed

Coverage: vendor-namespaced catalogues classifying on the real verb; both token refusals, including the `update_view` case the mutation-verb guard exists for; single-tool namespace inference; the all-share requirement; the empty-allowlist refusal end-to-end against a live test MCP server; and the 73-char name from the original report.