### PR TITLE
fix(mentions): a non-addressing active @slug no longer excuses a passive address

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3192,7 +3192,15 @@ all; a bold name written for mere emphasis is never touched) — **or** the same
 the **passive** `@@slug` form, via `detectPassiveTeammateAsks`, which is the likelier spelling of
 a closing verdict line (`APPROVED. Ready for @@marketing-lead review.`) and wakes exactly as many
 people as the bare name does. Either is the wakes-no-one
-trap — but the net does **not** rewrite the
+trap. Both detectors skip a slug that is also actively `@`-mentioned (it already notifies) —
+**except on the leading-line branch**, which asks whether the address is *marked* correctly
+rather than whether anyone was notified, so only an active mention that is itself an address
+(`hasActiveAddressingMention`, the same four shapes applied to the active spelling) excuses it.
+Without that carve-out a throwaway back-reference silenced the branch on the line carrying the
+ask — `@@admin — <directive>` plus `… the earlier @admin ZIP request …` two sentences later put
+the muted mark on the handoff and the live one on a mention that asks for nothing, and because
+the stray mention lands a real inbox row the wake receipt and the no-wake exit check both read
+clean. The net does **not** rewrite the
 agent's words or auto-deliver it (guessing intent to force a wake overreaches). `create_comment`
 already warns the agent interactively when it posts such a comment; the final-message path skips
 that check, so the runner surfaces the **same warning in the run log** and leaves the handoff

--- a/packages/server/src/lib/mentions.ts
+++ b/packages/server/src/lib/mentions.ts
@@ -215,6 +215,39 @@ function hasNameBoundSignoffGate(stripped: string, namePattern: string): boolean
 	return gateNameObject.test(stripped) || namePendingAction.test(stripped);
 }
 
+/**
+ * Whether the ACTIVE `@slug` in `stripped` is itself ADDRESSING the teammate —
+ * the same four shapes the two ask detectors below recognise, applied to the
+ * active spelling instead of `@@slug`/the bare name.
+ *
+ * This is what exempts a slug from those detectors, and the scope is the point.
+ * The exemption used to be comment-wide ("a slug reached by an active @mention
+ * already notifies"), which is true about NOTIFICATION and false about the
+ * ADDRESS FORM — the thing the detectors actually check. A name dropped
+ * mid-sentence as a back-reference does notify, but it does not make a passive
+ * line-opening address elsewhere correct, and under the wide rule it silenced
+ * the warning on it. That made a slug's treatment depend on unrelated text: two
+ * teammates written in the identical stranded form warned differently because
+ * one happened to be name-dropped in passing.
+ *
+ * The miss this was written for: `@@admin — optionally disable <setting>.` +
+ * `… since the earlier @admin ZIP request wasn't replied to.` The leading-line
+ * branch flags the first line on sight, and never ran — the second line's
+ * throwaway mention put `admin` in the exempt set. It also lands a real admin
+ * inbox row, so the wake receipt read `woke: ['admin']` and every other net
+ * (the runner's handoff warning, the no-wake exit check) stood down too.
+ */
+function hasActiveAddressingMention(stripped: string, slug: string): boolean {
+	const s = escapeRegExp(slug);
+	const namePattern = String.raw`(?<![\w@])@${s}(?![\w-])`;
+	if (hasActionAssignmentLine(stripped, namePattern)) return true;
+	if (leadingAddressRegex(`@${s}`).test(stripped)) return true;
+	if (hasNameBoundSignoffGate(stripped, namePattern)) return true;
+	return sentencesContaining(stripped, namePattern).some(
+		(sentence) => readsAsAsk(sentence) && !isPurelyReferential(sentence, namePattern),
+	);
+}
+
 export function extractMentionSlugs(content: unknown): string[] {
 	const text = flattenTextFields(content);
 	if (!text) return [];
@@ -409,30 +442,27 @@ export function detectUnlinkedTeammateReferences(content: unknown, knownSlugs: s
  *   whole paragraph, so a `you` in an unrelated sentence could pull an
  *   attribution into an ask.
  *
- * A slug that is also actively `@`-mentioned anywhere is never flagged — it
- * already notifies. Mirrors detectUnlinkedTeammateReferences for the passive form.
+ * A slug also reached by an active `@`-mention is skipped — it already notifies —
+ * EXCEPT on the leading-line branch, which asks a different question (see below).
+ * Mirrors detectUnlinkedTeammateReferences for the passive form.
  */
 export function detectPassiveTeammateAsks(content: unknown, knownSlugs: string[]): string[] {
 	const text = flattenTextFields(content);
 	if (!text) return [];
 	const stripped = text.replace(FENCED_CODE_RE, ' ').replace(INLINE_CODE_RE, ' ');
 
-	// A slug reached by an active @mention already notifies, so it never warns.
+	// A slug reached by an active @mention already notifies, so it never warns —
+	// on the branches whose question IS "was anyone notified".
 	const active = new Set(extractMentionSlugs(stripped));
 
 	const flagged = new Set<string>();
 	for (const rawSlug of knownSlugs) {
 		const slug = rawSlug.toLowerCase();
-		if (active.has(slug)) continue;
+		// An active @mention that is ITSELF an address exempts every branch: the
+		// handoff is both delivered and correctly marked, so the passive spelling
+		// elsewhere is the reference it looks like.
+		if (hasActiveAddressingMention(stripped, slug)) continue;
 		const s = escapeRegExp(slug);
-		// Action-assignment line: `## Required actions for @@slug` — the phrase on
-		// the line is itself the ask signal, no paragraph gate needed. The trailing
-		// guard keeps a slug from matching inside a longer hyphenated slug
-		// (`@@qa` in `@@qa-engineer`).
-		if (hasActionAssignmentLine(stripped, String.raw`(?<![\w@])@@${s}(?![\w-])`)) {
-			flagged.add(slug);
-			continue;
-		}
 		// Leading-line address (`@@slug — …`, optionally after a routing label): the
 		// line-opening name-then-separator shape IS the address form, and the only
 		// reason to write it is to hand the named teammate the next action — so the
@@ -441,7 +471,24 @@ export function detectPassiveTeammateAsks(content: unknown, knownSlugs: string[]
 		// sentence (`as @@slug noted, …`), not opening a line. This is the shape that
 		// strands the most work, because the status vocabulary it attracts
 		// (`@@admin — release is done.`) is exactly what the ask gate cannot see.
+		//
+		// Checked ABOVE the `active` exemption, and it is the only branch that is:
+		// this branch does not ask "was anyone notified", it asks "is the address
+		// marked correctly", and a mention that notifies from somewhere else in the
+		// comment does not answer that. `@@admin — <directive>` plus a throwaway
+		// `… the earlier @admin ZIP request …` two sentences later is the miss —
+		// the ask wears the muted mark and a back-reference wears the live one, so
+		// every net stood down while the reader's eye landed on the wrong chip.
 		if (leadingAddressRegex(`@@${s}`).test(stripped)) {
+			flagged.add(slug);
+			continue;
+		}
+		if (active.has(slug)) continue;
+		// Action-assignment line: `## Required actions for @@slug` — the phrase on
+		// the line is itself the ask signal, no paragraph gate needed. The trailing
+		// guard keeps a slug from matching inside a longer hyphenated slug
+		// (`@@qa` in `@@qa-engineer`).
+		if (hasActionAssignmentLine(stripped, String.raw`(?<![\w@])@@${s}(?![\w-])`)) {
 			flagged.add(slug);
 			continue;
 		}
@@ -500,7 +547,9 @@ export function detectPassiveTeammateAsks(content: unknown, knownSlugs: string[]
  * uses (see readsAsAsk) so a name written for mere emphasis or attribution is
  * never flagged; the action-assignment line and the name-bound sign-off gate are
  * self-gating (the binding IS the ask). A slug also reached by an active
- * `@`-mention anywhere is skipped — it already notifies. The runner's
+ * `@`-mention anywhere is skipped — it already notifies — except on the
+ * leading-line branch, which asks whether the address is marked correctly rather
+ * than whether anyone was notified (see detectPassiveTeammateAsks). The runner's
  * handoff-delivery net uses these to warn (in the run log) that a run ended with a
  * stranded bare-name handoff, mirroring create_comment's interactive warning.
  */
@@ -509,38 +558,46 @@ export function detectUnlinkedTeammateAsks(content: unknown, knownSlugs: string[
 	if (!text) return [];
 	const stripped = text.replace(FENCED_CODE_RE, ' ').replace(INLINE_CODE_RE, ' ');
 
-	// A slug reached by an active @mention already notifies, so it never warns.
+	// A slug reached by an active @mention already notifies, so it never warns —
+	// on the branches whose question IS "was anyone notified".
 	const active = new Set(extractMentionSlugs(stripped));
 
 	const flagged = new Set<string>();
 	for (const rawSlug of knownSlugs) {
 		const slug = rawSlug.toLowerCase();
-		if (active.has(slug)) continue;
+		// An active @mention that is ITSELF an address exempts every branch.
+		if (hasActiveAddressingMention(stripped, slug)) continue;
 		const s = escapeRegExp(slug);
-		// Action-assignment line with the bare name: `## Required actions for slug`
-		// — the phrase on the line is itself the ask signal, no paragraph gate
-		// needed. The lookbehind keeps `@slug`/`@@slug` out (handled elsewhere) and,
-		// with the trailing guard, keeps a slug from matching inside a longer
-		// hyphenated slug (`engineer` in `qa-engineer` / `engineer-lead`).
-		if (hasActionAssignmentLine(stripped, String.raw`(?<![\w@-])${s}(?![\w-])`)) {
-			flagged.add(slug);
-			continue;
-		}
-		// Name-bound sign-off gate: a mid-sentence handoff the address-position
-		// forms miss because the name sits inside the sentence rather than opening a
-		// line — `awaiting slug sign-off`, `needs slug's approval`, `slug to sign
-		// off`. The binding of the name to the sign-off gate is itself the ask
-		// signal, so like the action-assignment line it needs no readsAsAsk pass.
-		if (hasNameBoundSignoffGate(stripped, String.raw`(?<![\w@-])${s}(?![\w-])`)) {
-			flagged.add(slug);
-			continue;
+		const activeElsewhere = active.has(slug);
+		if (!activeElsewhere) {
+			// Action-assignment line with the bare name: `## Required actions for slug`
+			// — the phrase on the line is itself the ask signal, no paragraph gate
+			// needed. The lookbehind keeps `@slug`/`@@slug` out (handled elsewhere) and,
+			// with the trailing guard, keeps a slug from matching inside a longer
+			// hyphenated slug (`engineer` in `qa-engineer` / `engineer-lead`).
+			if (hasActionAssignmentLine(stripped, String.raw`(?<![\w@-])${s}(?![\w-])`)) {
+				flagged.add(slug);
+				continue;
+			}
+			// Name-bound sign-off gate: a mid-sentence handoff the address-position
+			// forms miss because the name sits inside the sentence rather than opening a
+			// line — `awaiting slug sign-off`, `needs slug's approval`, `slug to sign
+			// off`. The binding of the name to the sign-off gate is itself the ask
+			// signal, so like the action-assignment line it needs no readsAsAsk pass.
+			if (hasNameBoundSignoffGate(stripped, String.raw`(?<![\w@-])${s}(?![\w-])`)) {
+				flagged.add(slug);
+				continue;
+			}
 		}
 		// Emphasised name (**slug**/__slug__, not already @-prefixed) or a
 		// leading-line address (`slug —`/`slug:`, optionally after a routing label)
 		// — mirrors the addressing forms detectUnlinkedTeammateReferences recognises.
+		// The leading-line form survives an active mention elsewhere (it asks whether
+		// the address is marked, not whether anyone was notified); the bold form does
+		// not, since bold marks emphasis and attribution as readily as an address.
 		const bold = new RegExp(String.raw`(?<!@)(\*\*|__)${s}\1`, 'i');
 		const lead = leadingAddressRegex(s);
-		if (!bold.test(stripped) && !lead.test(stripped)) continue;
+		if (!lead.test(stripped) && (activeElsewhere || !bold.test(stripped))) continue;
 		// Only warn when the paragraph(s) carrying this address read as an ask —
 		// scoped to those paragraphs so a `you` elsewhere never leaks in.
 		const block = unlinkedMentionParagraphs(stripped, s);

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -332,16 +332,30 @@ async function buildPassiveMentionWarning(
 	if (offenders.length === 0) return null;
 	const named = offenders.map((s) => `@@${s}`).join(', ');
 	const fixes = offenders.map((s) => `@${s}`).join(', ');
+	// An offender can still have been notified — by an active mention somewhere
+	// else in this same comment that is NOT the address (a back-reference, a
+	// name-drop). Saying "no wakeup was created" there would be false, and the
+	// mismatch IS the finding: the ask wears the mark that notifies no one while
+	// something that asks for nothing wears the live one.
+	const activeElsewhere = new Set(extractMentionSlugs(content));
+	const misplaced = offenders.filter((s) => activeElsewhere.has(s));
+	const misplacedNote =
+		misplaced.length > 0
+			? ` Note that ${misplaced.map((s) => `@${s}`).join(', ')} did notify from elsewhere in ` +
+				`this comment - but that mention is not the address, so the notification points at a ` +
+				`line that asks for nothing while the ask itself wears the silent mark. Move the ` +
+				`active mention onto the address.`
+			: '';
 	return (
 		`You addressed ${named} with the passive form (@@) - that renders as a link and ` +
-		`notifies no one, so no wakeup or admin-inbox alert was created. If you need them to ` +
+		`notifies no one at that address. If you need them to ` +
 		`act on this task, edit this comment or post a follow-up with an active mention ` +
 		`(${fixes}). If you only meant to refer to them, keep the passive form but move the ` +
 		`reference out of the handoff position: a line that opens with a teammate reference and ` +
 		`a dash is an address, and a name bound to a sign-off gate ("ready for <name> review", ` +
 		`"awaiting <name> sign-off", "<name> to approve") hands them the next action - both ` +
 		`shapes are reserved for active mentions, so a plain reference belongs inside a ` +
-		`sentence that asks for nothing.`
+		`sentence that asks for nothing.${misplacedNote}`
 	);
 }
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -2002,6 +2002,13 @@ export async function runAgent(
 										[heartbeatRunId],
 									);
 									producedOutput = true;
+									// The comment just posted IS the final message, so every active
+									// mention in it is now delivered. Record that before (2) runs: a
+									// final message can carry both spellings for the same teammate
+									// (a passive line-opening address plus a mention elsewhere), and
+									// without this (2) would warn that a handoff was "NOT delivered"
+									// one statement after delivering it.
+									for (const slug of activeMentions) delivered.add(slug);
 									emit(
 										'stdout',
 										`\n[runner] auto-delivered stranded handoff (@${undeliveredActive.join(', @')}) from the run's final message as a comment\n`,

--- a/packages/server/test/passive-mention-warning.test.ts
+++ b/packages/server/test/passive-mention-warning.test.ts
@@ -381,8 +381,39 @@ describe('detectPassiveTeammateAsks', () => {
 		expect(detectPassiveTeammateAsks('as @@admin noted, ship it when you can.', slugs)).toEqual([]);
 	});
 
-	it('does not flag a slug that is also actively mentioned', () => {
+	it('does not flag a slug whose active mention is itself the address', () => {
+		// The active `@admin —` carries the address, so the passive echo later is the
+		// reference it looks like: both delivered and correctly marked.
 		expect(detectPassiveTeammateAsks('@admin — done. cc @@admin, your call.', slugs)).toEqual([]);
+	});
+
+	it('flags a line-leading passive address when the only active mention is a back-reference', () => {
+		// The screenshot: the ask wears the silent mark and a throwaway back-reference
+		// two sentences later wears the live one. The active `@admin` addresses no one
+		// (not line-leading, no ask in its sentence, no sign-off gate), so it must not
+		// excuse the passive address — under the old comment-wide exemption it did,
+		// and every net went quiet: this warning, the runner's, and the no-wake exit
+		// check (the stray mention lands a real inbox row, so the run "woke someone").
+		expect(
+			detectPassiveTeammateAsks(
+				'@@admin — optionally disable Email Address Obfuscation in the Cloudflare ' +
+					'dashboard to permanently eliminate those false-positive crawl errors. ' +
+					"HM-329 is in review since the earlier @admin ZIP request there wasn't " +
+					'replied to directly on that ticket.',
+				slugs,
+			),
+		).toEqual(['admin']);
+	});
+
+	it('flags a line-leading passive address even when a sibling paragraph mentions the slug in passing', () => {
+		// Generalised: any non-addressing active mention. The line-opening form asks
+		// whether the address is MARKED, not whether anyone was notified.
+		expect(
+			detectPassiveTeammateAsks(
+				'@architect kicked this off last week.\n\n@@architect — merged and shipped.',
+				slugs,
+			),
+		).toEqual(['architect']);
 	});
 
 	it('does not flag an active-only mention', () => {
@@ -633,6 +664,34 @@ describe('MCP create_comment / update_comment warn on passive-mention asks', () 
 		expect(result.warning).toContain('active mention');
 		// The passive form genuinely notified no one.
 		expect(await adminMentionCount(result.id!)).toBe(0);
+	});
+
+	it('warns on a passive @@admin address whose only active mention is a back-reference (screenshot case)', async () => {
+		const taskId = await insertTask(architectId, 'Passive admin address, stray active mention');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content:
+				'@@admin — optionally disable Email Address Obfuscation in the Cloudflare dashboard ' +
+				'to permanently eliminate those false-positive crawl errors. HM-329 is in review ' +
+				"since the earlier @admin ZIP request there wasn't replied to directly on that ticket.",
+		});
+		expect(result.warning).toBeDefined();
+		expect(result.warning).toContain('@@admin');
+		expect(result.warning).toContain('active mention');
+		// Both facts hold at once, and that mismatch IS the finding: the stray active
+		// mention really did fan out to the inbox, so the warning must not claim the
+		// comment notified nobody - it says the notification points at the wrong line.
+		expect(await adminMentionCount(result.id!)).toBeGreaterThan(0);
+		expect(result.warning).toContain('did notify from elsewhere');
 	});
 
 	it('warns on the routing-label handoff `**Next step:** @@captain — …your…` (screenshot case)', async () => {

--- a/packages/server/test/unlinked-mention-ask.test.ts
+++ b/packages/server/test/unlinked-mention-ask.test.ts
@@ -153,13 +153,28 @@ describe('detectUnlinkedTeammateAsks', () => {
 		).toEqual([]);
 	});
 
-	it('does not flag a slug that is also actively @-mentioned elsewhere', () => {
+	it('does not flag a BOLD name whose slug is also actively @-mentioned elsewhere', () => {
+		// The active mention notified, and bold marks emphasis and attribution as
+		// readily as an address — so this stays exempt. Warning here would claim a
+		// wakeup was missed when one was created.
 		expect(
 			detectUnlinkedTeammateAsks(
 				'@architect kicked this off. **architect** — can you finish it?',
 				slugs,
 			),
 		).toEqual([]);
+	});
+
+	it('flags a LEADING-LINE bare address when the active mention addresses no one', () => {
+		// The bare-name mirror of the screenshot. Unlike bold, opening a line with a
+		// name and a separator has only one reading, so a passing mention elsewhere
+		// does not excuse leaving the address itself inert.
+		expect(
+			detectUnlinkedTeammateAsks(
+				'@architect kicked this off last week.\n\narchitect — can you finish it?',
+				slugs,
+			),
+		).toEqual(['architect']);
 	});
 
 	it('does not flag a passive @@mention address', () => {

--- a/packages/shared/src/mentions/tokens.ts
+++ b/packages/shared/src/mentions/tokens.ts
@@ -159,6 +159,27 @@ export function extractActiveAgentMentionSlugs(value: string): string[] {
 }
 
 /**
+ * Whether `value` carries an ACTIVE `@admin` — the one mention that reaches a
+ * human rather than an agent, fanning out to an `admin_mentions` inbox row per
+ * project owner. It is the complement of {@link extractActiveAgentMentionSlugs},
+ * which drops admin because admin is not an agent and resolves to no roster row;
+ * the composer's "Wake:" preview needs both halves to match the server, which
+ * reports `woke: ['admin']` for exactly this input. The passive `@@admin`
+ * notifies no one and is excluded, as are code blocks and inline code.
+ */
+export function hasActiveAdminMention(value: string): boolean {
+	const stripped = stripCode(value);
+	const re = buildMentionRegex();
+	let m = re.exec(stripped);
+	while (m !== null) {
+		const token = parseMentionMatch(m);
+		if (token.kind === 'agent' && token.slug === ADMIN_MENTION_SLUG) return true;
+		m = re.exec(stripped);
+	}
+	return false;
+}
+
+/**
  * The inverse of {@link extractMentionCandidates}: pulls resolvable references
  * that are wrapped in *inline code* (and therefore render inert) instead of from
  * the surrounding prose. Fenced and indented code blocks are excluded — those

--- a/packages/shared/test/mentions-tokens.test.ts
+++ b/packages/shared/test/mentions-tokens.test.ts
@@ -7,6 +7,7 @@ import {
 	extractDocCandidates,
 	extractMentionCandidates,
 	extractTaskCandidates,
+	hasActiveAdminMention,
 	type MentionToken,
 	parseMentionMatch,
 	stripCode,
@@ -200,6 +201,26 @@ describe('extractActiveAgentMentionSlugs', () => {
 	it('returns [] when there is no active mention', () => {
 		expect(extractActiveAgentMentionSlugs('just @@passive and @admin here')).toEqual([]);
 		expect(extractActiveAgentMentionSlugs('')).toEqual([]);
+	});
+});
+
+describe('hasActiveAdminMention', () => {
+	it('is the complement of extractActiveAgentMentionSlugs for the admin token', () => {
+		// The pair has to cover the whole wake set: the server reports
+		// `woke: ['admin']` for an active @admin, so a preview built from the agent
+		// extractor alone reads "(no one)" on a comment that notifies every owner.
+		expect(hasActiveAdminMention('@admin please take a look')).toBe(true);
+		expect(hasActiveAdminMention('cc @admin')).toBe(true);
+		expect(extractActiveAgentMentionSlugs('@admin please take a look')).toEqual([]);
+	});
+
+	it('ignores the passive form, code, and non-admin slugs', () => {
+		expect(hasActiveAdminMention('@@admin is the passive form')).toBe(false);
+		expect(hasActiveAdminMention('inline `@admin` stays literal')).toBe(false);
+		expect(hasActiveAdminMention('```\n@admin in a fenced block\n```')).toBe(false);
+		expect(hasActiveAdminMention('@administrator is a different slug')).toBe(false);
+		expect(hasActiveAdminMention('@alice only')).toBe(false);
+		expect(hasActiveAdminMention('')).toBe(false);
 	});
 });
 

--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -1,4 +1,9 @@
-import { type AgentEffort, extractActiveAgentMentionSlugs } from '@hezo/shared';
+import {
+	ADMIN_MENTION_SLUG,
+	type AgentEffort,
+	extractActiveAgentMentionSlugs,
+	hasActiveAdminMention,
+} from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { CornerDownRight, Loader2, Maximize2, Minimize2, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
@@ -87,14 +92,22 @@ export function CommentComposer({
 
 	const { data: agents } = useAgents(projectId);
 
-	// The agents this comment will wake when posted: every actively `@`-mentioned
-	// agent resolvable in the project roster (which includes the HQ CEO/Coach),
-	// plus the reply-target agent. Deduped by id, so an agent that is both
-	// mentioned and replied-to shows once. Mirrors the server's wakeup fan-out.
+	// Who this comment will wake when posted: an active `@admin` (which fans out to
+	// an inbox row per project owner, not to an agent, so it resolves against no
+	// roster entry and is listed by its mention token), every actively
+	// `@`-mentioned agent resolvable in the project roster (which includes the HQ
+	// CEO/Coach), plus the reply-target agent. Deduped by id, so an agent that is
+	// both mentioned and replied-to shows once. Mirrors the server's wakeup fan-out.
 	const wakeAgents = useMemo(() => {
 		const roster = agents ?? [];
 		const bySlug = new Map(roster.map((a) => [a.slug.toLowerCase(), a] as const));
 		const picked = new Map<string, { id: string; name: string }>();
+		if (hasActiveAdminMention(commentText)) {
+			picked.set(ADMIN_MENTION_SLUG, {
+				id: ADMIN_MENTION_SLUG,
+				name: `@${ADMIN_MENTION_SLUG}`,
+			});
+		}
 		for (const slug of extractActiveAgentMentionSlugs(commentText)) {
 			const a = bySlug.get(slug);
 			if (a) picked.set(a.id, { id: a.id, name: a.title });

--- a/packages/web/test/task-comments.test.tsx
+++ b/packages/web/test/task-comments.test.tsx
@@ -436,6 +436,63 @@ test('actively @-mentioning an agent shows it as a wake pill', async () => {
 	expect((await findByTestId('wake-preview')).textContent).not.toContain('(no one)');
 });
 
+test('actively @-mentioning the admin shows a wake pill', async () => {
+	// @admin fans out to an inbox row per project owner, so the server reports
+	// `woke: ['admin']` - but admin resolves to no roster agent, so the preview
+	// used to read "(no one)" on a comment that notifies every owner.
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByPlaceholderText, findByTestId, findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Admin Wake Project' });
+			const task = await seedTask(ws, project, { title: 'Admin Wake Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	expect((await findByTestId('wake-preview')).textContent).toContain('(no one)');
+
+	const userMod = await import('@testing-library/user-event');
+	const user = userMod.default.setup({ delay: null });
+	await user.type(composer, '@admin please disable that setting');
+
+	const pills = await findAllByTestId('wake-pill');
+	expect(pills.some((p) => p.textContent === '@admin')).toBe(true);
+	expect((await findByTestId('wake-preview')).textContent).not.toContain('(no one)');
+});
+
+test('passively @@-mentioning the admin shows no wake pill', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByPlaceholderText, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Passive Admin Project' });
+			const task = await seedTask(ws, project, { title: 'Passive Admin Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	const userMod = await import('@testing-library/user-event');
+	const user = userMod.default.setup({ delay: null });
+	await user.type(composer, '@@admin noted this earlier');
+
+	expect((await findByTestId('wake-preview')).textContent).toContain('(no one)');
+});
+
 test('replying to a human wakes no one (no pill, no wake_assignee)', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 	const { findByPlaceholderText, findByTestId, findByText, getByRole, router } = await renderApp({


### PR DESCRIPTION
## The miss

A Captain comment carried its real directive to the admin as a line-opening **passive** address, with a throwaway active mention two sentences later:

```
@@admin — optionally disable Email Address Obfuscation in the Cloudflare dashboard …
HM-329 is in `review` since the earlier @admin ZIP request there wasn't replied to …
```

The first line is the one shape `detectPassiveTeammateAsks` flags *unconditionally* - the module calls the line-opening form "wrong on sight". It warned nowhere, and every deterministic net stayed silent at once:

| Net | Why it missed |
|---|---|
| `detectPassiveTeammateAsks` | `if (active.has(slug)) continue;` ran *before* the leading-line branch. The back-reference put `admin` in the active set. |
| `detectUnlinkedTeammateAsks` | same guard. |
| `buildWakeReceipt` | `admin` really was woken by the fan-out, so it is correctly absent from `named_not_woken`. Receipt read all-clear. |
| no-wake exit check | the run woke someone, so it skipped. |
| `detectNarratedActiveMentions` | needs the literal noun `mention`/`ping`; the text says "ZIP **request**". |

The marks ended up swapped: the ask wore the muted chip, a back-reference wore the live one - inverting the exact signal the passive muting exists to carry.

## The fix

The exemption's justification, "a slug reached by an active @mention already notifies", answers *was anyone notified*. The leading-line branch asks a different question - *is the address marked correctly* - which a mention from elsewhere in the comment does not answer.

That branch now runs above the exemption in both detectors. Every branch is still exempted when the active mention is **itself** an address, via a new `hasActiveAddressingMention` that reuses the same four shapes (`hasActionAssignmentLine`, `leadingAddressRegex`, `hasNameBoundSignoffGate`, `readsAsAsk` + `isPurelyReferential`) applied to the active spelling. No new phrase vocabulary, no new positional branch.

**Scoped to the leading-line branch deliberately.** Lifting the exemption from all four branches also flagged `@architect kicked this off. **architect** — can you finish it?`, where architect really was woken and the warning would have claimed otherwise. Bold marks emphasis and attribution as readily as an address; opening a line with a name and a separator has one reading. Every existing exemption test stays green **unedited**.

## Two follow-ons the change made reachable

- `buildPassiveMentionWarning` can now fire on a slug that *was* notified, so "no wakeup or admin-inbox alert was created" would have been false. It now says "notifies no one **at that address**" and names the mismatch: the notification points at a line that asks for nothing while the ask wears the silent mark.
- The runner's handoff net could warn "the handoff was NOT delivered" one statement after form (1) delivered it. The delivered active mentions are now recorded before form (2) runs.

## Also

The composer's "Wake:" preview read `(no one)` when a human typed `@admin`, while the server reported `woke: ['admin']` and created an inbox row per owner. `hasActiveAdminMention` complements `extractActiveAgentMentionSlugs`, which drops admin because admin resolves to no roster agent. The pill renders the literal `@admin` token, so no catalog key is added.

## Tests

- `passive-mention-warning.test.ts` - the screenshot case, the generalised sibling-paragraph case, and an MCP integration test asserting `warning` fires **and** `adminMentionCount > 0`. Both facts holding at once is the finding.
- `unlinked-mention-ask.test.ts` - bold stays exempt, with the reasoning; the new leading-line bare address fires.
- `mentions-tokens.test.ts` - `hasActiveAdminMention` incl. passive, inline code, fenced block, `@administrator` boundary.
- `task-comments.test.tsx` - `@admin` shows a pill, `@@admin` does not.

Green: `typecheck`, `--pattern mention` across all three tiers (231 + 51 + 35), the handoff-net / wake-receipt / admin-mention / done-gate suites, and the drift guards. `build:docs` regenerates with no diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jMnbJfENCMHDr4D3SNgLr)_