### PR TITLE
feat(providers): pin default models from each provider's catalog; fix four broken runtimes

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2853,7 +2853,7 @@ task-level `runtime_type` pin searches.
 
 Defaults: Anthropic + DeepSeek + Z.ai + Kimi → `claude_code` (DeepSeek/Z.ai/Kimi
 inject `ANTHROPIC_BASE_URL` + model defaults to point Claude Code at their Anthropic-compatible
-gateway — Kimi at `api.moonshot.ai/anthropic`, model `kimi-k2.7-code`), OpenAI → `codex`,
+gateway — Kimi at `api.moonshot.ai/anthropic`, model `KIMI_DEFAULT_MODEL`), OpenAI → `codex`,
 Google → `gemini`, OpenRouter → `opencode`, xAI → `grok` (its own first-party Grok Build CLI,
 `XAI_API_KEY` direct to `api.x.ai`, model `grok-4.5`), Ollama + LM Studio → `claude_code`
 (local runners, see below). Alternates: Kimi additionally declares `kimi` (Moonshot's own CLI,
@@ -2936,7 +2936,13 @@ runs price at `$0`, which for local inference is correct rather than the usual f
 **Provider config.** `ai_provider_configs` is instance-level (shared across teams), one
 row per `(provider, label)`, each inlining an encrypted credential. `auth_method`
 distinguishes an **API key** (injected as env at run start) from a **subscription** blob
-(materialized to a per-run mount in the container). Subscription auth is supported by
+(materialized to a per-run mount in the container). **One api-key exception:** Codex will not
+authenticate a request from `OPENAI_API_KEY` — `codex doctor` reports the variable as present
+and then reports `auth mode: none`, and every request 401s — so its key is written to the same
+per-run `auth.json` its subscription blob uses, in the `{auth_mode: "apikey", …}` shape
+`codex login --with-api-key` produces (`RUNTIME_HOME_LAYOUTS[codex].apiKeyAuthFile`). The mount
+reports `rotates: false` for a key, so the rotated-credential read-back never writes a
+key-derived file back over the operator's stored value. Subscription auth is supported by
 Anthropic, OpenAI, and Google (xAI is API-key only). A config's `status` is `verified` (the healthy default —
 the add flow live-verifies the key, the Verify action persists the result, and replacing the
 credential re-verifies it — each restoring `verified` on a key that had gone `invalid`),
@@ -2961,7 +2967,11 @@ it, and `setDefaultAiProvider` moves it atomically. `resolveRuntimeForTask` filt
 `status = 'verified'` and `PROVIDERS_BY_RUNTIME[runtime]`, then orders
 `is_default DESC, created_at ASC`, so the global default wins whenever it's a candidate
 for the chosen runtime, else the oldest verified config; an agent's `model_override_*`
-(or the config's `default_model`) sets the CLI `--model`.
+(or the config's `default_model`) selects the run's model. **How that reaches the CLI is per
+runtime** (`RUNTIME_MODEL_DELIVERY`): nearly all take `--model <id>`, but Kimi Code resolves
+`--model` against a `[models."<id>"]` table in its own `config.toml` — which Hezo never writes,
+because the model is registered through the shell-read `KIMI_MODEL_*` family instead — so
+passing the flag there fails the run outright and the id travels on `KIMI_MODEL_NAME` alone.
 
 **Live model listing.** Every UI surface that picks a specific model — the provider
 `default_model` selector and the per-agent model override — populates its options from
@@ -2973,6 +2983,22 @@ proxy). Subscription-auth configs short-circuit with `SUBSCRIPTION_UNSUPPORTED` 
 not an API key the catalog endpoint accepts), and the pickers degrade to the CLI's default
 model; the pricing-override model-id field stays free-text but offers the aggregated live
 catalog as autocomplete suggestions.
+
+**Pinned starting model.** A newly created config does not start on `NULL`: the create route
+sets `default_model` from that provider's *pin* (`services/model-pins.ts`). A pin names a
+**family** rather than a model (`MODEL_PIN_SPECS` in `@hezo/shared`) — `claude-opus-*`,
+`*-codex`, `gemini-*-flash` — and the daily `model-pin-refresh` cron re-reads each configured
+provider's catalog and moves the pin to the highest version inside that family, storing it in
+`system_meta` under `model_pin:<provider>`. A family rather than "the newest model" because a
+catalog mixes tiers, modalities and vendors, so an unrestricted maximum would pin an image
+model or jump price tier; version comparison reads `.` and `-` alike and drops dated snapshot
+suffixes, so `claude-haiku-4-5-20251001` cannot outrank a later release on a date. The refresh
+**never touches an existing row** — it moves only the default offered to the next config
+added — and holds the previous pin on an unreachable provider, a rejected key or a family that
+matched nothing. Providers with no spec (the local runners) get no pin at all. Why it exists:
+a hardcoded id cannot notice its own retirement, which is how `gemini-1.5-flash` stayed the
+Google stop-hook judge long after Google withdrew it, 404ing on every run while the hook
+failed open.
 
 **Reasoning effort.** Each run resolves an `agent_effort` level
 (`minimal|low|medium|high|max`) from the wakeup payload → `member_agents.default_effort` →

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -179,3 +179,20 @@ Wherever you pick a specific model - a provider's default model, or an agent's o
 Hezo loads the list of choices **live from that provider**, so you always see the models
 your key can actually use. Providers you signed in to with a subscription instead of an API
 key use the model their CLI selects, so there's no list to choose from there.
+
+## How the starting model is chosen
+
+A connection you add starts on a sensible current model for that provider rather than on
+nothing, so a key you paste and leave alone still runs. Hezo keeps that starting point
+fresh by re-reading each connected provider's catalog once a day and following the
+provider's own naming, so a new generation becomes the starting model without an update to
+Hezo. It stays within the same class of model, so the choice never jumps to a different
+price tier or to an image model.
+
+**Connections you already have are never changed.** The model on a stored connection is
+yours until you change it, and a refresh only moves the default offered to the *next*
+connection you add. If a provider is unreachable when the refresh runs, its previous
+default stands.
+
+Local model servers have no pinned default: the catalog is whatever you have pulled, so
+the CLI's own choice applies until you pick one.

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -44,6 +44,7 @@ handy for baking defaults into a service definition while still overriding per r
 | `--auto-install-updates` | `HEZO_AUTO_INSTALL_UPDATES` | off | Install staged updates automatically: once a newer release is downloaded and verified, Hezo gracefully restarts onto it without waiting for "Install & restart" in the web UI. The restart is deferred while agent runs are in flight, and only happens where in-app auto-update is available at all (the self-managed binary - not inside a container). The instance comes back **unlocked**: the unlock key is handed to the new process in memory, never written to disk. See [Updating](/docs/deployment/self-hosting#updating). |
 | - | `HEZO_AUTO_INSTALL_CRON` | `0 */5 * * * *` | Cron schedule (seconds-precision) for the auto-install check that restarts onto a staged update once no agent runs are in flight. Only registered when auto-install is enabled. |
 | - | `HEZO_PRICING_REFRESH_CRON` | `0 0 2 * * *` | Cron schedule (seconds-precision) for the daily model-pricing refresh from [pricepertoken.com](https://pricepertoken.com). Pricing also refreshes at startup; a failed refresh keeps the existing rates. |
+| - | `HEZO_MODEL_PIN_REFRESH_CRON` | `0 0 3 * * *` | Cron schedule (seconds-precision) for the daily re-read of each connected provider's model catalog, which keeps the model a **newly added** connection starts on current. Connections you already have keep the model you chose. A provider Hezo cannot reach keeps its previous default. |
 
 ## Examples
 

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -26,6 +26,8 @@ import {
 	storeAiProviderKey,
 	updateAiProviderConfig,
 } from '../services/ai-provider-keys';
+import { getPinnedModel, refreshModelPins } from '../services/model-pins';
+import { fetchProviderCatalog, probeProviderCatalog } from '../services/provider-catalog';
 import { validateSubscriptionBlob } from '../services/subscription-auth';
 
 const log = logger.child('routes');
@@ -147,20 +149,11 @@ async function prepareProviderCredential(
 	}
 
 	if (authMethod === AiAuthMethod.ApiKey && !process.env.SKIP_AI_KEY_VALIDATION) {
-		try {
-			const valid = await verifyProviderKey(provider, value, authMethod, baseUrl);
-			if (!valid) {
-				return {
-					ok: false,
-					code: 'INVALID_KEY',
-					message: `API key validation failed — the key was rejected by ${info.name}`,
-					status: 400,
-				};
-			}
-		} catch {
-			// For a local provider the usual cause is that the runner is not listening
-			// at the given URL, so name the endpoint rather than blaming a key that
-			// may not even be required.
+		const probe = await probeProviderCatalog(provider, value, baseUrl);
+		// "We could not ask" is not "your key is wrong", and the difference is the
+		// whole diagnosis for a local runner that simply is not running. Keep the
+		// two apart: only a provider that answered and refused blames the key.
+		if (!probe.ok && probe.reason === 'unreachable') {
 			return {
 				ok: false,
 				code: 'VALIDATION_FAILED',
@@ -168,6 +161,14 @@ async function prepareProviderCredential(
 					? `Could not reach ${info.name} at ${baseUrl}. Check the server is running and the URL is reachable from Hezo.`
 					: 'Could not reach the provider to validate the key. Please try again.',
 				status: 503,
+			};
+		}
+		if (!probe.ok) {
+			return {
+				ok: false,
+				code: 'INVALID_KEY',
+				message: `API key validation failed — the key was rejected by ${info.name}`,
+				status: 400,
 			};
 		}
 	}
@@ -252,6 +253,17 @@ aiProvidersRoutes.post('/ai-providers', async (c) => {
 			runtimeChoice.value,
 		);
 
+		// A new credential starts on the provider's pinned model rather than on
+		// "none". Only ever here, on creation: an existing config's model is the
+		// operator's choice and no refresh may move it (see services/model-pins).
+		// A subscription picks its own model inside the CLI, so it gets none.
+		if (authMethod !== AiAuthMethod.Subscription) {
+			const pinned = await getPinnedModel(db, provider);
+			if (pinned) {
+				await updateAiProviderConfig(db, configId, { defaultModel: pinned });
+			}
+		}
+
 		return ok(c, { id: configId }, 201);
 	} catch (e) {
 		const message = e instanceof Error ? e.message : 'Failed to store AI provider config';
@@ -260,6 +272,19 @@ aiProvidersRoutes.post('/ai-providers', async (c) => {
 		}
 		return err(c, 'INTERNAL', message, 500);
 	}
+});
+
+// Re-read every configured provider's catalog and move its pinned default model
+// to the newest in that provider's family. The same pass the daily cron runs,
+// exposed so an operator does not have to wait a day after a provider ships a
+// generation. Existing configs keep their model; only the default a NEW
+// credential starts on moves.
+aiProvidersRoutes.post('/ai-providers/refresh-model-pins', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+
+	const result = await refreshModelPins(c.get('db'), c.get('masterKeyManager'));
+	return ok(c, result);
 });
 
 // Delete an AI provider config
@@ -313,13 +338,14 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 	}
 
 	try {
-		const valid = await verifyProviderKey(
-			cred.provider as AiProvider,
-			cred.value,
-			cred.authMethod,
-			cred.baseUrl,
-		);
-		if (valid) {
+		// A subscription blob is not an API key any catalog endpoint accepts, so it
+		// is taken as verified rather than probed - the same rule the create path
+		// applies, kept in step with it here.
+		const probe =
+			cred.authMethod === AiAuthMethod.Subscription
+				? ({ ok: true } as const)
+				: await probeProviderCatalog(cred.provider as AiProvider, cred.value, cred.baseUrl);
+		if (probe.ok) {
 			// Persist the healthy state so the badge is truthful and a key that was
 			// previously marked `invalid` recovers on a successful re-verify.
 			await db.query(
@@ -327,6 +353,13 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 				[AiProviderStatus.Verified, configId],
 			);
 			return ok(c, { valid: true });
+		}
+		// An unreachable provider says nothing about the key, so the stored status
+		// is left alone rather than being marked invalid on a network blip - a
+		// badge that flips to "invalid" because the operator's laptop was offline
+		// is worse than no badge.
+		if (probe.reason === 'unreachable') {
+			return ok(c, { valid: false, message: 'Could not reach provider to verify key' });
 		}
 		await db.query(`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`, [
 			AiProviderStatus.Invalid,
@@ -515,90 +548,27 @@ aiProvidersRoutes.get('/ai-providers/:configId/models', async (c) => {
 		);
 	}
 
-	const endpoint = resolveCatalogEndpoint(provider, cred.value, cred.baseUrl);
-	if (!endpoint) {
-		return err(c, 'UNSUPPORTED', `No models endpoint for provider "${provider}"`, 400);
-	}
-
-	let res: Response;
-	try {
-		res = await fetch(endpoint.url, {
-			method: 'GET',
-			headers: endpoint.headers,
-			signal: AbortSignal.timeout(10000),
-		});
-	} catch {
-		// For a local provider this is the expected error when the operator's server
-		// simply is not running, which is exactly what PROVIDER_UNREACHABLE conveys.
-		return err(c, 'PROVIDER_UNREACHABLE', 'Could not reach provider to list models', 503);
-	}
-
-	if (!res.ok) {
-		if (res.status === 401 || res.status === 403) {
+	const catalog = await fetchProviderCatalog(provider, cred.value, cred.baseUrl);
+	if (!catalog.ok) {
+		if (catalog.reason === 'unsupported') {
+			return err(c, 'UNSUPPORTED', `No models endpoint for provider "${provider}"`, 400);
+		}
+		if (catalog.reason === 'unreachable') {
+			return err(c, 'PROVIDER_UNREACHABLE', 'Could not reach provider to list models', 503);
+		}
+		if (catalog.reason === 'rejected') {
 			return err(c, 'INVALID_KEY', 'Provider rejected the stored credential', 401);
 		}
-		return err(c, 'PROVIDER_ERROR', `Provider returned status ${res.status}`, 503);
+		return err(
+			c,
+			'PROVIDER_ERROR',
+			catalog.status
+				? `Provider returned status ${catalog.status}`
+				: 'Provider returned unparseable response',
+			503,
+		);
 	}
 
-	let json: unknown;
-	try {
-		json = await res.json();
-	} catch {
-		return err(c, 'PROVIDER_ERROR', 'Provider returned unparseable response', 503);
-	}
-
-	const models = parseProviderModels(provider, json);
+	const models = parseProviderModels(provider, catalog.json);
 	return ok(c, models);
 });
-
-/**
- * Resolve the catalog endpoint used both to verify a credential and to list a
- * provider's models. Hosted providers use their fixed `verifyEndpoint`; a
- * locally-hosted one (Ollama, LM Studio) has no fixed endpoint, so the URL is
- * built from the operator's configured base URL, falling back to the runner's
- * documented default port. Both runners expose the OpenAI-shaped `/v1/models`,
- * which `parseProviderModels` already handles via its generic `data[]` branch.
- */
-function resolveCatalogEndpoint(
-	provider: AiProvider,
-	apiKey: string,
-	baseUrl?: string | null,
-): { url: string; headers: Record<string, string> } | null {
-	const info = AI_PROVIDER_INFO[provider];
-	if (!info) return null;
-
-	if (info.local) {
-		const root = (baseUrl?.trim() || info.local.defaultBaseUrl).replace(/\/+$/, '');
-		return {
-			url: `${root}/v1/models`,
-			headers: { Authorization: `Bearer ${apiKey}` },
-		};
-	}
-
-	const endpoint = info.verifyEndpoint;
-	if (!endpoint) return null;
-	return {
-		url: typeof endpoint.url === 'function' ? endpoint.url(apiKey) : endpoint.url,
-		headers: typeof endpoint.headers === 'function' ? endpoint.headers(apiKey) : endpoint.headers,
-	};
-}
-
-async function verifyProviderKey(
-	provider: AiProvider,
-	apiKey: string,
-	authMethod: string,
-	baseUrl?: string | null,
-): Promise<boolean> {
-	if (authMethod === AiAuthMethod.Subscription) return true;
-
-	const endpoint = resolveCatalogEndpoint(provider, apiKey, baseUrl);
-	if (!endpoint) return false;
-
-	const res = await fetch(endpoint.url, {
-		method: 'GET',
-		headers: endpoint.headers,
-		signal: AbortSignal.timeout(10000),
-	});
-
-	return res.ok;
-}

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -15,6 +15,7 @@ import {
 	GEMINI_RUNTIME_ENV,
 	HeartbeatRunKind,
 	HeartbeatRunStatus,
+	kimiModelContextSize,
 	opencodeModelArg,
 	PROVIDER_RUNTIME_ADAPTERS,
 	type ProgressActivityKind,
@@ -25,6 +26,7 @@ import {
 	RUNTIME_DISALLOWED_TOOLS_ARGS,
 	RUNTIME_HEADLESS_PREFIX_ARGS,
 	RUNTIME_HEADLESS_SUFFIX_ARGS,
+	RUNTIME_MODEL_DELIVERY,
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 	repoNameFromIdentifier,
@@ -318,6 +320,11 @@ export function buildProviderEnv(
 				out.push(`${key}=${subagentOverride}`);
 			} else if (kimiModelOverride && key === 'KIMI_MODEL_NAME') {
 				out.push(`${key}=${kimiModelOverride}`);
+			} else if (kimiModelOverride && key === 'KIMI_MODEL_MAX_CONTEXT_SIZE') {
+				// Tracks the selected model rather than the pinned default: the window
+				// is a property of the model, and declaring the default's window for a
+				// smaller model makes the CLI compact too late and the endpoint refuse.
+				out.push(`${key}=${kimiModelContextSize(kimiModelOverride)}`);
 			} else {
 				out.push(`${key}=${value}`);
 			}
@@ -421,7 +428,7 @@ export function getPromptRelPath(heartbeatRunId: string): string {
 // is readable host-side after the run. Grok reports no token usage on stdout, so
 // the runner parses this file for cost, then scrubs it (it also contains the
 // XAI_API_KEY in plaintext). See `extractGrokUsageFromDebugLog`.
-const GROK_DEBUG_BASENAME = 'debug.log';
+export const GROK_DEBUG_BASENAME = 'debug.log';
 
 // Basename of Kimi Code's per-session wire log, written under
 // `$KIMI_CODE_HOME/sessions/<workspace>/<session>/agents/<agent>/`. Kimi Code's
@@ -796,7 +803,11 @@ export async function buildRuntimeInvocation(
 			cliModel = opencodeModelArg(provider, modelOverride);
 		}
 	}
-	const modelArgs = cliModel ? ['--model', cliModel] : [];
+	// A runtime that selects its model from the environment gets no flag: on Kimi
+	// Code `--model` looks the id up in a config table Hezo never writes, and the
+	// run dies before reaching the model at all.
+	const modelArgs =
+		cliModel && RUNTIME_MODEL_DELIVERY[runtimeType] === 'flag' ? ['--model', cliModel] : [];
 
 	// Grok reports no token usage on its stdout stream, so point it at a per-run
 	// debug log (inside the home mount, hence readable host-side) that the runner
@@ -1587,7 +1598,7 @@ export async function runAgent(
 		const priceFn = pricing
 			? (model: string | undefined, tokens: CostTokens) => pricing.costCents(model, tokens)
 			: undefined;
-		const parser = createAgentStreamParser(runtimeType, priceFn);
+		const parser = createAgentStreamParser(runtimeType, priceFn, modelOverride);
 
 		const persistRotatedAuth = async () => {
 			const mount = context.subscriptionMount;

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -99,9 +99,16 @@ export function classifyRuntimeError(raw: string | undefined | null): string | n
 	return text;
 }
 
+/**
+ * @param runModel the model the run was launched with, for the runtimes whose
+ *   stream names no model. OpenCode reports token counts but never a model id,
+ *   so without this every OpenCode run priced at $0 no matter what it spent. A
+ *   model named in the stream still wins - this is the floor, not an override.
+ */
 export function createAgentStreamParser(
 	runtime: AgentRuntime,
 	price: PriceModelFn = NO_PRICE,
+	runModel?: string | null,
 ): AgentStreamParser {
 	switch (runtime) {
 		case AgentRuntime.ClaudeCode:
@@ -114,10 +121,10 @@ export function createAgentStreamParser(
 		// across versions and aren't fully documented. The generic parser is
 		// lenient — it renders recognizable assistant text / tool activity and
 		// captures token usage from whatever terminal event carries it, dropping
-		// anything it doesn't recognize so the log stays clean. Tighten into a
-		// bespoke parser once a real run's events are captured (see PR notes).
+		// anything it doesn't recognize so the log stays clean. It names no model
+		// anywhere in the stream, so pricing depends on the run's own model.
 		case AgentRuntime.OpenCode:
-			return createGenericJsonlParser(price);
+			return createGenericJsonlParser(price, runModel?.trim() || undefined);
 		// Grok's `streaming-json` emits thought/text/end events and NO token usage;
 		// usage is recovered post-run from the `--debug-file` (see the runner and
 		// `extractGrokUsageFromDebugLog`), so this parser's getUsage() stays null.
@@ -262,6 +269,7 @@ function createJsonlEventReader<T>(render: (event: unknown) => T[]): {
 export function createAgentChatParser(
 	runtime: AgentRuntime,
 	price: PriceModelFn = NO_PRICE,
+	runModel?: string | null,
 ): AgentChatParser {
 	switch (runtime) {
 		case AgentRuntime.ClaudeCode:
@@ -271,7 +279,7 @@ export function createAgentChatParser(
 		case AgentRuntime.Gemini:
 			return createGeminiChatParser(price);
 		case AgentRuntime.OpenCode:
-			return createGenericChatParser(price);
+			return createGenericChatParser(price, runModel?.trim() || undefined);
 		case AgentRuntime.Grok:
 			return createGrokChatParser();
 		case AgentRuntime.Kimi:
@@ -851,12 +859,57 @@ interface GeminiTokens {
 	tool?: number;
 }
 
+/**
+ * One model's counts, in either of the two shapes the CLI has emitted.
+ *
+ * `tokens` is the telemetry object's own field names. The stream-json writer
+ * does not emit that object - it flattens it into the `*_tokens` names below,
+ * and drops the reasoning bucket while doing so. Both are read because only the
+ * flat one appears on the wire today and the nested one costs nothing to keep.
+ */
 interface GeminiModelStats {
 	tokens?: GeminiTokens;
+	total_tokens?: number;
+	input_tokens?: number;
+	output_tokens?: number;
+	cached?: number;
 }
 
 interface GeminiStats {
 	models?: Record<string, GeminiModelStats>;
+}
+
+/**
+ * One model's counts, normalized to what a run is billed for.
+ *
+ * The flat projection carries no reasoning bucket, so it is recovered as the
+ * residual the total leaves after the prompt and the visible answer. That
+ * residual also absorbs tool-prompt tokens, which bill at the input rate - a
+ * bounded over-attribution to output, against a guaranteed total loss of every
+ * reasoning token if the residual is ignored, which for a thinking model is
+ * most of what the run generated.
+ */
+function geminiModelTokens(model: GeminiModelStats): {
+	prompt: number;
+	cached: number;
+	output: number;
+} {
+	const t = model.tokens;
+	if (t) {
+		return {
+			prompt: t.prompt ?? 0,
+			cached: t.cached ?? 0,
+			output: (t.candidates ?? 0) + (t.thoughts ?? 0),
+		};
+	}
+	const prompt = model.input_tokens ?? 0;
+	const visible = model.output_tokens ?? 0;
+	const total = model.total_tokens ?? 0;
+	return {
+		prompt,
+		cached: model.cached ?? 0,
+		output: visible + Math.max(0, total - prompt - visible),
+	};
 }
 
 interface GeminiEvent {
@@ -879,24 +932,46 @@ interface GeminiEvent {
 function createGeminiParser(price: PriceModelFn): AgentStreamParser {
 	let usage: AgentRunUsage | null = null;
 	let finalMessage: string | null = null;
+	/**
+	 * Assistant text arrives as consecutive `message` events that are CHUNKS of
+	 * one answer, not whole answers - a reply of `HEZO-LIVE-OK` streams as
+	 * `HEZO-LIVE-` then `OK`. Treating each as complete left `getFinalAssistantMessage`
+	 * holding the last fragment, and the runner's handoff-delivery net posts that
+	 * value verbatim, so a stranded Gemini handoff was delivered as its final few
+	 * characters. Buffered and flushed on the next non-message event, the same way
+	 * the Grok parser handles its deltas.
+	 */
+	let textBuf = '';
+	const flushText = (out: string[]): void => {
+		const t = textBuf.trim();
+		textBuf = '';
+		if (!t) return;
+		finalMessage = t;
+		out.push(t);
+	};
 
 	const renderEvent = (raw: unknown): string[] => {
 		const event = raw as GeminiEvent;
 		const type = event.type ?? '';
 
-		if (type === 'init') {
-			return [`[session] model=${event.model ?? 'gemini'} tools=0`];
+		if (type === 'message' && event.role !== 'user') {
+			textBuf += event.content ?? event.text ?? '';
+			return [];
 		}
 
-		if (type === 'message') {
-			if (event.role === 'user') return [];
-			const text = (event.content ?? event.text ?? '').trim();
-			if (text) finalMessage = text;
-			return text ? [text] : [];
+		const out: string[] = [];
+		flushText(out);
+
+		if (type === 'init') {
+			out.push(`[session] model=${event.model ?? 'gemini'} tools=0`);
+			return out;
 		}
+
+		if (type === 'message') return out;
 
 		if (type === 'tool_use') {
-			return [formatToolUse(event.name ?? 'tool', event.input ?? event.args)];
+			out.push(formatToolUse(event.name ?? 'tool', event.input ?? event.args));
+			return out;
 		}
 
 		if (type === 'tool_result') {
@@ -904,7 +979,8 @@ function createGeminiParser(price: PriceModelFn): AgentStreamParser {
 				.replace(/\s+/g, ' ')
 				.trim();
 			const label = event.is_error ? '[tool-error]' : '[tool-result]';
-			return [body ? `${label} ${body}` : label];
+			out.push(body ? `${label} ${body}` : label);
+			return out;
 		}
 
 		if (type === 'result') {
@@ -912,59 +988,63 @@ function createGeminiParser(price: PriceModelFn): AgentStreamParser {
 			const costCents = priceGeminiModels(event.stats, price);
 			usage = { inputTokens: input, outputTokens: output, costCents };
 			const status = event.error ? 'error' : 'success';
-			return [`[done] ${status} tokens=${input}/${output}`];
+			out.push(`[done] ${status} tokens=${input}/${output}`);
+			return out;
 		}
 
 		if (type === 'error') {
 			const msg = extractErrorMessage(event.error, event.message);
-			return msg ? [msg.replace(/\s+/g, ' ').trim()] : [];
+			if (msg) out.push(msg.replace(/\s+/g, ' ').trim());
+			return out;
 		}
 
-		return [];
+		return out;
 	};
 
 	return createJsonlParser(
 		renderEvent,
 		() => usage,
 		() => null,
-		() => finalMessage,
+		// Flushed here too: a run whose last event is an assistant chunk has text
+		// still buffered, and the final message is exactly what the handoff net
+		// would deliver.
+		() => {
+			const pending: string[] = [];
+			flushText(pending);
+			return finalMessage;
+		},
 	);
 }
 
 /**
- * Sum token usage across every model Gemini reports. `prompt` is the full
- * input (the `cached` count is a subset of it, not additive); billed output is
- * the generated `candidates` plus reasoning `thoughts` tokens.
+ * Sum token usage across every model Gemini reports. The prompt count is the
+ * full input (the cached count is a subset of it, not additive); billed output
+ * is the visible answer plus reasoning.
  */
 function sumGeminiTokens(stats: GeminiStats | undefined): { input: number; output: number } {
 	let input = 0;
 	let output = 0;
 	for (const model of Object.values(stats?.models ?? {})) {
-		const t = model.tokens;
-		if (!t) continue;
-		input += t.prompt ?? 0;
-		output += (t.candidates ?? 0) + (t.thoughts ?? 0);
+		const t = geminiModelTokens(model);
+		input += t.prompt;
+		output += t.output;
 	}
 	return { input, output };
 }
 
 /**
- * Price each model Gemini reports separately and sum the cents. `cached` is a
- * subset of `prompt` billed at the cache-read rate; the rest of `prompt` is
- * full-rate input, and billed output is `candidates` + reasoning `thoughts`.
+ * Price each model Gemini reports separately and sum the cents. The cached
+ * count is a subset of the prompt billed at the cache-read rate; the rest of
+ * the prompt is full-rate input.
  */
 function priceGeminiModels(stats: GeminiStats | undefined, price: PriceModelFn): number {
 	let cents = 0;
 	for (const [modelId, model] of Object.entries(stats?.models ?? {})) {
-		const t = model.tokens;
-		if (!t) continue;
-		const prompt = t.prompt ?? 0;
-		const cached = t.cached ?? 0;
-		const output = (t.candidates ?? 0) + (t.thoughts ?? 0);
+		const t = geminiModelTokens(model);
 		cents += price(modelId, {
-			inputTokens: Math.max(0, prompt - cached),
-			cacheReadTokens: cached,
-			outputTokens: output,
+			inputTokens: Math.max(0, t.prompt - t.cached),
+			cacheReadTokens: t.cached,
+			outputTokens: t.output,
 		});
 	}
 	return cents;
@@ -1040,33 +1120,96 @@ function extractGenericTool(event: Record<string, unknown>, type: string): strin
 	return null;
 }
 
-/** Find a token-usage object on the event and normalize it. */
-function extractGenericUsage(
-	event: Record<string, unknown>,
-	price: PriceModelFn,
-	modelId: string | undefined,
-): AgentRunUsage | null {
-	const u = [event.usage, event.tokens, event.stats].find(isRecord);
+/** One event's token counts, before they are folded into a run total. */
+interface GenericTokenBuckets {
+	/** Input excluding anything the cache buckets already account for. */
+	input: number;
+	cacheRead: number;
+	cacheWrite: number;
+	output: number;
+}
+
+/**
+ * Find a token-usage object on the event and normalize it.
+ *
+ * Probed one level into `part` as well as at the top level: OpenCode reports
+ * per-step usage on `step_finish.part.tokens`, and a probe that only looked at
+ * the event root found nothing and priced every run at $0.
+ *
+ * The cache halves are read from a nested `cache` object as well as from flat
+ * names, and cache-creation is kept rather than dropped - it is the dominant
+ * bucket on a first step and is billed at its own rate.
+ */
+function extractGenericUsage(event: Record<string, unknown>): GenericTokenBuckets | null {
+	const part = isRecord(event.part) ? event.part : undefined;
+	const u = [event.usage, event.tokens, event.stats, part?.usage, part?.tokens].find(isRecord);
 	if (!u) return null;
-	const input = firstNumber(u, ['input_tokens', 'prompt_tokens', 'prompt', 'input']);
-	const cached = firstNumber(u, ['cached_input_tokens', 'cache_read_input_tokens', 'cached']);
+	const cache = isRecord(u.cache) ? u.cache : undefined;
+	const flatRead = firstNumber(u, ['cached_input_tokens', 'cache_read_input_tokens', 'cached']);
+	const flatWrite = firstNumber(u, ['cache_creation_input_tokens', 'cache_write_input_tokens']);
+	const cacheRead = flatRead + (cache ? firstNumber(cache, ['read']) : 0);
+	const cacheWrite = flatWrite + (cache ? firstNumber(cache, ['write']) : 0);
 	const output =
 		firstNumber(u, ['output_tokens', 'completion_tokens', 'candidates', 'output']) +
-		firstNumber(u, ['reasoning_output_tokens', 'thoughts']);
-	if (input === 0 && output === 0) return null;
-	const costCents = price(modelId, {
-		inputTokens: Math.max(0, input - cached),
-		cacheReadTokens: cached,
-		outputTokens: output,
-	});
-	return { inputTokens: input, outputTokens: output, costCents };
+		firstNumber(u, ['reasoning_output_tokens', 'reasoning', 'thoughts']);
+	const stated = firstNumber(u, ['input_tokens', 'prompt_tokens', 'prompt', 'input']);
+	// Whether the stated input already excludes the cache is a property of the
+	// shape, and the two shapes say which they are. A nested `cache` object is a
+	// per-bucket breakdown whose siblings are peers of it (OpenCode: total =
+	// input + output + read + write). Flat cache keys accompany a full prompt
+	// count that contains them, so there they must come off or the run is billed
+	// for its cache twice.
+	const input = cache ? stated : Math.max(0, stated - flatRead - flatWrite);
+	if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) return null;
+	return { input, cacheRead, cacheWrite, output };
+}
+
+/**
+ * Fold one event's counts into the run total.
+ *
+ * Accumulated rather than replaced, because these arrive per step: OpenCode
+ * emits a `step_finish` per turn and the last one describes that turn alone, so
+ * taking the latest recorded a multi-step run as whatever its final step cost.
+ */
+function addGenericUsage(
+	total: GenericTokenBuckets | null,
+	next: GenericTokenBuckets,
+): GenericTokenBuckets {
+	if (!total) return next;
+	return {
+		input: total.input + next.input,
+		cacheRead: total.cacheRead + next.cacheRead,
+		cacheWrite: total.cacheWrite + next.cacheWrite,
+		output: total.output + next.output,
+	};
+}
+
+/** Price an accumulated total, reporting input as everything the run read. */
+function priceGenericUsage(
+	total: GenericTokenBuckets,
+	price: PriceModelFn,
+	modelId: string | undefined,
+): AgentRunUsage {
+	return {
+		inputTokens: total.input + total.cacheRead + total.cacheWrite,
+		outputTokens: total.output,
+		costCents: price(modelId, {
+			inputTokens: total.input,
+			cacheReadTokens: total.cacheRead,
+			cacheCreationTokens: total.cacheWrite,
+			outputTokens: total.output,
+		}),
+	};
 }
 
 const GENERIC_TERMINAL_RE = /complete|finish|result|done|stop|\bend\b/i;
 
-function createGenericJsonlParser(price: PriceModelFn): AgentStreamParser {
-	let usage: AgentRunUsage | null = null;
-	let modelId: string | undefined;
+function createGenericJsonlParser(
+	price: PriceModelFn,
+	fallbackModelId: string | undefined,
+): AgentStreamParser {
+	let tokens: GenericTokenBuckets | null = null;
+	let modelId: string | undefined = fallbackModelId;
 	let finalMessage: string | null = null;
 
 	const renderEvent = (raw: unknown): string[] => {
@@ -1076,8 +1219,8 @@ function createGenericJsonlParser(price: PriceModelFn): AgentStreamParser {
 		const model = firstString(event, ['model']);
 		if (model) modelId = model;
 
-		const captured = extractGenericUsage(event, price, modelId);
-		if (captured) usage = captured;
+		const captured = extractGenericUsage(event);
+		if (captured) tokens = addGenericUsage(tokens, captured);
 
 		const errText = extractErrorMessage(
 			event.error as { message?: string } | string | undefined,
@@ -1104,37 +1247,47 @@ function createGenericJsonlParser(price: PriceModelFn): AgentStreamParser {
 		}
 
 		if (captured && GENERIC_TERMINAL_RE.test(type)) {
-			return [`[done] success tokens=${captured.inputTokens}/${captured.outputTokens}`];
+			// The running total rather than this step's own counts: the line reads as
+			// the run's cost so far, which is what it is once several steps report.
+			const soFar = priceGenericUsage(tokens ?? captured, price, modelId);
+			return [`[done] success tokens=${soFar.inputTokens}/${soFar.outputTokens}`];
 		}
 		return [];
 	};
 
 	return createJsonlParser(
 		renderEvent,
-		() => usage,
+		() => (tokens ? priceGenericUsage(tokens, price, modelId) : null),
 		() => null,
 		() => finalMessage,
 	);
 }
 
-function createGenericChatParser(price: PriceModelFn): AgentChatParser {
-	let usage: AgentRunUsage | null = null;
-	let modelId: string | undefined;
+function createGenericChatParser(
+	price: PriceModelFn,
+	fallbackModelId: string | undefined,
+): AgentChatParser {
+	let tokens: GenericTokenBuckets | null = null;
+	let modelId: string | undefined = fallbackModelId;
 	const render = (raw: unknown): AgentChatTurnEvent[] => {
 		if (!isRecord(raw)) return [];
 		const event = raw;
 		const type = typeof event.type === 'string' ? event.type : '';
 		const model = firstString(event, ['model']);
 		if (model) modelId = model;
-		const captured = extractGenericUsage(event, price, modelId);
-		if (captured) usage = captured;
+		const captured = extractGenericUsage(event);
+		if (captured) tokens = addGenericUsage(tokens, captured);
 		const toolName = extractGenericTool(event, type);
 		if (toolName) return [{ toolActivity: toolName }];
 		const text = extractGenericText(event);
 		return text ? [{ text }] : [];
 	};
 	const reader = createJsonlEventReader(render);
-	return { onStdout: reader.onStdout, flush: reader.flush, getUsage: () => usage };
+	return {
+		onStdout: reader.onStdout,
+		flush: reader.flush,
+		getUsage: () => (tokens ? priceGenericUsage(tokens, price, modelId) : null),
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -75,6 +75,7 @@ import type { EgressProxy } from './egress';
 import { getDueGoals } from './goals';
 import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
+import { refreshModelPins } from './model-pins';
 import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
 import { collectCandidateRunIds, decideSweepKills } from './process-sweeper';
@@ -291,6 +292,10 @@ const INBOX_ARCHIVE_CRON = process.env.HEZO_INBOX_ARCHIVE_CRON ?? '0 0 3 * * *';
 // Daily model-pricing refresh from the pricepertoken.com catalog. Failures
 // log and leave the existing rows — the boot-time refresh / next tick retries.
 const PRICING_REFRESH_CRON = process.env.HEZO_PRICING_REFRESH_CRON ?? '0 0 2 * * *';
+// Daily re-read of each configured provider's model catalog, moving the pinned
+// default a NEW credential starts on. Existing configs are never touched. An
+// hour after the pricing refresh so a newly pinned model already has a rate row.
+const MODEL_PIN_REFRESH_CRON = process.env.HEZO_MODEL_PIN_REFRESH_CRON ?? '0 0 3 * * *';
 // Daily check for a newer release; when auto-update is enabled and one is found,
 // download+verify+stage it so an operator "Update & restart" is instant.
 const UPDATE_CHECK_CRON = process.env.HEZO_UPDATE_CHECK_CRON ?? '0 0 4 * * *';
@@ -715,6 +720,11 @@ export class JobManager {
 				onTick: () => this.guarded('pricing-refresh', () => this.refreshPricing()),
 			});
 		}
+		this.cron.createJob('model-pin-refresh', {
+			cron: MODEL_PIN_REFRESH_CRON,
+			log: cronLog,
+			onTick: () => this.guarded('model-pin-refresh', () => this.refreshModelPins()),
+		});
 		if (this.deps.telemetry?.enabled) {
 			this.cron.createJob('telemetry', {
 				cron: TELEMETRY_CRON,
@@ -3663,6 +3673,21 @@ export class JobManager {
 		if (!this.deps.pricing) return;
 		const count = await this.deps.pricing.refresh();
 		log.info(`Model pricing refreshed from pricepertoken.com (${count} models)`);
+	}
+
+	/**
+	 * Move each configured provider's pinned default model to the newest in its
+	 * family. Best-effort: the service reports per-provider failures rather than
+	 * throwing, so one unreachable provider cannot skip the rest.
+	 */
+	private async refreshModelPins(): Promise<void> {
+		const result = await refreshModelPins(this.deps.db, this.deps.masterKeyManager);
+		if (result.changed.length > 0) {
+			log.info(`Model pins refreshed — ${result.changed.join(', ')}`);
+		}
+		if (result.skipped.length > 0) {
+			log.info(`Model pins skipped — ${result.skipped.join(', ')}`);
+		}
 	}
 
 	private async runTelemetry(): Promise<void> {

--- a/packages/server/src/services/mcp-injectors/kimi.ts
+++ b/packages/server/src/services/mcp-injectors/kimi.ts
@@ -120,14 +120,21 @@ function buildStdioEntry(d: McpStdioDescriptor): KimiStdioEntry {
  * answer. Approvals are safe to skip here for the same reason they are on every
  * other runtime: the container is an ephemeral, egress-constrained sandbox in
  * which the agent already executes arbitrary code.
+ *
+ * `permission.rules` is an ARRAY of `{pattern, decision}` — an inline table with
+ * a `default` key parses as one malformed rule, and the CLI then drops the whole
+ * `permission` section with a warning rather than failing, so the belt silently
+ * was not there. `kimi doctor` is what states the schema; check a change against
+ * it, since a rejected section reports as a warning and not an error.
  */
 function renderConfigToml(
 	judgeScriptContainerPath: string,
 	docWriteGuardContainerPath: string | null,
 ): string {
 	const lines = [
-		'[permission.rules]',
-		'default = "allow"',
+		'[[permission.rules]]',
+		'pattern = "*"',
+		'decision = "allow"',
 		'',
 		'[[hooks]]',
 		'event = "Stop"',

--- a/packages/server/src/services/model-pins.ts
+++ b/packages/server/src/services/model-pins.ts
@@ -1,0 +1,144 @@
+/**
+ * Keeps each provider's default model current in a **running** instance.
+ *
+ * The rule and the per-provider families live in `@hezo/shared`
+ * (`model-pins.ts`); this is the half that needs a database and a network: read
+ * each configured provider's live catalog, pick the newest id in its family, and
+ * record it.
+ *
+ * **A pin only ever supplies a default to a NEW credential.** Nothing here
+ * writes `ai_provider_configs.default_model` for a row that already exists - an
+ * operator's model choice is theirs until they change it, and a refresh that
+ * moved running agents onto a new model would be a silent, instance-wide
+ * behaviour change nobody asked for.
+ *
+ * **Why the catalog and not a constant.** A hardcoded id cannot notice its own
+ * retirement. `gemini-1.5-flash` stayed pinned as the Stop-hook judge long after
+ * Google withdrew it: the judge call 404'd on every run and the hook failed
+ * open, with nothing in the run looking wrong. Reading the provider's own
+ * catalog is the only thing that keeps a pin true.
+ *
+ * Best-effort throughout, and deliberately so: this runs on a cron against
+ * third-party endpoints, so an unreachable provider, a rejected key or a
+ * renamed family leaves the previous pin in place rather than failing the tick
+ * or clearing the pin.
+ */
+
+import {
+	AiAuthMethod,
+	type AiProvider,
+	ALL_AI_PROVIDERS,
+	fallbackPinnedModel,
+	MODEL_PIN_SPECS,
+	parseProviderModels,
+	pickLatestModel,
+} from '@hezo/shared';
+import type { MasterKeyManager } from '../crypto/master-key';
+import type { Db } from '../db/database';
+import { getSystemMeta, setSystemMeta } from '../lib/system-meta';
+import { logger } from '../logger';
+import { getProviderConfigCredential } from './ai-provider-keys';
+import { fetchProviderCatalog } from './provider-catalog';
+
+const log = logger.child('model-pins');
+
+/** One row per provider, so a refresh touches only the provider it re-read. */
+function pinKey(provider: AiProvider): string {
+	return `model_pin:${provider}`;
+}
+
+/**
+ * The model a newly-added credential for this provider should start on.
+ *
+ * The refreshed pin when there is one, else the compile-time fallback. Null for
+ * a provider with no pin at all - the local runners, whose catalog is whatever
+ * the operator has pulled, where the CLI's own default is the honest answer.
+ */
+export async function getPinnedModel(db: Db, provider: AiProvider): Promise<string | null> {
+	const stored = (await getSystemMeta(db, pinKey(provider)))?.trim();
+	return stored || fallbackPinnedModel(provider);
+}
+
+export interface ModelPinRefreshResult {
+	/** Providers whose pin moved, as `<provider>: <old> → <new>`. */
+	changed: string[];
+	/** Providers read successfully whose pin was already current. */
+	unchanged: number;
+	/** Providers that could not be read, with why. */
+	skipped: string[];
+}
+
+/**
+ * Re-read every configured provider's catalog and move its pin to the newest
+ * model in its family.
+ *
+ * Only providers with a stored credential are reachable - there is no catalog to
+ * read without one - so a provider nobody has configured keeps its compile-time
+ * fallback until the first credential for it is added.
+ */
+export async function refreshModelPins(
+	db: Db,
+	masterKeyManager: MasterKeyManager,
+): Promise<ModelPinRefreshResult> {
+	const result: ModelPinRefreshResult = { changed: [], unchanged: 0, skipped: [] };
+	if (!masterKeyManager.getKey()) {
+		result.skipped.push('instance locked');
+		return result;
+	}
+
+	// One config per provider is enough to read a catalog with, and the newest
+	// row is the likeliest to carry a working key. Providers with no pin spec are
+	// excluded in SQL rather than fetched and discarded.
+	const pinnable = ALL_AI_PROVIDERS.filter((p) => MODEL_PIN_SPECS[p]);
+	if (pinnable.length === 0) return result;
+	const configs = await db.query<{ id: string; provider: string }>(
+		`SELECT DISTINCT ON (provider) id, provider
+		   FROM ai_provider_configs
+		  WHERE provider = ANY($1)
+		  ORDER BY provider, created_at DESC`,
+		[pinnable],
+	);
+
+	for (const row of configs.rows) {
+		const provider = row.provider as AiProvider;
+		try {
+			const cred = await getProviderConfigCredential(db, masterKeyManager, row.id);
+			if (!cred) {
+				result.skipped.push(`${provider}: credential unreadable`);
+				continue;
+			}
+			// A subscription blob is not an API key the catalog endpoint accepts, so
+			// listing would only ever 401. The CLI picks the model in that case anyway.
+			if (cred.authMethod === AiAuthMethod.Subscription) {
+				result.skipped.push(`${provider}: subscription sign-in has no catalog`);
+				continue;
+			}
+			const catalog = await fetchProviderCatalog(provider, cred.value, cred.baseUrl);
+			if (!catalog.ok) {
+				result.skipped.push(`${provider}: catalog ${catalog.reason}`);
+				continue;
+			}
+			const ids = parseProviderModels(provider, catalog.json).map((m) => m.id);
+			const latest = pickLatestModel(provider, ids);
+			if (!latest) {
+				// The family matched nothing. Renamed upstream, or this key sees a
+				// restricted catalog - either way the previous pin is the better answer
+				// than something from a different tier.
+				result.skipped.push(`${provider}: no model matched the pinned family`);
+				continue;
+			}
+			const current = await getPinnedModel(db, provider);
+			if (current === latest) {
+				result.unchanged += 1;
+				continue;
+			}
+			await setSystemMeta(db, pinKey(provider), latest);
+			result.changed.push(`${provider}: ${current ?? 'none'} → ${latest}`);
+		} catch (e) {
+			result.skipped.push(`${provider}: ${(e as Error).message}`);
+		}
+	}
+
+	if (result.changed.length > 0) log.info(`Model pins moved — ${result.changed.join(', ')}`);
+	return result;
+}

--- a/packages/server/src/services/provider-catalog.ts
+++ b/packages/server/src/services/provider-catalog.ts
@@ -1,0 +1,123 @@
+/**
+ * Reading a provider's own model catalog.
+ *
+ * One home because there are now three callers with the same need and different
+ * reporting: the models route (which maps each failure to its own HTTP code),
+ * credential verification (which only cares whether the key was accepted), and
+ * the model-pin refresh (which runs on a cron and treats every failure the
+ * same). The endpoint resolution in particular must not be restated - a hosted
+ * provider's is a fixed table entry while a local runner's is built from the
+ * operator's own base URL, and getting that split wrong is silent.
+ */
+
+import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
+
+export interface CatalogEndpoint {
+	url: string;
+	headers: Record<string, string>;
+}
+
+/**
+ * Resolve the catalog endpoint used both to verify a credential and to list a
+ * provider's models. Hosted providers use their fixed `verifyEndpoint`; a
+ * locally-hosted one (Ollama, LM Studio) has no fixed endpoint, so the URL is
+ * built from the operator's configured base URL, falling back to the runner's
+ * documented default port. Both runners expose the OpenAI-shaped `/v1/models`,
+ * which `parseProviderModels` already handles via its generic `data[]` branch.
+ */
+export function resolveCatalogEndpoint(
+	provider: AiProvider,
+	apiKey: string,
+	baseUrl?: string | null,
+): CatalogEndpoint | null {
+	const info = AI_PROVIDER_INFO[provider];
+	if (!info) return null;
+
+	if (info.local) {
+		const root = (baseUrl?.trim() || info.local.defaultBaseUrl).replace(/\/+$/, '');
+		return {
+			url: `${root}/v1/models`,
+			headers: { Authorization: `Bearer ${apiKey}` },
+		};
+	}
+
+	const endpoint = info.verifyEndpoint;
+	if (!endpoint) return null;
+	return {
+		url: typeof endpoint.url === 'function' ? endpoint.url(apiKey) : endpoint.url,
+		headers: typeof endpoint.headers === 'function' ? endpoint.headers(apiKey) : endpoint.headers,
+	};
+}
+
+/**
+ * Why a catalog read failed, at the granularity callers actually branch on.
+ *
+ * `rejected` is separated from `error` because it is the one an operator can act
+ * on - the credential is wrong - and the route turns it into a 401 rather than a
+ * 503. Everything else is the provider's problem or the network's.
+ */
+export type CatalogFailure = 'unsupported' | 'unreachable' | 'rejected' | 'error';
+
+export type CatalogResult =
+	| { ok: true; json: unknown }
+	| { ok: false; reason: CatalogFailure; status?: number };
+
+const CATALOG_TIMEOUT_MS = 10_000;
+
+export type CatalogProbe =
+	| { ok: true; res: Response }
+	| { ok: false; reason: CatalogFailure; status?: number };
+
+/**
+ * Call the catalog endpoint and classify the outcome, **without reading the
+ * body**.
+ *
+ * Separate from {@link fetchProviderCatalog} because verifying a credential only
+ * asks whether the provider accepted it. Parsing there would be work nobody
+ * needs, and it would make verification fail on a provider that answers 200 with
+ * a body shape we do not recognise - a stricter bar than "the key works".
+ */
+export async function probeProviderCatalog(
+	provider: AiProvider,
+	apiKey: string,
+	baseUrl?: string | null,
+): Promise<CatalogProbe> {
+	const endpoint = resolveCatalogEndpoint(provider, apiKey, baseUrl);
+	if (!endpoint) return { ok: false, reason: 'unsupported' };
+
+	let res: Response;
+	try {
+		res = await fetch(endpoint.url, {
+			method: 'GET',
+			headers: endpoint.headers,
+			signal: AbortSignal.timeout(CATALOG_TIMEOUT_MS),
+		});
+	} catch {
+		// For a local provider this is the expected error when the operator's server
+		// simply is not running, which is exactly what `unreachable` conveys.
+		return { ok: false, reason: 'unreachable' };
+	}
+
+	if (!res.ok) {
+		if (res.status === 401 || res.status === 403) {
+			return { ok: false, reason: 'rejected', status: res.status };
+		}
+		return { ok: false, reason: 'error', status: res.status };
+	}
+	return { ok: true, res };
+}
+
+/** GET and parse the provider's catalog. Never throws - every failure is a result. */
+export async function fetchProviderCatalog(
+	provider: AiProvider,
+	apiKey: string,
+	baseUrl?: string | null,
+): Promise<CatalogResult> {
+	const probe = await probeProviderCatalog(provider, apiKey, baseUrl);
+	if (!probe.ok) return probe;
+	try {
+		return { ok: true, json: await probe.res.json() };
+	} catch {
+		return { ok: false, reason: 'error' };
+	}
+}

--- a/packages/server/src/services/runtime-home.ts
+++ b/packages/server/src/services/runtime-home.ts
@@ -69,6 +69,20 @@ export interface RuntimeHomeLayout {
 	 * omitted, `buildSubscriptionMount` writes no file and returns null.
 	 */
 	authFileRelative?: string;
+	/**
+	 * Renders {@link authFileRelative}'s contents for an **api key**, on a CLI
+	 * that will not authenticate a request from an environment variable.
+	 *
+	 * Codex is the case: it reports the env key as present (`codex doctor` says
+	 * "auth is provided by environment") and then sends no bearer at all, so every
+	 * api-key run 401s. The key it does honour is the one in its auth file, which
+	 * is the same file its subscription blob lands in - hence one mechanism here
+	 * rather than a second delivery path.
+	 *
+	 * Omitted for every CLI that does read the env var; those write no file and
+	 * keep the env-only delivery `credentialEnvByAuthMethod` describes.
+	 */
+	apiKeyAuthFile?: (apiKey: string) => string;
 	envVarName: string;
 	/** True when the runtime CLI rotates a single-use refresh token in place,
 	 *  so runs on the credential must serialise and the rotated file persist back. */
@@ -94,6 +108,11 @@ export const RUNTIME_HOME_LAYOUTS: Record<AgentRuntime, RuntimeHomeLayout> = {
 	[AgentRuntime.Codex]: {
 		dirPrefix: 'codex',
 		authFileRelative: 'auth.json',
+		// The shape `codex login --with-api-key` writes. Rendered rather than
+		// piped through that command because the run has no interactive step to
+		// hang it off, and the file is what the CLI reads either way.
+		apiKeyAuthFile: (apiKey) =>
+			`${JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: apiKey }, null, 2)}\n`,
 		envVarName: 'CODEX_HOME',
 		rotates: true,
 	},
@@ -218,14 +237,18 @@ export async function buildSubscriptionMount(
 	engine: ContainerEngine,
 	containerId: string,
 ): Promise<SubscriptionMount | null> {
-	if (credential.authMethod !== AiAuthMethod.Subscription) return null;
-
 	const layout = RUNTIME_HOME_LAYOUTS[runtime];
 	if (!layout) return null;
-	// No credential file for this runtime — the subscription credential is
-	// delivered via env var (buildProviderEnv), so there is nothing to mount.
+	// No credential file for this runtime — the credential is delivered via env
+	// var (buildProviderEnv), so there is nothing to mount.
 	const { authFileRelative } = layout;
 	if (!authFileRelative) return null;
+
+	const isSubscription = credential.authMethod === AiAuthMethod.Subscription;
+	// An api key only gets a file on a CLI that will not read it from the
+	// environment; everywhere else env delivery stands and this returns null.
+	const contents = isSubscription ? credential.value : layout.apiKeyAuthFile?.(credential.value);
+	if (contents === undefined) return null;
 
 	const hostDir = getHostSubscriptionRoot(
 		provider,
@@ -243,7 +266,7 @@ export async function buildSubscriptionMount(
 	// itself stays 0o600 (and is chowned to the run-user), never world-readable.
 	await subscriptionFiles(engine, containerId).write(
 		join(layoutDirName(layout, provider), heartbeatRunId, authFileRelative),
-		credential.value,
+		contents,
 		{ mode: 0o600, dirMode: SUBSCRIPTION_DIR_MODE },
 	);
 
@@ -253,7 +276,10 @@ export async function buildSubscriptionMount(
 		authFileRelative,
 		containerDir,
 		envEntries: [`${layout.envVarName}=${containerDir}`],
-		rotates: layout.rotates,
+		// Only a subscription blob rotates. An api-key file is written from the
+		// stored key every run, so reading it back would persist a rotation that
+		// never happened over the operator's own credential.
+		rotates: layout.rotates && isSubscription,
 	};
 }
 

--- a/packages/server/src/services/stop-hook-prompt.ts
+++ b/packages/server/src/services/stop-hook-prompt.ts
@@ -39,7 +39,11 @@ export const STOP_HOOK_JUDGE_MODEL_ANTHROPIC = 'claude-sonnet-4-6';
 export const STOP_HOOK_JUDGE_MODEL_DEEPSEEK = 'deepseek-v4-pro';
 export const STOP_HOOK_JUDGE_MODEL_ZAI = 'GLM-4.7';
 export const STOP_HOOK_JUDGE_MODEL_OPENAI = 'gpt-4o-mini';
-export const STOP_HOOK_JUDGE_MODEL_GOOGLE = 'gemini-1.5-flash';
+// Retiring a judge model is silent: the call 404s, the hook fails open, and
+// nothing about the run looks wrong. Check this id is still served when the
+// provider ships a generation - `gemini-1.5-flash` sat here long after Google
+// withdrew it.
+export const STOP_HOOK_JUDGE_MODEL_GOOGLE = 'gemini-3.5-flash-lite';
 // Shared by both ways of running Kimi. On the Claude Code runtime (against
 // Moonshot's Anthropic-compatible endpoint) the native `type:"prompt"` Stop hook
 // judges with it; on Moonshot's own CLI the command-script judge calls their

--- a/packages/server/test/agent-runner-branches.test.ts
+++ b/packages/server/test/agent-runner-branches.test.ts
@@ -5,7 +5,7 @@
 // agent-runner-extended.test.ts; this file fills the reachable per-branch gaps
 // in the building blocks those tests only touch on the happy path.
 
-import { AiAuthMethod, AiProvider } from '@hezo/shared';
+import { AiAuthMethod, AiProvider, KIMI_DEFAULT_MODEL } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -178,7 +178,7 @@ describe('buildProviderEnv', () => {
 		// → quiet env present, plus the Moonshot base URL + model defaults.
 		expect(env).toContain('DISABLE_TELEMETRY=1');
 		expect(env).toContain('ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic');
-		expect(env).toContain('ANTHROPIC_DEFAULT_SONNET_MODEL=kimi-k2.7-code');
+		expect(env).toContain(`ANTHROPIC_DEFAULT_SONNET_MODEL=${KIMI_DEFAULT_MODEL}`);
 		expect(env).toContain('ENABLE_TOOL_SEARCH=false');
 		expect(env).toContain('CLAUDE_CODE_AUTO_COMPACT_WINDOW=262144');
 		// Kimi's api-key var is ANTHROPIC_AUTH_TOKEN (Moonshot endpoint).

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -7,6 +7,8 @@ import {
 	ContainerStatus,
 	formatContainerMetaLogLine,
 	HeartbeatRunStatus,
+	KIMI_DEFAULT_MODEL,
+	kimiModelContextSize,
 } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -2293,6 +2295,68 @@ describe('runAgent', () => {
 			expect(capturedCmd).not.toContain('--model');
 		});
 
+		// Kimi Code resolves `--model` against a `[models."<id>"]` table in its
+		// config.toml, which Hezo never writes - the model is registered through the
+		// shell-read KIMI_MODEL_* family instead. Passing the flag kills the run with
+		// `config.invalid: Model "…" is not configured in config.toml`, before it
+		// reaches a model at all, so every Kimi Code run with an assigned model
+		// failed. The id has to travel on KIMI_MODEL_NAME only.
+		it('sends the model on the environment, not --model, for Kimi Code', async () => {
+			// Added rather than swapped in: the sibling cases in this block share the
+			// database and read the seeded Anthropic config, so the agent names the
+			// provider it wants instead of the suite deleting one.
+			globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+			await app.request('/api/ai-providers', {
+				method: 'POST',
+				headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					provider: 'kimi',
+					api_key: 'sk-kimi-code-model',
+					label: 'kimi-code',
+					runtime: 'kimi',
+				}),
+			});
+			globalThis.fetch = originalFetch;
+
+			let capturedCmd: string[] = [];
+			let capturedEnv: string[] = [];
+			const docker = createMockDocker({
+				execCreate: async (_id: string, opts: any) => {
+					capturedCmd = opts.Cmd;
+					capturedEnv = opts.Env ?? [];
+					return 'exec-kimi-model';
+				},
+				execStart: async () => ({ stdout: '', stderr: '' }),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+			});
+
+			await runAgent(
+				{
+					db,
+					docker,
+					masterKeyManager,
+					serverPort: 3000,
+					dataDir: testDataDir,
+					logs: new LogStreamBroker(),
+				},
+				{
+					...makeAgent(),
+					model_override_provider: 'kimi',
+					model_override_model: 'kimi-k3',
+				},
+				makeTask(),
+				makeProject(),
+			);
+
+			expect(capturedCmd).not.toContain('--model');
+			expect(capturedEnv).toContain('KIMI_MODEL_NAME=kimi-k3');
+			// The window travels with the model: declaring the pinned default's for a
+			// smaller one makes the CLI compact too late and the endpoint refuse.
+			expect(capturedEnv).toContain(
+				`KIMI_MODEL_MAX_CONTEXT_SIZE=${kimiModelContextSize('kimi-k3')}`,
+			);
+		});
+
 		it('passes --model when the active config has default_model', async () => {
 			let capturedCmd: string[] = [];
 			const docker = createMockDocker({
@@ -2498,16 +2562,20 @@ describe('runAgent', () => {
 			expect(await staged.read(mount!.authFileRelative)).toBe(validAuthJson);
 		});
 
-		it('returns null mount for providers without a paste flow', async () => {
+		it('returns null mount for an api key the CLI reads from the environment', async () => {
+			// Codex is deliberately absent: it will not authenticate from
+			// OPENAI_API_KEY, so its api key is written to the same auth file its
+			// subscription blob uses (covered in runtime-home.test.ts). Every runtime
+			// that does read the variable writes nothing.
 			expect(
 				await buildSubscriptionMount(
 					'/tmp',
 					'co',
 					'pj',
 					'r1',
-					AiProvider.OpenAI,
-					AgentRuntime.Codex,
-					{ value: 'sk-x', authMethod: AiAuthMethod.ApiKey, baseUrl: null, runtime: null },
+					AiProvider.Google,
+					AgentRuntime.Gemini,
+					{ value: 'AIza-x', authMethod: AiAuthMethod.ApiKey, baseUrl: null, runtime: null },
 					createStubDocker(),
 					'container-123',
 				),
@@ -2930,8 +2998,11 @@ describe('buildProviderEnv derives the subagent model from the run model', () =>
 	});
 
 	it('keeps the staticEnv constant when no run model is selected', () => {
+		// Against the constant, not a copy of its current value: the pinned model
+		// moves as the provider ships new ones, and a literal here turns every such
+		// bump into a test edit that says nothing.
 		expect(buildProviderEnv(AiProvider.Kimi, cred)).toContain(
-			'CLAUDE_CODE_SUBAGENT_MODEL=kimi-k2.7-code',
+			`CLAUDE_CODE_SUBAGENT_MODEL=${KIMI_DEFAULT_MODEL}`,
 		);
 		expect(buildProviderEnv(AiProvider.DeepSeek, cred, null)).toContain(
 			'CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash',

--- a/packages/server/test/agent-stream-parser-branches.test.ts
+++ b/packages/server/test/agent-stream-parser-branches.test.ts
@@ -552,7 +552,10 @@ describe('Gemini — message/tool/result edge arms', () => {
 
 	it('reads message text from the text field when content is absent', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Gemini);
-		expect(feed(parser, [{ type: 'message', text: 'via text' }])).toBe('via text\n');
+		// Buffered until the chunk run ends, so the flush is what emits it.
+		expect(feed(parser, [{ type: 'message', text: 'via text' }, { type: 'result' }])).toContain(
+			'via text',
+		);
 	});
 
 	it('drops a whitespace-only assistant message', () => {
@@ -731,6 +734,9 @@ describe('generic parser — usage/error/terminal arms', () => {
 			{ type: 'session', model: 'kimi-9' },
 			{ type: 'usage', usage: { input_tokens: 5, output_tokens: 2 } },
 		]);
+		// Priced when the total is read, not per event: the counts arrive per step
+		// and only their sum is what the run is charged for.
+		parser.getUsage();
 		expect(seen).toContain('kimi-9');
 	});
 

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -433,16 +433,79 @@ describe('agent-stream-parser', () => {
 			expect(parser.getUsage()).toEqual({ inputTokens: 1200, outputTokens: 160, costCents: 0 });
 		});
 
+		// The shape the CLI actually writes: `convertToStreamStats` flattens its
+		// internal token object into `*_tokens` names and drops the reasoning
+		// bucket entirely. Reading only the nested form found nothing here, so every
+		// Gemini run reported 0/0 and priced at $0.
+		it('captures usage from the flattened per-model stats the CLI emits', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini, price);
+			parser.onStdout(
+				`${JSON.stringify({
+					type: 'result',
+					stats: {
+						total_tokens: 94109,
+						input_tokens: 93507,
+						output_tokens: 22,
+						cached: 40586,
+						input: 52921,
+						models: {
+							'gemini-2.5-pro': {
+								total_tokens: 94109,
+								input_tokens: 93507,
+								output_tokens: 22,
+								cached: 40586,
+								input: 52921,
+							},
+						},
+					},
+				})}\n`,
+			);
+			const usage = parser.getUsage();
+			expect(usage?.inputTokens).toBe(93507);
+			// The visible answer plus the reasoning the flat projection leaves as the
+			// residual between the total and the two counts it does state.
+			expect(usage?.outputTokens).toBe(602);
+			// Priced, not $0: (93507-40586) full-rate input + 40586 cache-read + 602 output.
+			expect(usage?.costCents).toBeGreaterThan(0);
+		});
+
+		it('joins the assistant chunks the CLI streams into one final message', () => {
+			// A `HEZO-LIVE-OK` reply arrives as `HEZO-LIVE-` then `OK`. Treating each
+			// `message` as complete left the final message as the last fragment, which
+			// the runner's handoff net would then post verbatim in place of the answer.
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			parser.onStdout(
+				`${JSON.stringify({ type: 'message', role: 'assistant', content: 'HEZO-LIVE-' })}\n`,
+			);
+			parser.onStdout(`${JSON.stringify({ type: 'message', role: 'assistant', content: 'OK' })}\n`);
+			const out = parser.onStdout(`${JSON.stringify({ type: 'result', stats: {} })}\n`);
+			expect(out).toContain('HEZO-LIVE-OK');
+			expect(parser.getFinalAssistantMessage()).toBe('HEZO-LIVE-OK');
+		});
+
+		it('recovers a final message still buffered when the stream just stops', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			parser.onStdout(
+				`${JSON.stringify({ type: 'message', role: 'assistant', content: 'all done' })}\n`,
+			);
+			expect(parser.getFinalAssistantMessage()).toBe('all done');
+		});
+
 		it('renders an assistant message and skips the user echo', () => {
 			const parser = createAgentStreamParser(AgentRuntime.Gemini);
 			expect(
 				parser.onStdout(`${JSON.stringify({ type: 'message', role: 'user', content: 'hi' })}\n`),
 			).toBe('');
+			// Assistant text is buffered until the run of chunks ends, so it renders
+			// as one line on the next event rather than one line per chunk.
 			expect(
 				parser.onStdout(
 					`${JSON.stringify({ type: 'message', role: 'assistant', content: 'Done.' })}\n`,
 				),
-			).toBe('Done.\n');
+			).toBe('');
+			expect(parser.onStdout(`${JSON.stringify({ type: 'result', stats: {} })}\n`)).toContain(
+				'Done.',
+			);
 		});
 
 		it('renders the init event as a session line', () => {
@@ -565,6 +628,65 @@ describe('agent-stream-parser — generic (opencode)', () => {
 		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
 		const out = parser.onStdout(`${JSON.stringify({ type: 'session.status', status: 'busy' })}\n`);
 		expect(out).toBe('');
+	});
+
+	// The shape a real run emits: per-step counts nested under `part`, with the
+	// cache halves in their own object. Probing only the event root found nothing,
+	// so every OpenCode run priced at $0.
+	const STEP_FINISHES = [
+		{
+			type: 'step_finish',
+			part: {
+				type: 'step-finish',
+				tokens: {
+					total: 44557,
+					input: 3,
+					output: 40,
+					reasoning: 0,
+					cache: { write: 44514, read: 0 },
+				},
+				cost: 0.0558455,
+			},
+		},
+		{
+			type: 'step_finish',
+			part: {
+				type: 'step-finish',
+				tokens: {
+					total: 44797,
+					input: 5,
+					output: 11,
+					reasoning: 0,
+					cache: { write: 267, read: 44514 },
+				},
+				cost: 0.00484515,
+			},
+		},
+	];
+
+	it('sums per-step usage nested under part, including both cache buckets', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		for (const e of STEP_FINISHES) parser.onStdout(`${JSON.stringify(e)}\n`);
+		const usage = parser.getUsage();
+		// Every step counted, not just the last: 3+5 fresh input, 44514+267 cache
+		// writes and 0+44514 cache reads all read as input the run paid for.
+		expect(usage?.inputTokens).toBe(8 + 44_781 + 44_514);
+		expect(usage?.outputTokens).toBe(51);
+	});
+
+	it('prices from the run model when the stream names none', () => {
+		// OpenCode announces no model anywhere, so without the run's own model
+		// there is nothing to look up and the run prices at $0 whatever it spent.
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode, price, 'gemini-2.5-flash');
+		for (const e of STEP_FINISHES) parser.onStdout(`${JSON.stringify(e)}\n`);
+		expect(parser.getUsage()?.costCents).toBeGreaterThan(0);
+	});
+
+	it('ignores the run model once the stream names one', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode, price, 'not-in-the-table');
+		parser.onStdout(`${JSON.stringify({ type: 'init', model: 'gemini-2.5-flash' })}\n`);
+		for (const e of STEP_FINISHES) parser.onStdout(`${JSON.stringify(e)}\n`);
+		expect(parser.getUsage()?.costCents).toBeGreaterThan(0);
 	});
 });
 

--- a/packages/server/test/ai-providers.test.ts
+++ b/packages/server/test/ai-providers.test.ts
@@ -1,8 +1,10 @@
+import { AiProvider } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
+import { getPinnedModel } from '../src/services/model-pins';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp } from './helpers/app';
 
@@ -462,7 +464,7 @@ describe('AI providers default model', () => {
 		await db.query('DELETE FROM ai_provider_configs');
 	});
 
-	it('returns default_model null on list when not set', async () => {
+	it('starts a new config on the provider’s pinned model', async () => {
 		const create = await app.request('/api/ai-providers', {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -479,7 +481,10 @@ describe('AI providers default model', () => {
 		const row = (body.data as Array<{ provider: string; default_model: string | null }>).find(
 			(r) => r.provider === 'anthropic',
 		);
-		expect(row?.default_model).toBeNull();
+		// A new credential is offered the pinned default rather than left on none,
+		// so an operator who adds a key and walks away still has a working model.
+		// Against the pin, not a literal, since the pin moves with the catalog.
+		expect(row?.default_model).toBe(await getPinnedModel(db, AiProvider.Anthropic));
 	});
 
 	it('PATCH /ai-providers/:configId sets and clears default_model', async () => {

--- a/packages/server/test/conformance/agent-cli.ts
+++ b/packages/server/test/conformance/agent-cli.ts
@@ -66,10 +66,15 @@ import {
 	RUNTIME_DISALLOWED_TOOLS_ARGS,
 	RUNTIME_HEADLESS_PREFIX_ARGS,
 	RUNTIME_HEADLESS_SUFFIX_ARGS,
+	RUNTIME_MODEL_DELIVERY,
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 } from '@hezo/shared';
-import { buildProviderEnv } from '../../src/services/agent-runner';
+import {
+	buildProviderEnv,
+	GROK_DEBUG_BASENAME,
+	recoverOffStreamRunUsage,
+} from '../../src/services/agent-runner';
 import {
 	type AgentRunUsage,
 	createAgentStreamParser,
@@ -288,12 +293,17 @@ function providerEnv(mp: LiveModelProvider, runtime: AgentRuntime): string[] {
  * The argv the runner would build for this runtime, in the runner's own order -
  * including the MCP injection, which is where `--mcp-config` and `--settings`
  * come from. Mirrors `buildRuntimeInvocation`'s `cmd` (`agent-runner.ts`), minus
- * the effort args and Grok's debug-file flag.
+ * the effort args.
+ *
+ * Grok's `--debug-file` is included rather than dropped: it is the *only* place
+ * that runtime states what a run cost, so a suite that omitted it could not
+ * assert usage at all and recorded the runtime's real behaviour as a failure.
  */
 function cliArgv(
 	mp: LiveModelProvider,
 	runtime: AgentRuntime,
 	mcpArgs: readonly string[],
+	containerHomeDir: string | null,
 ): string[] {
 	// The model id is remapped per runtime, not per provider: Claude Code and
 	// OpenCode each want their own spelling, everything else takes it verbatim.
@@ -302,14 +312,19 @@ function cliArgv(
 		if (runtime === AgentRuntime.ClaudeCode) cliModel = claudeCodeModelArg(mp.provider, cliModel);
 		else if (runtime === AgentRuntime.OpenCode) cliModel = opencodeModelArg(mp.provider, cliModel);
 	}
+	const grokDebugArgs =
+		runtime === AgentRuntime.Grok && containerHomeDir
+			? ['--debug-file', `${containerHomeDir}/${GROK_DEBUG_BASENAME}`]
+			: [];
 	return [
 		RUNTIME_COMMANDS[runtime],
 		...RUNTIME_HEADLESS_PREFIX_ARGS[runtime],
 		...mcpArgs,
 		...RUNTIME_STREAM_ARGS[runtime],
+		...grokDebugArgs,
 		...RUNTIME_AUTO_APPROVE_ARGS[runtime],
 		...RUNTIME_DISALLOWED_TOOLS_ARGS[runtime],
-		...(cliModel ? ['--model', cliModel] : []),
+		...(cliModel && RUNTIME_MODEL_DELIVERY[runtime] === 'flag' ? ['--model', cliModel] : []),
 		...RUNTIME_HEADLESS_SUFFIX_ARGS[runtime],
 	];
 }
@@ -401,6 +416,8 @@ function describeOneAgentCliRun(
 		 * does not share it - which is a bug in the suite, not a finding.
 		 */
 		let usage: AgentRunUsage | null = null;
+		/** Why the off-stream usage recovery found nothing, if it was reached. */
+		let offStreamUsageError: string | null = null;
 		let finalMessage: string | null = null;
 		let exitCode = -1;
 		/** JSON-RPC methods that arrived on the host's `/mcp` endpoint. */
@@ -612,7 +629,9 @@ function describeOneAgentCliRun(
 			await files.mkdir('.');
 			await files.write(PROMPT_FILE, probePrompt(runtime));
 
-			const argv = cliArgv(mp, runtime, injection.cliArgs).map(shellQuote).join(' ');
+			const argv = cliArgv(mp, runtime, injection.cliArgs, homeMount?.containerDir ?? null)
+				.map(shellQuote)
+				.join(' ');
 			const promptPath = shellQuote(`${fixture.workRoot}/${PROMPT_FILE}`);
 			// Prompt delivery is the runtime's own convention, and getting it wrong is
 			// a hang rather than an error - a CLI waiting on a stdin that never closes
@@ -668,6 +687,19 @@ function describeOneAgentCliRun(
 			usage = parser.getUsage();
 			finalMessage = parser.getFinalAssistantMessage();
 			exitCode = (await engine.execInspect(execId)).ExitCode;
+			// Two runtimes stream no usage at all and have it recovered from a file
+			// afterwards. Production does that in `agent-runner.ts`; a suite that
+			// stopped at the stream recorded a correct run as a $0 one, which is the
+			// very failure the usage assertion exists to catch. Same helper, so what
+			// is asserted here is what the runner would actually have charged.
+			usage ??= await recoverOffStreamRunUsage(
+				runtime,
+				homeMount ? engine.files(containerId, homeMount.containerDir) : null,
+				undefined,
+				(msg) => {
+					offStreamUsageError = msg;
+				},
+			);
 			mark('exec-inspected');
 			if (process.env.HEZO_CONFORMANCE_DUMP) {
 				const { mkdirSync, writeFileSync } = await import('node:fs');
@@ -745,7 +777,14 @@ function describeOneAgentCliRun(
 		it('round-trips the prompt through the model', () => {
 			// The prompt reached the CLI on the channel its runtime expects, the CLI
 			// reached the provider, and the answer came back through the exec stream.
-			expect(transcript).toContain(SENTINEL);
+			//
+			// Asserted against what the PARSER made of the stream, not the raw bytes.
+			// A runtime that streams per-token deltas never puts the sentinel on the
+			// wire contiguously - Grok emits it as `HE`,`ZO`,`-`,`LIVE`,`-`,`OK` - so
+			// a substring search of the transcript fails a run that answered
+			// perfectly. Reassembling those chunks is the parser's job, and the
+			// parser's output is what the runner acts on.
+			expect(`${finalMessage ?? ''}\n${renderedLog}`).toContain(SENTINEL);
 		});
 
 		it('reports token usage the pricing table can charge against', () => {
@@ -753,7 +792,9 @@ function describeOneAgentCliRun(
 			// so a runtime that streams no usage prices every run at $0. That failure
 			// is invisible in production (a $0 run looks like a cheap run), and this is
 			// the only place it surfaces.
-			expect(usage).not.toBeNull();
+			expect(`usage=${JSON.stringify(usage)} recovery=${offStreamUsageError ?? 'none'}`).toContain(
+				'"inputTokens"',
+			);
 			const total = Object.values(usage ?? {}).reduce<number>(
 				(sum, v) => sum + (typeof v === 'number' ? v : 0),
 				0,

--- a/packages/server/test/conformance/fixture.ts
+++ b/packages/server/test/conformance/fixture.ts
@@ -204,15 +204,20 @@ export interface LiveModelProvider {
  * (OpenRouter).
  */
 const LIVE_PROVIDER_ENV: Record<AiProvider, { slug: string; model?: string }> = {
-	[AiProvider.Anthropic]: { slug: 'ANTHROPIC', model: 'claude-sonnet-4-6' },
-	[AiProvider.OpenAI]: { slug: 'OPENAI', model: 'gpt-4o-mini' },
-	[AiProvider.Google]: { slug: 'GOOGLE', model: 'gemini-1.5-flash' },
+	[AiProvider.Anthropic]: { slug: 'ANTHROPIC', model: 'claude-sonnet-5' },
+	// A codex-family id, not a general chat one: the CLI warns "model metadata
+	// not found" for anything else and falls back to guessed metadata.
+	[AiProvider.OpenAI]: { slug: 'OPENAI', model: 'gpt-5.3-codex' },
+	[AiProvider.Google]: { slug: 'GOOGLE', model: 'gemini-3.6-flash' },
 	[AiProvider.DeepSeek]: { slug: 'DEEPSEEK', model: 'deepseek-v4-flash' },
 	// Slugs, not `provider.toUpperCase()`: the enum values are `z_ai` / `x_ai`, and
 	// nobody types `HEZO_Z_AI_API_KEY`. One stem per provider, so the key variable
 	// and the model override below cannot drift apart.
 	[AiProvider.ZAi]: { slug: 'ZAI', model: 'GLM-4.7' },
-	[AiProvider.OpenRouter]: { slug: 'OPENROUTER' },
+	// OpenRouter routes by capability, and its own default resolves to endpoints
+	// that may not serve tool use at all - which fails as a 404 naming neither the
+	// model nor the cause. Pin one known to carry tools.
+	[AiProvider.OpenRouter]: { slug: 'OPENROUTER', model: 'anthropic/claude-haiku-4.5' },
 	[AiProvider.Kimi]: { slug: 'KIMI', model: KIMI_DEFAULT_MODEL },
 	[AiProvider.XAi]: { slug: 'XAI', model: 'grok-4.5' },
 	// The local runners take a server URL in place of a key - see `baseUrl`.

--- a/packages/server/test/doc-write-guard.test.ts
+++ b/packages/server/test/doc-write-guard.test.ts
@@ -89,6 +89,10 @@ describe('doc-write guard script', () => {
 		execFileSync('git', ['init', '-q'], { cwd: repo });
 		execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
 		execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+		// A throwaway repo still inherits the developer's global git config, and a
+		// commit signer that expects a human (1Password, gpg-agent, a hardware key)
+		// cannot run here - the commit fails and the test reads as a guard bug.
+		execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: repo });
 		writeFileSync(join(repo, 'todo-spec.md'), '# a real repo file\n');
 		execFileSync('git', ['add', 'todo-spec.md'], { cwd: repo });
 		execFileSync('git', ['commit', '-qm', 'add'], { cwd: repo });

--- a/packages/server/test/mcp-injectors.test.ts
+++ b/packages/server/test/mcp-injectors.test.ts
@@ -730,7 +730,16 @@ describe('kimi adapter', () => {
 		expect(contents).toContain('event = "Stop"');
 		expect(contents).toContain(`command = "node ${KIMI_HOME}/stop-hook-judge.mjs"`);
 		expect(contents).toContain('timeout = 30');
-		expect(contents).toContain('[permission.rules]');
+
+		// `permission.rules` is an ARRAY of {pattern, decision}. Written as a plain
+		// table with a `default` key it parses as one malformed rule and the CLI
+		// drops the whole section with a WARNING, not an error - so the allow-all
+		// silently was not applied and nothing failed. Assert the array-of-tables
+		// form and its two required keys rather than the header alone.
+		expect(contents).toContain('[[permission.rules]]');
+		expect(contents).toContain('pattern = "*"');
+		expect(contents).toContain('decision = "allow"');
+		expect(contents).not.toContain('default = "allow"');
 
 		// Kimi refuses to LOAD a config whose [[hooks]] entry carries any key beyond
 		// these four, which would break every run on this runtime rather than just

--- a/packages/server/test/model-pins.test.ts
+++ b/packages/server/test/model-pins.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The pin's behaviour against a real database and a stubbed provider catalog.
+ *
+ * The rule itself (which model wins) is covered in `@hezo/shared`; what matters
+ * here is the part that touches an operator's instance - a NEW credential picks
+ * up the pin, and an EXISTING one is never moved.
+ */
+
+import { AiProvider } from '@hezo/shared';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setSystemMeta } from '../src/lib/system-meta';
+import { getPinnedModel, refreshModelPins } from '../src/services/model-pins';
+import { authHeader } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+let ctx: ServerTestContext;
+const originalFetch = globalThis.fetch;
+
+/** Answer the catalog endpoint with an OpenAI-shaped listing. */
+function stubCatalog(ids: string[]): void {
+	globalThis.fetch = vi.fn().mockResolvedValue({
+		ok: true,
+		status: 200,
+		json: async () => ({ data: ids.map((id) => ({ id })) }),
+	}) as unknown as typeof fetch;
+}
+
+beforeEach(async () => {
+	if (ctx) await destroyTestContext(ctx);
+	ctx = await createTestContext();
+	globalThis.fetch = originalFetch;
+});
+
+afterAll(async () => {
+	globalThis.fetch = originalFetch;
+	if (ctx) await destroyTestContext(ctx);
+});
+
+async function addProvider(provider: string, apiKey: string): Promise<string> {
+	const res = await ctx.app.request('/api/ai-providers', {
+		method: 'POST',
+		headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ provider, api_key: apiKey, label: `${provider}-pin-test` }),
+	});
+	expect(res.status).toBe(201);
+	return ((await res.json()) as { data: { id: string } }).data.id;
+}
+
+async function modelOf(configId: string): Promise<string | null> {
+	const r = await ctx.db.query<{ default_model: string | null }>(
+		'SELECT default_model FROM ai_provider_configs WHERE id = $1',
+		[configId],
+	);
+	return r.rows[0]?.default_model ?? null;
+}
+
+describe('getPinnedModel', () => {
+	it('falls back to the compile-time pin before any refresh has run', async () => {
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-5');
+	});
+
+	it('prefers a refreshed pin over the compile-time one', async () => {
+		await setSystemMeta(ctx.db, `model_pin:${AiProvider.Anthropic}`, 'claude-opus-6');
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-6');
+	});
+
+	it('has no pin for a local runner, whose catalog is the operator’s own', async () => {
+		expect(await getPinnedModel(ctx.db, AiProvider.Ollama)).toBeNull();
+	});
+});
+
+describe('a new provider credential', () => {
+	it('starts on the pinned model rather than on none', async () => {
+		await setSystemMeta(ctx.db, `model_pin:${AiProvider.Anthropic}`, 'claude-opus-6');
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		const id = await addProvider('anthropic', 'sk-ant-pin-new');
+		globalThis.fetch = originalFetch;
+		expect(await modelOf(id)).toBe('claude-opus-6');
+	});
+});
+
+describe('refreshModelPins', () => {
+	it('moves the pin to the newest model the provider now serves', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		await addProvider('anthropic', 'sk-ant-pin-refresh');
+		stubCatalog(['claude-sonnet-4-6', 'claude-opus-6', 'claude-opus-5']);
+
+		const result = await refreshModelPins(ctx.db, ctx.masterKeyManager);
+		globalThis.fetch = originalFetch;
+
+		expect(result.changed.join()).toContain('claude-opus-6');
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-6');
+	});
+
+	// The rule the whole design rests on. A refresh that moved a configured
+	// credential would silently change which model every agent on it runs, which
+	// is an instance-wide behaviour change nobody asked for.
+	it('never moves a credential that is already configured', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		const id = await addProvider('anthropic', 'sk-ant-pin-existing');
+		globalThis.fetch = originalFetch;
+		const chosen = await modelOf(id);
+
+		stubCatalog(['claude-opus-9']);
+		await refreshModelPins(ctx.db, ctx.masterKeyManager);
+		globalThis.fetch = originalFetch;
+
+		// The pin moved; the operator's config did not.
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-9');
+		expect(await modelOf(id)).toBe(chosen);
+	});
+
+	it('holds the previous pin when the catalog offers nothing in the family', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		await addProvider('anthropic', 'sk-ant-pin-nomatch');
+		globalThis.fetch = originalFetch;
+		await setSystemMeta(ctx.db, `model_pin:${AiProvider.Anthropic}`, 'claude-opus-6');
+
+		stubCatalog(['some-unrelated-model']);
+		const result = await refreshModelPins(ctx.db, ctx.masterKeyManager);
+		globalThis.fetch = originalFetch;
+
+		expect(result.skipped.join()).toContain('no model matched');
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-6');
+	});
+
+	it('holds the previous pin when the provider cannot be reached', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		await addProvider('anthropic', 'sk-ant-pin-down');
+		await setSystemMeta(ctx.db, `model_pin:${AiProvider.Anthropic}`, 'claude-opus-6');
+
+		globalThis.fetch = vi
+			.fn()
+			.mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+		const result = await refreshModelPins(ctx.db, ctx.masterKeyManager);
+		globalThis.fetch = originalFetch;
+
+		expect(result.skipped.join()).toContain('unreachable');
+		expect(await getPinnedModel(ctx.db, AiProvider.Anthropic)).toBe('claude-opus-6');
+	});
+
+	it('reads no catalog at all when no provider is configured', async () => {
+		const spy = vi.fn();
+		globalThis.fetch = spy as unknown as typeof fetch;
+		const result = await refreshModelPins(ctx.db, ctx.masterKeyManager);
+		globalThis.fetch = originalFetch;
+		expect(result.changed).toEqual([]);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/server/test/runtime-home.test.ts
+++ b/packages/server/test/runtime-home.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { AgentRuntime, AiAuthMethod, AiProvider, PROVIDER_TO_RUNTIME } from '@hezo/shared';
@@ -247,5 +247,47 @@ describe('buildSubscriptionMount under a strict umask', () => {
 		);
 		const subscriptionDir = dirname(dirname(leaf as string));
 		expect(mode(subscriptionDir) & 0o001).toBe(0o001);
+	});
+});
+
+/**
+ * Codex will not authenticate a request from `OPENAI_API_KEY`. It reports the
+ * variable as present and then sends no bearer, so every api-key run 401s; the
+ * key it honours is the one in its auth file. These cover that the file is
+ * written, in the shape the CLI reads, and is not mistaken for a rotating one.
+ */
+describe('buildSubscriptionMount for an api-key credential', () => {
+	let base: string;
+	afterEach(() => {
+		if (base) rmSync(base, { recursive: true, force: true });
+	});
+
+	it('writes Codex an apikey auth file that never reports as rotating', async () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		const mount = await buildSubscriptionMountWithEngine(base, RUN, AiProvider.OpenAI, {
+			value: 'sk-proj-abc123',
+			authMethod: AiAuthMethod.ApiKey,
+		});
+		expect(mount).not.toBeNull();
+		const { hostAuthFile, rotates } = mount as { hostAuthFile: string; rotates: boolean };
+		expect(JSON.parse(readFileSync(hostAuthFile, 'utf8'))).toEqual({
+			auth_mode: 'apikey',
+			OPENAI_API_KEY: 'sk-proj-abc123',
+		});
+		expect(mode(hostAuthFile)).toBe(0o600);
+		// The subscription blob rotates on this CLI; a key written fresh each run
+		// does not, and reading one back would overwrite the operator's own value.
+		expect(rotates).toBe(false);
+	});
+
+	it('writes no file for a CLI that does read its key from the environment', async () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		// Gemini declares an auth file for its OAuth credential only; an api key
+		// there reaches the CLI as GEMINI_API_KEY and must not land on disk.
+		const mount = await buildSubscriptionMountWithEngine(base, RUN, AiProvider.Google, {
+			value: 'AIza-key',
+			authMethod: AiAuthMethod.ApiKey,
+		});
+		expect(mount).toBeNull();
 	});
 });

--- a/packages/server/test/stop-hook-judge-registry.test.ts
+++ b/packages/server/test/stop-hook-judge-registry.test.ts
@@ -1,4 +1,4 @@
-import { AgentRuntime, AiProvider } from '@hezo/shared';
+import { AgentRuntime, AiProvider, KIMI_DEFAULT_MODEL } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import {
 	buildClaudeCodeSettings,
@@ -44,7 +44,7 @@ describe('stop-hook judge spec registry', () => {
 		// Kimi runs on Claude Code (no command script), so it resolves to null in the
 		// registry and judges via buildClaudeCodeSettings with Moonshot's own model.
 		expect(buildJudgeScriptForRuntime(AgentRuntime.ClaudeCode)).toBeNull();
-		expect(STOP_HOOK_JUDGE_MODEL_KIMI).toBe('kimi-k2.7-code');
+		expect(STOP_HOOK_JUDGE_MODEL_KIMI).toBe(KIMI_DEFAULT_MODEL);
 		// No explicit run model → falls back to the per-provider constant.
 		expect(buildClaudeCodeSettings(AiProvider.Kimi).hooks.Stop[0].hooks[0].model).toBe(
 			STOP_HOOK_JUDGE_MODEL_KIMI,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,7 @@ export * from './marketplace.js';
 export * from './mcp/connector-status.js';
 export * from './mcp/method-access.js';
 export * from './mentions/index.js';
+export * from './model-pins.js';
 export * from './pricing.js';
 export * from './search/terms.js';
 export * from './system-prompt-vars.js';

--- a/packages/shared/src/model-pins.ts
+++ b/packages/shared/src/model-pins.ts
@@ -1,0 +1,132 @@
+/**
+ * Which model a newly-added provider credential starts on, and how that choice
+ * keeps up with the provider's catalog.
+ *
+ * **The problem this solves.** Every pinned model id in this repo is a constant
+ * someone typed once. Providers retire ids without warning, and nothing here
+ * notices: `gemini-1.5-flash` sat in the Stop-hook judge long after Google
+ * withdrew it, so the judge call 404'd on every run and the hook failed open
+ * with nothing looking wrong. A pin has to be able to move on its own.
+ *
+ * **What moves and what does not.** A pin is only ever the *default offered to a
+ * new credential*. A provider config already in the database keeps the model the
+ * operator chose, forever, until they change it - a refresh must never rewrite a
+ * running instance's model selections out from under it.
+ *
+ * **Why a family and not "the newest model".** A provider's catalog mixes
+ * tiers, modalities and vendors: Anthropic serves Opus and Haiku beside Sonnet,
+ * OpenAI serves chat models beside Codex ones, OpenRouter serves several
+ * thousand models from everyone. "Newest" across that set is meaningless and
+ * would happily pin an image model or jump price tier. So a pin names the
+ * *family* it tracks, and the refresh picks the highest version inside it. The
+ * class of model an operator gets is stable; only its version moves.
+ */
+
+import { AiProvider } from './types/common.js';
+
+export interface ModelPinSpec {
+	/**
+	 * The family this pin tracks, anchored. Only catalog ids matching it are
+	 * candidates, which is what stops a refresh crossing tiers or modalities.
+	 */
+	family: RegExp;
+	/**
+	 * The id used until a refresh has seen this provider's live catalog - on a
+	 * fresh instance, offline, or for a provider nobody has configured yet (there
+	 * is no credential to read a catalog with until the first one is added).
+	 */
+	fallback: string;
+}
+
+/**
+ * Per-provider families, chosen as the sensible default tier for agent work
+ * rather than the cheapest or the most capable.
+ *
+ * A provider absent here gets no pin and no default model, which is correct for
+ * the local runners: their catalog is whatever the operator has pulled, so there
+ * is nothing to know here and the CLI's own default is the honest answer.
+ */
+export const MODEL_PIN_SPECS: Partial<Record<AiProvider, ModelPinSpec>> = {
+	// The top tier, chosen deliberately: agent work is the case Opus is for, and a
+	// team that wants to spend less moves individual agents down rather than
+	// starting everyone on a weaker model.
+	[AiProvider.Anthropic]: { family: /^claude-opus-[\d.-]+$/, fallback: 'claude-opus-5' },
+	// A codex-family id, because this credential drives the Codex CLI - it warns
+	// "model metadata not found" for a general chat model and guesses its limits.
+	[AiProvider.OpenAI]: { family: /^gpt-[\d.]+-codex$/, fallback: 'gpt-5.3-codex' },
+	[AiProvider.Google]: { family: /^gemini-[\d.]+-flash$/, fallback: 'gemini-3.6-flash' },
+	[AiProvider.DeepSeek]: { family: /^deepseek-v[\d.]+-pro$/, fallback: 'deepseek-v4-pro' },
+	// Case-insensitive: z.ai's catalog answers `glm-5.2` while its own docs and
+	// this repo's static env use `GLM-4.7`, and the endpoint accepts either.
+	[AiProvider.ZAi]: { family: /^glm-[\d.]+$/i, fallback: 'GLM-4.7' },
+	// `-code` optional so both `kimi-k3` and `kimi-k2.7-code` are candidates; the
+	// version comparison, not the suffix, decides between them.
+	[AiProvider.Kimi]: { family: /^kimi-k[\d.]+(-code)?$/, fallback: 'kimi-k3' },
+	[AiProvider.XAi]: { family: /^grok-[\d.]+$/, fallback: 'grok-4.5' },
+	// OpenRouter is a router, not a vendor: "the latest model" across its whole
+	// catalog is not a question with an answer. The family names one vendor line
+	// known to serve tool use, which is what an agent run needs at all.
+	[AiProvider.OpenRouter]: {
+		family: /^anthropic\/claude-haiku-[\d.]+$/,
+		fallback: 'anthropic/claude-haiku-4.5',
+	},
+};
+
+/**
+ * A dated snapshot suffix, which is a release date and not a version.
+ *
+ * Left in, `claude-haiku-4-5-20251001` would outrank every later model on the
+ * strength of a number that is not a version at all. Matches both spellings
+ * providers use: a bare 8-digit stamp and a hyphenated ISO date.
+ */
+const DATE_SUFFIX = /-(?:\d{8}|\d{4}-\d{2}-\d{2})$/;
+
+/**
+ * A model id's version, as the sequence of numbers in it.
+ *
+ * Both separators mean the same thing - `claude-sonnet-4-6` and `gemini-3.6-flash`
+ * are the same shape - so `.` and `-` are read alike and the trailing words are
+ * ignored. Ids in a family differ only in these numbers, which is exactly what
+ * makes the family restriction load-bearing.
+ */
+export function parseModelVersion(id: string): number[] {
+	const withoutDate = id.replace(DATE_SUFFIX, '');
+	return (withoutDate.match(/\d+/g) ?? []).map(Number);
+}
+
+/**
+ * Compare two ids by version, newest last. Element-wise, so `5` beats `4.6`; a
+ * longer run of numbers breaks a tie, so `4.6` beats `4`.
+ */
+export function compareModelVersions(a: string, b: string): number {
+	const va = parseModelVersion(a);
+	const vb = parseModelVersion(b);
+	for (let i = 0; i < Math.max(va.length, vb.length); i += 1) {
+		const diff = (va[i] ?? -1) - (vb[i] ?? -1);
+		if (diff !== 0) return diff;
+	}
+	// Stable and deterministic for two ids carrying identical numbers, so a
+	// catalog's ordering cannot make the pin flap between refreshes.
+	return a.localeCompare(b);
+}
+
+/**
+ * The newest id in this provider's tracked family, or null when its catalog
+ * offers none.
+ *
+ * Null rather than a guess: a catalog with no family match means the family has
+ * been renamed or the credential sees a restricted catalog, and holding the
+ * previous pin is safer than pinning something from a different tier.
+ */
+export function pickLatestModel(provider: AiProvider, ids: readonly string[]): string | null {
+	const spec = MODEL_PIN_SPECS[provider];
+	if (!spec) return null;
+	const candidates = ids.filter((id) => spec.family.test(id));
+	if (candidates.length === 0) return null;
+	return candidates.reduce((best, id) => (compareModelVersions(id, best) > 0 ? id : best));
+}
+
+/** The compile-time default for a provider, before any refresh has run. */
+export function fallbackPinnedModel(provider: AiProvider): string | null {
+	return MODEL_PIN_SPECS[provider]?.fallback ?? null;
+}

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1618,7 +1618,28 @@ export const GEMINI_RUNTIME_ENV = {
  * Keep a `model_pricing` row for whatever this points at: runs are priced solely
  * from that table, so an unpriced model records $0.
  */
-export const KIMI_DEFAULT_MODEL = 'kimi-k2.7-code';
+export const KIMI_DEFAULT_MODEL = 'kimi-k3';
+
+/**
+ * Context window per Moonshot model, for the one place a window has to be
+ * declared rather than discovered.
+ *
+ * Kimi Code learns a model's metadata from the provider catalog, but the
+ * `KIMI_MODEL_*` family registers an *in-memory* provider it can look nothing up
+ * for - so it refuses to start unless the window is stated. Declaring one too
+ * large is the harmful direction (the CLI compacts too late and the endpoint
+ * rejects the request), so an unlisted model takes the smallest window Moonshot
+ * currently ships rather than the largest.
+ */
+const KIMI_CONTEXT_FALLBACK = 262_144;
+const KIMI_MODEL_CONTEXT_SIZES: Record<string, number> = {
+	'kimi-k3': 1_048_576,
+};
+
+/** The context window to declare for a Moonshot model. See the table above. */
+export function kimiModelContextSize(model: string | null | undefined): number {
+	return KIMI_MODEL_CONTEXT_SIZES[model?.trim() ?? ''] ?? KIMI_CONTEXT_FALLBACK;
+}
 
 /**
  * Moonshot reached through Claude Code, against the Anthropic-compatible
@@ -1670,6 +1691,9 @@ const MOONSHOT_KIMI_CODE_BINDING: ProviderRuntimeBinding = {
 		KIMI_MODEL_PROVIDER_TYPE: 'kimi',
 		KIMI_MODEL_BASE_URL: 'https://api.moonshot.ai/v1',
 		KIMI_MODEL_NAME: KIMI_DEFAULT_MODEL,
+		// An in-memory provider has no catalog to read a window from, and the CLI
+		// refuses to run without one. Overridden per run from the selected model.
+		KIMI_MODEL_MAX_CONTEXT_SIZE: String(kimiModelContextSize(KIMI_DEFAULT_MODEL)),
 		KIMI_MODEL_CAPABILITIES: 'image_in,thinking',
 		KIMI_DISABLE_TELEMETRY: '1',
 		KIMI_CODE_NO_AUTO_UPDATE: '1',
@@ -2047,6 +2071,30 @@ export const RUNTIME_PROMPT_DELIVERY: Record<AgentRuntime, 'stdin' | 'arg'> = {
 	// `kimi -p <PROMPT>` (--prompt) is the same shape as Grok: the prompt is the
 	// flag's value, not stdin. Kimi Code has no stdin-as-prompt mode at all.
 	[AgentRuntime.Kimi]: 'arg',
+};
+
+/**
+ * How each CLI is told which model to use.
+ *
+ * Nearly all take `--model <id>`. Kimi Code does not: its `--model` resolves the
+ * id against a `[models."<id>"]` table in `config.toml`, and Hezo registers its
+ * model through the shell-read `KIMI_MODEL_*` family instead - an in-memory
+ * provider that table knows nothing about. Passing the flag there fails the run
+ * outright with `config.invalid: Model "…" is not configured in config.toml`,
+ * so the id has to travel on `KIMI_MODEL_NAME` alone (`buildProviderEnv` puts
+ * the run's selected model there).
+ *
+ * Writing the model into `config.toml` instead is not an option: the same file
+ * would then need the provider's key, and only env delivery keeps that out of a
+ * file the agent can read.
+ */
+export const RUNTIME_MODEL_DELIVERY: Record<AgentRuntime, 'flag' | 'env'> = {
+	[AgentRuntime.ClaudeCode]: 'flag',
+	[AgentRuntime.Codex]: 'flag',
+	[AgentRuntime.Gemini]: 'flag',
+	[AgentRuntime.OpenCode]: 'flag',
+	[AgentRuntime.Grok]: 'flag',
+	[AgentRuntime.Kimi]: 'env',
 };
 
 /**

--- a/packages/shared/test/model-pins.test.ts
+++ b/packages/shared/test/model-pins.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+	compareModelVersions,
+	fallbackPinnedModel,
+	MODEL_PIN_SPECS,
+	parseModelVersion,
+	pickLatestModel,
+} from '../src/model-pins';
+import { AiProvider } from '../src/types/common';
+
+/**
+ * The selection rule, against real catalog listings.
+ *
+ * The ids below were read from each provider's live `/models` endpoint, because
+ * the whole point of this rule is to behave correctly on what providers actually
+ * serve - a hand-invented catalog would only prove the rule matches its author's
+ * expectations.
+ */
+describe('parseModelVersion', () => {
+	it('reads the two separators providers use interchangeably', () => {
+		expect(parseModelVersion('claude-sonnet-4-6')).toEqual([4, 6]);
+		expect(parseModelVersion('gemini-3.6-flash')).toEqual([3, 6]);
+		expect(parseModelVersion('gpt-5.3-codex')).toEqual([5, 3]);
+	});
+
+	it('drops a dated snapshot suffix, which is a release date and not a version', () => {
+		// Left in, this id would outrank every later model on the strength of a
+		// number that is not a version at all.
+		expect(parseModelVersion('claude-haiku-4-5-20251001')).toEqual([4, 5]);
+		expect(parseModelVersion('gpt-5-2025-08-07')).toEqual([5]);
+	});
+});
+
+describe('compareModelVersions', () => {
+	it('orders a major bump above a minor one', () => {
+		expect(compareModelVersions('claude-sonnet-5', 'claude-sonnet-4-6')).toBeGreaterThan(0);
+		expect(compareModelVersions('gemini-3.6-flash', 'gemini-3.5-flash')).toBeGreaterThan(0);
+	});
+
+	it('breaks a prefix tie on the longer version', () => {
+		expect(compareModelVersions('kimi-k2.7-code', 'kimi-k2')).toBeGreaterThan(0);
+	});
+
+	it('is deterministic for ids carrying identical numbers', () => {
+		// Otherwise a catalog's ordering could make the pin flap between refreshes.
+		expect(compareModelVersions('glm-5', 'glm-5')).toBe(0);
+		expect(Math.sign(compareModelVersions('a-1', 'b-1'))).toBe(-1);
+	});
+});
+
+describe('pickLatestModel', () => {
+	it('picks the newest Anthropic Opus without crossing tier', () => {
+		const catalog = [
+			'claude-opus-5',
+			'claude-sonnet-5',
+			'claude-fable-5',
+			'claude-opus-4-8',
+			'claude-sonnet-4-6',
+			'claude-haiku-4-5-20251001',
+		];
+		// The other tiers are in the catalog and must not be reachable from this
+		// pin, however their version numbers compare - crossing tier is the failure
+		// the family restriction exists to prevent, in either direction.
+		expect(pickLatestModel(AiProvider.Anthropic, catalog)).toBe('claude-opus-5');
+	});
+
+	it('picks a codex-family OpenAI model, never a general chat one', () => {
+		const catalog = [
+			'gpt-4o-mini',
+			'gpt-5',
+			'gpt-5.4-mini',
+			'gpt-5.1-codex',
+			'gpt-5.2-codex',
+			'gpt-5.3-codex',
+		];
+		// gpt-5.4-mini is the higher version but drives the Codex CLI badly - it
+		// warns "model metadata not found" and guesses the model's limits.
+		expect(pickLatestModel(AiProvider.OpenAI, catalog)).toBe('gpt-5.3-codex');
+	});
+
+	it('skips Google preview and non-text families', () => {
+		const catalog = [
+			'gemini-2.5-flash',
+			'gemini-3-flash-preview',
+			'gemini-3.1-flash-lite',
+			'gemini-3.1-flash-image',
+			'gemini-3.5-flash',
+			'gemini-3.6-flash',
+			'gemini-3.1-pro-preview',
+		];
+		expect(pickLatestModel(AiProvider.Google, catalog)).toBe('gemini-3.6-flash');
+	});
+
+	it('prefers a Kimi major over a longer-versioned older one', () => {
+		const catalog = [
+			'kimi-k2.5',
+			'kimi-k2.6',
+			'kimi-k2.7-code',
+			'kimi-k2.7-code-highspeed',
+			'kimi-k3',
+		];
+		expect(pickLatestModel(AiProvider.Kimi, catalog)).toBe('kimi-k3');
+	});
+
+	it('matches z.ai ids case-insensitively and keeps the catalog spelling', () => {
+		// The catalog answers lowercase while this repo's static env uses `GLM-4.7`;
+		// the endpoint accepts either, so the pin carries what the provider said.
+		expect(pickLatestModel(AiProvider.ZAi, ['glm-4.5', 'glm-4.7', 'glm-5', 'glm-5.2'])).toBe(
+			'glm-5.2',
+		);
+	});
+
+	it('ignores xAI ids carrying extra trailing segments', () => {
+		const catalog = [
+			'grok-4.20-0309-non-reasoning',
+			'grok-4.20-multi-agent-0309',
+			'grok-4.3',
+			'grok-4.5',
+			'grok-imagine-video',
+		];
+		expect(pickLatestModel(AiProvider.XAi, catalog)).toBe('grok-4.5');
+	});
+
+	it('holds the previous pin when the family matches nothing', () => {
+		// Renamed upstream, or a key that sees a restricted catalog. Null means the
+		// caller keeps what it had rather than pinning something from another tier.
+		expect(pickLatestModel(AiProvider.Anthropic, ['gpt-5.3-codex', 'gemini-3.6-flash'])).toBeNull();
+		expect(pickLatestModel(AiProvider.Anthropic, [])).toBeNull();
+	});
+
+	it('has no pin for the local runners, whose catalog is the operator’s own', () => {
+		expect(MODEL_PIN_SPECS[AiProvider.Ollama]).toBeUndefined();
+		expect(MODEL_PIN_SPECS[AiProvider.LmStudio]).toBeUndefined();
+		expect(pickLatestModel(AiProvider.Ollama, ['llama3'])).toBeNull();
+		expect(fallbackPinnedModel(AiProvider.Ollama)).toBeNull();
+	});
+
+	it('ships a fallback that its own family accepts', () => {
+		// A fallback outside the family would be replaced by the very first refresh,
+		// which makes the compile-time default a different model from the pinned one.
+		for (const [provider, spec] of Object.entries(MODEL_PIN_SPECS)) {
+			expect(`${provider}: ${spec.fallback}`).toBe(
+				`${provider}: ${pickLatestModel(provider as AiProvider, [spec.fallback])}`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
A live run of the provider × CLI conformance matrix (8 pairings over 7 providers, against real containers and real provider endpoints) found four defects no unit test could see. This fixes them, and adds a mechanism so the class of bug behind one of them stops recurring.

## Runtimes that could not run at all

**Codex api-key auth.** `codex-cli` 0.146.1 reports `OPENAI_API_KEY` as present and then sends no bearer — `codex doctor` says `auth mode: none` — so every OpenAI run 401'd. The key it honours is the one in its auth file, which is the same file its subscription blob already used, so the credential-file seam now renders an apikey-shaped `auth.json` rather than gaining a second delivery path. The mount reports `rotates: false` for a key, so the rotated-credential read-back never writes a key-derived file back over the operator's stored value.

**Kimi Code**, three separate faults, each fatal on its own:

- `permission.rules` was written as a table with a `default` key where the schema is an array of `{pattern, decision}`. The CLI drops the section with a *warning*, not an error, so the allow-all silently was not applied and nothing failed loudly.
- The env-registered provider has no catalog to read a context window from, and the CLI refuses to start without `KIMI_MODEL_MAX_CONTEXT_SIZE`.
- `--model` resolves against a `[models."<id>"]` table Hezo never writes, killing every run that had a model assigned. Model delivery is now per runtime (`RUNTIME_MODEL_DELIVERY`) and Kimi Code takes its id on `KIMI_MODEL_NAME` alone.

## Silent failures, which look exactly like healthy runs

**Gemini and OpenCode token usage.** Both parsers read shapes their CLI does not emit: Gemini flattens per-model counts into `*_tokens` and drops the reasoning bucket entirely, while OpenCode reports per-step counts under `step_finish.part.tokens` and names no model anywhere. Every run on either priced at **$0**, which in production is indistinguishable from a cheap run. OpenCode's counts are now summed across steps rather than overwritten by the last one, and it prices from the run's own model since its stream names none.

**Gemini's final message.** Assistant text arrives as chunks (`HEZO-LIVE-` then `OK`) and each was treated as a complete message, so `getFinalAssistantMessage` held only the last fragment — and the handoff-delivery net posts that value verbatim.

## Model pinning

A hardcoded model id cannot notice its own retirement. `gemini-1.5-flash` stayed pinned as the Google stop-hook judge long after Google withdrew it: the judge call 404'd on every run and the hook failed open, with nothing about the run looking wrong.

A pin now names a **family** (`claude-opus-*`, `*-codex`, `gemini-*-flash`) rather than a model, and a daily cron re-reads each connected provider's catalog to move it to the highest version inside that family. A family rather than "the newest model" because a catalog mixes tiers, modalities and vendors — an unrestricted maximum would happily pin an image model or jump price tier. Version comparison reads `.` and `-` alike and drops dated snapshot suffixes, so `claude-haiku-4-5-20251001` cannot outrank a later release on the strength of a date.

**The pin only ever supplies the default to a new credential.** A stored config keeps the operator's model until they change it; a refresh that moved configured credentials would be a silent, instance-wide behaviour change nobody asked for. That boundary is the test worth reading if you read only one (`never moves a credential that is already configured`). Unreachable provider, rejected key, or a family that matched nothing all hold the previous pin rather than clearing it.

## Incidental

Credential verification and model listing had drifted onto separate fetch paths; they now share one seam. As a result "provider unreachable" no longer reports as "your key is invalid", and no longer flips a stored badge to invalid on a network blip.

The conformance suite gained what it was missing: Grok's `--debug-file` (its only usage source), the runner's off-stream usage recovery for Grok/Kimi, and a sentinel assertion that reads the parser's output rather than raw bytes — which a per-token-delta runtime never carries contiguously.

Two test failures unrelated to the feature were also fixed, since both made the suite unrunnable rather than merely red: the backup/restore specs depended on a stale on-disk migrations bundle, and the doc-write-guard spec's throwaway git repo inherited a developer's interactive commit signer.

## Verification

- **Live matrix: 8/8.** Anthropic + z.ai + Kimi on Claude Code (10/10 each), OpenAI on Codex, Google on Gemini, OpenRouter on OpenCode, Kimi on Kimi Code, xAI on Grok (8/8 each). Each provisions its own container, opens a real tunnel to a real Hezo, and asserts host-side that the agent called a Hezo MCP tool and was answered 2xx.
- **Suite green:** server 7514, Bun-native 111, web 1588, shared 315. Typecheck and biome clean.
- Every fix was reproduced against the live CLI before the change and re-verified after, rather than inferred from the code.

One caveat: the Anthropic pin moved from Sonnet 5 to Opus 5 after the last live matrix run. The unit tests covering it were re-run; the conformance fixture still pins Sonnet for cost, which is deliberate — the fixture optimizes for the cheapest completion that proves the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01549Da2nBC5g5w9HgCcHvZH
