### PR TITLE
feat(agents): gate a new agent's tasks on its team setup review

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -898,6 +898,22 @@ project.
   role, `reports_to`, hire, or enable/disable change on the established team — are enqueued to that
   team's own **Captain** (`enqueueTeamCoherenceReviewTask` picks the assignee by reason, falling
   back to the CEO for HQ, which has no Captain). Coalescing and the change-summary section are unchanged.
+  **A newly created agent's work is gated on the review that onboarded it.** Every path that
+  *creates* agents — the hire approval handler, both `routes/agents.ts` create/onboard paths,
+  fresh-project provisioning, and both `team-template-apply` paths — goes through
+  `enqueueSetupReviewForNewAgents` (`services/description-tasks.ts`) instead of enqueuing
+  directly: it files (or coalesces onto) the review as before, then stamps its id onto
+  `member_agents.setup_review_task_id` for the agents that just joined (`null` slugs means the
+  whole roster, the fresh-project case). `createTask` reads `pendingSetupReviewBlockerId` for the
+  assignee and, while that review is non-terminal, inserts an ordinary `task_dependencies` edge —
+  so the task lands `blocked`, `shouldDeferWakeupForBlockers` parks its assignment wakeup, and
+  closing the review unblocks and wakes through the existing `recomputeDownstreamReadiness`
+  cascade. Two stamp guards: `setup_review_task_id IS NULL` (stamped once, so a later review never
+  re-gates an established agent) and skipping the review's own assignee (no agent is ever gated on
+  a review it owns). The pointer is never cleared — it stops gating on its own once the review is
+  terminal, and remains the record of which review onboarded the agent. The *reactive* enqueue
+  sites (prompt/Custom Prompt/role/`reports_to`/enable-disable changes) create no agents and stamp
+  nothing.
 - **Coach** — reviews completed tickets across **every** project to improve agent system
   prompts; woken on any task completion.
 

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -55,6 +55,23 @@ When you hire an agent you set:
 Once approved, the agent is onboarded into the team and starts picking up work on its
 heartbeat.
 
+## New agents wait for the team setup review
+
+Adding an agent - by hiring one, or by provisioning a whole roster when a project is
+created - files a **team setup review** task automatically. That review is what fits the
+new agent to the team: it reconciles reporting lines, rewrites the descriptive blobs
+teammates read, and gives the agent the team context its every run is built on.
+
+Until that review is done, any task assigned to the new agent is created **Blocked**, with
+the setup review listed as its blocker on the task page. Nothing is lost and nobody has to
+remember to sequence it: when the review is marked done, every task waiting on it moves
+back to Backlog and its assignee is woken automatically. This applies however the task was
+filed - by you in the web app, or by the CEO, a Captain or a teammate.
+
+Agents already on the team are unaffected: they keep picking up work as normal while a new
+teammate's setup review is open. If you deliberately want a new agent to start before its
+review lands, remove the blocker from the task's page.
+
 ## Editing system prompts
 
 Every agent's system prompt is editable from its settings at any time. Changes take

--- a/packages/server/migrations/059_agent_setup_review.sql
+++ b/packages/server/migrations/059_agent_setup_review.sql
@@ -1,0 +1,12 @@
+-- Gate a newly created agent's work on the team setup / coherence review that is
+-- auto-created when the agent joins. The pointer is stamped once at agent
+-- creation and read by createTask to attach a blocker edge while that review is
+-- still open; it stops gating on its own once the review reaches a terminal
+-- status, so nothing has to clear it.
+--
+-- Nullable with no backfill: every pre-existing agent is already established and
+-- has been through (or predates) its review, so NULL is the correct value.
+-- No index -- the only read is by member_agents.id (PK) joined to tasks.id (PK).
+
+ALTER TABLE member_agents
+    ADD COLUMN setup_review_task_id UUID REFERENCES tasks(id) ON DELETE SET NULL;

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -64,7 +64,10 @@ import {
 	type SystemPromptMode,
 } from '../services/agent-system-prompts';
 import { getChatMemory, upsertChatMemory } from '../services/chat-memory';
-import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
+import {
+	enqueueSetupReviewForNewAgents,
+	enqueueTeamCoherenceReviewTask,
+} from '../services/description-tasks';
 import {
 	getDocument,
 	initAgentSystemPrompt,
@@ -427,11 +430,14 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 		result.rows[0] as Record<string, unknown>,
 	);
 
-	trackBackground(
-		enqueueTeamCoherenceReviewTask(db, teamId, 'agent_hired').catch((e) =>
-			log.error('Failed to enqueue team coherence review after agent create:', e),
-		),
-	);
+	// Awaited, not backgrounded: the review's id is stamped onto the new agent as
+	// its setup gate, and the very next create_task for them must see it. A
+	// failure here still must not fail the agent creation.
+	try {
+		await enqueueSetupReviewForNewAgents(db, teamId, 'agent_hired', [slug]);
+	} catch (e) {
+		log.error('Failed to enqueue team coherence review after agent create:', e);
+	}
 
 	const createActor = await resolveActor(db, c.get('auth'), teamId);
 	c.get('events').emit({
@@ -532,11 +538,13 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 		const agentRow = agentResult.rows[0] as Record<string, unknown>;
 
 		broadcastChange(c, wsRoom.team(teamId), 'member_agents', 'INSERT', agentRow);
-		trackBackground(
-			enqueueTeamCoherenceReviewTask(db, teamId, 'agent_hired').catch((e) =>
-				log.error('Failed to enqueue team coherence review after onboard:', e),
-			),
-		);
+		// Awaited so the review's id lands on the new agent as its setup gate
+		// before any task can be filed for them; a failure must not fail onboard.
+		try {
+			await enqueueSetupReviewForNewAgents(db, teamId, 'agent_hired', [slug]);
+		} catch (e) {
+			log.error('Failed to enqueue team coherence review after onboard:', e);
+		}
 
 		return ok(c, { agent: agentRow, task: null, approval: null, bootstrap: true }, 201);
 	}

--- a/packages/server/src/services/approval-handlers/hire.ts
+++ b/packages/server/src/services/approval-handlers/hire.ts
@@ -7,11 +7,10 @@ import {
 	MemberType,
 } from '@hezo/shared';
 import { buildAgentAvatarSpec, checkHumanNameAvailable } from '../../lib/agent-identity';
-import { trackBackground } from '../../lib/background';
 import { resolveAgentId } from '../../lib/resolve';
 import { toSlug } from '../../lib/slug';
 import { logger } from '../../logger';
-import { enqueueTeamCoherenceReviewTask } from '../description-tasks';
+import { enqueueSetupReviewForNewAgents } from '../description-tasks';
 import { upsertDocument } from '../documents';
 import { resolveHireProposalCommentAndWake } from '../hire-proposal-comment';
 import type { ApprovalHandler, ApprovalSideEffectCtx, SideEffectBroadcast } from './types';
@@ -126,11 +125,14 @@ export const hireHandler: ApprovalHandler = {
 			broadcasts.push({ table: 'member_agents', op: 'INSERT', row: newAgent.rows[0] });
 		}
 
-		trackBackground(
-			enqueueTeamCoherenceReviewTask(db, teamId, 'agent_hired').catch((e) =>
-				log.error('Failed to enqueue team coherence review after hire:', e),
-			),
-		);
+		// Awaited, not backgrounded: the review's id is stamped onto the new agent
+		// as its setup gate, and the very next create_task for them must see it.
+		// A failure here still must not fail the hire.
+		try {
+			await enqueueSetupReviewForNewAgents(db, teamId, 'agent_hired', [slug]);
+		} catch (e) {
+			log.error('Failed to enqueue team coherence review after hire:', e);
+		}
 
 		// Flip the proposal comment on the originating ticket to "hired" and re-wake
 		// the requester (the CEO) so it can review the new hire and resume setup. The

--- a/packages/server/src/services/description-tasks.ts
+++ b/packages/server/src/services/description-tasks.ts
@@ -208,6 +208,86 @@ ${intro} — including whether every role's output gets verified by someone othe
 8. Move this task to **done** once the audit and rewrites are complete.${changesSection}`;
 }
 
+/**
+ * Stamp `setup_review_task_id` on agents that just joined `teamId`, so any task
+ * later created for them is auto-gated on `reviewTaskId` until that review is
+ * terminal. `slugs` of `null` means "every agent on this team is new" — the
+ * fresh-project path, where the whole roster was provisioned moments ago.
+ *
+ * Two guards, both load-bearing:
+ * - `setup_review_task_id IS NULL` — an agent is stamped once, so a later review
+ *   never re-gates an agent that has already been through setup (and a no-op
+ *   UPDATE never leaves a dead tuple behind).
+ * - the review's own assignee is skipped — an agent can never be gated on a
+ *   review it owns, which rules out the self-block class outright.
+ */
+async function stampAgentsAwaitingSetupReview(
+	db: Db,
+	teamId: string,
+	reviewTaskId: string,
+	slugs: readonly string[] | null,
+): Promise<void> {
+	if (slugs && slugs.length === 0) return;
+	const slugFilter = slugs ? 'AND ma.slug = ANY($3::text[])' : '';
+	await db.query(
+		`UPDATE member_agents ma
+		    SET setup_review_task_id = $1
+		   FROM members m
+		  WHERE m.id = ma.id
+		    AND m.team_id = $2
+		    AND ma.setup_review_task_id IS NULL
+		    AND ma.id IS DISTINCT FROM (SELECT assignee_id FROM tasks WHERE id = $1)
+		    ${slugFilter}`,
+		slugs ? [reviewTaskId, teamId, slugs] : [reviewTaskId, teamId],
+	);
+}
+
+/**
+ * Enqueue (or coalesce onto) the team's setup/coherence review and record it as
+ * the setup gate for the agents that just joined. Use this from every path that
+ * *creates* agents; reactive reviews on an established roster call
+ * {@link enqueueTeamCoherenceReviewTask} directly.
+ *
+ * Returns the review task id, or null when no review was filed (a team with no
+ * coordination context, or the E2E skip) — in which case nothing is stamped and
+ * no task is ever gated.
+ */
+export async function enqueueSetupReviewForNewAgents(
+	db: Db,
+	teamId: string,
+	reason: TeamCoherenceReviewReason,
+	newAgentSlugs: readonly string[] | null,
+	opts: { autoStart?: boolean; changeSummary?: string } = {},
+): Promise<string | null> {
+	const reviewTaskId = await enqueueTeamCoherenceReviewTask(db, teamId, reason, opts);
+	if (reviewTaskId) {
+		await stampAgentsAwaitingSetupReview(db, teamId, reviewTaskId, newAgentSlugs);
+	}
+	return reviewTaskId;
+}
+
+/**
+ * The setup review gating `memberAgentId`, or null when it has none or the
+ * review is already terminal (done/cancelled). A stamped pointer stops gating on
+ * its own once the review closes, so it is never cleared — it stays as the record
+ * of which review onboarded the agent.
+ */
+export async function pendingSetupReviewBlockerId(
+	db: Db,
+	memberAgentId: string,
+): Promise<string | null> {
+	const placeholders = TERMINAL_TASK_STATUSES.map((_, i) => `$${i + 2}::task_status`).join(', ');
+	const r = await db.query<{ id: string }>(
+		`SELECT t.id
+		   FROM member_agents ma
+		   JOIN tasks t ON t.id = ma.setup_review_task_id
+		  WHERE ma.id = $1
+		    AND t.status NOT IN (${placeholders})`,
+		[memberAgentId, ...TERMINAL_TASK_STATUSES],
+	);
+	return r.rows[0]?.id ?? null;
+}
+
 export async function enqueueTeamCoherenceReviewTask(
 	db: Db,
 	teamId: string,

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -17,7 +17,7 @@ import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 import { logger } from '../logger';
 import { type ContainerDeps, type ProjectRow, provisionContainer } from './containers';
-import { enqueueTeamCoherenceReviewTask } from './description-tasks';
+import { enqueueSetupReviewForNewAgents } from './description-tasks';
 import { getMarketplaceTeam } from './marketplace';
 import { snapshotTeamAsTemplate } from './team-template-snapshot';
 import { type CreatedTeamRow, createTeam } from './teams';
@@ -560,7 +560,12 @@ export async function createProjectWithTeam(
 	// blocks planning, so it's created before the planning task to take TO-1. On
 	// the CEO's create_project path it is created unassigned and not auto-woken —
 	// the CEO drafts it then kicks it off with `start_team_setup`.
-	const coherenceTaskId = await enqueueTeamCoherenceReviewTask(db, team.id, 'initial', {
+	// The whole roster was provisioned moments ago inside `createTeam`, so every
+	// agent on this team is new: each is stamped with this task as its setup
+	// gate, and any task filed for one waits until the setup pass closes. The
+	// pass itself is owned by the CEO (an HQ member), so no roster agent can end
+	// up gated on its own review.
+	const coherenceTaskId = await enqueueSetupReviewForNewAgents(db, team.id, 'initial', null, {
 		autoStart: !input.suppressCoherenceAutoStart,
 	});
 

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -10,6 +10,7 @@ import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 import { assertChildDepthAllowed } from '../lib/task-relationships';
 import { logger } from '../logger';
+import { pendingSetupReviewBlockerId } from './description-tasks';
 import { recordTaskLinks } from './task-events';
 import { createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
@@ -133,6 +134,13 @@ export async function createTask(
 		goalId = g.rows[0].id;
 	}
 
+	// An agent that has not yet been through its team setup review gets every
+	// task filed for it gated on that review, so it never runs on an
+	// unreconciled prompt with no team context. Resolved before the transaction
+	// — one PK-keyed lookup — and attached as an ordinary dependency edge, so the
+	// existing cascade unblocks and wakes the assignee when the review closes.
+	const setupBlockerId = await pendingSetupReviewBlockerId(db, assigneeId);
+
 	// Identifier allocation, the insert, and blocker attachment must land
 	// atomically — a rejected blocker reference would otherwise leave an
 	// orphan task row behind.
@@ -169,6 +177,18 @@ export async function createTask(
 
 		if (input.blocked_by_task_ids?.length) {
 			await attachBlockers(db, teamId, created.id, input.blocked_by_task_ids);
+		}
+		// No cycle check for the setup edge: the task was just inserted and has no
+		// dependents yet, so it cannot close a loop. A later `add_task_blocker`
+		// pointing the review back at this task is still caught by wouldCreateCycle.
+		if (setupBlockerId) {
+			await db.query(
+				`INSERT INTO task_dependencies (task_id, blocked_by_task_id)
+				 VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+				[created.id, setupBlockerId],
+			);
+		}
+		if (input.blocked_by_task_ids?.length || setupBlockerId) {
 			if (await hasOpenBlockers(db, created.id)) {
 				const updated = await db.query<typeof created>(
 					'UPDATE tasks SET status = $1::task_status WHERE id = $2 RETURNING *',

--- a/packages/server/src/services/team-template-apply.ts
+++ b/packages/server/src/services/team-template-apply.ts
@@ -12,7 +12,7 @@ import type { Db } from '../db/database';
 import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { resolveAgentBudgets } from './agent-budget';
-import { enqueueTeamCoherenceReviewTask } from './description-tasks';
+import { enqueueSetupReviewForNewAgents } from './description-tasks';
 import { initAgentSystemPrompt, upsertDocument } from './documents';
 import {
 	insertRosterAgents,
@@ -182,7 +182,14 @@ export async function applyTemplateToTeam(
 
 	if (rosterChanged) {
 		try {
-			await enqueueTeamCoherenceReviewTask(db, teamId, 'template_applied');
+			// Only the agents this apply *created* are new; an upgraded builtin has
+			// already been through setup and must not be re-gated.
+			await enqueueSetupReviewForNewAgents(
+				db,
+				teamId,
+				'template_applied',
+				provisionResult.created_slugs,
+			);
 		} catch (e) {
 			log.error('Failed to enqueue team coherence review after template apply:', e);
 		}
@@ -583,7 +590,8 @@ export async function applyMarketplaceTeamToTeam(
 	const rosterChanged = created.length > 0 || updated.length > 0 || captainResult.updated;
 	if (options.enqueueReconcile && rosterChanged) {
 		try {
-			await enqueueTeamCoherenceReviewTask(db, teamId, 'template_applied');
+			// `created` only — an updated existing role is not a new agent.
+			await enqueueSetupReviewForNewAgents(db, teamId, 'template_applied', created);
 		} catch (e) {
 			log.error('Failed to enqueue team coherence review after marketplace apply:', e);
 		}

--- a/packages/server/test/agent-setup-review-gate.test.ts
+++ b/packages/server/test/agent-setup-review-gate.test.ts
@@ -1,0 +1,237 @@
+import { CAPTAIN_AGENT_SLUG, TaskStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { compliantPrompt } from './helpers/prompt';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let teamId: string;
+let projectSlug: string;
+
+/** The team's open setup / coherence review, or null when none is filed. */
+async function openCoherenceTask(
+	team: string,
+): Promise<{ id: string; identifier: string; assignee_id: string | null } | null> {
+	const r = await db.query<{ id: string; identifier: string; assignee_id: string | null }>(
+		`SELECT id, identifier, assignee_id FROM tasks
+		  WHERE team_id = $1 AND labels @> '["team-coherence-review"]'::jsonb
+		    AND status NOT IN ('done'::task_status, 'cancelled'::task_status)
+		  ORDER BY created_at DESC LIMIT 1`,
+		[team],
+	);
+	return r.rows[0] ?? null;
+}
+
+async function setupReviewPointer(agentId: string): Promise<string | null> {
+	const r = await db.query<{ setup_review_task_id: string | null }>(
+		'SELECT setup_review_task_id FROM member_agents WHERE id = $1',
+		[agentId],
+	);
+	return r.rows[0]?.setup_review_task_id ?? null;
+}
+
+async function agentIdBySlug(team: string, slug: string): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		  WHERE m.team_id = $1 AND ma.slug = $2`,
+		[team, slug],
+	);
+	return r.rows[0].id;
+}
+
+/** Create an agent through the admin's Add-agent route and return its member id. */
+async function addAgent(project: string, title: string): Promise<string> {
+	const res = await app.request(`/api/projects/${project}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title, system_prompt: compliantPrompt(`You are the ${title}.`) }),
+	});
+	expect(res.status).toBe(201);
+	return (await res.json()).data.id;
+}
+
+async function createTask(
+	project: string,
+	title: string,
+	assigneeId: string,
+): Promise<Record<string, unknown>> {
+	const res = await app.request(`/api/projects/${project}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title, assignee_id: assigneeId }),
+	});
+	expect(res.status).toBe(201);
+	return (await res.json()).data;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	teamId = (await (await createTestTeam(db, { name: 'Gate Co' })).json()).data.id;
+	projectSlug = (await (await createTestProject(db, teamId, { name: 'Gate' })).json()).data.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('a new agent’s tasks are gated on its team setup review', () => {
+	let reviewTaskId: string;
+	let newAgentId: string;
+
+	it('stamps the auto-created setup review onto the newly added agent', async () => {
+		newAgentId = await addAgent(projectSlug, 'Data Scientist');
+
+		const review = await openCoherenceTask(teamId);
+		expect(review).not.toBeNull();
+		reviewTaskId = (review as { id: string }).id;
+
+		expect(await setupReviewPointer(newAgentId)).toBe(reviewTaskId);
+	});
+
+	it('never stamps the review’s own assignee, so no agent is gated on its own review', async () => {
+		const review = await openCoherenceTask(teamId);
+		const assigneeId = (review as { assignee_id: string | null }).assignee_id;
+		expect(assigneeId).not.toBeNull();
+		expect(await setupReviewPointer(assigneeId as string)).toBeNull();
+	});
+
+	it('blocks a task created for the new agent on that review', async () => {
+		const task = await createTask(projectSlug, 'Draft the model spec', newAgentId);
+		expect(task.status).toBe(TaskStatus.Blocked);
+
+		const deps = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}/dependencies`, {
+			headers: authHeader(token),
+		});
+		expect(deps.status).toBe(200);
+		const blockers = (await deps.json()).data as Array<{ blocked_by_task_id: string }>;
+		expect(blockers.map((b) => b.blocked_by_task_id)).toContain(reviewTaskId);
+	});
+
+	it('leaves a task for an established agent unblocked', async () => {
+		const captainId = await agentIdBySlug(teamId, CAPTAIN_AGENT_SLUG);
+		// The Captain predates the review and was never stamped.
+		expect(await setupReviewPointer(captainId)).toBeNull();
+
+		const task = await createTask(projectSlug, 'Routine planning check', captainId);
+		expect(task.status).toBe(TaskStatus.Backlog);
+	});
+
+	it('coalesces a second hire onto the same open review and stamps it too', async () => {
+		const secondAgentId = await addAgent(projectSlug, 'Research Analyst');
+		expect(await setupReviewPointer(secondAgentId)).toBe(reviewTaskId);
+
+		const task = await createTask(projectSlug, 'Survey the field', secondAgentId);
+		expect(task.status).toBe(TaskStatus.Blocked);
+	});
+
+	it('unblocks the gated tasks and wakes their assignees when the review closes', async () => {
+		const gated = await db.query<{ id: string; assignee_id: string }>(
+			`SELECT i.id, i.assignee_id FROM tasks i
+			   JOIN task_dependencies d ON d.task_id = i.id
+			  WHERE d.blocked_by_task_id = $1`,
+			[reviewTaskId],
+		);
+		expect(gated.rows.length).toBeGreaterThan(0);
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${reviewTaskId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: TaskStatus.Done }),
+		});
+		expect(res.status).toBe(200);
+
+		for (const row of gated.rows) {
+			const after = await db.query<{ status: string }>('SELECT status FROM tasks WHERE id = $1', [
+				row.id,
+			]);
+			expect(after.rows[0].status).toBe(TaskStatus.Backlog);
+
+			const wake = await db.query(
+				`SELECT id FROM agent_wakeup_requests
+				  WHERE member_id = $1 AND payload->>'task_id' = $2 AND status = 'queued'`,
+				[row.assignee_id, row.id],
+			);
+			expect(wake.rows.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('stops gating once the review is terminal, without clearing the pointer', async () => {
+		// The pointer stays as the record of which review onboarded the agent...
+		expect(await setupReviewPointer(newAgentId)).toBe(reviewTaskId);
+		// ...but a task filed now is no longer blocked.
+		const task = await createTask(projectSlug, 'Post-setup work', newAgentId);
+		expect(task.status).toBe(TaskStatus.Backlog);
+	});
+
+	it('does not re-gate an already-stamped agent when a later review opens', async () => {
+		// Adding another agent files a fresh review; the earlier agent keeps its
+		// original (now closed) pointer and is not dragged back into blocked.
+		const thirdAgentId = await addAgent(projectSlug, 'Ops Specialist');
+		const later = await openCoherenceTask(teamId);
+		expect((later as { id: string }).id).not.toBe(reviewTaskId);
+
+		expect(await setupReviewPointer(newAgentId)).toBe(reviewTaskId);
+		const task = await createTask(projectSlug, 'Still unblocked', newAgentId);
+		expect(task.status).toBe(TaskStatus.Backlog);
+
+		// The genuinely new agent is gated on the new review.
+		expect(await setupReviewPointer(thirdAgentId)).toBe((later as { id: string }).id);
+		const gated = await createTask(projectSlug, 'Ops onboarding work', thirdAgentId);
+		expect(gated.status).toBe(TaskStatus.Blocked);
+	});
+});
+
+describe('a freshly provisioned roster is gated on the initial team setup task', () => {
+	let freshProjectSlug: string;
+	let freshTeamId: string;
+
+	beforeAll(async () => {
+		const res = await app.request('/api/projects', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Fresh Roster Co',
+				description: 'A brand new project-team.',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+		freshProjectSlug = project.slug;
+		freshTeamId = project.team_id;
+	});
+
+	it('stamps every roster agent except the setup task’s own assignee', async () => {
+		const setup = await openCoherenceTask(freshTeamId);
+		expect(setup).not.toBeNull();
+		const setupId = (setup as { id: string }).id;
+
+		const roster = await db.query<{ id: string; setup_review_task_id: string | null }>(
+			`SELECT ma.id, ma.setup_review_task_id FROM member_agents ma
+			   JOIN members m ON m.id = ma.id WHERE m.team_id = $1`,
+			[freshTeamId],
+		);
+		expect(roster.rows.length).toBeGreaterThan(0);
+		for (const agent of roster.rows) {
+			expect(agent.setup_review_task_id).toBe(setupId);
+		}
+
+		// The setup pass is owned by the CEO, who lives in HQ - never on this roster.
+		const assigneeId = (setup as { assignee_id: string | null }).assignee_id;
+		expect(roster.rows.map((a) => a.id)).not.toContain(assigneeId);
+	});
+
+	it('blocks a task filed for a roster agent on the setup task', async () => {
+		const captainId = await agentIdBySlug(freshTeamId, CAPTAIN_AGENT_SLUG);
+		const task = await createTask(freshProjectSlug, 'Early work', captainId);
+		expect(task.status).toBe(TaskStatus.Blocked);
+	});
+});

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -16,6 +16,7 @@ import {
 	createTestProject,
 	createTestTeam,
 	mintAgentToken,
+	settleTeamSetupReview,
 } from './helpers/app';
 
 let app: Hono<Env>;
@@ -74,6 +75,10 @@ beforeAll(async () => {
 		}),
 	});
 	taskId = (await taskRes.json()).data.id;
+
+	// This fixture's subject is task behaviour, not agent onboarding: settle the
+	// setup review the new agents filed so their tasks start unblocked.
+	await settleTeamSetupReview(db, teamId);
 });
 
 afterAll(async () => {
@@ -434,6 +439,9 @@ describe('task status auto-transition on run start', () => {
 			body: JSON.stringify({ title: 'Other Runner' }),
 		});
 		const otherAgentId = (await otherRes.json()).data.id as string;
+		// Adding an agent files a fresh setup review; settle it so this task is
+		// about run/assignee status, not the onboarding gate.
+		await settleTeamSetupReview(db, teamId);
 		const localTaskId = await createTask({ assigneeId: otherAgentId });
 		const task = buildTask(localTaskId, { assignee_id: otherAgentId });
 

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -21,6 +21,7 @@ import { loadAgentRoles } from '../../src/db/agent-roles';
 import type { Db } from '../../src/db/database';
 import { seedBuiltins } from '../../src/db/seed';
 import { DomainEventBus } from '../../src/events/bus';
+import { recomputeDownstreamReadiness } from '../../src/lib/dependencies';
 import { getHostMemory } from '../../src/lib/host-memory';
 import type { SandboxBackendInfo } from '../../src/lib/sandbox-backend-info';
 import { toSlug, uniqueSlug } from '../../src/lib/slug';
@@ -588,6 +589,32 @@ export async function seedProjectContainer(
 export async function projectSlugForTeamSlug(db: Db, teamSlug: string): Promise<string> {
 	const t = await db.query<{ id: string }>('SELECT id FROM teams WHERE slug = $1', [teamSlug]);
 	return projectSlugFor(db, t.rows[0].id);
+}
+
+/**
+ * Settle any open team setup / coherence review for `teamId`, so the team's agents
+ * count as established and tasks filed for them are no longer auto-gated on it.
+ *
+ * Adding an agent (or provisioning a roster) stamps that review onto the new agents
+ * as their setup gate, which is exactly what `agent-setup-review-gate.test.ts`
+ * covers. A fixture whose subject is something else — task CRUD, comments, runs —
+ * calls this after building its roster so its tasks start in `backlog`, the state
+ * those tests are actually about.
+ *
+ * Marks the review done through the real cascade, so it is correct whether it runs
+ * before or after the gated tasks exist.
+ */
+export async function settleTeamSetupReview(db: Db, teamId: string): Promise<void> {
+	const open = await db.query<{ id: string }>(
+		`SELECT id FROM tasks
+		  WHERE team_id = $1 AND labels @> '["team-coherence-review"]'::jsonb
+		    AND status NOT IN ('done'::task_status, 'cancelled'::task_status)`,
+		[teamId],
+	);
+	for (const row of open.rows) {
+		await db.query("UPDATE tasks SET status = 'done'::task_status WHERE id = $1", [row.id]);
+		await recomputeDownstreamReadiness(db, teamId, row.id, null, undefined);
+	}
 }
 
 /** The single instance-level Coach member id (lives in HQ). */

--- a/packages/server/test/migrate-059-agent-setup-review.test.ts
+++ b/packages/server/test/migrate-059-agent-setup-review.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '059_agent_setup_review.sql';
+
+describe('059_agent_setup_review migration', () => {
+	let h: DataPreservationHarness;
+	let seededTeamId: string;
+	let seededProjectId: string;
+	let seededAgentId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// Seed a representative established agent (plus the project it works in) at
+		// the prior schema, so the ALTER has real rows to preserve.
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		seededTeamId = team.rows[0].id;
+
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, description)
+			 VALUES ($1, 'Acme Web', 'acme-web', 'AW', 'The web project')
+			 RETURNING id`,
+			[seededTeamId],
+		);
+		seededProjectId = project.rows[0].id;
+		await h.db.query('INSERT INTO project_task_counters (project_id, next_number) VALUES ($1, 1)', [
+			seededProjectId,
+		]);
+
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent'::member_type, 'Engineer') RETURNING id`,
+			[seededTeamId],
+		);
+		seededAgentId = member.rows[0].id;
+		await h.db.query(
+			`INSERT INTO member_agents (id, title, slug, role_description, summary, monthly_budget_cents)
+			 VALUES ($1, 'Engineer', 'engineer', 'Builds things', 'An engineer.', 4200)`,
+			[seededAgentId],
+		);
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('preserves the pre-existing agent row', async () => {
+		const r = await h.db.query<{
+			title: string;
+			slug: string;
+			role_description: string;
+			summary: string;
+			monthly_budget_cents: number;
+		}>(
+			`SELECT title, slug, role_description, summary, monthly_budget_cents
+			   FROM member_agents WHERE id = $1`,
+			[seededAgentId],
+		);
+		expect(r.rows).toHaveLength(1);
+		expect(r.rows[0].title).toBe('Engineer');
+		expect(r.rows[0].slug).toBe('engineer');
+		expect(r.rows[0].role_description).toBe('Builds things');
+		expect(r.rows[0].summary).toBe('An engineer.');
+		expect(Number(r.rows[0].monthly_budget_cents)).toBe(4200);
+	});
+
+	it('adds setup_review_task_id, null for every pre-existing agent', async () => {
+		const r = await h.db.query<{ setup_review_task_id: string | null }>(
+			'SELECT setup_review_task_id FROM member_agents WHERE id = $1',
+			[seededAgentId],
+		);
+		expect(r.rows).toHaveLength(1);
+		expect(r.rows[0].setup_review_task_id).toBeNull();
+	});
+
+	it('points at a task and nulls back out when that task is deleted', async () => {
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, status, priority)
+			 VALUES ($1, $2, 1, 'AW-1', 'Set up the team',
+			         'backlog'::task_status, 'high'::task_priority)
+			 RETURNING id`,
+			[seededTeamId, seededProjectId],
+		);
+		const taskId = task.rows[0].id;
+
+		await h.db.query('UPDATE member_agents SET setup_review_task_id = $1 WHERE id = $2', [
+			taskId,
+			seededAgentId,
+		]);
+		const stamped = await h.db.query<{ setup_review_task_id: string | null }>(
+			'SELECT setup_review_task_id FROM member_agents WHERE id = $1',
+			[seededAgentId],
+		);
+		expect(stamped.rows[0].setup_review_task_id).toBe(taskId);
+
+		// ON DELETE SET NULL: losing the review must never cascade the agent away.
+		await h.db.query('DELETE FROM tasks WHERE id = $1', [taskId]);
+		const cleared = await h.db.query<{ setup_review_task_id: string | null }>(
+			'SELECT setup_review_task_id FROM member_agents WHERE id = $1',
+			[seededAgentId],
+		);
+		expect(cleared.rows).toHaveLength(1);
+		expect(cleared.rows[0].setup_review_task_id).toBeNull();
+	});
+});

--- a/packages/server/test/queued-wakeups-covfill.test.ts
+++ b/packages/server/test/queued-wakeups-covfill.test.ts
@@ -10,6 +10,7 @@ import {
 	createTestProject,
 	createTestTeam,
 	projectSlugFor,
+	settleTeamSetupReview,
 } from './helpers/app';
 import {
 	clearContainerCapacityForTest,
@@ -175,6 +176,9 @@ beforeAll(async () => {
 
 	agentA = await createAgent('Covfill Alpha');
 	agentB = await createAgent('Covfill Beta');
+	// This fixture's subject is wakeup listing, not agent onboarding: settle the
+	// setup review the new agents filed so their task starts unblocked.
+	await settleTeamSetupReview(db, teamId);
 	taskId = await createTask('Covfill Task');
 	// Let the fire-and-forget assignment wakeup land before tests clear it.
 	await new Promise((r) => setTimeout(r, 50));

--- a/packages/server/test/task-events.test.ts
+++ b/packages/server/test/task-events.test.ts
@@ -13,6 +13,7 @@ import {
 	createTestTeam,
 	mintAgentToken,
 	projectSlugFor,
+	settleTeamSetupReview,
 } from './helpers/app';
 
 let app: Hono<Env>;
@@ -114,6 +115,10 @@ beforeAll(async () => {
 		body: JSON.stringify({ title: 'Status Bot' }),
 	});
 	agentId = (await agentRes.json()).data.id;
+
+	// This fixture's subject is task behaviour, not agent onboarding: settle the
+	// setup review the new agents filed so their tasks start unblocked.
+	await settleTeamSetupReview(db, teamId);
 });
 
 afterAll(async () => {

--- a/packages/server/test/tasks-coverage.test.ts
+++ b/packages/server/test/tasks-coverage.test.ts
@@ -11,6 +11,7 @@ import {
 	createTestProject,
 	createTestTeam,
 	mintAgentToken,
+	settleTeamSetupReview,
 } from './helpers/app';
 
 // Branch-coverage tests for packages/server/src/routes/tasks.ts.
@@ -79,6 +80,11 @@ beforeAll(async () => {
 		body: JSON.stringify({ title: 'Other team task', assignee_id: otherAgentId }),
 	});
 	otherTaskId = (await otherTaskRes.json()).data.id;
+
+	// This fixture's subject is task behaviour, not agent onboarding: settle the
+	// setup review the new agents filed so their tasks start unblocked.
+	await settleTeamSetupReview(db, teamId);
+	await settleTeamSetupReview(db, otherTeamId);
 });
 
 afterAll(async () => {

--- a/packages/server/test/tasks-routes-uncovered.test.ts
+++ b/packages/server/test/tasks-routes-uncovered.test.ts
@@ -12,6 +12,7 @@ import {
 	createTestTeam,
 	finalizeAgentRun,
 	mintAgentToken,
+	settleTeamSetupReview,
 } from './helpers/app';
 
 // Line-coverage tests for packages/server/src/routes/tasks.ts driven over real
@@ -67,6 +68,10 @@ beforeAll(async () => {
 		'SELECT id FROM users WHERE is_superuser = true ORDER BY created_at LIMIT 1',
 	);
 	adminUserId = admin.rows[0].id;
+
+	// This fixture's subject is task behaviour, not agent onboarding: settle the
+	// setup review the new agents filed so their tasks start unblocked.
+	await settleTeamSetupReview(db, teamId);
 });
 
 afterAll(async () => {

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -10,6 +10,7 @@ import {
 	createTestProject,
 	createTestTeam,
 	mintAgentToken,
+	settleTeamSetupReview,
 } from './helpers/app';
 
 let app: Hono<Env>;
@@ -48,6 +49,10 @@ beforeAll(async () => {
 		body: JSON.stringify({ title: 'Test Agent' }),
 	});
 	agentId = (await agentRes.json()).data.id;
+
+	// This fixture's subject is task behaviour, not agent onboarding: settle the
+	// setup review the new agents filed so their tasks start unblocked.
+	await settleTeamSetupReview(db, teamId);
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## What

A task created and assigned to an agent that has not yet been through its **team setup review** is now automatically `blocked_by` that review, and is auto-unblocked and woken when the review closes.

## Why

Adding an agent - a hire, the admin's Add-agent form, or roster provisioning for a new project-team - already files a team setup / coherence review. That review is what fits the new agent to the team: it reconciles reporting lines, rewrites the descriptive blobs teammates read, and writes the `team_context` injected into every one of the agent's runs.

Nothing stopped work being filed to that agent first. A task assigned to a brand-new agent landed in `backlog` and immediately woke them, so they ran with an unreconciled prompt and no team context. The only edge that existed was the Captain's planning task, wired by hand in `project-create.ts`; nothing generalized it to the roster.

## How

One nullable pointer on the agent, stamped at agent creation, read once in the single task-creation seam.

- **Migration `059_agent_setup_review.sql`** - adds `member_agents.setup_review_task_id UUID REFERENCES tasks(id) ON DELETE SET NULL`. Nullable with no backfill: every pre-existing agent is already established, so `NULL` is correct. No index - the only read is by `member_agents.id` (PK) joined to `tasks.id` (PK).

- **`services/description-tasks.ts`** - `enqueueSetupReviewForNewAgents` files (or coalesces onto) the review exactly as before, then stamps its id onto the agents that just joined (`null` slugs means the whole roster, the fresh-project case). `pendingSetupReviewBlockerId` reads the pointer back, returning it only while the review is non-terminal.

- **`services/tasks.ts`** - `createTask` resolves that blocker before its transaction and, when present, inserts an ordinary `task_dependencies` edge. Everything downstream already existed: `hasOpenBlockers` flips the task to `blocked`, `shouldDeferWakeupForBlockers` parks its assignment wakeup, and marking the review terminal reconciles and wakes through `recomputeDownstreamReadiness`. `createTask` is the single seam behind REST, MCP (`create_task` / `create_tasks`) and the CEO chat's conversation-to-task path, so one change covers every caller.

- **Six stamping sites** - the hire approval handler, both `routes/agents.ts` create/onboard paths, fresh-project provisioning, and both `team-template-apply` paths. The three hire sites move from `trackBackground` to an awaited call in `try`/`catch`: the stamp is state the very next `create_task` must see, and a coherence failure still must not fail the hire. The *reactive* enqueue sites (prompt, Custom Prompt, role, `reports_to`, enable/disable) create no agents and are untouched.

Two stamp guards, both load-bearing:

- `setup_review_task_id IS NULL` - an agent is stamped once, so a later review never re-gates an established agent (and a no-op `UPDATE` never leaves a dead tuple behind).
- the review's own assignee is skipped - no agent can be gated on a review it owns, which rules out the self-block class outright.

The pointer is never cleared: it stops gating on its own once the review is terminal, and remains the record of which review onboarded the agent. An admin who deliberately wants a new agent to start early removes the blocker from the task page.

No new reporting surface - the returned `status: "blocked"` and the blocker already shown by `get_task` and the task detail page carry it, so the generated MCP reference is untouched.

## Tests

- `migrate-059-agent-setup-review.test.ts` - data preservation: a pre-existing agent survives with its fields intact, the new column exists and is `NULL`, and the `ON DELETE SET NULL` contract holds.
- `agent-setup-review-gate.test.ts` - 10 integration tests: stamping on add; the review's assignee is never stamped; a task for the new agent lands `blocked` with the review listed as its blocker; a task for an established agent stays `backlog`; a second hire coalesces onto the same review and is stamped too; closing the review unblocks every gated task and queues a wakeup for each assignee; gating stops once the review is terminal without clearing the pointer; an already-stamped agent is not re-gated by a later review; and a freshly provisioned roster is gated on its "Set up the team" task.

Fixtures whose subject is task behaviour rather than onboarding (`tasks`, `tasks-coverage`, `tasks-routes-uncovered`, `task-events`, `heartbeat-runs`, `queued-wakeups-covfill`) settle their setup review via a new `settleTeamSetupReview` test helper, which marks it done through the real cascade.

Full local run (`bun run test --skip-browser`): server, Bun-native, web and shared tiers all green apart from 3 pre-existing Docker-daemon-dependent server files (`sandbox-open`, `sandbox-backend-store`, `startup-real-docker-branch`, 5 tests), which fail identically on a clean tree in this environment. The web-component and Playwright tiers set `HEZO_E2E_SKIP_COHERENCE_REVIEW=1`, so no review is filed there and nothing is stamped or gated.

## Docs

- `.dev/architecture.md` - the mechanism, the two stamp guards, and which enqueue sites stamp.
- `docs/concepts/hiring-and-agents.md` - a new "New agents wait for the team setup review" section covering what an operator sees and how to override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFnTnV6JCFe1v6bgQdwmZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFnTnV6JCFe1v6bgQdwmZ6)_