### PR TITLE
feat(ai-providers): guided subscription sign-in driven from inside a container

### DIFF
--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -18,6 +18,7 @@ import {
 	buildListHezoProcessesScript,
 	parseDfKilobytes,
 	parseHezoProcessList,
+	shellQuote,
 } from './sandbox/proc-scripts';
 import { tarSingleFile, untarFirstFile } from './sandbox/tar';
 import { DockerBinaryFrameDecoder } from './sandbox/tunnel/docker-frames-binary';
@@ -236,11 +237,6 @@ function withCgroupHeadroom(config: ContainerConfig): ContainerConfig {
 function cgroupLimitAsCeiling(limitBytes: number | undefined): number | null {
 	if (!limitBytes || limitBytes <= MEMORY_HARD_CAP_HEADROOM_BYTES) return null;
 	return limitBytes - MEMORY_HARD_CAP_HEADROOM_BYTES;
-}
-
-/** Single-quote for `sh -c`, closing and reopening around any embedded quote. */
-function shellQuote(arg: string): string {
-	return `'${arg.replaceAll("'", `'\\''`)}'`;
 }
 
 export class DockerClient implements ContainerEngine {

--- a/packages/server/src/services/sandbox/proc-scripts.ts
+++ b/packages/server/src/services/sandbox/proc-scripts.ts
@@ -346,3 +346,136 @@ export function parseHezoProcessList(stdout: string): ContainerProcessInfo[] {
 	}
 	return procs;
 }
+
+/** Single-quote for `sh -c`, closing and reopening around any embedded quote. */
+export function shellQuote(arg: string): string {
+	return `'${arg.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Terminal columns the login PTY is opened at.
+ *
+ * A vendor CLI wraps its sign-in URL to the terminal width, and a wrapped URL
+ * arrives interleaved with the spinner frames redrawn around it - Claude Code's
+ * visible URL text comes back in four overlapping fragments at 80 columns. Wide
+ * enough that nothing these CLIs print wraps at all, which is what lets the
+ * parsers below read a line rather than reassemble one.
+ */
+const LOGIN_PTY_COLUMNS = 1000;
+
+/** Per-flow file names under a login flow's own directory. */
+export const LOGIN_STDIN_FIFO = 'in';
+export const LOGIN_LOG_FILE = 'out';
+export const LOGIN_EXIT_FILE = 'exit';
+
+/**
+ * Run a vendor CLI's own login command, with a PTY Hezo allocates itself.
+ *
+ * **The PTY is ours, never the transport's.** Two of the three CLIs are
+ * full-screen TUIs that print nothing at all and hang forever on a pipe
+ * (`claude setup-token` emits zero bytes and never exits without one), so a PTY
+ * is required either way - and the two backends disagree about whether their
+ * exec channel has one. Docker's is a raw pipe; Daytona's is a PTY that
+ * redirects stderr to a file drained only when the channel closes, which would
+ * deadlock a flow whose challenge went to stderr. Allocating it here makes the
+ * flow behave identically on both, using only the exec triad and
+ * {@link SandboxFiles} - the two seams that are the same on every backend by
+ * rule.
+ *
+ * Streams are merged and teed to {@link LOGIN_LOG_FILE}, which the host polls
+ * rather than streams, for the same reason: a file read is identical on both
+ * backends where a byte channel is not.
+ *
+ * Stdin is a FIFO held open by a `sleep` for the flow's lifetime. Without a
+ * writer the CLI reads EOF the instant it opens the pipe and abandons its
+ * prompt; with one, {@link buildSubscriptionLoginCodeScript} can deliver the
+ * operator's code minutes later.
+ */
+export function buildSubscriptionLoginScript(opts: {
+	dir: string;
+	argv: readonly string[];
+	env?: Readonly<Record<string, string>>;
+	holdSecs: number;
+}): string {
+	const { dir, argv, env = {}, holdSecs } = opts;
+	if (!/^\/[A-Za-z0-9._/-]*$/.test(dir)) throw new Error(`unsafe dir: ${JSON.stringify(dir)}`);
+	if (argv.length === 0) throw new Error('login argv is empty');
+	if (!Number.isInteger(holdSecs) || holdSecs <= 0) throw new Error(`bad holdSecs: ${holdSecs}`);
+
+	const d = shellQuote(dir);
+	// `script` needs the command as one string; each argv element is quoted
+	// individually so nothing in it can reach the outer shell.
+	const inner = argv.map(shellQuote).join(' ');
+	const envPrefix = Object.entries(env)
+		.map(([k, v]) => {
+			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) throw new Error(`unsafe env name: ${k}`);
+			return `${k}=${shellQuote(v)}`;
+		})
+		.join(' ');
+
+	return (
+		`mkdir -p ${d} && cd ${d} && ` +
+		`rm -f ${LOGIN_STDIN_FIFO} ${LOGIN_LOG_FILE} ${LOGIN_EXIT_FILE} && ` +
+		`mkfifo -m 600 ${LOGIN_STDIN_FIFO} && : > ${LOGIN_LOG_FILE} && ` +
+		// Holds the write end open so the CLI never sees EOF while it waits.
+		`( sleep ${holdSecs} > ${LOGIN_STDIN_FIFO} ) & ` +
+		`( COLUMNS=${LOGIN_PTY_COLUMNS} ${envPrefix} ` +
+		`script -qec ${shellQuote(inner)} /dev/null ` +
+		`< ${LOGIN_STDIN_FIFO} > ${LOGIN_LOG_FILE} 2>&1; ` +
+		// Written last and read as the flow's "process is gone" signal.
+		`echo $? > ${LOGIN_EXIT_FILE} ) & ` +
+		'echo started'
+	);
+}
+
+/** Deliver the operator's pasted code to a waiting login process. */
+export function buildSubscriptionLoginCodeScript(dir: string, code: string): string {
+	if (!/^\/[A-Za-z0-9._/-]*$/.test(dir)) throw new Error(`unsafe dir: ${JSON.stringify(dir)}`);
+	return `printf '%s\\n' ${shellQuote(code)} > ${shellQuote(`${dir}/${LOGIN_STDIN_FIFO}`)}`;
+}
+
+/**
+ * Terminal control bytes, as **regex source** rather than literals.
+ *
+ * Written escaped and fed to `new RegExp` so the source file carries no literal
+ * control character - which a linter rightly refuses, and which is invisible in
+ * a diff. The regex engine resolves them identically.
+ */
+const ESC = '\\x1b';
+const BEL = '\\x07';
+/** OSC string terminator: either `ESC \` or a bare BEL. */
+const ST = `${ESC}\\\\|${BEL}`;
+
+/**
+ * OSC 8 hyperlink targets, in the order they appear.
+ *
+ * The sequence is `ESC ] 8 ; <params> ; <uri> ST`, where ST is either `ESC \` or
+ * BEL. Read in preference to the visible link text because a TUI redraw
+ * rewrites that text and leaves the escape intact - Claude Code's authorize URL
+ * survives here whole while its on-screen copy comes back in fragments.
+ */
+export function parseOsc8Links(raw: string): string[] {
+	const links: string[] = [];
+	for (const m of raw.matchAll(new RegExp(`${ESC}]8;[^;]*;([^${ESC}${BEL}]*)(?:${ST})`, 'g'))) {
+		const uri = m[1];
+		if (uri.length > 0) links.push(uri);
+	}
+	return links;
+}
+
+/**
+ * Drop the escape sequences a PTY interleaves with a CLI's own output.
+ *
+ * Covers CSI (colour, cursor moves, erases), OSC (window title, and the
+ * hyperlinks {@link parseOsc8Links} reads first), and the bare two-byte escapes
+ * a full-screen redraw emits. Carriage returns become newlines so a redrawn line
+ * is its own line to a line-oriented matcher rather than joining the one before.
+ */
+export function stripTerminalNoise(raw: string): string {
+	return raw
+		.replace(new RegExp(`${ESC}][^${ESC}${BEL}]*(?:${ST})`, 'g'), '')
+		.replace(new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, 'g'), '')
+		.replace(new RegExp(`${ESC}[()][A-Za-z0-9]`, 'g'), '')
+		.replace(new RegExp(`${ESC}[=><]`, 'g'), '')
+		.replace(/\r/g, '\n');
+}

--- a/packages/server/src/services/sandbox/proc-scripts.ts
+++ b/packages/server/src/services/sandbox/proc-scripts.ts
@@ -413,18 +413,35 @@ export function buildSubscriptionLoginScript(opts: {
 		})
 		.join(' ');
 
+	// Absolute paths throughout, and never a `cd`: `&` binds looser than `&&`, so
+	// a `cd` at the head of the chain backgrounds with the first subshell and the
+	// second one launches in whatever directory the exec happened to start in -
+	// where it reads a FIFO and writes a log that are not this flow's.
+	const fifo = shellQuote(`${dir}/${LOGIN_STDIN_FIFO}`);
+	const log = shellQuote(`${dir}/${LOGIN_LOG_FILE}`);
+	const exit = shellQuote(`${dir}/${LOGIN_EXIT_FILE}`);
+
 	return (
-		`mkdir -p ${d} && cd ${d} && ` +
-		`rm -f ${LOGIN_STDIN_FIFO} ${LOGIN_LOG_FILE} ${LOGIN_EXIT_FILE} && ` +
-		`mkfifo -m 600 ${LOGIN_STDIN_FIFO} && : > ${LOGIN_LOG_FILE} && ` +
+		`mkdir -p ${d} && rm -f ${fifo} ${log} ${exit} && ` +
+		`mkfifo -m 600 ${fifo} && : > ${log} && ` +
+		// Braces keep the `&&` chain in front of the whole launch rather than only
+		// the first background job.
+		'{ ' +
 		// Holds the write end open so the CLI never sees EOF while it waits.
-		`( sleep ${holdSecs} > ${LOGIN_STDIN_FIFO} ) & ` +
+		//
+		// Both background subshells detach their own stdio (`>/dev/null 2>&1`)
+		// **as well as** redirecting the commands inside them. Without the outer
+		// redirect they inherit the launching exec's stdout and stderr, and an
+		// exec does not complete while a child still holds its pipes open - so
+		// the call that starts the flow never returns and the flow never begins.
+		// The inner redirections still win for the commands they name.
+		`( sleep ${holdSecs} > ${fifo} ) >/dev/null 2>&1 & ` +
 		`( COLUMNS=${LOGIN_PTY_COLUMNS} ${envPrefix} ` +
 		`script -qec ${shellQuote(inner)} /dev/null ` +
-		`< ${LOGIN_STDIN_FIFO} > ${LOGIN_LOG_FILE} 2>&1; ` +
+		`< ${fifo} > ${log} 2>&1; ` +
 		// Written last and read as the flow's "process is gone" signal.
-		`echo $? > ${LOGIN_EXIT_FILE} ) & ` +
-		'echo started'
+		`echo $? > ${exit} ) >/dev/null 2>&1 & ` +
+		'echo started; }'
 	);
 }
 

--- a/packages/server/src/services/subscription-login-drivers.ts
+++ b/packages/server/src/services/subscription-login-drivers.ts
@@ -1,0 +1,176 @@
+import { AgentRuntime } from '@hezo/shared';
+import { parseOsc8Links, stripTerminalNoise } from './sandbox/proc-scripts';
+
+/**
+ * How each coding CLI mints a subscription credential from an interactive
+ * sign-in, and how Hezo reads what it printed.
+ *
+ * Keyed by RUNTIME, for the same reason `RUNTIME_HOME_LAYOUTS` is: the login
+ * command, the shape of the challenge and whether the CLI wants anything back
+ * are properties of the binary, not of the account. Pass the RESOLVED runtime
+ * (`effectiveRuntime`), never the provider default.
+ *
+ * **Where the credential lands is not restated here.** A driver harvesting
+ * `'auth-file'` reads `RUNTIME_HOME_LAYOUTS[runtime].authFileRelative` under the
+ * flow's own home, and the CLI is pointed at that home with the same layout's
+ * `envVarName` - so the path a login writes and the path a run reads can never
+ * drift apart.
+ */
+
+/** What the operator must be shown to complete a sign-in. */
+export interface LoginChallenge {
+	/** The URL to open. Opened on whatever device the operator is holding. */
+	url: string;
+	/** A one-time code to type on the vendor's page, when the flow uses one. */
+	userCode?: string;
+}
+
+export interface SubscriptionLoginDriver {
+	/** argv, run under the PTY `buildSubscriptionLoginScript` allocates. */
+	argv: readonly string[];
+	/**
+	 * Env beyond the runtime's own home var, which the caller always sets.
+	 * Anything here is a property of the login, not of a run.
+	 */
+	extraEnv?: Readonly<Record<string, string>>;
+	/**
+	 * Proof the installed CLI still offers this flow, run before the operator is
+	 * shown anything.
+	 *
+	 * The three coding CLIs are installed **unpinned** in the agent image, so a
+	 * flag can vanish under a rebuild. Without this the loss would surface as a
+	 * flow that hangs until its challenge timeout with nothing to say; with it,
+	 * the start fails naming the CLI and the flag.
+	 */
+	capabilityProbe?: { argv: readonly string[]; mustContain: string };
+	/** Recognise the challenge in the log so far. Null until the CLI has printed it. */
+	parseChallenge(log: string): LoginChallenge | null;
+	/**
+	 * What the operator returns. `'none'` means the CLI polls the vendor itself
+	 * and Hezo only waits - the sign-in never round-trips through Hezo at all.
+	 */
+	completion: 'none' | 'code';
+	/**
+	 * Where the credential ends up. `'auth-file'` reads the runtime's own
+	 * `authFileRelative`; a function reads it out of what the CLI printed.
+	 */
+	harvest: 'auth-file' | ((log: string) => string | null);
+	/** No challenge parsed by here means the output format moved. */
+	challengeTimeoutMs: number;
+	/** Matches the vendor's own expiry for the challenge. */
+	completionTimeoutMs: number;
+}
+
+const MINUTE = 60_000;
+
+/** First `https://` URL on a line of its own, ignoring anything inside prose. */
+function firstStandaloneUrl(text: string, hostContains: string): string | null {
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('https://')) continue;
+		if (!trimmed.includes(hostContains)) continue;
+		const url = trimmed.split(/\s+/)[0];
+		if (url.length > 0) return url;
+	}
+	return null;
+}
+
+/**
+ * Codex, via its device-code flow.
+ *
+ * The only one of the three that needs no PTY and returns nothing to Hezo: the
+ * CLI polls OpenAI itself and writes `auth.json` when the operator finishes on
+ * their own device. Verified against codex-cli 0.147.0, which prints the URL and
+ * code to stdout as their own lines:
+ *
+ *     1. Open this link in your browser and sign in to your account
+ *        https://auth.openai.com/codex/device
+ *
+ *     2. Enter this one-time code (expires in 15 minutes)
+ *        R314-OEASM
+ *
+ * `--device-auth` carries no description in `--help`, i.e. it is still beta -
+ * hence the probe.
+ */
+const CODEX_DRIVER: SubscriptionLoginDriver = {
+	argv: ['codex', 'login', '--device-auth'],
+	capabilityProbe: { argv: ['codex', 'login', '--help'], mustContain: '--device-auth' },
+	parseChallenge(log) {
+		const text = stripTerminalNoise(log);
+		const url = firstStandaloneUrl(text, 'auth.openai.com');
+		if (!url) return null;
+		// The code is printed alone on its line; matching that rather than
+		// scanning the whole text keeps it from picking a fragment out of the URL.
+		let userCode: string | undefined;
+		for (const line of text.split('\n')) {
+			const trimmed = line.trim();
+			if (/^[A-Z0-9]{4}-[A-Z0-9]{4,8}$/.test(trimmed)) {
+				userCode = trimmed;
+				break;
+			}
+		}
+		// Both halves or nothing: a URL without the code is an unfinished paint,
+		// and showing it would send the operator to a page they cannot complete.
+		return userCode ? { url, userCode } : null;
+	},
+	completion: 'none',
+	harvest: 'auth-file',
+	challengeTimeoutMs: 2 * MINUTE,
+	completionTimeoutMs: 15 * MINUTE,
+};
+
+/**
+ * Claude Code, via `setup-token`.
+ *
+ * Needs a PTY: on a pipe it emits zero bytes and never exits. Its callback is
+ * the hosted page `platform.claude.com/oauth/code/callback`, which displays a
+ * code rather than redirecting to a loopback port - so nothing has to listen
+ * anywhere and the operator simply brings the code back.
+ *
+ * The URL is read from the OSC 8 hyperlink rather than the visible text: the
+ * spinner redraws around it, and the on-screen copy comes back interleaved
+ * across several overlapping fragments while the escape stays whole.
+ */
+const CLAUDE_CODE_DRIVER: SubscriptionLoginDriver = {
+	argv: ['claude', 'setup-token'],
+	parseChallenge(log) {
+		for (const link of parseOsc8Links(log)) {
+			if (link.includes('/oauth/authorize')) return { url: link };
+		}
+		return null;
+	},
+	completion: 'code',
+	harvest: (log) => stripTerminalNoise(log).match(/sk-ant-oat01-[A-Za-z0-9_-]+/)?.[0] ?? null,
+	challengeTimeoutMs: 2 * MINUTE,
+	completionTimeoutMs: 15 * MINUTE,
+};
+
+/**
+ * Which runtimes can mint a credential from a guided sign-in, and which
+ * deliberately cannot.
+ *
+ * Exhaustive over `AgentRuntime` so a new CLI is a compile error here rather
+ * than a runtime that silently has no sign-in. `null` is a decision, not a gap:
+ * the provider keeps the manual paste path, and the UI offers only that.
+ */
+export const SUBSCRIPTION_LOGIN_DRIVERS: Record<AgentRuntime, SubscriptionLoginDriver | null> = {
+	[AgentRuntime.Codex]: CODEX_DRIVER,
+	[AgentRuntime.ClaudeCode]: CLAUDE_CODE_DRIVER,
+	/**
+	 * Gemini has no non-interactive sign-in to drive.
+	 *
+	 * It exposes no auth flag, boots straight into a full-screen TUI that
+	 * repaints continuously, and picks its auth method from a menu that only
+	 * arrow keys and Enter reach - so a driver would be synthesising keystrokes
+	 * against a redrawing screen, which breaks on any layout change. Google's own
+	 * headless guidance is to use `GOOGLE_API_KEY` or a service account instead.
+	 *
+	 * Google subscriptions therefore stay on manual paste until the CLI offers a
+	 * scriptable flow. Filling this in is one row, and nothing else changes.
+	 */
+	[AgentRuntime.Gemini]: null,
+	// Api-key only - no subscription auth to mint (see AI_PROVIDER_INFO).
+	[AgentRuntime.OpenCode]: null,
+	[AgentRuntime.Grok]: null,
+	[AgentRuntime.Kimi]: null,
+};

--- a/packages/server/src/services/subscription-login.ts
+++ b/packages/server/src/services/subscription-login.ts
@@ -1,0 +1,423 @@
+import { randomBytes } from 'node:crypto';
+import { type AgentRuntime, type AiProvider, effectiveRuntime } from '@hezo/shared';
+import { RUNTIME_HOME_LAYOUTS } from './runtime-home';
+import {
+	buildSubscriptionLoginCodeScript,
+	buildSubscriptionLoginScript,
+	LOGIN_EXIT_FILE,
+	LOGIN_LOG_FILE,
+} from './sandbox/proc-scripts';
+import type { ContainerEngine } from './sandbox/types';
+import {
+	type LoginChallenge,
+	SUBSCRIPTION_LOGIN_DRIVERS,
+	type SubscriptionLoginDriver,
+} from './subscription-login-drivers';
+
+/**
+ * Driving a coding CLI's own sign-in from Hezo, so the operator can complete it
+ * on whatever device they are holding.
+ *
+ * The CLI runs inside a container believing a local browser is available. It is
+ * not: Hezo reads the challenge the CLI printed, hands it to the operator's
+ * browser, and feeds back whatever that browser produced. The CLI performs its
+ * own token exchange and writes its own credential file, which is read out
+ * through {@link ContainerEngine.files} straight into the vault - so the
+ * credential never passes through the operator's clipboard, browser or form
+ * state, which is what pasting `auth.json` by hand requires today.
+ *
+ * **There is no port forwarding here, and there must not be.** The tunnel is
+ * container-initiated and restricted to fixed target keys, deliberately, so a
+ * CLI's loopback callback port can never be reached from outside. Every flow
+ * this drives is one the vendor already offers without a loopback: a device code
+ * the CLI polls itself, or a hosted callback page that displays a code.
+ */
+
+/** Where a flow's FIFO, log and exit file live inside the container. */
+const LOGIN_BASE_DIR = '/tmp/.hezo-login';
+
+/**
+ * How long an unfinished flow survives.
+ *
+ * Matches the longest vendor challenge expiry (15 minutes for a Codex device
+ * code) plus a minute of slack, so the flow outlives the code the operator is
+ * looking at rather than expiring under them.
+ */
+export const LOGIN_FLOW_TTL_MS = 16 * 60_000;
+
+/** How often the log is re-read while waiting for a challenge or a credential. */
+const POLL_INTERVAL_MS = 1_000;
+
+export type LoginFlowState =
+	| { status: 'starting' }
+	| { status: 'awaiting_user'; challenge: LoginChallenge; completion: 'none' | 'code' }
+	| { status: 'succeeded'; credential: string }
+	| { status: 'failed'; error: string; code: LoginFailureCode };
+
+/** Named so a caller can tell "the CLI moved" from "the operator gave up". */
+export type LoginFailureCode =
+	| 'unsupported'
+	| 'probe_failed'
+	| 'challenge_timeout'
+	| 'completion_timeout'
+	| 'exited_without_credential'
+	| 'cancelled'
+	| 'internal';
+
+export interface LoginFlow {
+	readonly id: string;
+	readonly provider: AiProvider;
+	readonly runtime: AgentRuntime;
+	/** The user this flow belongs to; re-checked on every poll. */
+	readonly ownerId: string;
+	readonly createdAt: number;
+	state: LoginFlowState;
+}
+
+interface FlowEntry extends LoginFlow {
+	driver: SubscriptionLoginDriver;
+	engine: ContainerEngine;
+	containerId: string;
+	dir: string;
+	/** Released on every exit path - success, failure, cancel, expiry. */
+	teardown: () => Promise<void>;
+	abort: AbortController;
+}
+
+export class SubscriptionLoginUnsupportedError extends Error {
+	readonly code: LoginFailureCode;
+	constructor(message: string, code: LoginFailureCode = 'unsupported') {
+		super(message);
+		this.name = 'SubscriptionLoginUnsupportedError';
+		this.code = code;
+	}
+}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const t = setTimeout(resolve, ms);
+		signal.addEventListener('abort', () => {
+			clearTimeout(t);
+			resolve();
+		});
+	});
+}
+
+async function execCapture(
+	engine: ContainerEngine,
+	containerId: string,
+	script: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const execId = await engine.execCreate(containerId, {
+		Cmd: ['sh', '-c', script],
+		AttachStdout: true,
+		AttachStderr: true,
+	});
+	const { stdout, stderr } = await engine.execStart(execId);
+	const { ExitCode } = await engine.execInspect(execId);
+	return { exitCode: ExitCode, stdout, stderr };
+}
+
+/**
+ * Which runtime a provider's guided sign-in would run on, or null when it has
+ * none.
+ *
+ * Resolved through `effectiveRuntime` so a config pinned to an alternate CLI
+ * gets that CLI's flow rather than the provider's default - the same resolution
+ * the run path uses.
+ */
+export function loginRuntimeFor(
+	provider: AiProvider,
+	storedRuntime: AgentRuntime | null,
+): AgentRuntime | null {
+	const runtime = effectiveRuntime(provider, storedRuntime);
+	if (!runtime) return null;
+	return SUBSCRIPTION_LOGIN_DRIVERS[runtime] ? runtime : null;
+}
+
+/**
+ * In-memory registry of live sign-ins.
+ *
+ * Deliberately not persisted: a flow is bound to a container and a challenge
+ * that both die with the process, so a row surviving a restart would describe
+ * something that no longer exists. A restart drops every flow and the operator
+ * starts again, which is the honest outcome.
+ */
+export class SubscriptionLoginService {
+	private readonly flows = new Map<string, FlowEntry>();
+
+	/** Flows whose TTL has passed, torn down lazily on every touch. */
+	private prune(): void {
+		const cutoff = Date.now() - LOGIN_FLOW_TTL_MS;
+		for (const [id, flow] of this.flows) {
+			if (flow.createdAt < cutoff) {
+				void this.finish(id, {
+					status: 'failed',
+					error: 'Sign-in expired before it was completed',
+					code: 'completion_timeout',
+				});
+			}
+		}
+	}
+
+	/**
+	 * Launch a sign-in and return its id. The challenge is not ready yet; the
+	 * caller polls {@link get} for it.
+	 *
+	 * The capability probe runs before anything is shown, so a CLI that no longer
+	 * offers this flow fails here by name rather than as a silent hang.
+	 */
+	async start(opts: {
+		provider: AiProvider;
+		storedRuntime: AgentRuntime | null;
+		ownerId: string;
+		engine: ContainerEngine;
+		containerId: string;
+		teardown: () => Promise<void>;
+	}): Promise<LoginFlow> {
+		this.prune();
+		const { provider, storedRuntime, ownerId, engine, containerId, teardown } = opts;
+
+		const runtime = effectiveRuntime(provider, storedRuntime);
+		const driver = runtime ? SUBSCRIPTION_LOGIN_DRIVERS[runtime] : null;
+		if (!runtime || !driver) {
+			await teardown();
+			throw new SubscriptionLoginUnsupportedError(
+				`${runtime ?? provider} has no guided sign-in - paste the credential manually instead`,
+			);
+		}
+
+		if (driver.capabilityProbe) {
+			const { argv, mustContain } = driver.capabilityProbe;
+			const probe = await execCapture(engine, containerId, argv.join(' ')).catch(() => null);
+			if (!probe || !`${probe.stdout}${probe.stderr}`.includes(mustContain)) {
+				await teardown();
+				throw new SubscriptionLoginUnsupportedError(
+					`the installed ${argv[0]} CLI no longer offers ${mustContain} - paste the credential manually instead`,
+					'probe_failed',
+				);
+			}
+		}
+
+		const id = randomBytes(16).toString('hex');
+		const dir = `${LOGIN_BASE_DIR}/${id}`;
+		const layout = RUNTIME_HOME_LAYOUTS[runtime];
+
+		const entry: FlowEntry = {
+			id,
+			provider,
+			runtime,
+			ownerId,
+			createdAt: Date.now(),
+			state: { status: 'starting' },
+			driver,
+			engine,
+			containerId,
+			dir,
+			teardown,
+			abort: new AbortController(),
+		};
+		this.flows.set(id, entry);
+
+		// The CLI's config home is the flow's own directory, so `auth-file`
+		// harvesting reads exactly the path a run would later mount.
+		const home = `${dir}/home`;
+		const script = buildSubscriptionLoginScript({
+			dir,
+			argv: driver.argv,
+			env: { [layout.envVarName]: home, ...driver.extraEnv },
+			holdSecs: Math.ceil(LOGIN_FLOW_TTL_MS / 1000),
+		});
+
+		const launched = await execCapture(engine, containerId, `mkdir -p ${home} && ${script}`).catch(
+			(e: unknown) => ({ exitCode: 1, stdout: '', stderr: String(e) }),
+		);
+		if (launched.exitCode !== 0) {
+			await this.finish(id, {
+				status: 'failed',
+				error: `could not start ${driver.argv[0]}: ${launched.stderr.trim() || 'unknown error'}`,
+				code: 'internal',
+			});
+			throw new SubscriptionLoginUnsupportedError(
+				`could not start ${driver.argv[0]} in the container`,
+				'internal',
+			);
+		}
+
+		void this.watch(id);
+		return entry;
+	}
+
+	/** Current state, with the owner re-checked as `routes/oauth.ts` does on poll. */
+	get(id: string, ownerId: string): LoginFlow | null {
+		this.prune();
+		const flow = this.flows.get(id);
+		if (!flow || flow.ownerId !== ownerId) return null;
+		return flow;
+	}
+
+	/**
+	 * Deliver the operator's code to a waiting CLI.
+	 *
+	 * Rejected unless the flow actually asked for one - a driver whose CLI polls
+	 * the vendor itself has no prompt to answer, and writing to its FIFO would
+	 * put stray input in front of whatever it does read.
+	 */
+	async submitCode(id: string, ownerId: string, code: string): Promise<boolean> {
+		const flow = this.flows.get(id);
+		if (!flow || flow.ownerId !== ownerId) return false;
+		if (flow.state.status !== 'awaiting_user' || flow.driver.completion !== 'code') return false;
+		const res = await execCapture(
+			flow.engine,
+			flow.containerId,
+			buildSubscriptionLoginCodeScript(flow.dir, code.trim()),
+		).catch(() => null);
+		return res?.exitCode === 0;
+	}
+
+	/** Operator-initiated stop. Tears the container down like any other exit. */
+	async cancel(id: string, ownerId: string): Promise<boolean> {
+		const flow = this.flows.get(id);
+		if (!flow || flow.ownerId !== ownerId) return false;
+		await this.finish(id, { status: 'failed', error: 'Sign-in cancelled', code: 'cancelled' });
+		return true;
+	}
+
+	/** Drop every flow - process shutdown, so nothing is left holding a container. */
+	async shutdown(): Promise<void> {
+		await Promise.all(
+			[...this.flows.keys()].map((id) =>
+				this.finish(id, { status: 'failed', error: 'Server shutting down', code: 'cancelled' }),
+			),
+		);
+	}
+
+	/**
+	 * Poll the flow's log until it yields a challenge and then a credential.
+	 *
+	 * A file read rather than a byte stream, because `SandboxFiles` behaves
+	 * identically on every backend where an exec channel's stream semantics do
+	 * not - Daytona's redirects stderr to a file drained only on close, which
+	 * would strand a challenge printed there.
+	 */
+	private async watch(id: string): Promise<void> {
+		const flow = this.flows.get(id);
+		if (!flow) return;
+		const { driver, engine, containerId, dir, abort } = flow;
+		const files = engine.files(containerId, dir);
+		const startedAt = Date.now();
+
+		try {
+			while (!abort.signal.aborted) {
+				const log = await files.read(LOGIN_LOG_FILE).catch(() => '');
+
+				if (flow.state.status === 'starting') {
+					const challenge = driver.parseChallenge(log);
+					if (challenge) {
+						flow.state = {
+							status: 'awaiting_user',
+							challenge,
+							completion: driver.completion,
+						};
+					} else if (Date.now() - startedAt > driver.challengeTimeoutMs) {
+						await this.finish(id, {
+							status: 'failed',
+							error: `${driver.argv[0]} printed no sign-in link - its output format may have changed`,
+							code: 'challenge_timeout',
+						});
+						return;
+					}
+				}
+
+				if (flow.state.status === 'awaiting_user') {
+					const credential = await this.tryHarvest(flow, files, log);
+					if (credential) {
+						await this.finish(id, { status: 'succeeded', credential });
+						return;
+					}
+					// The CLI exiting without a credential is terminal: nothing else
+					// is going to write one, so waiting out the TTL would only make
+					// the operator watch a spinner for fifteen minutes.
+					if (await files.exists(LOGIN_EXIT_FILE)) {
+						await this.finish(id, {
+							status: 'failed',
+							error: `${driver.argv[0]} exited before a credential was issued`,
+							code: 'exited_without_credential',
+						});
+						return;
+					}
+					if (Date.now() - startedAt > driver.completionTimeoutMs) {
+						await this.finish(id, {
+							status: 'failed',
+							error: 'Sign-in expired before it was completed',
+							code: 'completion_timeout',
+						});
+						return;
+					}
+				}
+
+				await delay(POLL_INTERVAL_MS, abort.signal);
+			}
+		} catch (e) {
+			await this.finish(id, {
+				status: 'failed',
+				error: e instanceof Error ? e.message : String(e),
+				code: 'internal',
+			});
+		}
+	}
+
+	private async tryHarvest(
+		flow: FlowEntry,
+		files: ReturnType<ContainerEngine['files']>,
+		log: string,
+	): Promise<string | null> {
+		const { harvest } = flow.driver;
+		if (typeof harvest === 'function') return harvest(log);
+
+		// `auth-file`: the runtime's own auth path under the flow's home, so the
+		// path a login writes and the path a run reads cannot drift.
+		const rel = RUNTIME_HOME_LAYOUTS[flow.runtime].authFileRelative;
+		if (!rel) return null;
+		const path = `home/${rel}`;
+		if (!(await files.exists(path))) return null;
+		const contents = await files.read(path).catch(() => '');
+		return contents.trim().length > 0 ? contents : null;
+	}
+
+	/**
+	 * Settle a flow and release its container, exactly once.
+	 *
+	 * Every exit path lands here - success, each failure, cancel, TTL expiry and
+	 * shutdown - so there is one place that can strand a container and it is this
+	 * one. Teardown failures are swallowed: the flow's outcome is already decided,
+	 * and a container that outlives it is swept by label.
+	 */
+	private async finish(id: string, state: LoginFlowState): Promise<void> {
+		const flow = this.flows.get(id);
+		if (!flow) return;
+		this.flows.delete(id);
+		flow.state = state;
+		flow.abort.abort();
+		await flow.teardown().catch(() => undefined);
+
+		// A settled flow stays readable briefly so the poll that follows the last
+		// state change sees the outcome rather than a bare 404.
+		this.settled.set(id, { flow, at: Date.now() });
+		for (const [key, held] of this.settled) {
+			if (Date.now() - held.at > SETTLED_RETENTION_MS) this.settled.delete(key);
+		}
+	}
+
+	private readonly settled = new Map<string, { flow: FlowEntry; at: number }>();
+
+	/** State of a flow that has already settled, for the poll that reads the result. */
+	getSettled(id: string, ownerId: string): LoginFlow | null {
+		const held = this.settled.get(id);
+		if (!held || held.flow.ownerId !== ownerId) return null;
+		return held.flow;
+	}
+}
+
+/** How long a settled flow's outcome remains readable to its poller. */
+const SETTLED_RETENTION_MS = 60_000;

--- a/packages/server/test/subscription-login-drivers.test.ts
+++ b/packages/server/test/subscription-login-drivers.test.ts
@@ -1,0 +1,167 @@
+import { AgentRuntime } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import { parseOsc8Links, stripTerminalNoise } from '../src/services/sandbox/proc-scripts';
+import { SUBSCRIPTION_LOGIN_DRIVERS } from '../src/services/subscription-login-drivers';
+
+/**
+ * The fixtures below are **recorded verbatim** from the real CLIs at the
+ * versions an unpinned image build installs, captured with the streams
+ * separated and no TTY (Codex) and under a PTY (Claude Code).
+ *
+ * They are the whole point of this file: a parser written against prose in a
+ * vendor doc is a guess, and the failure mode of a wrong guess is a sign-in that
+ * hangs with nothing to say. Replace a fixture only by re-recording it.
+ */
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+/** codex-cli 0.147.0, `codex login --device-auth`, stdout, no TTY. */
+const CODEX_DEVICE_AUTH_STDOUT = [
+	'',
+	`Welcome to Codex [v${ESC}[90m0.147.0${ESC}[0m]`,
+	`${ESC}[90mOpenAI's command-line coding agent${ESC}[0m`,
+	'',
+	'Follow these steps to sign in with ChatGPT using device code authorization:',
+	'',
+	'1. Open this link in your browser and sign in to your account',
+	`   ${ESC}[94mhttps://auth.openai.com/codex/device${ESC}[0m`,
+	'',
+	`2. Enter this one-time code ${ESC}[90m(expires in 15 minutes)${ESC}[0m`,
+	`   ${ESC}[94mR314-OEASM${ESC}[0m`,
+	'',
+	`${ESC}[90mContinue only if you started this login in Codex. If a website or another person gave you this code, cancel.${ESC}[0m`,
+	'',
+].join('\n');
+
+const CLAUDE_AUTHORIZE_URL =
+	'https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e' +
+	'&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback' +
+	'&scope=user%3Ainference&code_challenge=8GlbqwGcLfCjSZqd4YKPNlnkImyrVGhW4JyztmEYzKo' +
+	'&code_challenge_method=S256&state=SaXNZH65yg7VK-VEbRRQHqkLeMLCqg9ylLXiQcLJ4_4';
+
+/**
+ * claude-code 2.1.232, `claude setup-token`, under a PTY.
+ *
+ * The visible link text is deliberately reproduced as the mangled fragments the
+ * spinner redraw leaves behind - that mangling is exactly why the driver reads
+ * the OSC 8 escape instead.
+ */
+const CLAUDE_SETUP_TOKEN_PTY = [
+	`${ESC}[?25lWelcome to Claude Code v2.1.232`,
+	`${ESC}[90m·${ESC}[0m Opening browser to sign in…`,
+	'✢  ✶  ✻  ✽  ✻  ✶  ✢  ·',
+	"Browser didn't open? Use the url below to sign in (c to copy)",
+	`${ESC}]8;id=155gj3v;${CLAUDE_AUTHORIZE_URL}${ESC}\\https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88${ESC}]8;;${ESC}\\`,
+	`${ESC}]8;id=155gj3v;${CLAUDE_AUTHORIZE_URL}${ESC}\\ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.co${ESC}]8;;${ESC}\\`,
+	'Paste code here if prompted >',
+].join('\r\n');
+
+describe('terminal output parsing', () => {
+	it('strips CSI colour runs but keeps the text between them', () => {
+		const text = stripTerminalNoise(CODEX_DEVICE_AUTH_STDOUT);
+		expect(text).toContain('https://auth.openai.com/codex/device');
+		expect(text).toContain('R314-OEASM');
+		expect(text).not.toContain(ESC);
+		expect(text).not.toContain('[94m');
+	});
+
+	it('turns carriage returns into line breaks so a redrawn line stands alone', () => {
+		expect(stripTerminalNoise('a\rb')).toBe('a\nb');
+	});
+
+	it('recovers an OSC 8 target whose visible text was redrawn into fragments', () => {
+		expect(parseOsc8Links(CLAUDE_SETUP_TOKEN_PTY)[0]).toBe(CLAUDE_AUTHORIZE_URL);
+	});
+
+	it('accepts a BEL-terminated OSC 8 sequence as well as ESC-backslash', () => {
+		expect(parseOsc8Links(`${ESC}]8;;https://example.com/x${BEL}text`)).toEqual([
+			'https://example.com/x',
+		]);
+	});
+
+	it('ignores an OSC 8 close sequence, which carries no target', () => {
+		expect(parseOsc8Links(`${ESC}]8;;${ESC}\\`)).toEqual([]);
+	});
+});
+
+describe('codex device-auth driver', () => {
+	const driver = SUBSCRIPTION_LOGIN_DRIVERS[AgentRuntime.Codex];
+
+	it('reads the verification URL and the one-time code from real output', () => {
+		expect(driver?.parseChallenge(CODEX_DEVICE_AUTH_STDOUT)).toEqual({
+			url: 'https://auth.openai.com/codex/device',
+			userCode: 'R314-OEASM',
+		});
+	});
+
+	it('withholds a half-painted challenge rather than sending the operator to an unusable page', () => {
+		const upToUrl = CODEX_DEVICE_AUTH_STDOUT.split('2. Enter this one-time code')[0];
+		expect(upToUrl).toContain('auth.openai.com');
+		expect(driver?.parseChallenge(upToUrl)).toBeNull();
+	});
+
+	it('returns null on output that carries no challenge at all', () => {
+		expect(driver?.parseChallenge('Welcome to Codex\n')).toBeNull();
+	});
+
+	it('needs nothing back from the operator and harvests the runtime auth file', () => {
+		expect(driver?.completion).toBe('none');
+		expect(driver?.harvest).toBe('auth-file');
+	});
+
+	it('probes for the beta flag it depends on', () => {
+		expect(driver?.capabilityProbe?.mustContain).toBe('--device-auth');
+	});
+});
+
+describe('claude setup-token driver', () => {
+	const driver = SUBSCRIPTION_LOGIN_DRIVERS[AgentRuntime.ClaudeCode];
+
+	it('reads the authorize URL out of the PTY redraw', () => {
+		expect(driver?.parseChallenge(CLAUDE_SETUP_TOKEN_PTY)).toEqual({ url: CLAUDE_AUTHORIZE_URL });
+	});
+
+	it('offers no user code, because its callback page displays one instead', () => {
+		expect(driver?.parseChallenge(CLAUDE_SETUP_TOKEN_PTY)?.userCode).toBeUndefined();
+	});
+
+	it('ignores a hyperlink that is not an authorize URL', () => {
+		expect(driver?.parseChallenge(`${ESC}]8;;https://claude.com/docs${ESC}\\`)).toBeNull();
+	});
+
+	it('asks the operator for a code', () => {
+		expect(driver?.completion).toBe('code');
+	});
+
+	it('harvests the oat token the CLI prints, not an API key', () => {
+		const harvest = driver?.harvest;
+		expect(typeof harvest).toBe('function');
+		if (typeof harvest !== 'function') return;
+		expect(harvest(`${ESC}[32mtoken:${ESC}[0m sk-ant-oat01-AbC123_x-Y\n`)).toBe(
+			'sk-ant-oat01-AbC123_x-Y',
+		);
+		expect(harvest('sk-ant-api03-not-a-subscription-token')).toBeNull();
+		expect(harvest('Paste code here if prompted >')).toBeNull();
+	});
+});
+
+describe('driver coverage', () => {
+	it('is exhaustive over every runtime, so a new CLI cannot be silently missed', () => {
+		for (const runtime of Object.values(AgentRuntime)) {
+			expect(SUBSCRIPTION_LOGIN_DRIVERS).toHaveProperty(runtime);
+		}
+	});
+
+	it('leaves Gemini on manual paste deliberately, having no scriptable sign-in', () => {
+		expect(SUBSCRIPTION_LOGIN_DRIVERS[AgentRuntime.Gemini]).toBeNull();
+	});
+
+	it('gives every driver a challenge timeout below its completion timeout', () => {
+		for (const driver of Object.values(SUBSCRIPTION_LOGIN_DRIVERS)) {
+			if (!driver) continue;
+			expect(driver.challengeTimeoutMs).toBeGreaterThan(0);
+			expect(driver.challengeTimeoutMs).toBeLessThan(driver.completionTimeoutMs);
+		}
+	});
+});

--- a/packages/server/test/subscription-login-script.test.ts
+++ b/packages/server/test/subscription-login-script.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -31,8 +31,21 @@ function tempDir(): string {
 	return d;
 }
 
+/**
+ * Best-effort, because the script deliberately outlives the command that
+ * launched it - a `sleep` holds the FIFO open for the whole flow, which is the
+ * mechanism under test. Every test below waits for its own exit file first, so
+ * a leftover here is a stray temp directory the OS will reap, never a signal
+ * worth failing a suite over.
+ */
 afterAll(() => {
-	for (const d of dirs) rmSync(d, { recursive: true, force: true });
+	for (const d of dirs) {
+		try {
+			rmSync(d, { recursive: true, force: true });
+		} catch {
+			// see above
+		}
+	}
 });
 
 describe('shellQuote', () => {
@@ -154,6 +167,17 @@ describe('the generated script, under real sh', () => {
 		throw new Error('timed out');
 	}
 
+	/**
+	 * Wait until the flow has fully finished, not merely produced its output.
+	 *
+	 * The exit file is written *after* the CLI is reaped, so it is the only
+	 * signal that nothing under the flow directory will be created again. Racing
+	 * teardown against it is how this suite first failed on CI: cleanup deleted
+	 * the log, the CLI then exited, and `echo $? > exit` recreated an entry in a
+	 * directory that had just been walked - ENOTEMPTY.
+	 */
+	const exited = (dir: string) => () => existsSync(join(dir, LOGIN_EXIT_FILE));
+
 	it('carries a challenge out and the operator code back in', async () => {
 		const home = tempDir();
 		const dir = join(tempDir(), 'flow');
@@ -178,6 +202,7 @@ describe('the generated script, under real sh', () => {
 
 		await run('sh', ['-c', buildSubscriptionLoginCodeScript(dir, 'CODE-1234')]);
 		await waitFor(() => log().includes('got:CODE-1234'));
+		await waitFor(exited(dir));
 	});
 
 	it('writes the exit file once the CLI is gone', async () => {
@@ -186,14 +211,7 @@ describe('the generated script, under real sh', () => {
 		const cli = fakeCli(home, 'echo done; exit 0');
 
 		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
-		await waitFor(() => {
-			try {
-				readFileSync(join(dir, LOGIN_EXIT_FILE), 'utf8');
-				return true;
-			} catch {
-				return false;
-			}
-		});
+		await waitFor(exited(dir));
 	});
 
 	it('delivers a code containing shell metacharacters verbatim', async () => {
@@ -211,5 +229,6 @@ describe('the generated script, under real sh', () => {
 
 		expect(log()).toContain(`got:${hostile}`);
 		expect(() => readFileSync(join(home, 'pwned'))).toThrow();
+		await waitFor(exited(dir));
 	});
 });

--- a/packages/server/test/subscription-login-script.test.ts
+++ b/packages/server/test/subscription-login-script.test.ts
@@ -1,0 +1,215 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+	buildSubscriptionLoginCodeScript,
+	buildSubscriptionLoginScript,
+	LOGIN_EXIT_FILE,
+	LOGIN_LOG_FILE,
+	LOGIN_STDIN_FIFO,
+	shellQuote,
+} from '../src/services/sandbox/proc-scripts';
+
+const run = promisify(execFile);
+
+/**
+ * The login script is the one piece of this feature that is shell rather than
+ * TypeScript, so it is tested the way `agent-prompt-delivery.test.ts` tests its
+ * own block: asserted on as a string for the parts that must be exact, then
+ * **executed under real `sh`** for the part that only running proves - that a
+ * CLI launched by it can print a challenge, block on stdin minutes later, and
+ * still receive what the operator eventually types.
+ */
+
+const dirs: string[] = [];
+function tempDir(): string {
+	const d = mkdtempSync(join(tmpdir(), 'hezo-login-'));
+	dirs.push(d);
+	return d;
+}
+
+afterAll(() => {
+	for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+describe('shellQuote', () => {
+	it('wraps a plain argument', () => {
+		expect(shellQuote('codex')).toBe("'codex'");
+	});
+
+	it('closes and reopens around an embedded quote, so nothing escapes the string', () => {
+		expect(shellQuote("a'b")).toBe(`'a'\\''b'`);
+	});
+
+	it('neutralises every shell metacharacter that would otherwise run', async () => {
+		const hostile = `x'; touch ${'${PWD}'}/pwned; echo '`;
+		const { stdout } = await run('sh', ['-c', `printf '%s' ${shellQuote(hostile)}`]);
+		expect(stdout).toBe(hostile);
+	});
+});
+
+describe('buildSubscriptionLoginScript', () => {
+	const base = { dir: '/tmp/flow', argv: ['codex', 'login', '--device-auth'], holdSecs: 60 };
+
+	it('rejects a directory that could break out of its quoting', () => {
+		expect(() => buildSubscriptionLoginScript({ ...base, dir: '/tmp/$(id)' })).toThrow(
+			/unsafe dir/,
+		);
+		expect(() => buildSubscriptionLoginScript({ ...base, dir: 'relative' })).toThrow(/unsafe dir/);
+	});
+
+	it('rejects an empty command and a nonsensical hold', () => {
+		expect(() => buildSubscriptionLoginScript({ ...base, argv: [] })).toThrow(/argv is empty/);
+		expect(() => buildSubscriptionLoginScript({ ...base, holdSecs: 0 })).toThrow(/bad holdSecs/);
+		expect(() => buildSubscriptionLoginScript({ ...base, holdSecs: 1.5 })).toThrow(/bad holdSecs/);
+	});
+
+	it('rejects an env name that is not a shell identifier', () => {
+		expect(() => buildSubscriptionLoginScript({ ...base, env: { 'A;rm -rf /': 'x' } })).toThrow(
+			/unsafe env name/,
+		);
+	});
+
+	/**
+	 * Quoted twice on purpose: once per element, then again around the joined
+	 * string, because `script -qec` takes the whole command as one argument and
+	 * re-parses it with a shell. Both layers have to hold for an argv element to
+	 * be safe, so this asserts on the nesting rather than the flat form.
+	 */
+	it('quotes each argv element separately, inside the outer quoting', () => {
+		const script = buildSubscriptionLoginScript(base);
+		expect(script).toContain(`'\\''codex'\\'' '\\''login'\\'' '\\''--device-auth'\\''`);
+	});
+
+	it('opens the PTY wide enough that a sign-in URL cannot wrap', () => {
+		expect(buildSubscriptionLoginScript(base)).toContain('COLUMNS=1000');
+	});
+
+	it('holds the stdin FIFO open for the whole flow', () => {
+		const script = buildSubscriptionLoginScript({ ...base, holdSecs: 960 });
+		expect(script).toContain(`sleep 960 > '/tmp/flow/${LOGIN_STDIN_FIFO}'`);
+	});
+
+	it('merges stderr into the polled log, so a challenge printed there is not lost', () => {
+		expect(buildSubscriptionLoginScript(base)).toContain(`> '/tmp/flow/${LOGIN_LOG_FILE}' 2>&1`);
+	});
+
+	it('records the exit status last, as the "process is gone" signal', () => {
+		expect(buildSubscriptionLoginScript(base)).toContain(
+			`echo $? > '/tmp/flow/${LOGIN_EXIT_FILE}'`,
+		);
+	});
+
+	it('addresses every file absolutely, so the second background job cannot land elsewhere', () => {
+		const script = buildSubscriptionLoginScript(base);
+		expect(script).not.toMatch(/\bcd\b/);
+		// Both background jobs must name the same absolute FIFO.
+		expect(script.match(/'\/tmp\/flow\/in'/g)?.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('detaches both background jobs stdio, so the launching exec can complete', () => {
+		const script = buildSubscriptionLoginScript(base);
+		expect(script.match(/>\/dev\/null 2>&1 &/g)).toHaveLength(2);
+	});
+
+	it('passes driver env through to the CLI', () => {
+		const script = buildSubscriptionLoginScript({ ...base, env: { CODEX_HOME: '/tmp/flow/home' } });
+		expect(script).toContain(`CODEX_HOME='/tmp/flow/home'`);
+	});
+});
+
+describe('buildSubscriptionLoginCodeScript', () => {
+	it('rejects an unsafe directory', () => {
+		expect(() => buildSubscriptionLoginCodeScript('/tmp/`id`', 'abc')).toThrow(/unsafe dir/);
+	});
+
+	it('quotes a code containing shell metacharacters', () => {
+		const script = buildSubscriptionLoginCodeScript('/tmp/flow', "a'; id #");
+		expect(script).toContain(`'a'\\''; id #'`);
+	});
+});
+
+describe('the generated script, under real sh', () => {
+	/**
+	 * A stand-in for a vendor CLI: prints a challenge, then blocks reading a code
+	 * from stdin and writes a credential once it arrives. That sequence - print,
+	 * then block for an unbounded time, then read - is exactly what the FIFO
+	 * exists for, and what a string assertion cannot prove works.
+	 */
+	function fakeCli(dir: string, body: string): string {
+		const path = join(dir, 'fake-cli.sh');
+		writeFileSync(path, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+		return path;
+	}
+
+	async function waitFor(check: () => boolean, timeoutMs = 15_000): Promise<void> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			if (check()) return;
+			await new Promise((r) => setTimeout(r, 100));
+		}
+		throw new Error('timed out');
+	}
+
+	it('carries a challenge out and the operator code back in', async () => {
+		const home = tempDir();
+		const dir = join(tempDir(), 'flow');
+		const cli = fakeCli(
+			home,
+			[
+				'echo "Open this link:"',
+				'echo "   https://auth.example.com/device"',
+				'read code',
+				'echo "got:$code"',
+			].join('\n'),
+		);
+
+		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
+
+		const log = () => readFileSync(join(dir, LOGIN_LOG_FILE), 'utf8');
+		await waitFor(() => log().includes('https://auth.example.com/device'));
+
+		// The CLI is still blocked on stdin here - minutes may pass in production
+		// while the operator signs in on another device.
+		expect(log()).not.toContain('got:');
+
+		await run('sh', ['-c', buildSubscriptionLoginCodeScript(dir, 'CODE-1234')]);
+		await waitFor(() => log().includes('got:CODE-1234'));
+	});
+
+	it('writes the exit file once the CLI is gone', async () => {
+		const home = tempDir();
+		const dir = join(tempDir(), 'flow');
+		const cli = fakeCli(home, 'echo done; exit 0');
+
+		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
+		await waitFor(() => {
+			try {
+				readFileSync(join(dir, LOGIN_EXIT_FILE), 'utf8');
+				return true;
+			} catch {
+				return false;
+			}
+		});
+	});
+
+	it('delivers a code containing shell metacharacters verbatim', async () => {
+		const home = tempDir();
+		const dir = join(tempDir(), 'flow');
+		const cli = fakeCli(home, 'echo ready\nread code\necho "got:$code"');
+		const hostile = `a'; touch ${join(home, 'pwned')}; echo '`;
+
+		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
+		const log = () => readFileSync(join(dir, LOGIN_LOG_FILE), 'utf8');
+		await waitFor(() => log().includes('ready'));
+
+		await run('sh', ['-c', buildSubscriptionLoginCodeScript(dir, hostile)]);
+		await waitFor(() => log().includes('got:'));
+
+		expect(log()).toContain(`got:${hostile}`);
+		expect(() => readFileSync(join(home, 'pwned'))).toThrow();
+	});
+});


### PR DESCRIPTION
## Why

To use a provider **subscription** today, an operator must install the vendor CLI locally, run its login, locate the credential file, and paste its raw contents into a textarea. That is impractical on a phone, and OpenAI's own docs say `auth.json` should never be pasted into a form or chat.

This makes Hezo drive the CLI's *own* sign-in inside a container: Hezo reads the challenge the CLI prints, the operator completes it on whatever device they are holding, and the credential is harvested through the sandbox file seam straight into the vault - never passing through a clipboard, browser or form state. That is a security improvement as much as a UX one.

## Research this is built on

The design was settled by probing the **real** published CLIs rather than vendor prose, because a parser written against a doc is a guess and a wrong guess hangs a sign-in with nothing to say.

| Provider | Command | PTY | Challenge | Operator returns | Harvest |
|---|---|---|---|---|---|
| OpenAI | `codex login --device-auth` | no | stdout; constant URL + `XXXX-XXXXX` code, 15-min expiry | **nothing** - the CLI polls itself | `$CODEX_HOME/auth.json` |
| Anthropic | `claude setup-token` | **yes** | URL inside an OSC 8 hyperlink; hosted callback page | code on stdin | `sk-ant-oat01-…` from output |
| Google | interactive TUI only | **yes** | repainting full-screen TUI, auth chosen by menu navigation | n/a | n/a |

Three findings shaped the code:

1. **`--device-auth` is real in codex-cli 0.147.0** (verified against the binary; undocumented in `--help`, i.e. beta). It needs no PTY and returns nothing to Hezo.
2. **`claude setup-token` emits zero bytes and never exits on a pipe.** It needs a PTY, and its URL must be read from the OSC 8 escape - the visible copy comes back as overlapping fragments around the spinner redraw.
3. **Gemini has no scriptable sign-in.** No auth flag, a menu only arrow keys reach, and Google's own headless guidance is to use an API key instead.

**Callback-URL replay was considered and dropped**: no provider's blocker is the loopback callback. Codex polls itself, Anthropic's callback is a hosted page, and Gemini's blocker is the TUI.

## What is here

- **`sandbox/proc-scripts.ts`** - the login script and its parsers, together as that module requires. The PTY is allocated *by the script*, never taken from the exec channel: the two backends disagree about whether theirs has one, and Daytona's redirects stderr to a file drained only on close, which would strand a challenge printed there. Streams are merged to a log the host polls, so the flow uses only the exec triad and `SandboxFiles` - the two seams identical on every backend by rule.
- **`subscription-login-drivers.ts`** - one table keyed by runtime, exhaustive over `AgentRuntime`. Harvest paths are read from `RUNTIME_HOME_LAYOUTS` rather than restated, so a login writes exactly where a run reads. Gemini is `null` with its reason recorded.
- **`subscription-login.ts`** - the flow registry, mirroring the device-flow shape already in `routes/oauth.ts` (opaque id, TTL, lazy prune, owner re-checked on poll). Every exit path releases its container through one place.

**No port forwarding, and none is possible** - the tunnel stays container-initiated and target-key restricted.

`shellQuote` moved from `docker.ts` into `proc-scripts.ts` on its second call site, per the two-call-sites rule.

## Testing

18 tests against output **recorded verbatim** from codex-cli 0.147.0 and claude-code 2.1.232 - ANSI stripping, OSC 8 extraction, fragment-resistant URL recovery, half-painted challenges withheld, and an API key rejected where an oat token is expected. `bun run typecheck` and `biome check` clean.

## Not yet here

This commit is the mechanism only and is **not yet reachable**. Still to come: the four routes under `/api/ai-providers/subscription-login/*`, container acquisition and teardown wiring, the web dialog (with the manual paste form retained behind a disclosure), i18n across all 12 catalogs, and the `docs/ai-models.md` + `.dev/architecture.md` passes.

**Gemini needs a call.** The user asked for all three providers; the probing found Gemini has no scriptable flow to drive, so it is `null` in the table and stays on manual paste. Filling it in later is one row and nothing else changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TKENbkGrjsELmGLthvWCR)_