### PR TITLE
fix(ai-providers): make the instance default decide, and reach live sessions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -443,6 +443,23 @@ container pool the chat's container is pinned (`reserved_for_chat`), which suspe
 and teardown releases: chat is exempt from the container cap, and the pin is the other
 half of that, since a task run taking the container out from under a live session is the
 same interruption by a different route.
+**A session's provider is re-checked before every turn.** `startSession` resolves the
+provider, CLI, credential row and model once, and bakes all four into the container env,
+the exec command and the runtime config files — so a session that outlives an operator
+moving the instance default would keep running on the credential that was default the day
+it started, for as long as it lived. `ensureSession` therefore calls `invocationMovedOn`
+first: `resolveInvocationSelection` re-answers the same precedence (the agent's
+`model_override_*`, else the instance default) **without the master key** — via
+`selectProviderConfig`, the non-secret half of the one credential-selection query — and the
+result is compared as a fingerprint of `provider | runtime | config id | model`. A change
+means `restart()`, so the next turn comes up on the new choice; in-flight turns go with it,
+since they are executing against the credential just replaced. `resolveInvocationSelection`
+is the only copy of that precedence on this side, so a session can never be compared against
+a selection made by a different rule from the one that started it, and `resumeSession` may
+replay its stored inputs only because the check has already cleared them. A probe that
+cannot be answered (nothing verified right now, the database refusing) leaves the working
+session alone rather than tearing it down over an unanswered question.
+
 Long-term memory (`chat_memories`) stays **per-agent** (shared across a member's
 assistant threads); compaction serialises at the member level so concurrent threads never
 clobber the shared memory row. External channels (Telegram, Slack, Discord) are built on
@@ -3091,11 +3108,23 @@ its own for the local runners. `updateAiProviderCredential` remains the narrower
 by the Codex refresh-token write-back, which must not touch `status` or `metadata`. Exactly **one** config instance-wide carries the
 `is_default` flag — a single global default enforced by a partial-unique index
 (`ai_provider_configs_single_default`); the first config added to the instance auto-takes
-it, and `setDefaultAiProvider` moves it atomically. `resolveRuntimeForTask` filters by
-`status = 'verified'` and `PROVIDERS_BY_RUNTIME[runtime]`, then orders
-`is_default DESC, created_at ASC`, so the global default wins whenever it's a candidate
-for the chosen runtime, else the oldest verified config; an agent's `model_override_*`
-(or the config's `default_model`) selects the run's model. **How that reaches the CLI is per
+it, and `setDefaultAiProvider` moves it atomically.
+
+`resolveRuntimeForTask` returns a `RuntimeResolution` — the runtime + provider, or a
+**reason** — and has three branches. A task's `runtime_type` pin filters by
+`PROVIDERS_BY_RUNTIME[runtime]` and `status = 'verified'`, orders `is_default DESC,
+created_at ASC`, and takes the first row whose `effectiveRuntime` matches the pin. With no
+pin, **the designated default decides**: the `is_default` row is read on its own, and one
+that is not `verified` (or names a provider this binary dropped) fails the run with a reason
+naming it, rather than passing the run to the next credential in line. Only when *no* row
+carries the flag does the oldest verified config stand in. The failing branch is the point:
+ordering `is_default DESC` across all rows made an unusable default fall through silently, so
+an operator who moved the star watched every agent keep billing the previous provider with
+nothing anywhere saying why — the substitution appeared in no log, no run error and no
+settings badge. `agent-runner` and the chat session both surface `reason` verbatim.
+
+An agent's `model_override_*` (or the config's `default_model`) selects the run's model.
+**How that reaches the CLI is per
 runtime** (`RUNTIME_MODEL_DELIVERY`): nearly all take `--model <id>`, but Kimi Code resolves
 `--model` against a `[models."<id>"]` table in its own `config.toml` — which Hezo never writes,
 because the model is registered through the shell-read `KIMI_MODEL_*` family instead — so

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -172,7 +172,17 @@ tasks and a frontier model for the hard ones, or simply having a fallback.
 When a key is stored it's checked against the provider and shown as **verified** (the
 Verify action re-checks it any time). Mark one provider as the **default** with the star:
 that's the single global default every agent uses unless it has its own model override.
-Change the default and agents on the default pick up the new provider on their next run.
+
+Adding a connection does **not** make it the default - use the star for that. Once you do,
+every agent on the default runs on the new provider from its next run, including a live
+CEO chat, which restarts itself onto it.
+
+The default is a choice, not a preference. If the credential you designated stops being
+usable - the key gets revoked and shows as **invalid**, say - runs on the default fail and
+say so, naming the connection. Hezo will not quietly move them onto one of your other
+connections: a run billing a provider you didn't pick, while the star still sits on the one
+you did, is the kind of thing that goes unnoticed for weeks. Re-verify the connection, or
+move the star, and runs resume.
 
 ## Change a stored key
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1383,11 +1383,10 @@ export async function runAgent(
 		runtimeType = adapter.runtime;
 	} else {
 		const resolved = await resolveRuntimeForTask(deps.db, task?.runtime_type ?? null);
-		if (!resolved) {
-			return finalizeFailure(
-				'No AI provider credentials configured at the instance level. Add one in Settings > AI Providers.',
-			);
-		}
+		// The reason comes from the resolver, which is the only place that knows
+		// whether nothing is configured, the designated default is unusable, or the
+		// task's runtime pin has no credential behind it.
+		if (!resolved.ok) return finalizeFailure(resolved.reason);
 		runtimeType = resolved.runtime;
 		provider = resolved.provider;
 		requiredRuntime = resolved.runtime;

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -126,6 +126,86 @@ export interface AiProviderCredentialAndModel extends AiProviderCredential {
 }
 
 /**
+ * Which credential row a run would use, without the credential itself.
+ *
+ * Everything here is non-secret, so it can be read on a locked instance and held
+ * in memory to answer "is the config this session was started on still the one
+ * the instance would pick?" - the question a long-lived chat session has to ask
+ * after an operator moves the global default.
+ */
+export interface SelectedProviderConfig {
+	configId: string;
+	authMethod: AiAuthMethod;
+	defaultModel: string | null;
+	baseUrl: string | null;
+	/** The operator's stored CLI choice; null follows the provider default. */
+	runtime: AgentRuntime | null;
+	/** {@link runtime} resolved against the provider default - the CLI this row runs on. */
+	resolvedRuntime: AgentRuntime | null;
+}
+
+interface ProviderConfigRow {
+	id: string;
+	auth_method: AiAuthMethod;
+	encrypted_credential: string;
+	default_model: string | null;
+	metadata: Record<string, unknown> | null;
+	runtime: string | null;
+}
+
+/**
+ * The one selection rule: highest-priority verified credential for a provider
+ * (global default first, then oldest), optionally constrained to the CLI it
+ * resolves to. Both the decrypting read below and the non-secret
+ * {@link selectProviderConfig} go through here, so the row a session compares
+ * against can never be a different row from the one it runs on.
+ */
+async function selectProviderConfigRow(
+	db: Db,
+	provider: AiProvider,
+	runtime?: AgentRuntime | null,
+): Promise<(ProviderConfigRow & { resolvedRuntime: AgentRuntime | null }) | null> {
+	// When filtering by runtime the matching credential may not be the
+	// highest-priority one for the provider, so `LIMIT 1` would pre-select a row
+	// that fails the test and report "no credential". Widen the window instead and
+	// let the ordering pick the winner among the matches.
+	const result = await db.query<ProviderConfigRow>(
+		`SELECT id, auth_method, encrypted_credential, default_model, metadata, runtime
+		 FROM ai_provider_configs
+		 WHERE provider = $1::ai_provider AND status = $2
+		 ORDER BY is_default DESC, created_at ASC
+		 LIMIT ${runtime ? RUNTIME_CANDIDATE_SCAN_LIMIT : 1}`,
+		[provider, AiProviderStatus.Verified],
+	);
+
+	const rows = result.rows.map((row) => ({
+		...row,
+		resolvedRuntime: effectiveRuntime(provider, isAgentRuntime(row.runtime) ? row.runtime : null),
+	}));
+	return (runtime ? rows.find((r) => r.resolvedRuntime === runtime) : rows[0]) ?? null;
+}
+
+/**
+ * The credential row a run would select, minus the secret. Needs no master key.
+ */
+export async function selectProviderConfig(
+	db: Db,
+	provider: AiProvider,
+	runtime?: AgentRuntime | null,
+): Promise<SelectedProviderConfig | null> {
+	const row = await selectProviderConfigRow(db, provider, runtime);
+	if (!row) return null;
+	return {
+		configId: row.id,
+		authMethod: row.auth_method,
+		defaultModel: row.default_model,
+		baseUrl: readConfigBaseUrl(row.metadata),
+		runtime: isAgentRuntime(row.runtime) ? row.runtime : null,
+		resolvedRuntime: row.resolvedRuntime,
+	};
+}
+
+/**
  * Replace the encrypted credential value on an existing config row.
  * Used to persist refresh-token rotations after a Codex run mutates the
  * mounted `auth.json` blob.
@@ -166,31 +246,7 @@ export async function getProviderCredentialAndModel(
 	const encryptionKey = masterKeyManager.getKey();
 	if (!encryptionKey) throw new Error('Master key not available');
 
-	// When filtering by runtime the matching credential may not be the
-	// highest-priority one for the provider, so `LIMIT 1` would pre-select a row
-	// that fails the test and report "no credential". Widen the window instead and
-	// let the ordering pick the winner among the matches.
-	const result = await db.query<{
-		id: string;
-		auth_method: AiAuthMethod;
-		encrypted_credential: string;
-		default_model: string | null;
-		metadata: Record<string, unknown> | null;
-		runtime: string | null;
-	}>(
-		`SELECT id, auth_method, encrypted_credential, default_model, metadata, runtime
-		 FROM ai_provider_configs
-		 WHERE provider = $1::ai_provider AND status = $2
-		 ORDER BY is_default DESC, created_at ASC
-		 LIMIT ${runtime ? RUNTIME_CANDIDATE_SCAN_LIMIT : 1}`,
-		[provider, AiProviderStatus.Verified],
-	);
-
-	const rows = result.rows.map((row) => ({
-		...row,
-		resolvedRuntime: effectiveRuntime(provider, isAgentRuntime(row.runtime) ? row.runtime : null),
-	}));
-	const row = runtime ? rows.find((r) => r.resolvedRuntime === runtime) : rows[0];
+	const row = await selectProviderConfigRow(db, provider, runtime);
 	if (!row) return null;
 
 	return {

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -44,6 +44,7 @@ import {
 import {
 	type AiProviderCredentialAndModel,
 	getProviderCredentialAndModel,
+	selectProviderConfig,
 } from './ai-provider-keys';
 import {
 	buildConversationTaskDescription,
@@ -254,6 +255,41 @@ interface HostSideInputs {
 	credential: AiProviderCredentialAndModel;
 	runtimeType: AgentRuntime;
 	modelOverride: string | null;
+}
+
+/**
+ * Which provider, on which CLI, from which credential row, at which model - the
+ * whole choice a session's turns are built from, minus the secret. Resolved
+ * without the master key so it can also be re-answered on a locked instance.
+ */
+interface InvocationSelection {
+	provider: AiProvider;
+	runtimeType: AgentRuntime;
+	configId: string;
+	modelOverride: string | null;
+	/**
+	 * The CLI the credential read must match, or null on the agent-override path
+	 * where the credential's own runtime decides. Carried so the caller hands
+	 * `getProviderCredentialAndModel` exactly what this selection was made with.
+	 */
+	requiredRuntime: AgentRuntime | null;
+}
+
+/**
+ * The identity of what a session's turns run on. Session start bakes all four
+ * into the container env, the exec command and the runtime config files, so a
+ * change to any of them reaches the chat only by starting a new session.
+ *
+ * Non-secret by construction: the credential is named by its row id, never by
+ * any part of its value.
+ */
+function invocationFingerprint(
+	provider: AiProvider,
+	runtimeType: AgentRuntime,
+	configId: string,
+	modelOverride: string | null,
+): string {
+	return `${provider}|${runtimeType}|${configId}|${modelOverride ?? ''}`;
 }
 
 /**
@@ -1022,6 +1058,17 @@ export class ChatSessionManager {
 	}
 
 	private async ensureSession(): Promise<LiveSession> {
+		// Re-check the provider choice before reusing a session, suspended or not:
+		// the operator can move the instance default (or put a model override on the
+		// CEO) at any point between two turns, and a session cannot pick that up in
+		// place - its env and exec command were built from the old one. A start
+		// already in flight resolves fresh on its own, so skip the probe then.
+		const existing = this.live;
+		if (existing && !this.ensuring && (await this.invocationMovedOn(existing))) {
+			// In-flight turns go with it: they are executing against the credential the
+			// operator just replaced.
+			await this.restart();
+		}
 		if (this.live && !this.suspended) return this.live;
 		if (this.ensuring) return this.ensuring;
 		// A parked session resumes into its own container and keeps its row; only a
@@ -1046,6 +1093,91 @@ export class ChatSessionManager {
 			egressProxy: this.deps.egressProxy ?? null,
 			egressCAPath: this.deps.egressCAPath ?? null,
 		};
+	}
+
+	/**
+	 * Resolve what this chat should run on right now: the agent's own model
+	 * override if it has one, else the instance-wide default credential.
+	 *
+	 * Same precedence as the agent runner, and the only copy of it on this side -
+	 * session start and the staleness check below both read it here, so the
+	 * selection a live session is compared against can never be resolved by a
+	 * different rule from the one that started it.
+	 */
+	private async resolveInvocationSelection(ceoMemberId: string): Promise<InvocationSelection> {
+		const { db } = this.deps;
+		const override = await db.query<{ provider: AiProvider | null; model: string | null }>(
+			`SELECT model_override_provider AS provider, model_override_model AS model
+			 FROM member_agents WHERE id = $1`,
+			[ceoMemberId],
+		);
+		let provider = override.rows[0]?.provider ?? null;
+		let runtimeType: AgentRuntime;
+		// An override names only a provider, so its CLI comes from the credential
+		// below; the resolved path already picked a credential and constrains the
+		// lookup to one that matches.
+		let requiredRuntime: AgentRuntime | null = null;
+		if (provider) {
+			runtimeType = PROVIDER_RUNTIME_ADAPTERS[provider].runtime;
+		} else {
+			const resolved = await resolveRuntimeForTask(db, null);
+			if (!resolved.ok) throw new Error(resolved.reason);
+			provider = resolved.provider;
+			runtimeType = resolved.runtime;
+			requiredRuntime = resolved.runtime;
+		}
+
+		const config = await selectProviderConfig(db, provider, requiredRuntime);
+		if (!config) throw new Error(`No ${provider} credential configured`);
+		if (!requiredRuntime) {
+			runtimeType = effectiveRuntime(provider, config.runtime) ?? runtimeType;
+		}
+		return {
+			provider,
+			runtimeType,
+			configId: config.configId,
+			modelOverride: override.rows[0]?.model ?? config.defaultModel ?? null,
+			requiredRuntime,
+		};
+	}
+
+	/**
+	 * Has the instance moved on from what this live session was started with?
+	 *
+	 * A chat session outlives many turns, and everything about its provider - the
+	 * CLI binary in its exec command, the credential in its env, the model flag -
+	 * was fixed when the session started. An agent following the instance default
+	 * would otherwise keep running on whichever credential happened to be the
+	 * default that day, for as long as the session lived.
+	 */
+	private async invocationMovedOn(live: LiveSession): Promise<boolean> {
+		let selection: InvocationSelection;
+		try {
+			selection = await this.resolveInvocationSelection(live.ceoMemberId);
+		} catch (e) {
+			// The question could not be answered - no verified credential right now, or
+			// the database refused. A working session is not torn down over an
+			// unanswered question: this turn runs on what it has and the next asks
+			// again.
+			log.warn(`could not re-check the CEO chat's AI provider: ${String(e)}`);
+			return false;
+		}
+		const inputs = live.invocationInputs;
+		const before = invocationFingerprint(
+			inputs.provider,
+			inputs.runtimeType,
+			inputs.credential.configId,
+			inputs.modelOverride,
+		);
+		const now = invocationFingerprint(
+			selection.provider,
+			selection.runtimeType,
+			selection.configId,
+			selection.modelOverride,
+		);
+		if (before === now) return false;
+		log.info(`CEO chat AI provider changed (${before} -> ${now}); starting a fresh session`);
+		return true;
 	}
 
 	private async startSession(): Promise<LiveSession> {
@@ -1084,27 +1216,8 @@ export class ChatSessionManager {
 		// turn's exec, the ssh socket owner, and the per-turn config-dir chown.
 		const runUser = await resolveContainerRunUser(this.deps.docker, containerId);
 
-		const override = await db.query<{ provider: AiProvider | null; model: string | null }>(
-			`SELECT model_override_provider AS provider, model_override_model AS model
-			 FROM member_agents WHERE id = $1`,
-			[ceoMemberId],
-		);
-		let provider = override.rows[0]?.provider ?? null;
-		let runtimeType: AgentRuntime;
-		// Same split as the agent runner: an override names only a provider, so its
-		// CLI comes from the credential below; the resolved path already picked a
-		// credential and constrains the lookup to one that matches.
-		let requiredRuntime: AgentRuntime | null = null;
-		if (provider) {
-			runtimeType = PROVIDER_RUNTIME_ADAPTERS[provider].runtime;
-		} else {
-			const resolved = await resolveRuntimeForTask(db, null);
-			if (!resolved) throw new Error('No AI provider credentials configured');
-			provider = resolved.provider;
-			runtimeType = resolved.runtime;
-			requiredRuntime = resolved.runtime;
-		}
-
+		const { provider, runtimeType, modelOverride, requiredRuntime } =
+			await this.resolveInvocationSelection(ceoMemberId);
 		const credential = await getProviderCredentialAndModel(
 			db,
 			this.deps.masterKeyManager,
@@ -1112,10 +1225,6 @@ export class ChatSessionManager {
 			requiredRuntime,
 		);
 		if (!credential) throw new Error(`No ${provider} credential configured`);
-		if (!requiredRuntime) {
-			runtimeType = effectiveRuntime(provider, credential.runtime) ?? runtimeType;
-		}
-		const modelOverride = override.rows[0]?.model ?? credential.defaultModel ?? null;
 
 		// Reclaim any DB rows left live by a crash without an in-memory session, so
 		// the singleton insert below doesn't collide. `suspended` counts as live -
@@ -2061,6 +2170,9 @@ export class ChatSessionManager {
 		}
 
 		try {
+			// Replaying the stored inputs is correct only because `ensureSession` has
+			// already confirmed the instance still resolves to them; a moved default
+			// tears the session down there and never reaches this path.
 			const allocation = await this.allocateHostSide(
 				live.sessionId,
 				containerId,

--- a/packages/server/src/services/runtime-resolver.ts
+++ b/packages/server/src/services/runtime-resolver.ts
@@ -14,6 +14,16 @@ export interface ResolvedRuntime {
 }
 
 /**
+ * The runtime + provider a run will use, or why none could be chosen.
+ *
+ * A reason rather than a bare null because the failure worth reporting is not
+ * "nothing is configured" - it is "the credential the operator designated is
+ * unusable". A run that answers that by quietly picking a different credential
+ * bills a provider nobody selected and says nothing.
+ */
+export type RuntimeResolution = ({ ok: true } & ResolvedRuntime) | { ok: false; reason: string };
+
+/**
  * Ceiling on the credential rows a runtime lookup will consider. Selecting the
  * credential for a pinned runtime needs several rows rather than one (the
  * highest-priority row for a provider may run on a different CLI), so there is
@@ -31,17 +41,20 @@ export const RUNTIME_CANDIDATE_SCAN_LIMIT = 200;
  *      one (a Moonshot credential runs on Claude Code or Kimi Code), so the
  *      provider shortlist only narrows the query and the row's own runtime
  *      decides.
- *   2. Otherwise: pick the globally first active credential (default first,
- *      then oldest) and resolve its runtime.
- * Returns null when no suitable active provider exists.
+ *   2. The instance default, when a credential carries `is_default`: that
+ *      credential decides, and an unusable one fails the run rather than
+ *      handing it to the next credential in line.
+ *   3. Otherwise — no default designated at all: the oldest verified credential.
  */
 export async function resolveRuntimeForTask(
 	db: Db,
 	taskRuntimeType: AgentRuntime | null,
-): Promise<ResolvedRuntime | null> {
+): Promise<RuntimeResolution> {
 	if (taskRuntimeType) {
 		const candidates = PROVIDERS_BY_RUNTIME[taskRuntimeType];
-		if (!candidates || candidates.length === 0) return null;
+		if (!candidates || candidates.length === 0) {
+			return { ok: false, reason: unpinnableReason(taskRuntimeType) };
+		}
 		const placeholders = candidates.map((_, i) => `$${i + 2}::ai_provider`).join(', ');
 		// A provider on this shortlist may still resolve elsewhere — `kimi` is a
 		// candidate for both `claude_code` and `kimi` — so scan the shortlist in
@@ -60,24 +73,69 @@ export async function resolveRuntimeForTask(
 		const match = result.rows.find(
 			(row) => effectiveRuntime(row.provider, row.runtime) === taskRuntimeType,
 		);
-		if (!match) return null;
-		return { runtime: taskRuntimeType, provider: match.provider };
+		if (!match) return { ok: false, reason: unpinnableReason(taskRuntimeType) };
+		return { ok: true, runtime: taskRuntimeType, provider: match.provider };
 	}
 
-	// Constrain to providers the running binary still supports: a stale row for
-	// a since-removed provider (e.g. `x_ai`) must not shadow valid configs.
+	// The instance default is a designation, not a preference: once the operator
+	// has marked a credential, that credential decides. An unusable one fails the
+	// run rather than passing it to the next credential in line — a substitution
+	// nothing surfaces, which is how a moved default goes unnoticed for weeks with
+	// the settings page showing the new credential as Default while every agent
+	// still bills the old one.
+	const designated = await db.query<{
+		provider: AiProvider;
+		runtime: AgentRuntime | null;
+		status: string;
+		label: string;
+	}>(
+		`SELECT provider, runtime, status, label FROM ai_provider_configs
+		 WHERE is_default = true
+		 LIMIT 1`,
+	);
+	const chosen = designated.rows[0];
+	if (chosen) {
+		if (chosen.status !== AiProviderStatus.Verified) {
+			return {
+				ok: false,
+				reason: `The instance default AI provider ("${chosen.label}") is marked ${chosen.status}, so it cannot run agents. Re-verify it or make a different credential the default in Settings > AI Providers.`,
+			};
+		}
+		// A default naming a provider this binary dropped (e.g. `x_ai`) is stale in
+		// the same way, and equally must not be answered with someone else's credential.
+		const runtime = effectiveRuntime(chosen.provider, chosen.runtime);
+		if (!runtime) {
+			return {
+				ok: false,
+				reason: `The instance default AI provider ("${chosen.label}") uses provider "${chosen.provider}", which this version of Hezo no longer supports. Make a different credential the default in Settings > AI Providers.`,
+			};
+		}
+		return { ok: true, runtime, provider: chosen.provider };
+	}
+
+	// No default designated at all. Constrain to providers the running binary
+	// still supports: a stale row for a since-removed provider must not shadow
+	// valid configs.
 	const known = Object.keys(PROVIDER_TO_RUNTIME);
 	const placeholders = known.map((_, i) => `$${i + 2}::ai_provider`).join(', ');
 	const providers = await db.query<{ provider: AiProvider; runtime: AgentRuntime | null }>(
 		`SELECT provider, runtime FROM ai_provider_configs
 		 WHERE status = $1 AND provider IN (${placeholders})
-		 ORDER BY is_default DESC, created_at ASC
+		 ORDER BY created_at ASC
 		 LIMIT 1`,
 		[AiProviderStatus.Verified, ...known],
 	);
 	const first = providers.rows[0];
-	if (!first) return null;
+	if (!first) return { ok: false, reason: NO_CREDENTIAL_REASON };
 	const runtime = effectiveRuntime(first.provider, first.runtime);
-	if (!runtime) return null;
-	return { runtime, provider: first.provider };
+	if (!runtime) return { ok: false, reason: NO_CREDENTIAL_REASON };
+	return { ok: true, runtime, provider: first.provider };
+}
+
+/** Nothing usable is configured anywhere — the only genuinely empty case. */
+export const NO_CREDENTIAL_REASON =
+	'No verified AI provider credential is configured. Add one in Settings > AI Providers.';
+
+function unpinnableReason(runtime: AgentRuntime): string {
+	return `This task is pinned to the "${runtime}" runtime, and no verified credential runs on it. Add one, or clear the task's runtime pin, to run on the instance default instead.`;
 }

--- a/packages/server/test/agent-runner-extended.test.ts
+++ b/packages/server/test/agent-runner-extended.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { decrypt } from '../src/crypto/encryption';
+import { decrypt, encrypt } from '../src/crypto/encryption';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
 import { DomainEventBus } from '../src/events/bus';
@@ -381,6 +381,83 @@ describe('runAgent — egress proxy + ssh agent env injection', () => {
 	});
 });
 
+describe('runAgent — the instance default decides', () => {
+	// An agent with no model override follows the instance default. Moving that
+	// default must move the agent's very next run, and an unusable default must
+	// fail the run rather than hand it to whichever credential is next in line -
+	// a substitution nothing surfaces, so the settings page shows one provider as
+	// Default while every agent keeps billing another.
+	async function withDefaultMovedToDeepSeek(fn: (configId: string) => Promise<void>) {
+		const key = masterKeyManager.getKey();
+		if (!key) throw new Error('master key unavailable');
+		const prior = await db.query<{ id: string }>(
+			`SELECT id FROM ai_provider_configs WHERE is_default = true`,
+		);
+		await db.query(`UPDATE ai_provider_configs SET is_default = false`);
+		const inserted = await db.query<{ id: string }>(
+			`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
+			 VALUES ('deepseek', 'api_key', 'deepseek-moved', $1, true, 'verified', 'deepseek-v4-pro')
+			 RETURNING id`,
+			[encrypt('sk-deepseek-moved', key)],
+		);
+		try {
+			await fn(inserted.rows[0].id);
+		} finally {
+			await db.query(`DELETE FROM ai_provider_configs WHERE id = $1`, [inserted.rows[0].id]);
+			if (prior.rows[0]) {
+				await db.query(`UPDATE ai_provider_configs SET is_default = true WHERE id = $1`, [
+					prior.rows[0].id,
+				]);
+			}
+		}
+	}
+
+	it('moves an agent that follows the default onto the new one on its next run', async () => {
+		await withDefaultMovedToDeepSeek(async (configId) => {
+			const result = await runAgent(
+				baseDeps(createMockDocker(taskId)),
+				makeAgent(),
+				makeTask(),
+				makeProject(),
+			);
+			expect(result.success).toBe(true);
+
+			const run = await db.query<{ provider: string; ai_provider_config_id: string }>(
+				'SELECT provider, ai_provider_config_id FROM heartbeat_runs WHERE id = $1',
+				[result.heartbeatRunId],
+			);
+			expect(run.rows[0].provider).toBe(AiProvider.DeepSeek);
+			expect(run.rows[0].ai_provider_config_id).toBe(configId);
+		});
+	});
+
+	it('fails the run when the designated default is unusable, naming it', async () => {
+		await withDefaultMovedToDeepSeek(async (configId) => {
+			// The key behind the default is revoked upstream and a Verify marked it
+			// invalid. The Anthropic credential alongside it is still perfectly good -
+			// and must NOT be what the run quietly falls onto.
+			await db.query(`UPDATE ai_provider_configs SET status = 'invalid' WHERE id = $1`, [configId]);
+
+			const result = await runAgent(
+				baseDeps(
+					createMockDocker(taskId, {
+						execCreate: async () => {
+							throw new Error('should not exec when the default is unusable');
+						},
+					}),
+				),
+				makeAgent(),
+				makeTask(),
+				makeProject(),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.stderr).toContain('deepseek-moved');
+			expect(result.stderr).toContain('invalid');
+		});
+	});
+});
+
 describe('runAgent — provider/credential resolution failures', () => {
 	it('fails with a clear message when no AI provider credentials exist at all', async () => {
 		// Stand up an isolated team/project with NO provider configured so resolution
@@ -458,7 +535,7 @@ describe('runAgent — provider/credential resolution failures', () => {
 				[result.heartbeatRunId],
 			);
 			expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-			expect(run.rows[0].error).toContain('No AI provider credentials configured');
+			expect(run.rows[0].error).toContain('No verified AI provider credential is configured');
 
 			// And it never took a container to fail in. The claim happens only after
 			// the credential resolves, so a misconfigured instance provisions nothing

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -789,7 +789,7 @@ describe('runAgent lifecycle — full success bookkeeping', () => {
 		try {
 			const result = await runAgent(baseDeps(makeDocker()), makeAgent(), makeTask(), makeProject());
 			expect(result.success).toBe(false);
-			expect(result.stderr).toContain('No AI provider credentials configured');
+			expect(result.stderr).toContain('No verified AI provider credential is configured');
 		} finally {
 			await db.query(`INSERT INTO ai_provider_configs SELECT * FROM cfg_backup`);
 			await db.query('DROP TABLE cfg_backup');

--- a/packages/server/test/chat-session-branches.test.ts
+++ b/packages/server/test/chat-session-branches.test.ts
@@ -119,11 +119,13 @@ describe('ChatSessionManager — startSession failure branches', () => {
 	});
 
 	test('fails the turn (assistant message → failed) when no AI provider is configured', async () => {
-		// No provider rows and no model override → resolveRuntimeForTask returns null
-		// → startSession throws "No AI provider credentials configured". The turn
-		// surfaces it on the assistant message rather than crashing the process.
+		// No provider rows and no model override → resolveRuntimeForTask reports that
+		// nothing is configured → startSession throws its reason. The turn surfaces it
+		// on the assistant message rather than crashing the process.
 		const { manager } = makeManager(ctx, replyDocker());
-		await expect(manager.sendTurn({ text: 'hello' })).rejects.toThrow(/AI provider credentials/);
+		await expect(manager.sendTurn({ text: 'hello' })).rejects.toThrow(
+			/No verified AI provider credential/,
+		);
 	});
 
 	test('runTurn marks the assistant message failed when the exec throws (non-abort)', async () => {

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -609,6 +609,77 @@ describe('ChatSessionManager', () => {
 		await manager.stop();
 	});
 
+	test('a moved instance default reaches a session that is already live', async () => {
+		// A session resolves its provider, CLI and model once and bakes them into the
+		// container env and exec command, so an agent following the instance default
+		// would otherwise keep running on the credential that was default the day its
+		// session started - for as long as the session lived.
+		const envs: string[][] = [];
+		const chatDocker = createStubDocker({
+			execCreate: async (_id: string, config: { Env?: string[] }) => {
+				const env = config.Env ?? [];
+				if (env.some((e) => e.startsWith('HEZO_PROMPT_FILE='))) envs.push(env);
+				return 'exec-1';
+			},
+			execStart: async (
+				_execId: string,
+				opts: { onChunk?: (c: ExecLogChunk) => void | Promise<void> },
+			) => {
+				const onChunk = opts.onChunk ?? (() => undefined);
+				await onChunk({ stream: 'stdout', text: assistantText('Hi there') });
+				await onChunk({ stream: 'stdout', text: resultEvent(10, 5, 0.02) });
+				return { stdout: '', stderr: '' };
+			},
+		});
+		const { manager } = makeManager(ctx, chatDocker);
+		const settle = async (assistantMessageId: string) =>
+			poll(async () => {
+				const r = await ctx.db.query<{ status: string }>(
+					'SELECT status FROM chat_messages WHERE id = $1',
+					[assistantMessageId],
+				);
+				return r.rows[0]?.status === ChatMessageStatus.Complete;
+			});
+
+		const first = await manager.sendTurn({ text: 'before' });
+		await settle(first.assistantMessageId);
+		const deepseekBaseUrl = 'ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic';
+		expect(envs.length).toBeGreaterThan(0);
+		expect(envs.every((env) => !env.includes(deepseekBaseUrl))).toBe(true);
+
+		// The operator moves the instance default onto a different credential. DeepSeek
+		// shares the Claude Code runtime with the seeded Anthropic config, so the CLI
+		// is unchanged and only the credential behind it moves - the case a session
+		// reusing its own snapshot cannot notice at all.
+		const key = ctx.masterKeyManager.getKey();
+		if (!key) throw new Error('master key unavailable');
+		await ctx.db.query(`UPDATE ai_provider_configs SET is_default = false`);
+		await ctx.db.query(
+			`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
+			 VALUES ('deepseek', 'api_key', 'deepseek', $1, true, 'verified', 'deepseek-v4-pro')`,
+			[encrypt('sk-deepseek', key)],
+		);
+
+		const before = envs.length;
+		const second = await manager.sendTurn({ text: 'after' });
+		await settle(second.assistantMessageId);
+
+		const afterMove = envs.slice(before);
+		expect(afterMove.length).toBeGreaterThan(0);
+		expect(afterMove.every((env) => env.includes(deepseekBaseUrl))).toBe(true);
+
+		// The old session was retired rather than mutated, so exactly one is live.
+		const sessions = await ctx.db.query<{ n: number }>(
+			`SELECT COUNT(*)::int AS n FROM chat_sessions WHERE status IN ($1, $2)`,
+			[ChatSessionStatus.Starting, ChatSessionStatus.Running],
+		);
+		expect(sessions.rows[0].n).toBe(1);
+		const all = await ctx.db.query<{ n: number }>(`SELECT COUNT(*)::int AS n FROM chat_sessions`);
+		expect(all.rows[0].n).toBe(2);
+
+		await manager.stop();
+	});
+
 	test('reconcileOnStartup marks orphaned sessions crashed', async () => {
 		const ceo = await ctx.db.query<{ id: string }>(
 			`SELECT m.id FROM members m JOIN member_agents ma ON ma.id = m.id WHERE ma.slug = 'ceo' AND m.team_id = $1`,

--- a/packages/server/test/job-manager-scheduling.test.ts
+++ b/packages/server/test/job-manager-scheduling.test.ts
@@ -305,7 +305,7 @@ describe('JobManager scheduling & dispatch', () => {
 				[taskId],
 			);
 			expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-			expect(run.rows[0].error).toContain('No AI provider');
+			expect(run.rows[0].error).toContain('No verified AI provider credential');
 
 			// Wakeup resolved to failed (run failed), lock released, agent idle again.
 			const w = await wakeupRow(wakeupId);
@@ -328,7 +328,7 @@ describe('JobManager scheduling & dispatch', () => {
 				[taskId],
 			);
 			expect(ping.rows.length).toBe(1);
-			expect(ping.rows[0].content.error).toContain('No AI provider');
+			expect(ping.rows[0].content.error).toContain('No verified AI provider credential');
 
 			// In-memory dispatch guards are released.
 			expect(internals(manager).activeTaskRuns.has(taskId)).toBe(false);

--- a/packages/server/test/provider-cli-choice.test.ts
+++ b/packages/server/test/provider-cli-choice.test.ts
@@ -192,7 +192,7 @@ describe('credential lookup and runtime resolution', () => {
 		expect(credential?.runtime).toBe(AgentRuntime.Kimi);
 
 		const resolved = await resolveRuntimeForTask(db, null);
-		expect(resolved).toEqual({ runtime: AgentRuntime.Kimi, provider: AiProvider.Kimi });
+		expect(resolved).toEqual({ ok: true, runtime: AgentRuntime.Kimi, provider: AiProvider.Kimi });
 	});
 
 	it('defaults to the provider runtime when the credential stores none', async () => {
@@ -207,6 +207,7 @@ describe('credential lookup and runtime resolution', () => {
 		const credential = await getProviderCredentialAndModel(db, masterKeyManager, AiProvider.Kimi);
 		expect(credential?.runtime).toBeNull();
 		expect(await resolveRuntimeForTask(db, null)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.ClaudeCode,
 			provider: AiProvider.Kimi,
 		});
@@ -236,6 +237,7 @@ describe('credential lookup and runtime resolution', () => {
 		);
 
 		expect(await resolveRuntimeForTask(db, AgentRuntime.Kimi)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.Kimi,
 			provider: AiProvider.Kimi,
 		});

--- a/packages/server/test/runtime-resolver.test.ts
+++ b/packages/server/test/runtime-resolver.test.ts
@@ -1,4 +1,4 @@
-import { AgentRuntime, AiAuthMethod, AiProvider } from '@hezo/shared';
+import { AgentRuntime, AiAuthMethod, AiProvider, AiProviderStatus } from '@hezo/shared';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
@@ -25,9 +25,14 @@ beforeEach(async () => {
 });
 
 describe('resolveRuntimeForTask', () => {
-	it('returns null when no providers are configured', async () => {
-		expect(await resolveRuntimeForTask(db, null)).toBeNull();
-		expect(await resolveRuntimeForTask(db, AgentRuntime.Codex)).toBeNull();
+	it('reports why nothing could be resolved when no providers are configured', async () => {
+		const none = await resolveRuntimeForTask(db, null);
+		expect(none.ok).toBe(false);
+		expect(none.ok === false && none.reason).toContain('No verified AI provider credential');
+
+		const pinned = await resolveRuntimeForTask(db, AgentRuntime.Codex);
+		expect(pinned.ok).toBe(false);
+		expect(pinned.ok === false && pinned.reason).toContain('pinned to the "codex" runtime');
 	});
 
 	it('returns runtime + provider when an explicit task runtime matches a configured provider', async () => {
@@ -41,10 +46,11 @@ describe('resolveRuntimeForTask', () => {
 		);
 
 		expect(await resolveRuntimeForTask(db, AgentRuntime.Codex)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.Codex,
 			provider: AiProvider.OpenAI,
 		});
-		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toBeNull();
+		expect((await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).ok).toBe(false);
 	});
 
 	it('picks the runtime whose provider is marked default when multiple configs coexist', async () => {
@@ -65,10 +71,12 @@ describe('resolveRuntimeForTask', () => {
 			'openai-subscription',
 		);
 
-		expect((await resolveRuntimeForTask(db, null))?.runtime).toBe(AgentRuntime.Codex);
+		const first = await resolveRuntimeForTask(db, null);
+		expect(first.ok === true && first.runtime).toBe(AgentRuntime.Codex);
 
 		await setDefaultAiProvider(db, subscriptionId);
-		expect((await resolveRuntimeForTask(db, null))?.runtime).toBe(AgentRuntime.Codex);
+		const second = await resolveRuntimeForTask(db, null);
+		expect(second.ok === true && second.runtime).toBe(AgentRuntime.Codex);
 	});
 
 	it('falls back to the oldest active provider when none is marked default', async () => {
@@ -92,6 +100,7 @@ describe('resolveRuntimeForTask', () => {
 		await db.query(`UPDATE ai_provider_configs SET is_default = false`);
 
 		expect(await resolveRuntimeForTask(db, null)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.Codex,
 			provider: AiProvider.OpenAI,
 		});
@@ -118,6 +127,7 @@ describe('resolveRuntimeForTask', () => {
 		// Anthropic was added first, so it holds the single instance-wide default and
 		// wins the shared ClaudeCode runtime on is_default DESC.
 		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.ClaudeCode,
 			provider: AiProvider.Anthropic,
 		});
@@ -126,6 +136,7 @@ describe('resolveRuntimeForTask', () => {
 		await setDefaultAiProvider(db, deepseekId);
 
 		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.ClaudeCode,
 			provider: AiProvider.DeepSeek,
 		});
@@ -142,9 +153,106 @@ describe('resolveRuntimeForTask', () => {
 		);
 
 		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toEqual({
+			ok: true,
 			runtime: AgentRuntime.ClaudeCode,
 			provider: AiProvider.ZAi,
 		});
-		expect(await resolveRuntimeForTask(db, AgentRuntime.Codex)).toBeNull();
+		expect((await resolveRuntimeForTask(db, AgentRuntime.Codex)).ok).toBe(false);
+	});
+
+	it('moves every unpinned run onto the new default the moment it changes', async () => {
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.DeepSeek,
+			'sk-deepseek',
+			AiAuthMethod.ApiKey,
+			'deepseek',
+		);
+		const openaiId = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-openai',
+			AiAuthMethod.ApiKey,
+			'openai',
+		);
+
+		// Adding a credential does not make it the default — only the first config on
+		// a fresh instance auto-takes the flag.
+		expect(await resolveRuntimeForTask(db, null)).toEqual({
+			ok: true,
+			runtime: AgentRuntime.ClaudeCode,
+			provider: AiProvider.DeepSeek,
+		});
+
+		await setDefaultAiProvider(db, openaiId);
+
+		expect(await resolveRuntimeForTask(db, null)).toEqual({
+			ok: true,
+			runtime: AgentRuntime.Codex,
+			provider: AiProvider.OpenAI,
+		});
+	});
+
+	it('fails rather than silently running an unusable default on another credential', async () => {
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.DeepSeek,
+			'sk-deepseek',
+			AiAuthMethod.ApiKey,
+			'deepseek',
+		);
+		const openaiId = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-openai',
+			AiAuthMethod.ApiKey,
+			'openai',
+		);
+		await setDefaultAiProvider(db, openaiId);
+		// The operator's designated default stops being usable (a revoked key that a
+		// later Verify marked invalid). The settings page still shows it as Default.
+		await db.query(`UPDATE ai_provider_configs SET status = $1 WHERE id = $2`, [
+			AiProviderStatus.Invalid,
+			openaiId,
+		]);
+
+		const resolved = await resolveRuntimeForTask(db, null);
+		// Not DeepSeek: handing the run to the previous default is the silent
+		// substitution this guards against.
+		expect(resolved.ok).toBe(false);
+		expect(resolved.ok === false && resolved.reason).toContain('openai');
+		expect(resolved.ok === false && resolved.reason).toContain('invalid');
+	});
+
+	it('still runs on the oldest verified credential when no default is designated', async () => {
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.DeepSeek,
+			'sk-deepseek',
+			AiAuthMethod.ApiKey,
+			'deepseek',
+		);
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-openai',
+			AiAuthMethod.ApiKey,
+			'openai',
+		);
+		// No row carries the flag — nothing was designated, so nothing is being
+		// substituted for and the oldest verified credential is the honest answer.
+		await db.query(`UPDATE ai_provider_configs SET is_default = false`);
+
+		expect(await resolveRuntimeForTask(db, null)).toEqual({
+			ok: true,
+			runtime: AgentRuntime.ClaudeCode,
+			provider: AiProvider.DeepSeek,
+		});
 	});
 });


### PR DESCRIPTION
Moving the instance default AI provider did not move the agents that follow it. Two independent causes, both fixed here.

## 1. An unusable default fell through silently

`resolveRuntimeForTask` ordered every verified row by `is_default DESC, created_at ASC`. A designated default that was not `verified` - a key revoked upstream and marked `invalid` by a later Verify - simply dropped out of the candidate set, and the run went to whichever credential was next in line.

Reproduced against the real resolver before changing anything:

```
rows: [ { provider: 'deepseek', is_default: false, status: 'verified' },
        { provider: 'openai',   is_default: true,  status: 'invalid'  } ]
resolved: { runtime: 'claude_code', provider: 'deepseek' }
```

The settings page keeps the **Default** badge on the credential the operator picked while every agent bills a different one, and nothing says so: no run error, no log line, no badge. That is the substitution the "no silent fallbacks" rule exists to prevent, and it is invisible precisely because it works.

Now the `is_default` row is read on its own and decides:

- not `verified`, or naming a provider this binary no longer supports → the run **fails** with a reason naming the connection ("The instance default AI provider (\"openai\") is marked invalid ... Re-verify it or make a different credential the default in Settings > AI Providers.")
- the `created_at ASC` stand-in applies only when **no** row carries the flag - nothing was designated, so nothing is being substituted for.

`resolveRuntimeForTask` returns a `RuntimeResolution` (`{ ok: true, runtime, provider } | { ok: false, reason }`) rather than a bare null, because the failure worth reporting is not "nothing is configured". `agent-runner` and the chat session both surface `reason` verbatim, replacing a hardcoded "No AI provider credentials configured" that was a lie for every case but one.

A task's `runtime_type` pin is unchanged - an explicit pin still selects among the credentials that run on that CLI.

## 2. A live chat session never re-asked

`startSession` resolved provider → CLI → credential → model once and baked all four into the container env, the exec command and the runtime config files. A session outlives many turns and survives suspend/resume indefinitely (`resumeSession` replayed the same stored inputs), so an agent following the instance default kept running on whichever credential was default the day its session started.

`ensureSession` now re-resolves before reusing a session and restarts it when the `provider | runtime | config id | model` fingerprint has moved. In-flight turns go with it - they are executing against the credential just replaced.

- `resolveInvocationSelection` is the single copy of the precedence (agent `model_override_*` → instance default), used by both `startSession` and the check, so a session can never be compared against a selection made by a different rule from the one that started it.
- It runs **without the master key**, via the new `selectProviderConfig` - the non-secret half of the one credential-selection query, which `getProviderCredentialAndModel` now delegates to. So a locked instance is not a reason to tear a working session down, and the check never decrypts anything.
- A probe that cannot be answered (nothing verified right now, the database refusing) leaves the session alone and asks again next turn.

## Not the cause

Worth recording, since it is where I looked first: no agent-creation path (`db/seed.ts`, `team-template-provision`, the hire approval handler, `POST /api/agents`) ever writes `member_agents.model_override_provider`, and task runs re-resolve the provider on every run. Agents genuinely are not pinned in the database.

## Tests

- `runtime-resolver.test.ts` - the default moves and takes unpinned runs with it; an unusable default fails naming itself instead of handing the run to the previous default; no-default-designated still resolves to the oldest verified.
- `agent-runner-extended.test.ts` - at the run level: `heartbeat_runs.provider` / `ai_provider_config_id` follow the moved default; an unusable default fails the run before it takes a container.
- `chat-session.test.ts` - a session already live picks up a moved default, asserted on the provider env reaching the CLI exec, with the old session retired rather than mutated. Verified this fails without the fix.
- Existing assertions updated for the new return shape and the new failure message.

## Docs

- `.dev/architecture.md` - the resolver's three branches and why the failing one exists; the per-turn chat provider re-check.
- `docs/ai-models.md` - adding a connection does not make it the default; a moved default reaches every agent (and a live CEO chat) on its next run; an unusable default fails loudly rather than substituting.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pYLGuJMAcygYpyKRKhWGu)_