### PR TITLE
fix(web): fit the org chart to its column, scroll below the readable floor

### DIFF
--- a/packages/web/src/components/org-chart-tree.tsx
+++ b/packages/web/src/components/org-chart-tree.tsx
@@ -1,51 +1,86 @@
 import { isBudgetPauseStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import type { OrgNode } from '../hooks/use-org-chart';
 import { agentAvatarUrl } from '../lib/agent-avatar';
 import { useI18n } from '../lib/i18n';
+import { computeOrgChartFit, type OrgChartFit } from '../lib/org-chart-fit';
 import { AgentIdentityTooltipContent, agentDisplayName } from './agent-identity-tooltip';
 import { agentPageParams } from './agent-link';
 import { Avatar, getInitials } from './ui/avatar';
 import { StatusDot } from './ui/status-dot';
 import { Tooltip } from './ui/tooltip';
 
-export function useOrgChartAutoFit() {
-	const containerRef = useRef<HTMLDivElement | null>(null);
+const INITIAL_FIT: OrgChartFit = { scale: 1, width: 0, height: 0, overflows: false };
+
+/**
+ * Measure the chart against its viewport and keep the two in step.
+ *
+ * The content is `w-max`, so `offsetWidth`/`offsetHeight` report its natural
+ * size — and unlike `getBoundingClientRect()` those are layout values, read
+ * straight through the transform this hook itself wrote last pass. Measuring a
+ * transformed box would feed each scale into the next and converge on zero.
+ *
+ * This replaced a `scrollWidth` measurement, which is where the bug was: with a
+ * content box the width of its container and `items-center`, a wide row
+ * overflows symmetrically, and in LTR `scrollWidth` only ever reports the right
+ * half. The chart was measured about half its overhang too narrow, so the scale
+ * came out too high and it clipped on both sides.
+ */
+function useOrgChartAutoFit() {
+	const viewportRef = useRef<HTMLDivElement | null>(null);
 	const contentRef = useRef<HTMLDivElement | null>(null);
-	const [scale, setScale] = useState(1);
-	const [height, setHeight] = useState<number | undefined>(undefined);
+	const [fit, setFit] = useState<OrgChartFit>(INITIAL_FIT);
 
-	useEffect(() => {
-		const container = containerRef.current;
+	// Layout effect, not effect: the fit lands in the frame the tree mounts, so
+	// there is no flash of an unscaled chart overhanging its column.
+	useLayoutEffect(() => {
+		const viewport = viewportRef.current;
 		const content = contentRef.current;
-		if (!container || !content) return;
+		if (!viewport || !content) return;
 
-		const recompute = () => {
-			const containerWidth = container.clientWidth;
-			const contentWidth = content.scrollWidth;
-			const contentHeight = content.scrollHeight;
-			if (!containerWidth || !contentWidth) return;
-			const next = Math.min(1, containerWidth / contentWidth);
-			setScale(next);
-			// The container is border-box with vertical padding and clips via
-			// overflow-hidden, so the height must cover the scaled content *plus*
-			// that padding — otherwise the padding eats into the box and the last
-			// row's bottom border falls outside the clip. Round the scaled height
-			// up and add 1px to absorb the sub-pixel rounding of the scaled border.
-			const style = getComputedStyle(container);
-			const paddingY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
-			setHeight(Math.ceil(contentHeight * next) + paddingY + 1);
+		const measure = () => {
+			const next = computeOrgChartFit({
+				viewportWidth: viewport.clientWidth,
+				contentWidth: content.offsetWidth,
+				contentHeight: content.offsetHeight,
+			});
+			// `overflows` has to be compared too: either side of the floor boundary
+			// two different viewport widths can share a `width`, and a comparison
+			// without it would leave the scrollbar off on a chart that needs one.
+			setFit((prev) =>
+				prev.scale === next.scale &&
+				prev.width === next.width &&
+				prev.height === next.height &&
+				prev.overflows === next.overflows
+					? prev
+					: next,
+			);
 		};
 
-		recompute();
-		const ro = new ResizeObserver(recompute);
-		ro.observe(container);
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(viewport);
 		ro.observe(content);
 		return () => ro.disconnect();
 	}, []);
 
-	return { containerRef, contentRef, scale, height };
+	// The chart is centred on its root, so a scrolling one left at scrollLeft 0
+	// opens on the leftmost worker with "You (Admin)" off-screen. Centre it once,
+	// then leave the scroll position to whoever is panning.
+	//
+	// Separate from the measure pass on purpose: `scrollWidth` only becomes the
+	// new sizer's width after React has committed it, so centring inside
+	// `measure` would divide up the *previous* extent.
+	const centred = useRef(false);
+	useLayoutEffect(() => {
+		const viewport = viewportRef.current;
+		if (!viewport || !fit.overflows || centred.current) return;
+		centred.current = true;
+		viewport.scrollLeft = (viewport.scrollWidth - viewport.clientWidth) / 2;
+	}, [fit.overflows]);
+
+	return { viewportRef, contentRef, fit };
 }
 
 type VisibleStatus = 'active' | 'paused' | 'disabled';
@@ -97,7 +132,7 @@ const CONNECTOR_COLUMN =
 	'first:before:hidden last:after:hidden';
 
 export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartTreeProps) {
-	const { containerRef, contentRef, scale, height } = useOrgChartAutoFit();
+	const { viewportRef, contentRef, fit } = useOrgChartAutoFit();
 	const { t } = useI18n();
 
 	const renderNode = (node: OrgNode): ReactNode => {
@@ -190,21 +225,53 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 
 	return (
 		<div data-testid={testId}>
+			{/* The viewport's height is left to the content so a space-taking
+			    horizontal scrollbar gets a gutter below the chart instead of eating
+			    ~15px out of the box and shearing the bottom row's border — the same
+			    border PR #620 was about. Its vertical overflow must be stated
+			    explicitly: a non-`visible` value on one axis computes the other to
+			    `auto`, which would let a vertical scrollbar appear alongside.
+
+			    Scrollability is driven from our own measurement rather than left to
+			    `auto`, so a chart measured a sub-pixel narrow shows an invisible
+			    hairline clip instead of a flickering scrollbar. */}
 			<div
-				ref={containerRef}
+				ref={viewportRef}
 				data-testid={testId ? `${testId}-viewport` : undefined}
-				className="w-full overflow-hidden py-1"
-				style={{ height }}
+				className={`w-full py-1 overflow-y-hidden overscroll-x-contain ${
+					fit.overflows ? 'overflow-x-auto' : 'overflow-x-hidden'
+				}`}
 			>
+				{/* The scaled chart keeps its untransformed layout box, so this sizer
+				    carries the painted size instead — it is what gives the viewport a
+				    correct scroll extent, and clipping to it keeps the untransformed
+				    tree's layout overflow from leaking into that extent.
+
+				    `mx-auto` is the whole centring story: CSS 2.1 §10.3.3 zeroes
+				    over-constrained auto margins, so the sizer centres while the chart
+				    fits and goes flush left the moment it outgrows the viewport —
+				    which is what puts the chart's left edge at scrollLeft 0 instead of
+				    stranding it out of reach. `justify-center` on a scroll container
+				    would strand it, the same way the old measurement did. */}
 				<div
-					ref={contentRef}
-					className="flex flex-col items-center"
-					style={{ transform: `scale(${scale})`, transformOrigin: 'top center' }}
+					data-testid={testId ? `${testId}-canvas` : undefined}
+					className="mx-auto overflow-hidden"
+					style={{ width: fit.width || undefined, height: fit.height || undefined }}
 				>
-					<div className="inline-flex items-center gap-2 rounded-md border-2 border-inverse bg-info-soft px-4 py-2 text-[13px] font-medium text-info-soft-fg">
-						You (Admin)
+					{/* `w-max` sizes the tree to its widest row rather than to the column,
+					    so nothing overflows it and `offsetWidth` is the true width. Origin
+					    top-left pins the painted result to the sizer; `top center` would
+					    put half of it at negative x, unreachable all over again. */}
+					<div
+						ref={contentRef}
+						className="w-max flex flex-col items-center"
+						style={{ transform: `scale(${fit.scale})`, transformOrigin: 'top left' }}
+					>
+						<div className="inline-flex items-center gap-2 rounded-md border-2 border-inverse bg-info-soft px-4 py-2 text-[13px] font-medium text-info-soft-fg">
+							You (Admin)
+						</div>
+						{renderBranch(roots)}
 					</div>
-					{renderBranch(roots)}
 				</div>
 			</div>
 			{hint && <p className="text-[11px] text-text-3 mt-3">{hint}</p>}

--- a/packages/web/src/lib/org-chart-fit.ts
+++ b/packages/web/src/lib/org-chart-fit.ts
@@ -1,0 +1,98 @@
+/**
+ * How far the org chart is scaled down to sit inside its viewport, and the
+ * layout box that scaled chart needs to stand in for it.
+ *
+ * Pure arithmetic so it unit-tests in the component tier (happy-dom has no
+ * layout engine and answers 0 to every measurement); the DOM reads and the
+ * ResizeObserver wiring live with the component in
+ * `components/org-chart-tree.tsx`.
+ *
+ * A `transform: scale()` changes what is painted and leaves the layout box
+ * alone, so the caller has to give the scaled chart a real box of its own -
+ * that is what `width`/`height` are for. Without one, a scrolling chart's
+ * scroll extent stays the *unscaled* width and it scrolls into hundreds of
+ * pixels of nothing.
+ */
+
+/**
+ * The chart stops shrinking here and the viewport scrolls instead.
+ *
+ * Derived from the smallest text in a node: the role line under a named agent
+ * is 11px, and 8/11 = 0.727 keeps it at or above 8px. The card's own 13px label
+ * lands at ~9.5px. Below this the chart has stopped being readable, and panning
+ * a legible tree beats staring at an illegible whole one - which is the entire
+ * point of having a floor. Lowering it trades legibility for fitting more
+ * roster on screen.
+ */
+export const ORG_CHART_MIN_SCALE = 0.73;
+
+/**
+ * A pixel held back from the width the chart is fitted into.
+ *
+ * `offsetWidth` and `clientWidth` are both integer-rounded, so a chart measured
+ * a fraction narrow would otherwise be scaled to exactly the room available and
+ * shear its outermost card's 1px border against the clip. This is the
+ * horizontal twin of the pixel added to the height, which guards the bottom
+ * row's border (PR #620).
+ */
+export const ORG_CHART_EDGE_SLACK_PX = 1;
+
+export interface OrgChartFitInput {
+	/** Room the viewport gives the chart: its `clientWidth`, scrollbars excluded. */
+	viewportWidth: number;
+	/** The chart's natural, untransformed width - `offsetWidth` of a `max-content` box. */
+	contentWidth: number;
+	/** The chart's natural, untransformed height - `offsetHeight`. */
+	contentHeight: number;
+}
+
+export interface OrgChartFit {
+	/** Factor for `transform: scale(...)`. Never above 1 - the chart is not enlarged. */
+	scale: number;
+	/** Layout width of the box standing in for the scaled chart. */
+	width: number;
+	/** Its layout height, carrying the slack that keeps the bottom border inside the clip. */
+	height: number;
+	/** The box is wider than the room, so the viewport has to scroll. */
+	overflows: boolean;
+}
+
+/** A measurement that never arrived (happy-dom, pre-layout, a `display: none` ancestor). */
+function unmeasured(value: number): boolean {
+	return !Number.isFinite(value) || value <= 0;
+}
+
+/**
+ * Fit the chart to the viewport, shrink-only and floored at
+ * `ORG_CHART_MIN_SCALE`.
+ *
+ * Both dimensions round *up*, so the box is never narrower than what is painted
+ * inside it. That is safe in the fitting regime only because the scale was
+ * derived against `viewportWidth - ORG_CHART_EDGE_SLACK_PX`: rounding a box up
+ * to exactly the room available would grow a permanent 1px scrollbar on a chart
+ * that fits.
+ */
+export function computeOrgChartFit({
+	viewportWidth,
+	contentWidth,
+	contentHeight,
+}: OrgChartFitInput): OrgChartFit {
+	// Nothing has been laid out yet: render at full size rather than deriving a
+	// scale from zeroes. The ResizeObserver re-runs this once real boxes exist.
+	if (unmeasured(contentWidth) || unmeasured(contentHeight) || unmeasured(viewportWidth)) {
+		return { scale: 1, width: 0, height: 0, overflows: false };
+	}
+
+	const room = Math.max(1, viewportWidth - ORG_CHART_EDGE_SLACK_PX);
+	const scale = Math.min(1, Math.max(ORG_CHART_MIN_SCALE, room / contentWidth));
+	const width = Math.ceil(contentWidth * scale);
+
+	return {
+		scale,
+		width,
+		height: Math.ceil(contentHeight * scale) + ORG_CHART_EDGE_SLACK_PX,
+		// Asked of the box, not of the scale: a chart clamped at the floor can
+		// still land inside the viewport, and it should not scroll for nothing.
+		overflows: width > viewportWidth,
+	};
+}

--- a/packages/web/test/org-chart-fit.test.ts
+++ b/packages/web/test/org-chart-fit.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure arithmetic tier: happy-dom has no layout engine, so the scale/clamp/
+ * rounding rules can only be exercised here. That the rules produce a chart
+ * nothing is clipped out of is a browser matter - see
+ * `test/browser/org-chart-fit.spec.ts`.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	computeOrgChartFit,
+	ORG_CHART_EDGE_SLACK_PX,
+	ORG_CHART_MIN_SCALE,
+} from '../src/lib/org-chart-fit';
+
+const HEIGHT = 400;
+
+describe('computeOrgChartFit', () => {
+	it('leaves a chart narrower than its viewport at full size', () => {
+		const fit = computeOrgChartFit({
+			viewportWidth: 1200,
+			contentWidth: 800,
+			contentHeight: HEIGHT,
+		});
+
+		expect(fit.scale).toBe(1);
+		expect(fit.overflows).toBe(false);
+		expect(fit.width).toBe(800);
+	});
+
+	it('never enlarges - a chart with room to spare is not stretched to fill it', () => {
+		const fit = computeOrgChartFit({
+			viewportWidth: 4000,
+			contentWidth: 500,
+			contentHeight: HEIGHT,
+		});
+
+		expect(fit.scale).toBe(1);
+		expect(fit.width).toBe(500);
+	});
+
+	it('shrinks a wider chart into the room available', () => {
+		const fit = computeOrgChartFit({
+			viewportWidth: 1000,
+			contentWidth: 1250,
+			contentHeight: HEIGHT,
+		});
+
+		expect(fit.scale).toBeCloseTo(999 / 1250, 5);
+		expect(fit.overflows).toBe(false);
+		expect(fit.width).toBeLessThan(1000);
+	});
+
+	it('stops shrinking at the floor and reports that the viewport must scroll', () => {
+		// A nine-role roster on a phone: fitting it outright would need scale 0.13.
+		const fit = computeOrgChartFit({
+			viewportWidth: 390,
+			contentWidth: 3000,
+			contentHeight: HEIGHT,
+		});
+
+		expect(fit.scale).toBe(ORG_CHART_MIN_SCALE);
+		expect(fit.overflows).toBe(true);
+		// Wider than the viewport by construction - that width *is* the scroll extent.
+		expect(fit.width).toBe(Math.ceil(3000 * ORG_CHART_MIN_SCALE));
+		expect(fit.width).toBeGreaterThan(390);
+	});
+
+	it('does not scroll a floored chart that still lands inside the viewport', () => {
+		const contentWidth = 1000;
+		// The one width where both hold: the pixel of slack pushes the ratio just
+		// under the floor, yet the floored box is exactly the viewport wide. A
+		// scrollbar here would be for a chart already fully visible.
+		const fit = computeOrgChartFit({
+			viewportWidth: Math.ceil(contentWidth * ORG_CHART_MIN_SCALE),
+			contentWidth,
+			contentHeight: HEIGHT,
+		});
+
+		expect(fit.scale).toBe(ORG_CHART_MIN_SCALE);
+		expect(fit.overflows).toBe(false);
+	});
+
+	it('never hands a chart that fits a scrollbar it does not need', () => {
+		// The rounding trap: a box rounded up to exactly the room available grows a
+		// permanent 1px scroll range. Sweep the awkward ratios.
+		for (let viewportWidth = 300; viewportWidth <= 1400; viewportWidth += 7) {
+			for (const contentWidth of [301, 617, 999, 1001, 1333, 1499]) {
+				const fit = computeOrgChartFit({ viewportWidth, contentWidth, contentHeight: HEIGHT });
+				if (fit.scale > ORG_CHART_MIN_SCALE) {
+					expect(fit.width).toBeLessThanOrEqual(viewportWidth);
+					expect(fit.overflows).toBe(false);
+				}
+			}
+		}
+	});
+
+	it('never sizes the box narrower than what is painted inside it', () => {
+		// The mirror trap: the sizer clips, so a box short of the painted width
+		// shears the outermost card's border.
+		for (let viewportWidth = 200; viewportWidth <= 1400; viewportWidth += 11) {
+			for (const contentWidth of [457, 913, 1490, 2371]) {
+				const fit = computeOrgChartFit({ viewportWidth, contentWidth, contentHeight: HEIGHT });
+				expect(fit.width).toBeGreaterThanOrEqual(contentWidth * fit.scale);
+				expect(fit.height).toBeGreaterThanOrEqual(HEIGHT * fit.scale);
+			}
+		}
+	});
+
+	it('holds a pixel back on each axis for the scaled 1px borders', () => {
+		// Inside the fitting band, where the scale is derived rather than clamped.
+		const fit = computeOrgChartFit({
+			viewportWidth: 1000,
+			contentWidth: 1200,
+			contentHeight: 777,
+		});
+
+		// Width: the slack comes off the room the scale is derived from, so the box
+		// lands inside the viewport rather than flush against it.
+		expect(fit.scale).toBeCloseTo((1000 - ORG_CHART_EDGE_SLACK_PX) / 1200, 5);
+		expect(fit.width).toBeLessThan(1000);
+		// Height: the slack is added, guarding the bottom row's border (PR #620).
+		expect(fit.height).toBe(Math.ceil(777 * fit.scale) + ORG_CHART_EDGE_SLACK_PX);
+		expect(Number.isInteger(fit.width)).toBe(true);
+		expect(Number.isInteger(fit.height)).toBe(true);
+	});
+
+	for (const [name, input] of [
+		['nothing laid out yet', { viewportWidth: 0, contentWidth: 0, contentHeight: 0 }],
+		['viewport not measured', { viewportWidth: 0, contentWidth: 900, contentHeight: HEIGHT }],
+		['content not measured', { viewportWidth: 900, contentWidth: 0, contentHeight: HEIGHT }],
+		['content has no height', { viewportWidth: 900, contentWidth: 900, contentHeight: 0 }],
+		[
+			'a non-finite measurement',
+			{ viewportWidth: Number.NaN, contentWidth: 900, contentHeight: HEIGHT },
+		],
+		['a negative measurement', { viewportWidth: -50, contentWidth: 900, contentHeight: HEIGHT }],
+	] as const) {
+		it(`renders at full size with ${name} rather than dividing by zero`, () => {
+			const fit = computeOrgChartFit(input);
+
+			expect(fit.scale).toBe(1);
+			expect(fit.overflows).toBe(false);
+			// No dimensions are forced onto the sizer until a real measurement lands.
+			expect(fit.width).toBe(0);
+			expect(fit.height).toBe(0);
+		});
+	}
+
+	it('keeps the floor legible - the 11px role line stays at or above 8px', () => {
+		expect(11 * ORG_CHART_MIN_SCALE).toBeGreaterThanOrEqual(8);
+	});
+});

--- a/test/browser/org-chart-card-border-clip.spec.ts
+++ b/test/browser/org-chart-card-border-clip.spec.ts
@@ -1,8 +1,9 @@
 // Playwright (decision tree #1: real CSS layout / overflow clipping). The org
-// chart auto-fits by scaling its content and clipping the wrapper to a computed
-// height via `overflow-hidden`. If that height doesn't account for the wrapper's
-// vertical padding, the padding eats into the border box and the bottom row's
-// cards have their 1px bottom border sheared off. Asserting "not clipped" means
+// chart auto-fits by scaling its content into a sizer box of the scaled size.
+// Anything that eats into the height available to that box shears the bottom
+// row's cards of their 1px bottom border: originally a forced border-box height
+// the wrapper's vertical padding ate into, and now also a horizontal scrollbar
+// on a chart too wide to fit. Asserting "not clipped" means
 // comparing each bottom-row card's real layout box against the clip container's
 // bottom edge — only a browser engine resolves this. happy-dom reports 0 for
 // boundingBox, so this cannot be a component test.
@@ -29,7 +30,13 @@ test('bottom-row agent cards are not clipped by the org-chart viewport', async (
 
 	const viewportBox = await viewport.boundingBox();
 	if (!viewportBox) throw new Error('org-chart viewport has no layout box');
-	const viewportBottom = viewportBox.y + viewportBox.height;
+	// Measure to the bottom of the *visible* area, not the border box: on a wide
+	// roster the viewport scrolls horizontally, and a space-taking scrollbar comes
+	// out of the content box. `clientHeight` excludes it, so this catches both the
+	// original clip (padding eating into a forced height) and the newer way to
+	// shear the same border - a scrollbar laid over the bottom row.
+	const clientHeight = await viewport.evaluate((el) => el.clientHeight);
+	const viewportBottom = viewportBox.y + clientHeight;
 
 	const count = await cards.count();
 	let lowestCardBottom = Number.NEGATIVE_INFINITY;

--- a/test/browser/org-chart-fit.spec.ts
+++ b/test/browser/org-chart-fit.spec.ts
@@ -1,0 +1,137 @@
+// Playwright for two reasons off the decision tree. #1 real CSS layout: the org
+// chart is shrunk by a `transform: scale()` into a sizer box, and "no card is
+// clipped" means comparing live client rects against a scroll container's client
+// box across a scroll - happy-dom answers 0 to every one of those reads. #2
+// viewport-conditional: the whole point of the change is that the same roster
+// fits, floors and scrolls differently at phone, tablet and desktop widths.
+//
+// The regression it guards: the chart used to measure itself with `scrollWidth`
+// on a container-width content box centred by `items-center`. A row wider than
+// the column overflows symmetrically, and in LTR `scrollWidth` only ever reports
+// the right half - so the chart was measured about half its overhang too narrow,
+// scaled too little, and sheared on both sides.
+
+import type { Locator, Page } from '@playwright/test';
+import { ORG_CHART_MIN_SCALE } from '../../packages/web/src/lib/org-chart-fit';
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+const CHART = 'team-org-chart';
+
+/** Layout numbers the assertions need, read in one round trip. */
+async function readViewport(viewport: Locator) {
+	return viewport.evaluate((el) => ({
+		left: el.getBoundingClientRect().left,
+		clientWidth: el.clientWidth,
+		scrollWidth: el.scrollWidth,
+		scrollLeft: el.scrollLeft,
+	}));
+}
+
+/** The applied scale, straight off the computed transform matrix. */
+async function readScale(page: Page): Promise<number> {
+	return page.getByTestId(`${CHART}-canvas`).evaluate((el) => {
+		const content = el.firstElementChild;
+		if (!(content instanceof HTMLElement)) return 1;
+		const transform = getComputedStyle(content).transform;
+		if (!transform || transform === 'none') return 1;
+		return new DOMMatrixReadOnly(transform).a;
+	});
+}
+
+/** Outermost painted edges of every agent card. */
+async function cardEdges(cards: Locator) {
+	return cards.evaluateAll((els) => {
+		const rects = els.map((el) => el.getBoundingClientRect());
+		return {
+			minLeft: Math.min(...rects.map((r) => r.left)),
+			maxRight: Math.max(...rects.map((r) => r.right)),
+		};
+	});
+}
+
+async function scrollChartTo(viewport: Locator, position: 'start' | 'end') {
+	await viewport.evaluate((el, pos) => {
+		el.scrollLeft = pos === 'start' ? 0 : el.scrollWidth;
+	}, position);
+}
+
+async function openChart(page: Page, projectSlug: string) {
+	await page.goto(`/projects/${projectSlug}/agents`);
+	await waitForPageLoad(page);
+	const viewport = page.getByTestId(`${CHART}-viewport`);
+	await expect(viewport).toBeVisible({ timeout: 15_000 });
+	const cards = viewport.getByRole('link');
+	await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+	return { viewport, cards };
+}
+
+const BREAKPOINTS = [
+	{ name: 'mobile', width: 390, height: 844 },
+	{ name: 'tablet', width: 820, height: 1024 },
+	{ name: 'desktop', width: 1440, height: 900 },
+] as const;
+
+for (const bp of BREAKPOINTS) {
+	test(`the whole org chart is reachable at ${bp.name} (${bp.width}px)`, async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		await page.setViewportSize({ width: bp.width, height: bp.height });
+		const { viewport, cards } = await openChart(page, sharedWorkspace.projectSlug);
+
+		// The floor is the readability guarantee: past it the chart scrolls rather
+		// than shrinking into illegibility.
+		expect(await readScale(page)).toBeGreaterThanOrEqual(ORG_CHART_MIN_SCALE - 1e-6);
+
+		// The chart must never widen the page itself, at any width.
+		const pageOverflow = await page.evaluate(
+			() => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+		);
+		expect(pageOverflow).toBeLessThanOrEqual(1);
+
+		// Scrolled fully left, nothing sits off the left edge. This is the direct
+		// regression: under the old measurement the leftmost card was hundreds of
+		// pixels out, and unreachable, because the overflow was symmetric.
+		await scrollChartTo(viewport, 'start');
+		const atStart = await readViewport(viewport);
+		expect(atStart.scrollLeft).toBe(0);
+		expect((await cardEdges(cards)).minLeft).toBeGreaterThanOrEqual(atStart.left - 1);
+
+		// Scrolled fully right, nothing sits off the right edge either - so the
+		// scroll extent really does span the whole chart.
+		await scrollChartTo(viewport, 'end');
+		const atEnd = await readViewport(viewport);
+		expect((await cardEdges(cards)).maxRight).toBeLessThanOrEqual(
+			atEnd.left + atEnd.clientWidth + 1,
+		);
+
+		// No dead scroll space. Drop the sizer and the scroll extent reverts to the
+		// chart's *unscaled* width, leaving hundreds of pixels of nothing to pan
+		// through - a transform paints smaller but leaves the layout box alone.
+		const canvasWidth = await page
+			.getByTestId(`${CHART}-canvas`)
+			.evaluate((el) => el.getBoundingClientRect().width);
+		expect(atEnd.scrollWidth).toBeLessThanOrEqual(Math.max(atEnd.clientWidth, canvasWidth) + 2);
+	});
+}
+
+test('a chart that fits is centred and does not scroll', async ({ page, lightWorkspace }) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	const { viewport } = await openChart(page, lightWorkspace.projectSlug);
+
+	expect(await readScale(page)).toBe(1);
+
+	const { left, clientWidth, scrollWidth } = await readViewport(viewport);
+	expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+
+	// `mx-auto` still centres the common case. Fixing the overflow regime by
+	// left-aligning everything would pass every assertion above and look wrong on
+	// every desktop, so it is asserted separately.
+	const canvas = await page
+		.getByTestId(`${CHART}-canvas`)
+		.evaluate((el) => el.getBoundingClientRect());
+	const leftGap = canvas.left - left;
+	const rightGap = left + clientWidth - canvas.right;
+	expect(Math.abs(leftGap - rightGap)).toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
On a wide roster the team org chart spilled past both edges of its column and was clipped - the leftmost and rightmost cards sheared in half.

## The bug

The component already had fit-to-width logic, so this was a measurement error rather than a missing feature. It computed:

```ts
const contentWidth = content.scrollWidth;
const next = Math.min(1, containerWidth / contentWidth);
```

The content box was the width of its container and centred its rows with `items-center`, so a roster wider than the column overflowed **symmetrically on both sides**. In LTR, `scrollWidth` only reports overflow past the *right* padding edge - left overflow is unreachable and excluded from the scrollable overflow region. The chart was measured roughly `containerWidth + overhang/2` instead of its true width, scaled too little, and clipped at both edges.

A library was considered first. The candidate scale-to-fit packages (`react-auto-scale`, `react-scaling`, `react-scale-text`) are unmaintained or text-only, and the one that genuinely guarantees fit - React Flow plus a `dagre`/`d3-hierarchy` layout engine - is a full rewrite of the chart, its CSS connectors, its node cards and its tests for what is three lines of arithmetic. Fixed in place, no new dependency.

## The fix

**Measure the true width.** The content becomes `w-max` and is measured with `offsetWidth`/`offsetHeight` - layout values, so they read straight through the transform the hook itself wrote last pass. `getBoundingClientRect()` would return the transformed box and feed each scale into the next.

**Floor the scale, then scroll.** Fitting a 9-role roster to a 390px phone would render ~4px text. Scaling now stops at `ORG_CHART_MIN_SCALE = 0.73` (derived from the 11px role line landing at 8px) and the viewport pans horizontally past that.

**Give the scaled tree a real layout box.** A transform paints smaller but leaves the layout box alone, so the scaled chart gets an explicitly sized sizer - without it the scroll extent would be the *unscaled* width and the chart would pan through hundreds of pixels of nothing. `mx-auto` on that sizer is the whole centring story: CSS 2.1 §10.3.3 zeroes over-constrained auto margins, so it centres while the chart fits and goes flush left once it scrolls, which is what puts the left edge at `scrollLeft` 0 rather than stranding it out of reach. Origin moves to `top left` for the same reason.

**Drop the viewport's forced pixel height.** Height comes from the sizer now, so a space-taking horizontal scrollbar gets a gutter below the chart instead of eating ~15px out of the box and shearing the bottom row's border - the same border #620 was about. That spec now measures against `clientHeight`, which excludes the scrollbar, so it covers both ways of shearing it.

## Behaviour by breakpoint

| Width | Result |
|---|---|
| <768px | Floors at 0.73 and pans; opens centred on the root spine so `You (Admin)` is on screen, not off to the left |
| 768-1023px | Mid-size rosters fit, large ones scroll |
| 1024px+ | Typical rosters fit and stay centred |

The page itself never gains a horizontal scrollbar at any width.

## Tests

- `packages/web/test/org-chart-fit.test.ts` - the clamp and rounding rules, including brute-force sweeps over both rounding traps: a box rounded up to exactly the room available grows a permanent 1px scrollbar on a chart that fits, and a box short of the painted width shears the outermost border. happy-dom has no layout engine, so this tier can only reach the pure math - hence the split into `lib/org-chart-fit.ts`, following the existing `panel-placement` precedent.
- `test/browser/org-chart-fit.spec.ts` - at 390 / 820 / 1440: the floor holds, the page never scrolls sideways, nothing sits off the left edge at `scrollLeft` 0, nothing sits off the right edge when scrolled fully right, and there is no dead scroll space. Plus a separate assertion that a chart which fits is still centred, since left-aligning everything would pass all of the above and look wrong on every desktop.
- `test/browser/org-chart-card-border-clip.spec.ts` - updated for the scrollbar case.

**The new spec was verified to catch the original defect**: with the old `scrollWidth` measurement restored, the leftmost card sits at x=104 while the viewport starts at x=300 - 196px outside it and unreachable - and the spec fails on exactly that assertion.

The `mode: 'onboarding'` branch is dead code (no call site passes it) but is deliberately left alone: it is the only reference to `agents.identity.tooltipHint`, so removing it would force that key out of all twelve catalogs. That belongs in its own commit with its own `Translations-Checked:` trailer.

No user-facing strings changed, and no doc surface describes how the chart is laid out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCRiSJnmwBghZ83fZekp7X)_