### PR TITLE
test(shared): cover sanitizeWidgetOrder in the tier that now owns it

### DIFF
--- a/packages/shared/test/dashboard-widget-order.test.ts
+++ b/packages/shared/test/dashboard-widget-order.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DASHBOARD_WIDGET_IDS,
+	DEFAULT_WIDGET_ORDER,
+	sanitizeWidgetOrder,
+} from '../src/types/project-dashboard';
+
+describe('DEFAULT_WIDGET_ORDER', () => {
+	it('covers every widget id exactly once', () => {
+		expect([...DEFAULT_WIDGET_ORDER].sort()).toEqual([...DASHBOARD_WIDGET_IDS].sort());
+	});
+
+	it('leads with the work in flight', () => {
+		expect(DEFAULT_WIDGET_ORDER).toEqual(['in_progress', 'team_snapshot', 'goals', 'spend']);
+	});
+});
+
+describe('sanitizeWidgetOrder', () => {
+	it('falls back to the default order when nothing is stored', () => {
+		expect(sanitizeWidgetOrder(null)).toEqual(DEFAULT_WIDGET_ORDER);
+		expect(sanitizeWidgetOrder(undefined)).toEqual(DEFAULT_WIDGET_ORDER);
+	});
+
+	it('returns a full stored order untouched', () => {
+		// A saved order is a deliberate choice: reordering the default must never
+		// re-sort a project whose owner already arranged it.
+		const stored = ['spend', 'goals', 'team_snapshot', 'in_progress'];
+		expect(sanitizeWidgetOrder(stored)).toEqual(stored);
+	});
+
+	it('appends the ids a partial order omits, keeping the stored prefix', () => {
+		expect(sanitizeWidgetOrder(['spend'])).toEqual([
+			'spend',
+			'in_progress',
+			'team_snapshot',
+			'goals',
+		]);
+	});
+
+	it('drops unknown ids and duplicates', () => {
+		expect(sanitizeWidgetOrder(['goals', 'goals', 'nope', 'spend'])).toEqual([
+			'goals',
+			'spend',
+			'in_progress',
+			'team_snapshot',
+		]);
+	});
+
+	it('ignores non-array and non-string input rather than throwing', () => {
+		expect(sanitizeWidgetOrder('spend')).toEqual(DEFAULT_WIDGET_ORDER);
+		expect(sanitizeWidgetOrder({ order: ['spend'] })).toEqual(DEFAULT_WIDGET_ORDER);
+		expect(sanitizeWidgetOrder([1, null, 'spend'])).toEqual([
+			'spend',
+			'in_progress',
+			'team_snapshot',
+			'goals',
+		]);
+	});
+});


### PR DESCRIPTION
Follow-up to #939, which is merged. Not a re-open - a separate, test-only change.

#939 moved `sanitizeWidgetOrder` and `DEFAULT_WIDGET_ORDER` out of duplicate copies in the server and web packages into `@hezo/shared`. Their only coverage came with them: the server exercises the function through `PATCH /dashboard-widget-order`, which is an integration test in another package, so the shared package's own pure-logic tier had nothing on a pure function now living there. Coveralls put the moved lines at 30% on that PR.

## What it covers

Cases the route test cannot reach cheaply:

- **A full stored order comes back untouched.** A saved order is the user's own arrangement, so retuning `DEFAULT_WIDGET_ORDER` must never re-sort a project whose owner already dragged the widgets. That is the property most likely to be broken by a future default change, and nothing asserted it.
- **A partial order keeps its prefix and gains the rest**, in default order.
- **Non-array and non-string input degrade to the default rather than throwing.** The function reads a `jsonb` column, so its input is only as well-formed as the row - `'spend'`, `{order: [...]}` and `[1, null, 'spend']` are all reachable.
- **`DEFAULT_WIDGET_ORDER` holds every widget id exactly once**, which is what makes the append loop total. A widget id added to `DASHBOARD_WIDGET_IDS` but forgotten in the default order would otherwise go unnoticed until it silently failed to render.

7 tests, ~6ms, in `packages/shared/test/` per the pure-logic tier in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCnuRYtPTj6HeUxQEA1VtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCnuRYtPTj6HeUxQEA1VtM)_