### PR TITLE
feat(tasks): order the task list running, then waiting-on-admin, then the rest

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1004,10 +1004,12 @@ immediately; the CEO-assisted path leaves it **unassigned and un-woken**.
    approval gate. The coherence/setup task **auto-runs** (assigned to the CEO and woken).
    The 201 response carries `setup_task_id`/`setup_task_identifier` alongside the planning
    pair, and the web dialog (`CreateProjectWithTeamDialog.handleCreateNow`) lands the
-   operator on the project's **task list** rather than a single task: the default
-   `work_order` sort (unblocked before blocked, then priority, then number) puts the setup
-   task on top with the blocked planning task below it, so no deep link is needed and the
-   landing stays correct when no setup task was created.
+   operator on the project's **task list** rather than a single task: neither task is
+   running or waiting on the admin, so both fall past the list's two ordering tiers (§ 11 ›
+   Task list ordering) into the default `work_order` sort (unblocked before blocked, then
+   priority, then number), which puts the setup task on top with the blocked planning task
+   below it. No deep link is needed and the landing stays correct when no setup task was
+   created.
 2. **CEO-assisted** — `POST /api/project-intakes`: opens a CEO-run intake conversation
    ticket in HQ (label `project-intake`) recording the form data and the admin's chosen
    team type as the CEO's **baseline suggestion**. **Nothing is created up front — no
@@ -4327,6 +4329,35 @@ them. Read state is per user (`read_at`), and acting on the request clears it fo
 `fulfill-credential` and `resolve-asset-deletion` both mark the comment's rows read, the
 same way resolving an approval retires it. Migration `057` backfilled rows for the
 credential requests that predate the fan-out.
+
+**Task list ordering: two tiers, then the chosen sort.** `buildTaskListOrderBy`
+(`lib/task-sort.ts`) prefixes every sort mode of `GET /api/projects/:projectId/tasks` with
+two boolean keys, so the caller's sort only orders *within* a tier:
+
+1. **A run is in flight or queued** - `taskActiveRunExistsSql`, the same fact the row's
+   `has_active_run` and the amber pulsing dot carry.
+2. **The task is waiting on the admin** - `adminActionPendingSql`, projected on the row as
+   `admin_action_pending`. Two legs OR'd: an unread `admin_mentions` row for the *viewing*
+   admin (what the blue `@` icon shows), or an ask comment nobody has answered
+   (`chosen_option IS NULL` on an `action` / `credential_request` / `asset_deletion_request`
+   comment). The second leg is what the icon misses: a pending hire, goal-suggestion or
+   repo-setup card parks a task on a human while raising no inbox row at all, and a
+   read-but-unresolved credential request drops out of the first leg while still being
+   unanswered. `connect_required` is excluded - it never sets `chosen_option` (a
+   connector's resolved state lives on its `oauth_status`), so it would read as unanswered
+   forever.
+
+Because it is server-side it reaches every consumer at once - the pinned In-progress
+section, the infinitely-paged Backlog (where a client-side sort could only reorder pages
+already fetched), and the dashboard's in-progress widget. Only the first leg of tier 2 is
+per-user, so an agent or API key sees the tier driven by unanswered asks alone, the same
+way `has_unread_admin_mention` already reads false for them. Two deliberate exclusions:
+the web "Done" section re-sorts terminal rows by `updated_at` client-side, overriding the
+tiers; and MCP `list_tasks` keeps its keyset `created_at` order, which the tiers would
+break. The ask leg's predicate is spelled with enum **literals** so it matches migration
+`059`'s partial index (`idx_comments_pending_ask`) verbatim - a parameterized `IN` list
+leaves the planner unable to prove the implication under a generic plan, and the index
+goes unused.
 
 **PWA / installability.** The SPA ships a web manifest (`packages/web/public/manifest.webmanifest`,
 `display: standalone`, brand icons under `public/icons/`) and a deliberately **network-only**

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -93,6 +93,24 @@ If a run is stranded (its process vanished, or it never managed to start), Hezo 
 within a couple of minutes and marks it failed, which releases the task and returns the
 assignee to **Idle**. You do not need to restart Hezo to clear a stuck task.
 
+## How the task list is ordered
+
+Every task list puts the tasks you are most likely to care about first, in three bands,
+whichever sort you have chosen:
+
+1. **Tasks an agent is working on right now** - a run in flight or queued. These carry the
+   pulsing amber dot next to the task ID.
+2. **Tasks waiting on you** - the task has an unread item in your inbox (an @admin
+   question, a credential request, an asset-deletion request), or it is holding on a
+   choice nobody has made yet, such as a pending hire proposal, a goal suggestion, or a
+   repo to work in. The inbox ones carry the blue @ icon.
+3. **Everything else.**
+
+Your chosen sort - work order, newest, or recently updated - orders the tasks inside each
+band rather than across them, so a task that needs you never sinks out of sight just
+because something newer arrived. The **Done** section is the exception: finished work
+always reads most-recently-updated first.
+
 ## Sub-tasks and hierarchy
 
 A task can be filed **under** another one as a sub-task. Agents reach for this when the

--- a/packages/server/migrations/059_pending_admin_ask_index.sql
+++ b/packages/server/migrations/059_pending_admin_ask_index.sql
@@ -1,0 +1,29 @@
+-- Index the "is this task waiting on the admin?" probe.
+--
+-- The task list now orders in three tiers - a run in flight, then a task parked
+-- on the admin, then the rest - and the second tier asks, per row, whether the
+-- task carries an ask comment nobody has answered yet. Without an index that
+-- probe walks every comment on the task through idx_comments_task_created
+-- (task_id, created_at); a task with a long thread pays for its whole history on
+-- every page of every task list.
+--
+-- Partial, so the index holds only unanswered asks: a resolved one leaves the
+-- index on the next write, and the whole structure stays proportional to the
+-- open backlog rather than to the comment table. `connect_required` is absent
+-- deliberately - it never sets chosen_option (a connector's resolved state lives
+-- on its oauth_status), so it is not answerable this way.
+--
+-- The WHERE clause must stay verbatim-identical to the predicate in
+-- adminActionPendingSql (packages/server/src/lib/task-sort.ts), which spells the
+-- content types as literals for exactly this reason: the planner can only use a
+-- partial index when it can prove the query implies the index predicate.
+--
+-- Index-only. No rows are read, written or moved.
+CREATE INDEX idx_comments_pending_ask
+    ON task_comments (task_id)
+    WHERE chosen_option IS NULL
+      AND content_type IN (
+        'action'::comment_content_type,
+        'credential_request'::comment_content_type,
+        'asset_deletion_request'::comment_content_type
+      );

--- a/packages/server/src/lib/task-sort.ts
+++ b/packages/server/src/lib/task-sort.ts
@@ -1,4 +1,4 @@
-import { TaskPriority, TERMINAL_TASK_STATUSES } from '@hezo/shared';
+import { CommentContentType, TaskPriority, TERMINAL_TASK_STATUSES } from '@hezo/shared';
 
 const TASK_ALIAS = 'i';
 
@@ -15,6 +15,62 @@ export function taskActiveRunExistsSql(alias = TASK_ALIAS): string {
 	return `EXISTS (
     SELECT 1 FROM heartbeat_runs hr
     WHERE hr.task_id = ${alias}.id AND hr.status IN ('running', 'queued')
+  )`;
+}
+
+/**
+ * The comment kinds that park a task on a human until they answer, identified by
+ * `chosen_option IS NULL`. `connect_required` is deliberately absent: it never
+ * sets `chosen_option` (a connector's resolved state lives on its `oauth_status`),
+ * so it would read as unanswered forever.
+ */
+const PENDING_ASK_CONTENT_TYPES = [
+	CommentContentType.Action,
+	CommentContentType.CredentialRequest,
+	CommentContentType.AssetDeletionRequest,
+] as const;
+
+// Spelled as literals rather than placeholders so the predicate matches migration
+// 059's partial-index WHERE clause verbatim - a parameterized IN list leaves the
+// planner unable to prove the implication under a generic plan, and the index goes
+// unused. The values come from a frozen enum, never from a request.
+const PENDING_ASK_CONTENT_TYPE_LIST = PENDING_ASK_CONTENT_TYPES.map(
+	(kind) => `'${kind}'::comment_content_type`,
+).join(', ');
+
+/**
+ * EXISTS for an unread admin-inbox row on the task, scoped to one admin user.
+ * `adminUserIdx` is the placeholder holding that user's id; a non-admin caller
+ * passes NULL there and the predicate matches nothing.
+ */
+export function adminUnreadMentionExistsSql(alias: string, adminUserIdx: number): string {
+	return `EXISTS (
+    SELECT 1 FROM admin_mentions bm
+    WHERE bm.task_id = ${alias}.id AND bm.user_id = $${adminUserIdx}
+      AND bm.read_at IS NULL AND bm.archived_at IS NULL
+  )`;
+}
+
+/**
+ * "This task is waiting on the admin" - the task list's second ordering tier, and
+ * a column on its rows. Two legs: an unread inbox row for the viewing admin (an
+ * `@admin` ask, a credential request, an asset-deletion ask), or an ask comment
+ * nobody has answered yet (the hire, goal and repo-setup choice cards, which park
+ * a task on a human without raising an inbox row at all).
+ *
+ * Only the first leg is per-user, so a non-admin caller sees this driven by
+ * unanswered asks alone - the same way `has_unread_admin_mention` already reads
+ * false for them.
+ */
+export function adminActionPendingSql(alias: string, adminUserIdx: number): string {
+	return `(
+    ${adminUnreadMentionExistsSql(alias, adminUserIdx)}
+    OR EXISTS (
+      SELECT 1 FROM task_comments ask
+      WHERE ask.task_id = ${alias}.id
+        AND ask.chosen_option IS NULL
+        AND ask.content_type IN (${PENDING_ASK_CONTENT_TYPE_LIST})
+    )
   )`;
 }
 
@@ -69,16 +125,23 @@ export function parseTaskListSort(sortParam: string | undefined): {
 }
 
 /**
- * Build ORDER BY for the task list. Always pins active runs first.
+ * Build ORDER BY for the task list. Every sort mode is tiered first: tasks with a
+ * run in flight or queued, then tasks waiting on the admin, then the rest. The
+ * chosen field only orders within a tier.
  * `work_order`: ready → priority → ticket number (matches agent dispatch).
+ *
+ * `adminActionPending` is the expression from {@link adminActionPendingSql}, passed
+ * in rather than built here so the caller can project the same tier as a column
+ * without pushing its params twice.
  */
 export function buildTaskListOrderBy(
 	field: TaskListSortField,
 	direction: 'ASC' | 'DESC',
 	params: unknown[],
 	idx: number,
+	adminActionPending: string,
 ): { sql: string; nextIdx: number } {
-	const activeRun = taskActiveRunExistsSql();
+	const tiers = `${taskActiveRunExistsSql()} DESC, ${adminActionPending} DESC`;
 	if (field === 'work_order') {
 		const blockerStart = idx;
 		const blockerSql = appendOpenBlockerExistsSql(TASK_ALIAS, blockerStart, params);
@@ -87,12 +150,12 @@ export function buildTaskListOrderBy(
 		const prioritySql = appendPriorityOrderSql(TASK_ALIAS, priorityStart, params);
 		idx += 4;
 		return {
-			sql: `${activeRun} DESC, ${blockerSql} ASC, ${prioritySql} ASC, ${TASK_ALIAS}.number ASC`,
+			sql: `${tiers}, ${blockerSql} ASC, ${prioritySql} ASC, ${TASK_ALIAS}.number ASC`,
 			nextIdx: idx,
 		};
 	}
 	return {
-		sql: `${activeRun} DESC, ${TASK_ALIAS}.${field} ${direction}`,
+		sql: `${tiers}, ${TASK_ALIAS}.${field} ${direction}`,
 		nextIdx: idx,
 	};
 }

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -29,9 +29,12 @@ import {
 	resolveParentAssignment,
 } from '../lib/task-relationships';
 import {
+	adminActionPendingSql,
+	adminUnreadMentionExistsSql,
 	buildSearchRelevanceOrderSql,
 	buildTaskListOrderBy,
 	parseTaskListSort,
+	taskActiveRunExistsSql,
 } from '../lib/task-sort';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -195,10 +198,21 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
 		idx = rel.nextIdx;
 	}
 
-	const orderBy = buildTaskListOrderBy(sortField, sortDirection, params, idx);
+	// The viewing admin's id is read by both the projection and the ordering, so it
+	// takes a placeholder of its own ahead of the ORDER BY params rather than being
+	// appended after them.
+	const adminUserIdx = idx;
+	params.push(adminUserId);
+	idx++;
+
+	// One expression, two uses: the `admin_action_pending` column and the ordering
+	// tier below active runs. Building it once keeps the two from drifting.
+	const adminActionPending = adminActionPendingSql('i', adminUserIdx);
+
+	const orderBy = buildTaskListOrderBy(sortField, sortDirection, params, idx, adminActionPending);
 	idx = orderBy.nextIdx;
 
-	const dataParams = [...params, adminUserId, perPage, offset];
+	const dataParams = [...params, perPage, offset];
 	const result = await db.query(
 		`SELECT i.id, i.team_id, i.project_id, i.assignee_id, i.parent_task_id,
             i.number, i.identifier, i.title, i.description, i.status, i.priority,
@@ -207,15 +221,9 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
             ${agentDisplayNameSql('ma', 'm')} AS assignee_name,
             ma.slug AS assignee_slug,
             m.member_type AS assignee_type,
-            EXISTS (
-              SELECT 1 FROM heartbeat_runs hr
-              WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
-            ) AS has_active_run,
-            EXISTS (
-              SELECT 1 FROM admin_mentions bm
-              WHERE bm.task_id = i.id AND bm.user_id = $${idx}
-                AND bm.read_at IS NULL AND bm.archived_at IS NULL
-            ) AS has_unread_admin_mention,
+            ${taskActiveRunExistsSql('i')} AS has_active_run,
+            ${adminUnreadMentionExistsSql('i', adminUserIdx)} AS has_unread_admin_mention,
+            ${adminActionPending} AS admin_action_pending,
             lr.status AS last_run_status,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
               'reason', qw.last_skipped_reason,
@@ -252,7 +260,7 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
      ) lr ON true
      WHERE ${where}
      ORDER BY ${relevancePrefix}${orderBy.sql}
-     LIMIT $${idx + 1} OFFSET $${idx + 2}`,
+     LIMIT $${idx} OFFSET $${idx + 1}`,
 		dataParams,
 	);
 
@@ -1015,10 +1023,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId/dependencies', async (c) => 
 		`SELECT d.id, d.task_id, d.blocked_by_task_id, d.created_at,
             i.identifier AS blocked_by_identifier, i.title AS blocked_by_title, i.status AS blocked_by_status,
             p.slug AS blocked_by_project_slug,
-            EXISTS (
-              SELECT 1 FROM heartbeat_runs hr
-              WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
-            ) AS blocked_by_has_active_run,
+            ${taskActiveRunExistsSql('i')} AS blocked_by_has_active_run,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
               'reason', qw.last_skipped_reason,
               'since', qw.last_skipped_at,

--- a/packages/server/test/migrate-059-pending-admin-ask-index.test.ts
+++ b/packages/server/test/migrate-059-pending-admin-ask-index.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '059_pending_admin_ask_index.sql';
+
+describe('059_pending_admin_ask_index migration', () => {
+	let h: DataPreservationHarness;
+	let taskId: string;
+	const commentIds: string[] = [];
+	let pendingAskId = '';
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema at N-1
+
+		// A task carrying the mix the partial index has to sort out: ordinary text
+		// comments, one answered ask and one still open.
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Ops', 'ops', 'OPS') RETURNING id`,
+			[team.rows[0].id],
+		);
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+			 VALUES ($1, $2, 1, 'OPS-1', 'Seed task') RETURNING id`,
+			[team.rows[0].id, project.rows[0].id],
+		);
+		taskId = task.rows[0].id;
+
+		for (let i = 0; i < 3; i++) {
+			const c = await h.db.query<{ id: string }>(
+				`INSERT INTO task_comments (task_id, content_type, content)
+				 VALUES ($1, 'text'::comment_content_type, $2::jsonb) RETURNING id`,
+				[taskId, JSON.stringify({ text: `comment ${i}` })],
+			);
+			commentIds.push(c.rows[0].id);
+		}
+
+		const answered = await h.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, content_type, content, chosen_option)
+			 VALUES ($1, 'action'::comment_content_type, $2::jsonb, $3::jsonb) RETURNING id`,
+			[taskId, JSON.stringify({ kind: 'setup_repo' }), JSON.stringify({ status: 'approved' })],
+		);
+		commentIds.push(answered.rows[0].id);
+
+		const pending = await h.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, content_type, content)
+			 VALUES ($1, 'credential_request'::comment_content_type, $2::jsonb) RETURNING id`,
+			[taskId, JSON.stringify({ name: 'STRIPE_KEY', kind: 'api_key' })],
+		);
+		pendingAskId = pending.rows[0].id;
+		commentIds.push(pendingAskId);
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the partial unanswered-ask index', async () => {
+		const idx = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM pg_indexes WHERE indexname = 'idx_comments_pending_ask'`,
+		);
+		expect(idx.rows[0].c).toBe(1);
+	});
+
+	it('indexes only unanswered asks, matching the ordering predicate', async () => {
+		// The tier-2 predicate from adminActionPendingSql, spelled exactly as the
+		// index's WHERE clause spells it. The answered action comment and the three
+		// text comments must not qualify; the open credential request must.
+		const matched = await h.db.query<{ id: string }>(
+			`SELECT id FROM task_comments
+			  WHERE task_id = $1
+			    AND chosen_option IS NULL
+			    AND content_type IN (
+			      'action'::comment_content_type,
+			      'credential_request'::comment_content_type,
+			      'asset_deletion_request'::comment_content_type
+			    )`,
+			[taskId],
+		);
+		expect(matched.rows.map((r) => r.id)).toEqual([pendingAskId]);
+	});
+
+	it('preserves pre-existing comments, their ordering and their chosen_option', async () => {
+		const rows = await h.db.query<{ id: string; chosen_option: unknown }>(
+			`SELECT id, chosen_option FROM task_comments WHERE task_id = $1 ORDER BY created_at ASC, id ASC`,
+			[taskId],
+		);
+		expect(rows.rows.map((r) => r.id).sort()).toEqual([...commentIds].sort());
+		expect(rows.rows.filter((r) => r.chosen_option !== null)).toHaveLength(1);
+	});
+});

--- a/packages/server/test/tasks-sort.test.ts
+++ b/packages/server/test/tasks-sort.test.ts
@@ -1,6 +1,6 @@
 import { TaskPriority, TaskStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
 import { buildSearchRelevanceOrderSql } from '../src/lib/task-sort';
 import type { Env } from '../src/lib/types';
@@ -65,14 +65,24 @@ async function insertTask(
 	return res.rows[0];
 }
 
-async function listIds(sort?: string): Promise<string[]> {
-	const qs = sort ? `?sort=${encodeURIComponent(sort)}&per_page=50` : '?per_page=50';
+interface ListedTask {
+	id: string;
+	title: string;
+	has_active_run: boolean;
+	admin_action_pending: boolean;
+}
+
+async function listRows(sort?: string): Promise<ListedTask[]> {
+	const qs = sort ? `?sort=${encodeURIComponent(sort)}&per_page=100` : '?per_page=100';
 	const res = await app.request(`/api/projects/${projectSlug}/tasks${qs}`, {
 		headers: authHeader(token),
 	});
 	expect(res.status).toBe(200);
-	const rows = (await res.json()).data as Array<{ id: string; title: string }>;
-	return rows.map((r) => r.id);
+	return (await res.json()).data as ListedTask[];
+}
+
+async function listIds(sort?: string): Promise<string[]> {
+	return (await listRows(sort)).map((r) => r.id);
 }
 
 describe('GET /projects/:projectId/tasks sort=work_order', () => {
@@ -104,6 +114,155 @@ describe('GET /projects/:projectId/tasks sort=work_order', () => {
 
 		const ids = await listIds('work_order:asc');
 		expect(ids.indexOf(urgent.id)).toBeLessThan(ids.indexOf(medium.id));
+	});
+});
+
+/**
+ * The three ordering tiers, seeded oldest-first so the *idle* task is always the
+ * most recently created and updated - under any recency sort it would lead if the
+ * tiers were not applied.
+ */
+async function seedTieredTrio(idlePriority: string = TaskPriority.Medium): Promise<{
+	running: string;
+	pending: string;
+	idle: string;
+}> {
+	const running = await insertTask('Tier: agent running', { priority: TaskPriority.Low });
+	await db.query(
+		`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+		 VALUES ($1, $2, $3, 'running')`,
+		[teamId, agentId, running.id],
+	);
+	await new Promise((r) => setTimeout(r, 10));
+
+	const pending = await insertTask('Tier: waiting on admin', { priority: TaskPriority.Low });
+	await insertUnansweredAsk(pending.id);
+	await new Promise((r) => setTimeout(r, 10));
+
+	const idle = await insertTask('Tier: idle', { priority: idlePriority });
+	return { running: running.id, pending: pending.id, idle: idle.id };
+}
+
+/** An ask comment nobody has answered yet - `chosen_option IS NULL`. */
+async function insertUnansweredAsk(
+	taskId: string,
+	contentType = 'credential_request',
+): Promise<string> {
+	const res = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING id`,
+		[taskId, agentId, contentType, JSON.stringify({ name: 'SOME_KEY', kind: 'api_key' })],
+	);
+	return res.rows[0].id;
+}
+
+/** An unread inbox row for the admin whose JWT the list requests carry. */
+async function insertAdminMention(taskId: string): Promise<void> {
+	const comment = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+		[taskId, agentId, JSON.stringify({ text: '@admin your call please' })],
+	);
+	const admin = await db.query<{ id: string }>(
+		'SELECT id FROM users WHERE is_superuser = true LIMIT 1',
+	);
+	await db.query(
+		`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)`,
+		[teamId, taskId, comment.rows[0].id, admin.rows[0].id],
+	);
+}
+
+/** Reset every tier signal so one case cannot tier another case's tasks. */
+async function clearTierSignals(): Promise<void> {
+	await db.query('DELETE FROM heartbeat_runs');
+	await db.query('DELETE FROM admin_mentions');
+	await db.query(
+		`DELETE FROM task_comments
+		  WHERE content_type IN ('credential_request'::comment_content_type, 'action'::comment_content_type)`,
+	);
+}
+
+describe('GET /projects/:projectId/tasks ordering tiers', () => {
+	afterEach(clearTierSignals);
+
+	it('orders running, then waiting-on-admin, then the rest under work_order', async () => {
+		// The idle task is urgent and newest, so every work_order key below the tiers
+		// (ready → priority → number) would put it first.
+		const { running, pending, idle } = await seedTieredTrio(TaskPriority.Urgent);
+
+		const ids = await listIds('work_order:asc');
+		expect(ids.indexOf(running)).toBeLessThan(ids.indexOf(pending));
+		expect(ids.indexOf(pending)).toBeLessThan(ids.indexOf(idle));
+	});
+
+	it('applies the same tiers under a recency sort', async () => {
+		const { running, pending, idle } = await seedTieredTrio();
+
+		const ids = await listIds('updated_at:desc');
+		expect(ids.indexOf(running)).toBeLessThan(ids.indexOf(pending));
+		expect(ids.indexOf(pending)).toBeLessThan(ids.indexOf(idle));
+	});
+
+	it('lifts a task on an unanswered ask alone, and drops it once answered', async () => {
+		const asked = await insertTask('Ask: unanswered hire card', { priority: TaskPriority.Low });
+		const commentId = await insertUnansweredAsk(asked.id, 'action');
+		await new Promise((r) => setTimeout(r, 10));
+		const idle = await insertTask('Ask: idle neighbour', { priority: TaskPriority.Urgent });
+
+		const before = await listRows('updated_at:desc');
+		expect(before.find((r) => r.id === asked.id)?.admin_action_pending).toBe(true);
+		expect(before.findIndex((r) => r.id === asked.id)).toBeLessThan(
+			before.findIndex((r) => r.id === idle.id),
+		);
+
+		// Answering the card resolves the ask; the task falls back into the last tier
+		// and the newer idle task reclaims the top under updated_at:desc.
+		await db.query(`UPDATE task_comments SET chosen_option = $1::jsonb WHERE id = $2`, [
+			JSON.stringify({ status: 'approved' }),
+			commentId,
+		]);
+
+		const after = await listRows('updated_at:desc');
+		expect(after.find((r) => r.id === asked.id)?.admin_action_pending).toBe(false);
+		expect(after.findIndex((r) => r.id === idle.id)).toBeLessThan(
+			after.findIndex((r) => r.id === asked.id),
+		);
+	});
+
+	it('lifts a task on an unread admin mention alone', async () => {
+		const mentioned = await insertTask('Mention: needs the admin', { priority: TaskPriority.Low });
+		await insertAdminMention(mentioned.id);
+		await new Promise((r) => setTimeout(r, 10));
+		const idle = await insertTask('Mention: idle neighbour', { priority: TaskPriority.Urgent });
+
+		const rows = await listRows('updated_at:desc');
+		expect(rows.find((r) => r.id === mentioned.id)?.admin_action_pending).toBe(true);
+		expect(rows.find((r) => r.id === idle.id)?.admin_action_pending).toBe(false);
+		expect(rows.findIndex((r) => r.id === mentioned.id)).toBeLessThan(
+			rows.findIndex((r) => r.id === idle.id),
+		);
+	});
+
+	it('keeps a running task above a waiting-on-admin task that also has a run queued', async () => {
+		// has_active_run covers queued runs too, so a task with both signals belongs in
+		// the first tier - the second must not pull it down.
+		const both = await insertTask('Both signals', { priority: TaskPriority.Low });
+		await insertUnansweredAsk(both.id);
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+			 VALUES ($1, $2, $3, 'queued')`,
+			[teamId, agentId, both.id],
+		);
+		await new Promise((r) => setTimeout(r, 10));
+		const pendingOnly = await insertTask('Ask only', { priority: TaskPriority.Urgent });
+		await insertUnansweredAsk(pendingOnly.id);
+
+		const rows = await listRows('updated_at:desc');
+		expect(rows.find((r) => r.id === both.id)?.has_active_run).toBe(true);
+		expect(rows.findIndex((r) => r.id === both.id)).toBeLessThan(
+			rows.findIndex((r) => r.id === pendingOnly.id),
+		);
 	});
 });
 

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -56,6 +56,13 @@ export interface Task {
 	/** Summed cost across the task's runs, in cents. */
 	total_cost_cents: number;
 	has_unread_admin_mention: boolean;
+	/**
+	 * The task is parked on the admin: an unread inbox row for the viewing admin, or
+	 * an ask comment (hire, goal, repo-setup card, credential request) nobody has
+	 * answered. This is the list's second ordering tier, below active runs. List rows
+	 * only, like `has_unread_admin_mention`.
+	 */
+	admin_action_pending: boolean;
 	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
 	/** Id of the last completed run — the target of a manual retry. */
 	last_run_id: string | null;

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -491,6 +491,59 @@ test('tasks with active runs pin to the top regardless of sort order', async () 
 	});
 });
 
+test('in progress section orders running, then waiting-on-admin, then the rest', async () => {
+	let projectSlug = '';
+	const titles = {
+		running: 'Zeta running task',
+		mentioned: 'Yankee mention task',
+		idle: 'Xray idle task',
+	};
+
+	const { findByText, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Tier Project' });
+			const agentId = ws.agents[0].id;
+
+			const running = await seedTask(ws, project, { title: titles.running, assignee_id: agentId });
+			const mentioned = await seedTask(ws, project, {
+				title: titles.mentioned,
+				assignee_id: agentId,
+			});
+			const idle = await seedTask(ws, project, { title: titles.idle, assignee_id: agentId });
+
+			await insertActiveRun(agentId, ws.team.id, running.id);
+			await seedAdminMention(ws, mentioned.id, '@admin your call please.');
+
+			// The section sorts updated_at:desc within a tier, and a status PATCH
+			// bumps updated_at — so patching the idle task last makes it the most
+			// recently updated. Only the tiers can keep it below the other two.
+			await patchStatus(ws, running.id, 'in_progress');
+			await patchStatus(ws, mentioned.id, 'in_progress');
+			await patchStatus(ws, idle.id, 'in_progress');
+
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	await findByText(titles.idle, undefined, { timeout: 10_000 });
+	const section = await findByTestId('task-list-in-progress');
+
+	await waitFor(() => {
+		const ordered = Array.from(section.querySelectorAll('tbody tr'))
+			.map((row) => row.textContent ?? '')
+			.map((text) => Object.values(titles).find((title) => text.includes(title)))
+			.filter((title): title is string => title !== undefined);
+		expect(ordered).toEqual([titles.running, titles.mentioned, titles.idle]);
+	});
+});
+
 test('in progress tasks render in a pinned section without duplicating in the main list', async () => {
 	let projectSlug = '';
 


### PR DESCRIPTION
## What

The task list ordering gains a second tier, so every list reads:

1. **An agent is running on it** - a run in flight or queued (the amber pulsing dot).
2. **It is waiting on the admin** - new.
3. **Everything else.**

The chosen sort (work order / created / updated) now orders *within* a band rather than across them.

## Why

`buildTaskListOrderBy` already prefixed every sort mode with `taskActiveRunExistsSql() DESC`, which is why the amber-dot rows lead. Below that single tier the order collapsed straight into the chosen sort, so a task parked on a human sat wherever recency happened to drop it, interleaved with tasks nobody was waiting on.

## How

`adminActionPendingSql` (`lib/task-sort.ts`) is the new tier, also projected on the row as `admin_action_pending`. Two legs OR'd:

- an unread `admin_mentions` row for the **viewing** admin - exactly what the blue `@` icon renders (`@admin` asks, credential requests, asset-deletion asks);
- an ask comment nobody has answered - `chosen_option IS NULL` on an `action` / `credential_request` / `asset_deletion_request` comment.

The second leg is the one the icon misses: a pending hire proposal, goal suggestion or `setup_repo` card parks a task on a human while raising no inbox row at all, and a read-but-unresolved credential request drops out of the first leg while still being unanswered. `connect_required` is excluded on purpose - it never sets `chosen_option` (a connector's resolved state lives on its `oauth_status`), so it would read as unanswered forever.

**Why server-side.** The Backlog pages in 50 rows at a time via `useInfiniteTasks`, so a client-side sort could only reorder pages already fetched and page-2 rows would jump above page-1. Doing it in the existing ORDER BY seam also reaches the pinned In-progress section, the Backlog and the dashboard's in-progress widget at once.

Only the first leg is per-user, so an agent or API key sees the tier driven by unanswered asks alone - the same way `has_unread_admin_mention` already reads false for them.

**Migration 059** adds `idx_comments_pending_ask`, a partial index matching the ask predicate; without it the probe walks every comment on the task. The predicate is spelled with enum **literals** so it matches the index `WHERE` clause verbatim - a parameterized `IN` list leaves the planner unable to prove the implication under a generic plan, and the index goes unused.

Also folds the two hand-inlined active-run `EXISTS` projections in `routes/tasks.ts` onto the existing `taskActiveRunExistsSql`, so the column and the ordering key cannot drift.

## Deliberately not in scope

- **No UI change.** The dot and the `@` icon are untouched; a badge for the non-mention half of tier 2 would need a new string in all twelve catalogs.
- **No nesting change.** `nestTasksForDisplay` still glues children under their parent, as an active-run child already does today.
- **The "Done" section** keeps its client-side `updated_at` re-sort, and **MCP `list_tasks`** keeps its keyset `created_at` order (the tiers would break its cursor).

## Tests

- `tasks-sort.test.ts` - a new `ordering tiers` block: the three-way order under both `work_order:asc` and `updated_at:desc` (the idle task seeded newest *and* urgent so it would otherwise lead); an unanswered `action` comment lifting a task alone and dropping back once answered; an unread mention lifting a task alone; a task with both signals staying in tier 1.
  Verified these bite - neutralizing the tier fails 4 of the 5.
- `migrate-059-pending-admin-ask-index.test.ts` - data-preservation harness: the index exists, indexes only unanswered asks, and pre-existing comments plus their `chosen_option` survive.
- `task-list.test.tsx` - the rendered In-progress section orders running → mentioned → idle, with the idle task patched last so it is the most recently updated.

`bun run typecheck`, `bunx biome check --diagnostic-level=error .` and `bun run build` all pass; the affected server and web suites are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v1WtsjuhZcWWVoUhqEhGf

---
_Generated by [Claude Code](https://claude.ai/code/session_016v1WtsjuhZcWWVoUhqEhGf)_