### PR TITLE
feat(web): render team and agent summaries as markdown

### DIFF
--- a/packages/web/src/components/ui/expandable-text.tsx
+++ b/packages/web/src/components/ui/expandable-text.tsx
@@ -1,16 +1,30 @@
 import { ChevronDown } from 'lucide-react';
 import { type ReactNode, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { MarkdownProse } from '../markdown-prose';
 
 interface ExpandableTextProps {
 	text: string;
 	placeholder?: ReactNode;
 	className?: string;
+	/** Mention scope for the rendered markdown (the route-param project slug). */
+	projectId?: string;
 }
 
-export function ExpandableText({ text, placeholder, className = '' }: ExpandableTextProps) {
+/**
+ * Agent-authored summary prose (team/agent summaries, team context), clamped to
+ * one line until expanded. The generators routinely emit markdown (bold leads,
+ * numbered handoff lists, @mentions), so the text renders through MarkdownProse
+ * rather than as raw characters.
+ */
+export function ExpandableText({
+	text,
+	placeholder,
+	className = '',
+	projectId,
+}: ExpandableTextProps) {
 	const [expanded, setExpanded] = useState(false);
 	const [overflows, setOverflows] = useState(false);
-	const textRef = useRef<HTMLParagraphElement>(null);
+	const textRef = useRef<HTMLDivElement>(null);
 	const contentId = useId();
 
 	const hasText = text?.trim().length > 0;
@@ -49,13 +63,14 @@ export function ExpandableText({ text, placeholder, className = '' }: Expandable
 
 	return (
 		<div className={`flex items-start gap-2 ${className}`}>
-			<p
+			<div
 				ref={textRef}
 				id={contentId}
-				className={`min-w-0 flex-1 whitespace-pre-wrap ${expanded ? '' : 'line-clamp-1'}`}
+				data-testid="expandable-content"
+				className={`min-w-0 flex-1 ${expanded ? '' : 'line-clamp-1'}`}
 			>
-				{text}
-			</p>
+				<MarkdownProse projectId={projectId}>{text}</MarkdownProse>
+			</div>
 			{showToggle && (
 				<button
 					type="button"

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -79,6 +79,7 @@ function AgentLayout() {
 			>
 				<ExpandableText
 					text={agent.summary ?? ''}
+					projectId={projectId}
 					placeholder={<span className="italic text-text-2">Description being generated…</span>}
 				/>
 			</div>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -247,6 +247,7 @@ function AgentSettingsPage() {
 					>
 						<ExpandableText
 							text={agent.team_context ?? ''}
+							projectId={projectId}
 							placeholder={
 								<span className="italic text-text-2">Team relationships being generated…</span>
 							}

--- a/packages/web/src/routes/projects/$projectId/agents/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/index.tsx
@@ -104,6 +104,7 @@ function TeamPage() {
 				>
 					<ExpandableText
 						text={team?.summary ?? ''}
+						projectId={projectId}
 						placeholder={
 							<span className="italic text-text-2">Team description being generated…</span>
 						}

--- a/packages/web/test/team-summary-collapse.test.tsx
+++ b/packages/web/test/team-summary-collapse.test.tsx
@@ -1,5 +1,6 @@
 import { createTestTeam } from '@hezo/server/test/helpers/app';
-import { test } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedWorkspace } from './helpers/seed';
 
@@ -48,4 +49,36 @@ test('renders the team-summary box with attribution caption', async () => {
 	await findByText("Auto-generated from the agents' system prompts.", undefined, {
 		timeout: 10_000,
 	});
+});
+
+test('renders the team summary as markdown, not raw characters', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			seeded.projectSlug = ws.internalSlug;
+			const { db } = getTestContext();
+			await db.query(`UPDATE teams SET summary = $1 WHERE id = $2`, [
+				'**Reporting structure:** the Captain routes work to the roster.\n\n1. **Sourcing:** weekly screening cadence.',
+				ws.team.id,
+			]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	const box = await findByTestId('team-summary', undefined, { timeout: 10_000 });
+	await waitFor(
+		() => {
+			const strong = box.querySelector('strong');
+			expect(strong?.textContent ?? '').toContain('Reporting structure:');
+			expect(box.querySelector('ol li')).not.toBeNull();
+			expect(box.textContent ?? '').not.toContain('**');
+		},
+		{ timeout: 10_000 },
+	);
 });

--- a/test/browser/agent-detail.spec.ts
+++ b/test/browser/agent-detail.spec.ts
@@ -48,31 +48,33 @@ test('long agent summary collapses to first line and toggles on click; short sum
 
 	const summary = page.getByTestId('agent-summary');
 	await expect(summary).toBeVisible({ timeout: 15000 });
-	const paragraph = summary.locator('p');
-	await expect(paragraph).toContainText('Line 1');
+	// The clamp lives on the wrapper around the rendered markdown, so heights are
+	// measured there rather than on the inner <p>.
+	const content = summary.getByTestId('expandable-content');
+	await expect(content).toContainText('Line 1');
 
 	const expandButton = summary.getByRole('button', { name: 'Expand' });
 	await expect(expandButton).toBeVisible();
 
-	const collapsedHeight = await paragraph.evaluate((el) => el.clientHeight);
-	const fullHeight = await paragraph.evaluate((el) => el.scrollHeight);
+	const collapsedHeight = await content.evaluate((el) => el.clientHeight);
+	const fullHeight = await content.evaluate((el) => el.scrollHeight);
 	expect(fullHeight).toBeGreaterThan(collapsedHeight);
 
 	await expandButton.click();
 	const collapseButton = summary.getByRole('button', { name: 'Collapse' });
 	await expect(collapseButton).toBeVisible();
-	expect(await paragraph.evaluate((el) => el.clientHeight)).toBeGreaterThan(collapsedHeight);
+	expect(await content.evaluate((el) => el.clientHeight)).toBeGreaterThan(collapsedHeight);
 
 	await collapseButton.click();
 	await expect(summary.getByRole('button', { name: 'Expand' })).toBeVisible();
-	expect(await paragraph.evaluate((el) => el.clientHeight)).toBe(collapsedHeight);
+	expect(await content.evaluate((el) => el.clientHeight)).toBe(collapsedHeight);
 
 	if (shortAgent !== longAgent) {
 		await setAgentSummary(page, token, projectSlug, shortAgent.id, 'Short.');
 		await page.goto(`/projects/${projectSlug}/agents/${shortAgent.id}`);
 		const shortSummary = page.getByTestId('agent-summary');
 		await expect(shortSummary).toBeVisible({ timeout: 15000 });
-		await expect(shortSummary.locator('p')).toContainText('Short.');
+		await expect(shortSummary.getByTestId('expandable-content')).toContainText('Short.');
 		await expect(shortSummary.getByRole('button', { name: /Expand|Collapse/ })).toHaveCount(0);
 	}
 });


### PR DESCRIPTION
## What

The team summary box on the Team page rendered its text as plain characters, so the markdown the Captain routinely emits (`**Reporting structure:**`, numbered handoff lists) showed up as raw `**` and `1.` markers. `ExpandableText` now renders its text through `MarkdownProse`, which fixes the same problem in the two sibling surfaces that share it: the agent summary on the agent page and the team-context box on agent settings.

## How

- `ExpandableText` renders `MarkdownProse` inside the clamp wrapper instead of a plain `<p>`, keeping the one-line collapse and expand toggle unchanged. The clamp (`line-clamp-1`) and its overflow measurement moved from the inner `<p>` to a wrapper `div` around the rendered prose.
- All three call sites pass their route `projectId`, so `@mentions` in the team context resolve to agent links the same way they do in comments.

## Tests

- New component test: a summary seeded with bold and a numbered list renders `<strong>`/`<ol>` with no raw `**` leaking through (`team-summary-collapse.test.tsx`).
- `agent-detail.spec.ts` (Playwright) updated to measure the clamp wrapper rather than the inner `<p>`; ran it plus `team-summary-collapse.spec.ts` in real Chromium at mobile and desktop viewports - all green, confirming the clamp still collapses and expands over rendered markdown.
- Existing `agent-team-context` and `mention-handoff` component tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgRf887XijUSxRGNkycjMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgRf887XijUSxRGNkycjMq)_