### PR TITLE
feat(web): make the dashboard metric tiles link to their pages

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -280,7 +280,9 @@ being top-level is also what lets the sidebar's "no goals yet" dot ride the Goal
 under a parent it could not, because a sub-item only renders once its parent's route is active.
 
 The dashboard reads as four bands - the metric strip, the summary, the active-agents strip, then two
-columns over the heartbeat history (`components/dashboard/`). Its two capped lists are sized against
+columns over the heartbeat history (`components/dashboard/`). Every metric tile is a `Link` to the
+page that owns its number (inbox, agents, tasks, goals, budget); HQ drops the goals and spend tiles,
+which are also the two pages HQ's sidebar hides, so no tile points at a page a project lacks. Its two capped lists are sized against
 each other by `DASHBOARD_IN_PROGRESS_LIMIT` (7) and `DASHBOARD_GOAL_SLOTS` (4) in `@hezo/shared`, so
 the columns bottom out level; the goals card ranks by `sortGoalsByTriage` (worst health first) since
 a capped list should spend its slots on what needs a decision. The active-agents strip keeps its

--- a/docs/concepts/progress.md
+++ b/docs/concepts/progress.md
@@ -33,7 +33,8 @@ project and rewrites the summary; the **Updated** time shows when that last happ
 Reading down the page:
 
 - a **metric strip** - what needs you, how many agents are working, open tasks, goal progress and
-  month-to-date spend,
+  month-to-date spend. Each tile is a link to the page that owns its number: the inbox, the team,
+  the task list, your goals and the budget,
 - the **progress summary** above,
 - a strip naming the agents **working right now** and the task each is on,
 - **action items** waiting on you, and the tasks **in progress**,

--- a/packages/web/src/components/dashboard/dashboard-metrics.tsx
+++ b/packages/web/src/components/dashboard/dashboard-metrics.tsx
@@ -5,6 +5,7 @@ import {
 	type GoalWithProject,
 	TaskStatus,
 } from '@hezo/shared';
+import { Link } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 import { useAgents } from '../../hooks/use-agents';
 import { useBudgetStatus } from '../../hooks/use-costs';
@@ -18,7 +19,22 @@ import { useI18n } from '../../lib/i18n';
  *
  * Every tile reads from a query the page below it already needs, so the strip costs no extra
  * request - it is a second projection of the same data, not a second fetch.
+ *
+ * Each tile is a link to the page that owns its number, so the strip doubles as the route into
+ * whatever it just reported. The two tiles HQ drops (goals, spend) are also the two pages HQ's
+ * sidebar hides, so no tile ever points at a page the project does not have.
  */
+/**
+ * Where a tile sends you: the page that owns the number it reports. Every one of them is scoped by
+ * `projectId` alone, so the tile needs no per-target params.
+ */
+type MetricTarget =
+	| '/projects/$projectId/inbox'
+	| '/projects/$projectId/agents'
+	| '/projects/$projectId/tasks'
+	| '/projects/$projectId/goals'
+	| '/projects/$projectId/budget';
+
 function Metric({
 	label,
 	value,
@@ -26,6 +42,8 @@ function Metric({
 	valueClass,
 	children,
 	testId,
+	projectId,
+	to,
 }: {
 	label: string;
 	value: string;
@@ -36,9 +54,17 @@ function Metric({
 	/** Rendered under the value - the month-spend tile's cap bar. */
 	children?: ReactNode;
 	testId: string;
+	projectId: string;
+	/** The page this tile's number is reported on. */
+	to: MetricTarget;
 }) {
 	return (
-		<div className="bg-surface px-3 py-2.5 sm:px-4" data-testid={testId}>
+		<Link
+			to={to}
+			params={{ projectId }}
+			className="block bg-surface px-3 py-2.5 outline-none transition-colors hover:bg-surface-2 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring sm:px-4"
+			data-testid={testId}
+		>
 			<p className="font-mono text-[10px] uppercase tracking-wider text-text-3">{label}</p>
 			<p className="mt-0.5 flex items-baseline gap-1.5">
 				<span
@@ -50,7 +76,7 @@ function Metric({
 				{detail && <span className="text-[11px] text-text-3">{detail}</span>}
 			</p>
 			{children}
-		</div>
+		</Link>
 	);
 }
 
@@ -100,6 +126,8 @@ export function DashboardMetrics({
 		<Metric
 			key="needs-you"
 			testId="dashboard-metric-needs-you"
+			projectId={projectId}
+			to="/projects/$projectId/inbox"
 			label={t('dashboard.metric.needsYou')}
 			value={String(actionCount)}
 			valueClass={actionCount > 0 ? 'text-accent' : 'text-text-1'}
@@ -107,6 +135,8 @@ export function DashboardMetrics({
 		<Metric
 			key="active-agents"
 			testId="dashboard-metric-active-agents"
+			projectId={projectId}
+			to="/projects/$projectId/agents"
 			label={t('dashboard.metric.activeAgents')}
 			value={String(running)}
 			detail={t('dashboard.metric.ofRoster', { count: roster.length })}
@@ -115,6 +145,8 @@ export function DashboardMetrics({
 		<Metric
 			key="open-tasks"
 			testId="dashboard-metric-open-tasks"
+			projectId={projectId}
+			to="/projects/$projectId/tasks"
 			label={t('dashboard.metric.openTasks')}
 			value={String(project?.open_task_count ?? 0)}
 			detail={inReview > 0 ? t('dashboard.metric.inReview', { count: inReview }) : undefined}
@@ -126,6 +158,8 @@ export function DashboardMetrics({
 			<Metric
 				key="goals"
 				testId="dashboard-metric-goals"
+				projectId={projectId}
+				to="/projects/$projectId/goals"
 				label={t('dashboard.metric.goalProgress')}
 				value={rollup ? `${rollup.percent}%` : '-'}
 				detail={
@@ -137,6 +171,8 @@ export function DashboardMetrics({
 			<Metric
 				key="spend"
 				testId="dashboard-metric-spend"
+				projectId={projectId}
+				to="/projects/$projectId/budget"
 				label={t('dashboard.metric.monthSpend')}
 				value={monthly ? formatMoney(monthly.spentCents) : '-'}
 				detail={

--- a/packages/web/test/project-dashboard.test.tsx
+++ b/packages/web/test/project-dashboard.test.tsx
@@ -451,6 +451,63 @@ test('HQ drops the summary, goals and spend, and shows the empty HQ state', asyn
 	expect(queryByTestId('dashboard-active-agents')).not.toBeNull();
 });
 
+test('each metric tile links to the page that owns its number', async () => {
+	const ref = { slug: '' };
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Tile Links' });
+			ref.slug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/dashboard',
+		params: { projectId: ref.slug },
+	});
+
+	await findByTestId('dashboard-metrics', undefined, { timeout: 15_000 });
+
+	for (const [testId, path] of [
+		['dashboard-metric-needs-you', 'inbox'],
+		['dashboard-metric-active-agents', 'agents'],
+		['dashboard-metric-open-tasks', 'tasks'],
+		['dashboard-metric-goals', 'goals'],
+		['dashboard-metric-spend', 'budget'],
+	] as const) {
+		const tile = await findByTestId(testId);
+		expect(tile.getAttribute('href')).toBe(`/projects/${ref.slug}/${path}`);
+	}
+
+	// The whole tile is the target, so a click anywhere on it navigates - including on the number.
+	await user.click(await findByTestId('dashboard-metric-open-tasks-value'));
+	await waitFor(() => expect(router.state.location.pathname).toBe(`/projects/${ref.slug}/tasks`));
+});
+
+test('HQ metric tiles link only to the pages HQ has', async () => {
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/dashboard',
+		params: { projectId: HQ_PROJECT_SLUG },
+	});
+
+	await findByTestId('dashboard-metrics', undefined, { timeout: 15_000 });
+
+	// HQ's sidebar hides Goals and Budget, so the strip must not offer a route to either.
+	expect(queryByTestId('dashboard-metric-goals')).toBeNull();
+	expect(queryByTestId('dashboard-metric-spend')).toBeNull();
+	expect((await findByTestId('dashboard-metric-needs-you')).getAttribute('href')).toBe(
+		`/projects/${HQ_PROJECT_SLUG}/inbox`,
+	);
+});
+
 test('project index redirects to dashboard', async () => {
 	const ref = { slug: '' };
 	const { router } = await renderApp({


### PR DESCRIPTION
Each tile in the project dashboard's metric strip is now a link to the page that owns the number it reports, so the strip doubles as the route into whatever it just told you.

| Tile | Goes to |
|---|---|
| Needs you | `/projects/:projectId/inbox` |
| Active agents | `/projects/:projectId/agents` |
| Open tasks | `/projects/:projectId/tasks` |
| Goal progress | `/projects/:projectId/goals` |
| Month spend | `/projects/:projectId/budget` |

The whole tile is the target - label, number, detail and the spend cap bar - so a tap anywhere on it navigates, which is what makes it usable on a phone. Hover gets a `bg-surface-2` wash and keyboard focus an inset outline, so the affordance is visible before the click.

HQ already drops the goals and spend tiles, and those are the same two pages HQ's sidebar hides, so no tile can point at a page a project does not have. The `to` prop is typed as a union of the five route literals rather than a bare string, so a target that is not a real route is a compile error.

## Testing

Two component tests in `packages/web/test/project-dashboard.test.tsx`:

- every tile carries the expected `href`, and a click on the open-tasks number lands the router on the task list;
- HQ renders neither the goals nor the spend tile, and its needs-you tile points at HQ's own inbox.

`bunx vitest run test/project-dashboard.test.tsx` - 15 passed. `bun run typecheck` and `bunx biome check` clean.

## Docs

- `docs/concepts/progress.md` - the metric strip bullet now says each tile links to the page it reports on.
- `.dev/architecture.md` - the dashboard-bands paragraph records the links and the HQ rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Md1C7vzhvn4ERZEWDHGqWx)_