### PR TITLE
feat(web): make dashboard action-item rows whole-row links

### DIFF
--- a/packages/web/src/components/project-dashboard.tsx
+++ b/packages/web/src/components/project-dashboard.tsx
@@ -114,16 +114,6 @@ function approvalText(approval: { type: string; requested_by_name: string | null
 	}
 }
 
-function approvalActionLabel(type: string): string {
-	if (type === ApprovalType.DesignatedRepoRequest) return 'Set up';
-	if (type === ApprovalType.PlanReview) return 'Open plan';
-	if (type === ApprovalType.SkillProposal) return 'Review';
-	return 'Open';
-}
-
-const ACTION_LINK_CLASS =
-	'shrink-0 rounded-md border border-border px-2 py-1 text-[12px] text-text-1 hover:bg-surface-2';
-
 // ---------------------------------------------------------------------------
 // Drag handle
 // ---------------------------------------------------------------------------
@@ -173,84 +163,69 @@ function WidgetHeader({
 // Needs You (Action items) — full width, no drag
 // ---------------------------------------------------------------------------
 
-function NeedsYouRowShell({
+const NEEDS_YOU_ROW_CLASS = 'flex items-center gap-3 px-3 py-2.5 hover:bg-surface-2';
+
+/** The row itself is the control, so its inner layout is all this renders. */
+function NeedsYouRowContent({
 	tag,
 	tagColor,
 	children,
 	createdAt,
-	actionLink,
 }: {
 	tag: string;
 	tagColor: 'accent' | 'info' | 'warning';
 	children: ReactNode;
 	createdAt: string;
-	actionLink: ReactNode;
 }) {
 	return (
-		<div
-			className="flex items-center gap-3 px-3 py-2.5"
-			data-testid="project-dashboard-needs-you-row"
-		>
+		<>
 			<Badge color={tagColor} mono className="shrink-0">
 				{tag}
 			</Badge>
 			<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{children}</span>
 			<span className="shrink-0 font-mono text-[11px] text-text-3">{relativeTime(createdAt)}</span>
-			{actionLink}
-		</div>
+		</>
 	);
 }
 
 function NeedsYouRow({ projectId, row }: { projectId: string; row: ProjectDashboardNeedsYouItem }) {
 	if (row.kind === 'approval') {
 		return (
-			<NeedsYouRowShell
-				tag="action"
-				tagColor="accent"
-				createdAt={row.created_at}
-				actionLink={
-					<Link
-						to="/projects/$projectId/inbox"
-						params={{ projectId }}
-						className={ACTION_LINK_CLASS}
-					>
-						{approvalActionLabel(row.approval.type)}
-					</Link>
-				}
+			<Link
+				to="/projects/$projectId/inbox"
+				params={{ projectId }}
+				className={NEEDS_YOU_ROW_CLASS}
+				data-testid="project-dashboard-needs-you-row"
 			>
-				{approvalText(row.approval)}
-			</NeedsYouRowShell>
+				<NeedsYouRowContent tag="action" tagColor="accent" createdAt={row.created_at}>
+					{approvalText(row.approval)}
+				</NeedsYouRowContent>
+			</Link>
 		);
 	}
 	const m = row.mention;
 	const kind = inboxRowKind(m.content_type);
 	const lead = inboxRowLead(m);
 	return (
-		<NeedsYouRowShell
-			tag={kind.tag}
-			tagColor={kind.tagColor}
-			createdAt={row.created_at}
-			actionLink={
-				<Link
-					to="/projects/$projectId/tasks/$taskId"
-					params={{ projectId, taskId: m.task_identifier.toLowerCase() }}
-					hash={`comment-${m.comment_public_id}`}
-					className={ACTION_LINK_CLASS}
-				>
-					{kind.actionLabel}
-				</Link>
-			}
+		<Link
+			to="/projects/$projectId/tasks/$taskId"
+			params={{ projectId, taskId: m.task_identifier.toLowerCase() }}
+			hash={`comment-${m.comment_public_id}`}
+			className={NEEDS_YOU_ROW_CLASS}
+			data-testid="project-dashboard-needs-you-row"
 		>
-			{lead ? (
-				<>
-					{m.task_identifier}: {lead}
-				</>
-			) : (
-				<>
-					{m.author_display_name} on {m.task_identifier}: {m.snippet || m.task_title}
-				</>
-			)}
-		</NeedsYouRowShell>
+			<NeedsYouRowContent tag={kind.tag} tagColor={kind.tagColor} createdAt={row.created_at}>
+				{lead ? (
+					<>
+						{m.task_identifier}: {lead}
+					</>
+				) : (
+					<>
+						{m.author_display_name} on {m.task_identifier}: {m.snippet || m.task_title}
+					</>
+				)}
+			</NeedsYouRowContent>
+		</Link>
 	);
 }
 

--- a/packages/web/test/dashboard-inbox-parity.test.tsx
+++ b/packages/web/test/dashboard-inbox-parity.test.tsx
@@ -100,9 +100,8 @@ test('the project dashboard lists exactly the unread rows its inbox shows', asyn
 	);
 	expect(section.textContent).toContain('drafted a plan to review');
 	expect(section.textContent).toContain('please confirm the rollout window');
-	// The credential request reads as what it asks for, with its own control.
+	// The credential request reads as what it asks for.
 	expect(section.textContent).toContain(`provide ${CREDENTIAL_NAME}`);
-	expect(section.textContent).toContain('Provide');
 
 	await router.navigate({
 		to: '/projects/$projectId/inbox',
@@ -116,6 +115,45 @@ test('the project dashboard lists exactly the unread rows its inbox shows', asyn
 	});
 	expect(document.body.textContent).toContain(`provide ${CREDENTIAL_NAME}`);
 	expect(document.body.textContent).toContain('credential');
+});
+
+test('each dashboard action item is a whole-row link to the item it names', async () => {
+	const ref = { slug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ref.slug = (await seedAllThree()).slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/dashboard',
+		params: { projectId: ref.slug },
+	});
+
+	const section = await findByTestId('project-dashboard-needs-you', undefined, {
+		timeout: 20_000,
+	});
+	await waitFor(() => expect(section.textContent).toContain('Action items · 3'));
+
+	const rows = [
+		...section.querySelectorAll<HTMLAnchorElement>(
+			'[data-testid="project-dashboard-needs-you-row"]',
+		),
+	];
+	expect(rows).toHaveLength(3);
+	// The row *is* the control - clicking anywhere on it navigates - so it must
+	// be the anchor itself and must carry no nested one to swallow the click.
+	for (const row of rows) {
+		expect(row.tagName).toBe('A');
+		expect(row.querySelector('a')).toBeNull();
+	}
+
+	// The approval opens the inbox where it is resolved; the mention and the
+	// credential request each land on their own comment.
+	const hrefs = rows.map((row) => row.getAttribute('href') ?? '');
+	expect(hrefs.filter((h) => h.endsWith(`/projects/${ref.slug}/inbox`))).toHaveLength(1);
+	expect(hrefs.filter((h) => /\/tasks\/[a-z0-9]+-\d+#comment-/i.test(h))).toHaveLength(2);
 });
 
 test('reading a credential request in the inbox drops it from the dashboard', async () => {


### PR DESCRIPTION
## What

Each row in the project dashboard's **Action items** widget ended in a small trailing button - `Reply` for a mention, `Provide` for a credential request, `Open plan` / `Set up` / `Review` / `Open` for an approval. That button was the only thing that navigated, so the other ~90% of the row was dead space.

The row is now the link itself. Clicking anywhere on it goes where the button went:

- a mention or credential request lands on its comment (`/projects/$projectId/tasks/$taskId#comment-<id>`),
- an approval opens the project inbox.

The trailing button is gone, and with it `approvalActionLabel` and `ACTION_LINK_CLASS` in `project-dashboard.tsx`, which had nowhere left to render. No information is lost: the row text already says what each item wants (`... drafted a plan to review`, `HM-1: provide PARITY_API_KEY`), and the badge already names the kind.

## How

`NeedsYouRowShell` (a `div` plus an `actionLink` slot) became `NeedsYouRowContent`, which renders only the row's inner layout. Each branch of `NeedsYouRow` now wraps it in a `<Link>` carrying the row classes and the `data-testid`. That is the idiom the **In progress** and **Goals** rows in this same file already use, and it matches the whole-card click the inbox's own `MentionCard` has had all along - so the dashboard now behaves like the surface its header links to.

`inboxRowKind().actionLabel` is untouched and still drives the home page's "Needs you" rows.

## Scope

Only the project dashboard's Action items widget - the surface in the report. The home page's "Needs you" list has the same button pattern and was deliberately left alone; happy to do it in a follow-up if wanted.

## Testing

- `packages/web/test/dashboard-inbox-parity.test.tsx` - new spec `each dashboard action item is a whole-row link to the item it names`: seeds an approval, an unread `@admin` mention and a credential request, then asserts all three rows are anchors, carry no nested anchor to swallow the click, and point at the right targets. The existing `toContain('Provide')` assertion (which tested the removed button) is dropped; the row's own `provide <NAME>` text is still asserted.
- `bunx vitest run test/dashboard-inbox-parity.test.tsx` - 4 passed
- `bunx vitest run test/project-dashboard.test.tsx` - 6 passed
- `bunx vitest run test/home-needs-you.test.tsx test/inbox-global.test.tsx` - 11 passed (home unaffected)
- `bun run typecheck`, `biome check`, and `bun run build` all green via the pre-commit hook.

## Docs

No change needed. `docs/concepts/projects-and-teams.md` and `.dev/architecture.md` describe what the widget lists and where **Open inbox** lands; neither documented a per-row control, and both still match the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xFJf2iczojKWrLCnfQ3rE


---
_Generated by [Claude Code](https://claude.ai/code/session_016xFJf2iczojKWrLCnfQ3rE)_