### PR TITLE
fix(web): name each teammate on the team roster instead of listing roles alone

### DIFF
--- a/docs/concepts/marketplace.md
+++ b/docs/concepts/marketplace.md
@@ -18,7 +18,9 @@ Open it from the **Marketplace** button in the top navigation (just left of Sett
 The marketplace lists every available team with its name, a short description, how many roles it
 includes, and its version. Click a team to see its full details:
 
-- the **roster** - every role, who it reports to, and what it's responsible for;
+- the **roster** - every teammate by name and face, their role, who they report to, and what
+  they're responsible for. A team ships a fixed name per role, so you meet the same people here
+  that you'll work with once the project exists. The Captain is listed by role alone;
 - the **version** and **changelog** - what changed in each release of the team;
 - two actions: **Launch new project** and **Add to a project**.
 

--- a/packages/web/src/components/team-roster-table.tsx
+++ b/packages/web/src/components/team-roster-table.tsx
@@ -1,6 +1,8 @@
 import { CAPTAIN_AGENT_SLUG, type MarketplaceTeamDef } from '@hezo/shared';
 import type { Agent } from '../hooks/use-agents';
 import type { TeamTemplateAgentType } from '../hooks/use-team-templates';
+import { agentAvatarUrl } from '../lib/agent-avatar';
+import { Avatar, getInitials } from './ui/avatar';
 
 /**
  * One role as the roster views render it, normalised from whichever source it came
@@ -11,6 +13,17 @@ import type { TeamTemplateAgentType } from '../hooks/use-team-templates';
 export interface TeamRosterRow {
 	slug: string;
 	title: string;
+	/**
+	 * The teammate's human name ("Nova"), or null for a role that carries none. Null
+	 * is the normal case for the Captain and for every local team template — identity
+	 * lives on `member_agents`, and `agent_types` has no name or avatar columns.
+	 *
+	 * When set it leads the row and the role drops to a second line, so the roster
+	 * names the same person the rest of the UI does rather than only their job.
+	 */
+	humanName: string | null;
+	/** Spec the row's avatar is drawn from; undefined falls back to initials. */
+	avatarSpec?: unknown;
 	reportsTo: string;
 	roleDescription: string;
 }
@@ -24,6 +37,9 @@ export interface TeamRosterRow {
 export const CAPTAIN_ROSTER_ROW: TeamRosterRow = {
 	slug: CAPTAIN_AGENT_SLUG,
 	title: 'Captain',
+	// A marketplace team's Captain override carries only a prompt and team context,
+	// so the synthetic row has no name to show — it renders as "Captain" alone.
+	humanName: null,
 	reportsTo: 'CEO',
 	roleDescription: 'Leads the team and delegates work.',
 };
@@ -65,13 +81,21 @@ export function marketplaceRosterRows(def: MarketplaceTeamDef): TeamRosterRow[] 
 		roles.map((r) => ({
 			slug: r.slug,
 			title: r.title,
+			humanName: r.human_name,
+			avatarSpec: r.avatar_spec,
 			reportsTo: resolveReportsTo(r.reports_to_slug, known),
 			roleDescription: r.role_description,
 		})),
 	);
 }
 
-/** A local team template's roles. Same Captain rule as a marketplace team. */
+/**
+ * A local team template's roles. Same Captain rule as a marketplace team.
+ *
+ * Always name-less: a template's roles are `agent_types` rows, and that table has
+ * no `human_name`/`avatar_spec` — identity is authored per marketplace team and
+ * otherwise assigned when an agent is hired. These rows render role-only.
+ */
 export function templateRosterRows(agentTypes: TeamTemplateAgentType[]): TeamRosterRow[] {
 	const roles = [...agentTypes].sort((a, b) => a.sort_order - b.sort_order);
 	const known = [CAPTAIN_ROSTER_ROW, ...roles.map((a) => ({ slug: a.slug, title: a.name }))];
@@ -79,6 +103,7 @@ export function templateRosterRows(agentTypes: TeamTemplateAgentType[]): TeamRos
 		roles.map((a) => ({
 			slug: a.slug,
 			title: a.name,
+			humanName: null,
 			reportsTo: resolveReportsTo(a.reports_to_slug, known),
 			roleDescription: a.role_description,
 		})),
@@ -97,6 +122,10 @@ export function agentRosterRows(agents: Agent[]): TeamRosterRow[] {
 			.map((a) => ({
 				slug: a.slug,
 				title: a.title,
+				// `human_name` rather than `display_name`: the latter already falls back to
+				// the role, which would render the same word on both lines of the cell.
+				humanName: a.human_name ?? null,
+				avatarSpec: a.avatar_spec,
 				reportsTo: a.reports_to_title ?? NO_REPORTS_TO,
 				roleDescription: a.role_description ?? '',
 			}))
@@ -107,9 +136,11 @@ export function agentRosterRows(agents: Agent[]): TeamRosterRow[] {
 }
 
 // Written out literally (not composed at runtime) so Tailwind's source scan sees
-// every class it has to generate.
-const ROW_GRID = 'grid grid-cols-1 sm:grid-cols-[9rem_8rem_1fr] gap-x-4';
-const HEADER_GRID = 'hidden sm:grid grid-cols-[9rem_8rem_1fr] gap-x-4';
+// every class it has to generate. The first track is 12rem rather than 9rem to fit
+// the avatar beside the name/role pair without the longest titles ("Distribution
+// Manager") wrapping to three lines.
+const ROW_GRID = 'grid grid-cols-1 sm:grid-cols-[12rem_8rem_1fr] gap-x-4';
+const HEADER_GRID = 'hidden sm:grid grid-cols-[12rem_8rem_1fr] gap-x-4';
 
 /**
  * A team's roster: role, who it reports to, and what it's responsible for. Shared by
@@ -129,20 +160,38 @@ export function TeamRosterTable({ rows, testId }: { rows: TeamRosterRow[]; testI
 				<span>Reports to</span>
 				<span>Responsibility</span>
 			</li>
-			{rows.map((r) => (
-				<li
-					key={r.slug}
-					data-testid={`roster-row-${r.slug}`}
-					className={`${ROW_GRID} gap-y-0.5 py-2 text-[13px]`}
-				>
-					<span className="font-medium">{r.title}</span>
-					<span className="text-[12px] text-text-2 sm:text-[13px]">
-						<span className="sm:hidden">Reports to </span>
-						{r.reportsTo}
-					</span>
-					<span className="text-[12px] text-text-2 sm:text-[13px]">{r.roleDescription}</span>
-				</li>
-			))}
+			{rows.map((r) => {
+				// A named teammate leads with their name and drops the role to a second
+				// line; a name-less role (Captain, any team template) keeps the role as
+				// the only line rather than rendering an empty one.
+				const name = r.humanName ?? r.title;
+				return (
+					<li
+						key={r.slug}
+						data-testid={`roster-row-${r.slug}`}
+						className={`${ROW_GRID} gap-y-0.5 py-2 text-[13px]`}
+					>
+						<span className="flex items-start gap-2">
+							<Avatar
+								initials={getInitials(name)}
+								size="sm"
+								imageUrl={agentAvatarUrl({ slug: r.slug, avatar_spec: r.avatarSpec })}
+							/>
+							{/* min-w-0 so a long title wraps inside the cell instead of
+							    forcing the grid column wider than its track. */}
+							<span className="min-w-0">
+								<span className="block font-medium">{name}</span>
+								{r.humanName && <span className="block text-[12px] text-text-2">{r.title}</span>}
+							</span>
+						</span>
+						<span className="text-[12px] text-text-2 sm:text-[13px]">
+							<span className="sm:hidden">Reports to </span>
+							{r.reportsTo}
+						</span>
+						<span className="text-[12px] text-text-2 sm:text-[13px]">{r.roleDescription}</span>
+					</li>
+				);
+			})}
 		</ul>
 	);
 }

--- a/packages/web/test/create-project-team-detail.test.tsx
+++ b/packages/web/test/create-project-team-detail.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
 
 /**
@@ -8,13 +8,14 @@ import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed
  * team's detail (its roster) inside the dialog, and "Select team" is the only way to
  * commit from there. The browse screens carry no create actions.
  */
-async function openCatalogFromHome() {
+async function openCatalogFromHome(afterSeed?: (ws: SeededWorkspace) => Promise<void>) {
 	let ws!: SeededWorkspace;
 	const utils = await renderApp({
 		initialPath: '/home',
 		seed: async () => {
 			ws = await seedWorkspace();
 			await seedProject(ws, { name: 'Existing Project' });
+			await afterSeed?.(ws);
 			sessionStorage.setItem('hezo:activeTeamSlug', ws.team.slug);
 		},
 	});
@@ -118,10 +119,41 @@ test("an existing team's detail lists its live agents and hides the HQ CEO/Coach
 	expect(rows[0].getAttribute('data-testid')).toBe('roster-row-captain');
 	expect(rows.some((r) => r.getAttribute('data-testid') === 'roster-row-engineer')).toBe(true);
 
+	// This team is provisioned from a `team_templates` row, and `agent_types` carries
+	// no identity columns - so its agents have no human name and each row is its role
+	// alone. (Names reach `member_agents` only via the marketplace provisioning path.)
+	expect((await findByTestId('roster-row-engineer')).textContent).toContain('Engineer');
+
 	// HQ's CEO and Coach are surfaced as virtual members of every project but are not
 	// part of the roster a clone would copy, so they get no row.
 	expect(screen.queryByTestId('roster-row-ceo')).toBeNull();
 	expect(screen.queryByTestId('roster-row-coach')).toBeNull();
+});
+
+test("a named agent's roster row leads with the name and keeps the role beneath", async () => {
+	const { user, findByTestId, ws } = await openCatalogFromHome(async (seeded) => {
+		const engineer = seeded.agents.find((a) => a.slug === 'engineer');
+		if (!engineer) throw new Error('seeded roster is missing the engineer');
+		const { apiBase } = getTestContext();
+		const res = await apiBase(`/api/projects/${seeded.internalSlug}/agents/${engineer.id}`, {
+			method: 'PATCH',
+			headers: seeded.headers,
+			body: JSON.stringify({ human_name: 'Max' }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	await user.click(await findByTestId('team-tab-copy', undefined, { timeout: 15_000 }));
+	await user.click(await findByTestId(`source-team-card-${ws.team.slug}`));
+
+	// Named: "Max" leads and "Engineer" stays as the supporting line, so the roster
+	// matches the name this agent is called by everywhere else in the UI.
+	const engineer = await findByTestId('roster-row-engineer');
+	expect(engineer.textContent).toContain('Max');
+	expect(engineer.textContent).toContain('Engineer');
+
+	// Naming an agent also composes its avatar, so the row shows the sprite.
+	expect(engineer.querySelector('img')?.getAttribute('src')).toMatch(/^data:image\/svg\+xml/);
 });
 
 test('mod+Enter does not create the project from the catalog or the detail', async () => {

--- a/packages/web/test/marketplace.test.tsx
+++ b/packages/web/test/marketplace.test.tsx
@@ -33,6 +33,30 @@ test('marketplace detail shows the roster, version, and changelog with breadcrum
 	await findByTestId('marketplace-add-existing');
 });
 
+test('the marketplace roster names each teammate and shows their avatar', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/marketplace/software-development' });
+	await findByTestId('marketplace-roster');
+
+	// The team authors a fixed human name per role, so the roster introduces the
+	// person and keeps the role as the supporting line - not the role alone.
+	const engineer = await findByTestId('roster-row-engineer');
+	expect(engineer.textContent).toContain('Max');
+	expect(engineer.textContent).toContain('Engineer');
+	const architect = await findByTestId('roster-row-architect');
+	expect(architect.textContent).toContain('Ada');
+
+	// The row's avatar is drawn from the team's own `avatar_spec`, so it is a real
+	// generated sprite rather than the initials fallback.
+	const img = engineer.querySelector('img');
+	expect(img?.getAttribute('src')).toMatch(/^data:image\/svg\+xml/);
+
+	// The Captain carries no human name, so its row stays role-only and falls back
+	// to initials - asserting no name line got invented for it.
+	const captain = await findByTestId('roster-row-captain');
+	expect(captain.textContent).toContain('Captain');
+	expect(captain.querySelector('img')).toBeNull();
+});
+
 test('Launch new project opens the standard create dialog preselected to the team', async () => {
 	const { findByTestId, user } = await renderApp({
 		initialPath: '/marketplace/software-development',


### PR DESCRIPTION
## What

The team roster table showed roles where the rest of the UI shows people. Opening **Social Media Marketing** in the marketplace listed "Brand Strategist", "Content Writer", "Media Producer" - never Nova, Cleo or Hugo, even though the team authors a fixed name and avatar for every one of them.

## Why it happened

`TeamRosterRow` (`packages/web/src/components/team-roster-table.tsx`) carried only `slug / title / reportsTo / roleDescription`. `marketplaceRosterRows` received `human_name`, `gender` and `avatar_spec` on each `MarketplaceRosterAgent` and dropped all three on the floor, then the table rendered `r.title`.

Nothing was missing from the data: the fields are on the shared type (`packages/shared/src/marketplace.ts`), validated server-side (`services/marketplace.ts`), and populated in the committed `marketplace/teams/*.json`. It was purely the projection.

`docs/concepts/projects-and-teams.md` § Agent names already told users the roster "shows the name, with the role alongside it" - the doc described the intended behaviour and the UI did not deliver it. This makes it true.

## What changed

- `TeamRosterRow` gains `humanName` and `avatarSpec`. A named teammate leads the row with the role beneath; a name-less role keeps the role as its only line rather than rendering an empty one.
- Each row renders the sprite from the team's own `avatar_spec` via the existing `agentAvatarUrl` + `Avatar` seam, falling back to initials where there is none.
- First grid track widens 9rem -> 12rem to fit the avatar without wrapping the longest titles. The mobile single-column stack and the three desktop tracks are unchanged.

Applied to all three row-builders:

| Builder | Behaviour |
|---|---|
| `marketplaceRosterRows` | Reads the team's authored `human_name` + `avatar_spec`. |
| `agentRosterRows` | Reads `human_name`, **not** `display_name` - the latter already falls back to the role and would render the same word on both lines. |
| `templateRosterRows` | Always name-less by construction: a template's roles are `agent_types` rows, and that table has no identity columns. Stays role-only. |

The Captain is name-less on every path (a marketplace team's Captain override carries only a prompt and team context), so it renders as "Captain" with initials.

## Tests

- New component test: the marketplace roster names Max/Ada, shows a real generated sprite (`data:image/svg+xml`), and leaves the Captain role-only with no image.
- New component test on the live-agent path: an agent renamed through the API leads its row with the name and keeps the role beneath. `openCatalogFromHome` gained an optional post-seed hook to set this up.
- Tightened the existing live-agents test to assert the template-provisioned roster is role-only, documenting why that path has no names.
- Browser specs re-run against the widened grid: both roster geometry assertions still hold (3 tracks desktop, 1 mobile) and the mobile dialog still has no horizontal overflow with the avatar added. 17 passed.
- Full web tiers touching the roster pass; `docs-terminology` and `docs-links` pass.

## Docs

`docs/concepts/marketplace.md` - the roster bullet said the page showed "every role, who it reports to, and what it's responsible for", which now understates it.

## Note, unrelated to this change

The screenshot that prompted this was serving **v11** of the team while the repo is on **v12** (v12 replaced the em dashes in the team copy). Production fetches the team JSONs from GitHub raw `main`, so the deployed marketplace keeps serving v11 until v12 lands there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiSYmg6ftTvq6hUo64thjn)_