### PR TITLE
Make the whole assignee option the identity-card trigger

### DIFF
--- a/packages/web/src/components/agent-ref.tsx
+++ b/packages/web/src/components/agent-ref.tsx
@@ -30,6 +30,19 @@ interface AgentRefProps {
 	/** Rendered in place of the plain label - lets the avatar and name share one trigger. */
 	children?: ReactNode;
 	/**
+	 * Hang the card off `children` itself rather than a wrapper of our own, so the
+	 * hover target is the caller's element.
+	 *
+	 * Use it when the label sits inside a bigger interactive row - a menu option, a
+	 * list item. Without it the trigger is only the name text, which is a target a
+	 * few characters wide inside a full-width row: the pointer lands on the row's
+	 * padding and nothing opens. `className`, `testId` and `tapToOpen` are the
+	 * caller's business in this mode and are ignored.
+	 */
+	asChild?: boolean;
+	/** Which side the card opens on. Defaults to `top`. */
+	side?: 'top' | 'right' | 'bottom' | 'left';
+	/**
 	 * Whether a touch tap opens the card. Set false when the label sits inside a
 	 * link or button the tap has to reach: suppressing the tap's click is what
 	 * opens the card, and it would swallow the navigation or the selection.
@@ -56,6 +69,8 @@ export function AgentRef({
 	className,
 	testId,
 	children,
+	asChild = false,
+	side,
 	tapToOpen = true,
 }: AgentRefProps) {
 	const [open, setOpen] = useState(false);
@@ -67,6 +82,17 @@ export function AgentRef({
 	const tooltip = agent ? agentIdentityTooltip(agent) : null;
 	const slug = agent?.slug ?? undefined;
 	const linked = link && !!projectId && !!slug;
+
+	// The caller's element is the trigger, so there is nothing of ours to render:
+	// with no card to show, `children` passes straight through untouched.
+	if (asChild) {
+		if (!tooltip) return <>{content}</>;
+		return (
+			<Tooltip content={tooltip} side={side} contentClassName={TOOLTIP_PANEL}>
+				{content}
+			</Tooltip>
+		);
+	}
 
 	if (!tooltip) {
 		return linked && projectId && slug ? (
@@ -86,7 +112,7 @@ export function AgentRef({
 	// itself open, matching `RelativeTime`.
 	if (linked && projectId && slug) {
 		return (
-			<Tooltip content={tooltip} contentClassName={TOOLTIP_PANEL}>
+			<Tooltip content={tooltip} side={side} contentClassName={TOOLTIP_PANEL}>
 				<AgentLink projectId={projectId} agentId={slug} className={className} testId={testId}>
 					{content}
 				</AgentLink>
@@ -96,7 +122,7 @@ export function AgentRef({
 
 	if (!tapToOpen) {
 		return (
-			<Tooltip content={tooltip} contentClassName={TOOLTIP_PANEL}>
+			<Tooltip content={tooltip} side={side} contentClassName={TOOLTIP_PANEL}>
 				<span className={className} data-testid={testId}>
 					{content}
 				</span>
@@ -108,7 +134,13 @@ export function AgentRef({
 	// bare span has no role that supports one. The tap handler is a pointer
 	// affordance only - a screen reader reads the name and role from the text.
 	return (
-		<Tooltip content={tooltip} open={open} onOpenChange={setOpen} contentClassName={TOOLTIP_PANEL}>
+		<Tooltip
+			content={tooltip}
+			side={side}
+			open={open}
+			onOpenChange={setOpen}
+			contentClassName={TOOLTIP_PANEL}
+		>
 			<span
 				className={className}
 				data-testid={testId}

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -265,23 +265,28 @@ export function TaskSidebar({
 									data-placement={assigneeSide}
 								>
 									{assigneeOptions?.map((a) => (
-										<button
-											type="button"
-											key={a.id}
-											onClick={() => {
-												updateTask.mutate({ assignee_id: a.id });
-												setAssigneeOpen(false);
-											}}
-											className={`flex items-center w-full px-2.5 py-1.5 text-xs text-left hover:bg-surface-2 transition-colors ${
-												a.id === task.assignee_id ? 'bg-surface-2 font-medium' : ''
-											}`}
-										>
-											<AgentStatusLabel
-												name={agentDisplayName(a)}
-												agent={a}
-												runtimeStatus={AgentRuntimeStatus.Idle}
-											/>
-										</button>
+										// The whole option is the hover target, not just the name inside
+										// it - a name is a few characters wide in a full-width row, so
+										// pointing at the row would otherwise land on padding and show
+										// nothing. Opens to the side so the card clears the list rather
+										// than covering the option above it.
+										<AgentRef key={a.id} agent={a} asChild side="left">
+											<button
+												type="button"
+												onClick={() => {
+													updateTask.mutate({ assignee_id: a.id });
+													setAssigneeOpen(false);
+												}}
+												className={`flex items-center w-full px-2.5 py-1.5 text-xs text-left hover:bg-surface-2 transition-colors ${
+													a.id === task.assignee_id ? 'bg-surface-2 font-medium' : ''
+												}`}
+											>
+												<AgentStatusLabel
+													name={agentDisplayName(a)}
+													runtimeStatus={AgentRuntimeStatus.Idle}
+												/>
+											</button>
+										</AgentRef>
 									))}
 								</div>
 							)}

--- a/packages/web/test/agent-ref.test.tsx
+++ b/packages/web/test/agent-ref.test.tsx
@@ -94,3 +94,38 @@ test('renders nothing when there is neither an agent nor a fallback', () => {
 	const { container } = render(withI18n(<AgentRef />));
 	expect(container.textContent).toBe('');
 });
+
+test('asChild makes the caller element the trigger, not a wrapper of ours', () => {
+	// The bug this exists for: with the trigger on the name span, the hover target
+	// in a menu row is a few characters wide and pointing at the row hits padding.
+	const { container } = render(
+		withI18n(
+			<AgentRef agent={{ human_name: 'Riley', title: 'Market Researcher' }} asChild>
+				<button type="button" data-testid="row">
+					Riley
+				</button>
+			</AgentRef>,
+		),
+	);
+	const trigger = container.querySelector(TRIGGER);
+	expect(trigger?.tagName).toBe('BUTTON');
+	expect(trigger?.getAttribute('data-testid')).toBe('row');
+	// Nothing of ours wraps it - the button is the only element rendered.
+	expect(container.firstElementChild).toBe(trigger);
+});
+
+test('asChild passes children straight through when there is no card to show', () => {
+	// An unnamed agent with no role description has nothing to add, so the row
+	// must render exactly as the caller wrote it - no stray trigger attributes.
+	const { container } = render(
+		withI18n(
+			<AgentRef agent={{ title: 'Market Researcher' }} asChild>
+				<button type="button" data-testid="row">
+					Market Researcher
+				</button>
+			</AgentRef>,
+		),
+	);
+	expect(container.querySelector(TRIGGER)).toBeNull();
+	expect(container.querySelector('[data-testid="row"]')).not.toBeNull();
+});

--- a/packages/web/test/assignee-menu-identity.test.tsx
+++ b/packages/web/test/assignee-menu-identity.test.tsx
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// Picking an assignee from the menu is the one place you cannot click through to
+// find out who someone is - you either recognise the name or you choose blind. So
+// each option carries the identity card, and the *whole option row* is the hover
+// target: with the trigger on the name alone, the target is a few characters wide
+// in a full-width row and pointing at the row lands on padding.
+//
+// happy-dom cannot open a Radix tooltip's portal, but it can see which element
+// Radix made the trigger - `data-state` lands on it - and that is precisely the
+// thing that was wrong.
+
+async function nameAgent(projectSlug: string, agentSlug: string, humanName: string) {
+	const { token, apiBase } = getTestContext();
+	const res = await apiBase(`/api/projects/${projectSlug}/agents/${agentSlug}`, {
+		method: 'PATCH',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ human_name: humanName }),
+	});
+	if (!res.ok) throw new Error(`naming ${agentSlug} failed: ${res.status}`);
+}
+
+test('each assignee option is itself the identity-card trigger', async () => {
+	let projectSlug = '';
+	let taskIdentifier = '';
+
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Assignee Menu Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Assignee Menu Task',
+				assignee_id: ws.agents[0].id,
+			});
+			// A named agent, so the card has something to say that the label does not.
+			await nameAgent(ws.internalSlug, 'engineer', 'Morgan');
+			projectSlug = project.slug;
+			taskIdentifier = task.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projectSlug, taskId: taskIdentifier.toLowerCase() },
+	});
+
+	const assignee = await findByTestId('task-assignee', undefined, { timeout: 20_000 });
+	const toggle = assignee.querySelector('[aria-label="Change assignee"]') as HTMLElement | null;
+	expect(toggle).not.toBeNull();
+	await user.click(toggle as HTMLElement);
+
+	const options = [...assignee.querySelectorAll('button')].filter(
+		(b) => b.getAttribute('aria-label') !== 'Change assignee',
+	);
+	expect(options.length).toBeGreaterThan(1);
+
+	// The option row is the trigger, not something nested inside it.
+	const named = options.find((b) => b.textContent?.includes('Morgan'));
+	expect(named).toBeDefined();
+	expect(named?.getAttribute('data-state')).not.toBeNull();
+
+	// And the label still reads the display name, so the row you hover and the row
+	// you pick say the same thing.
+	expect(named?.textContent).toContain('Morgan');
+});

--- a/packages/web/test/markdown-prose-mentions.test.tsx
+++ b/packages/web/test/markdown-prose-mentions.test.tsx
@@ -302,3 +302,53 @@ test('a mention of an open (in-progress) task is not struck through', async () =
 // hover→pill assertion lives in test/browser/task-mention-status.spec.ts. The
 // `data-mention-task-status` assertions above prove the exact value that feeds the
 // pill reaches the DOM.
+
+test('a mention written by role slug renders the name once the agent has one', async () => {
+	// The case the other mention specs miss: they use an unnamed agent, where the
+	// display name and the role title are the same string, so they cannot tell a
+	// chip that reads the *name* from one that merely reads the title. Here the
+	// author writes the role handle and the reader sees "Morgan".
+	const seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const { container, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Named Mention Project' });
+			const task = await seedTask(ws, project, { title: 'Named Mention Task' });
+			const agent = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			const res = await ctx.apiBase(`/api/projects/${ws.internalSlug}/agents/${agent.slug}`, {
+				method: 'PATCH',
+				headers: { Authorization: `Bearer ${ws.token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ human_name: 'Morgan' }),
+			});
+			if (!res.ok) throw new Error(`naming ${agent.slug} failed: ${res.status}`);
+
+			await seedComment(ws, task, `Cosmetic note from @@${agent.slug}, non-blocking.`);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = agent.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByText(/Cosmetic note/, undefined, { timeout: 20_000 });
+	const chip = await waitFor(() => {
+		const el = container.querySelector(
+			'[data-testid="agent-mention-link"][data-mention-passive="true"]',
+		) as HTMLAnchorElement | null;
+		if (!el) throw new Error('passive mention link not yet resolved');
+		return el;
+	});
+
+	// The name, not the slug the author typed and not the role title.
+	expect(chip.textContent).toBe('Morgan');
+	expect(chip.textContent).not.toBe(seeded.agentSlug);
+	// The link still points at the role slug, so it survives a later rename.
+	expect(chip.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`,
+	);
+});


### PR DESCRIPTION
Follow-up to #949. The identity hover card was already wired to the assignee menu, but it never appeared in practice.

## The bug

The trigger was the **name text** inside each option, not the option itself. A name is a few characters wide in a full-width row, so pointing anywhere on the row landed on padding and nothing opened.

That made the card unreachable exactly where it earns its keep: picking an assignee is the one place you *cannot* click through to find out who someone is. A menu of Morgan / Alex / Reid / Blair / Quinn tells you nothing about which one is the Architect.

## The fix

`AgentRef` gains **`asChild`**, which hangs the card off the caller's own element rather than a wrapper of its own — so the option row becomes the trigger. With no card to show (an unnamed agent with no role description) `children` passes straight through untouched, so nothing changes for rows that had nothing to say.

It also gains **`side`**, and the menu opens its card to the left, clearing the list rather than covering the option above it.

## Tests

- `agent-ref.test.tsx` (+2): `asChild` makes the caller's element the trigger and renders no wrapper of ours; with no card, children pass through with no stray trigger attributes.
- `assignee-menu-identity.test.tsx` (new): at the real surface — opens the menu and asserts the **option button itself** carries the Radix trigger. This fails on the previous code, where `data-state` sat on an inner span.
- `markdown-prose-mentions.test.tsx` (+1): a mention written by **role slug** renders the agent's **name** once one is set. The existing mention specs all use an unnamed agent, where the display name and the role title are the same string — so none of them could distinguish a chip reading the name from one merely reading the title. This closes that gap.

`typecheck` and `biome check` are clean; the full web tier is still running locally and I'll act on anything it flags.

## Not changed

The project sidebar's agent rows have the same narrow trigger, but those rows are links to the agent's page — clicking already tells you everything the card would. Happy to extend `asChild` there if you'd rather they matched.

---
_Generated by [Claude Code](https://claude.ai/code/session_016iwUYAYxtNKEF6sUQKP8o3)_