### PR TITLE
feat(web): stack the agent run list into readable bands on mobile

### DIFF
--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
@@ -44,14 +44,27 @@ function ExecutionRow({
 	const trigger = formatTriggerReason(run, projectId);
 	const projectLabel = run.project_name ?? run.project_slug;
 
+	// The title band carries the task title and, for an instance agent, which
+	// project the task lives in - both only ever shown for a run that has a task.
+	const showTitle =
+		!!run.task_identifier && (!!run.task_title || (isInstanceAgent && !!projectLabel));
+
+	// Mobile-first: the row wraps into three bands - status + task id + when,
+	// then the task title on its own line, then the meta strip. The `w-full` on
+	// the title is what forces the band breaks (a full-width item can share a
+	// flex line with nothing), and `order-*` lifts the timestamp up beside the
+	// id, since its DOM position is the desktop one - after the trigger. Every
+	// override drops at `sm`, where the row is the single line it has always
+	// been. DOM order stays the desktop order so the accessible name reads
+	// status, task, trigger, timing in that sequence at both sizes.
 	return (
 		<Link
 			to="/projects/$projectId/agents/$agentId/executions/$runId"
 			params={{ projectId, agentId, runId: run.id }}
 			data-testid="execution-row"
-			className="flex items-center gap-2 rounded-md border border-border-subtle bg-surface px-3 py-2.5 text-xs hover:bg-surface-2 transition-colors"
+			className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border-subtle bg-surface px-3 py-2.5 text-xs hover:bg-surface-2 transition-colors sm:flex-nowrap sm:gap-2"
 		>
-			<Badge color={statusColor(run.status) as 'green'}>
+			<Badge color={statusColor(run.status) as 'green'} className="order-1 sm:order-none">
 				{(run.status === 'running' || run.status === 'queued') && (
 					<span className="w-1.5 h-1.5 rounded-full bg-current animate-pulse mr-1" />
 				)}
@@ -59,35 +72,55 @@ function ExecutionRow({
 			</Badge>
 
 			{run.task_identifier && (
-				<span className="text-text-2 font-mono">
+				<span className="order-2 text-text-2 font-mono whitespace-nowrap sm:order-none">
 					{run.task_identifier}
-					{run.task_title && <span className="font-sans ml-1.5 text-text-1">{run.task_title}</span>}
+				</span>
+			)}
+
+			{showTitle && (
+				<span
+					data-testid="execution-row-title"
+					className="order-4 w-full line-clamp-2 text-text-1 sm:order-none sm:w-auto sm:line-clamp-none"
+				>
+					{run.task_title}
 					{isInstanceAgent && projectLabel && (
-						<span data-testid="run-row-project" className="font-sans ml-1.5 text-text-3">
+						<span data-testid="run-row-project" className="ml-1.5 text-text-3">
 							· {projectLabel}
 						</span>
 					)}
 				</span>
 			)}
 
+			{/* Capped rather than free-shrinking on mobile: a flex line only shrinks
+			    its items once they overflow it, so an untruncated long trigger would
+			    take the whole meta band and push the timing figures onto a fourth. */}
 			<Tooltip content={trigger.text}>
-				<span className="text-text-3 truncate">{trigger.text}</span>
+				<span className="order-5 max-w-[55%] truncate text-text-3 sm:order-none sm:max-w-none">
+					{trigger.text}
+				</span>
 			</Tooltip>
 
 			{run.started_at ? (
-				<RelativeTime iso={run.started_at} className="text-text-2 ml-auto whitespace-nowrap" />
+				<RelativeTime
+					iso={run.started_at}
+					className="order-3 text-text-2 ml-auto whitespace-nowrap sm:order-none"
+				/>
 			) : (
-				<span className="text-text-2 ml-auto whitespace-nowrap">queued</span>
+				<span className="order-3 text-text-2 ml-auto whitespace-nowrap sm:order-none">queued</span>
 			)}
 
-			<span className="text-text-3 whitespace-nowrap">{elapsed}</span>
+			<span className="order-6 text-text-3 whitespace-nowrap sm:order-none">{elapsed}</span>
 
 			{run.cost_cents != null && run.cost_cents > 0 && (
-				<span className="text-text-3 whitespace-nowrap">${(run.cost_cents / 100).toFixed(2)}</span>
+				<span className="order-7 text-text-3 whitespace-nowrap sm:order-none">
+					${(run.cost_cents / 100).toFixed(2)}
+				</span>
 			)}
 
 			{run.exit_code !== null && run.exit_code !== 0 && (
-				<span className="text-danger whitespace-nowrap">exit: {run.exit_code}</span>
+				<span className="order-8 text-danger whitespace-nowrap sm:order-none">
+					exit: {run.exit_code}
+				</span>
 			)}
 		</Link>
 	);

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -38,7 +38,11 @@ function AgentLayout() {
 		: [executionsTab, settingsTab];
 
 	return (
-		<div className="max-w-3xl">
+		// The chat launcher is fixed at `bottom-4 right-4` over every page, so the
+		// last row of any tab - a run, the infinite-scroll sentinel, a Save button -
+		// needs clearance under it at mobile widths, where the content column runs
+		// the full width and passes beneath the button.
+		<div className="max-w-3xl pb-20 sm:pb-8">
 			<Link
 				to="/projects/$projectId/agents"
 				params={{ projectId }}
@@ -54,8 +58,12 @@ function AgentLayout() {
 					size="md"
 					running={agent.runtime_status === 'active'}
 				/>
+				{/* `min-w-0 truncate` keeps the status badge on the name's own line at
+				    mobile widths: without it a long name is unshrinkable and orphans
+				    the badge onto a line of its own. */}
 				<h1
-					className={`text-lg font-semibold${agent.admin_status === AgentAdminStatus.Disabled ? ' text-text-2' : ''}`}
+					title={agentDisplayName(agent)}
+					className={`min-w-0 truncate text-lg font-semibold${agent.admin_status === AgentAdminStatus.Disabled ? ' text-text-2' : ''}`}
 				>
 					{agentDisplayName(agent)}
 					{agent.admin_status === AgentAdminStatus.Disabled ? ' (disabled)' : ''}

--- a/test/browser/agent-executions.mobile.spec.ts
+++ b/test/browser/agent-executions.mobile.spec.ts
@@ -1,0 +1,185 @@
+// Criterion #2 (viewport-conditional behaviour): the execution row is one flex
+// line on desktop and three wrapped bands below `sm`, which only resolves once a
+// real layout pass runs the media query and wraps the line. happy-dom reports no
+// geometry at all, so a component test would pass whatever the row did.
+//
+// The `mobile` Playwright project runs every *.mobile.spec.ts at 390px (see
+// playwright.config.ts). The run list is stubbed rather than driven from real
+// agent runs: what is under test is the row's geometry at a narrow viewport, and
+// a synthetic list pins the content the boxes are measured against.
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, waitForPageLoad } from './helpers';
+
+type CreatedProject = { id: string; slug: string; team_id: string };
+
+const LONG_TITLE = 'Daily X engagement: discover conversations and draft replies';
+
+/**
+ * Runs stamped relative to now, so `RelativeTime` renders its "N minutes ago"
+ * form - past a day old it switches to an absolute date and the band-1
+ * assertions would be measuring a different string.
+ */
+function minutesAgo(minutes: number): string {
+	return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+function makeRun(overrides: Record<string, unknown>) {
+	return {
+		id: 'aaaa0000-0000-0000-0000-0000000000a1',
+		member_id: 'm-1',
+		team_id: 't-1',
+		wakeup_id: null,
+		task_id: 'task-1',
+		kind: 'task',
+		task_identifier: 'HM-345',
+		task_title: LONG_TITLE,
+		project_id: 'p-1',
+		project_slug: 'demo',
+		project_name: 'Demo Project',
+		status: 'succeeded',
+		queued_reason: null,
+		started_at: minutesAgo(2),
+		finished_at: minutesAgo(1),
+		exit_code: 0,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 9,
+		usage_partial: false,
+		invocation_command: null,
+		log_text: null,
+		working_dir: null,
+		trigger_source: 'heartbeat',
+		trigger_payload: null,
+		trigger_comment_id: null,
+		trigger_comment_public_id: null,
+		trigger_actor_member_id: null,
+		trigger_actor_slug: null,
+		trigger_actor_title: null,
+		trigger_comment_task_id: null,
+		trigger_comment_task_identifier: null,
+		trigger_comment_project_slug: null,
+		run_comment_id: null,
+		run_comment_public_id: null,
+		created_tasks: [],
+		created_docs: [],
+		created_skills: [],
+		proposed_skills: [],
+		...overrides,
+	};
+}
+
+async function stubRuns(page: Page) {
+	const runs = [
+		makeRun({}),
+		makeRun({
+			id: 'aaaa0000-0000-0000-0000-0000000000a2',
+			started_at: minutesAgo(5),
+			finished_at: minutesAgo(4),
+		}),
+		makeRun({
+			id: 'aaaa0000-0000-0000-0000-0000000000a3',
+			started_at: minutesAgo(20),
+			finished_at: minutesAgo(19),
+		}),
+	];
+	await page.route('**/api/projects/*/agents/*/heartbeat-runs?*', async (route) => {
+		if (route.request().method() !== 'GET') return route.continue();
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: runs, meta: { page: 1, per_page: 50, total: runs.length } }),
+		});
+	});
+}
+
+async function openExecutions(page: Page, token: string, name: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const projectRes = await createProjectAndClearPlanning(page, '', token, {
+		name,
+		description: 'Mobile run-list layout test.',
+	});
+	const project = ((await projectRes.json()) as { data: CreatedProject }).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	await stubRuns(page);
+	await page.goto(`/projects/${project.slug}/agents/${captain.id}/executions`);
+	await waitForPageLoad(page);
+	return { project, captainId: captain.id };
+}
+
+test.describe('Agent executions — mobile layout (390px)', () => {
+	test('a run row stacks into status/title/meta bands instead of a squeezed column', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		await openExecutions(page, freshWorkspace.token, 'Mobile Runs Stack');
+
+		const row = page.getByTestId('execution-row').first();
+		await expect(row).toBeVisible({ timeout: 20000 });
+
+		const rowBox = (await row.boundingBox())!;
+		const badgeBox = (await row.getByText('succeeded').boundingBox())!;
+		const idBox = (await row.getByText('HM-345').boundingBox())!;
+		const titleBox = (await row.getByTestId('execution-row-title').boundingBox())!;
+		const whenBox = (await row.getByText(/ago$/).boundingBox())!;
+
+		// Band 1: status, task id and the timestamp share a line, the timestamp
+		// pushed to the row's right edge.
+		expect(Math.abs(idBox.y - badgeBox.y)).toBeLessThan(6);
+		expect(Math.abs(whenBox.y - badgeBox.y)).toBeLessThan(6);
+		expect(rowBox.x + rowBox.width - (whenBox.x + whenBox.width)).toBeLessThan(20);
+
+		// The identifier is never broken across lines - that split is what made the
+		// old single-line row unreadable here.
+		expect(idBox.height).toBeLessThan(24);
+
+		// Band 2: the title starts below band 1 and gets the full column width,
+		// clamped to two lines rather than wrapping into a narrow ribbon.
+		expect(titleBox.y).toBeGreaterThan(badgeBox.y + badgeBox.height - 2);
+		expect(titleBox.width).toBeGreaterThan(rowBox.width * 0.8);
+		expect(titleBox.height).toBeLessThan(44);
+
+		// The whole row stays compact enough that several runs fit one screen.
+		expect(rowBox.height).toBeLessThan(120);
+	});
+
+	test('the run list clears the fixed chat launcher and never scrolls sideways', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		await openExecutions(page, freshWorkspace.token, 'Mobile Runs Clearance');
+
+		const rows = page.getByTestId('execution-row');
+		await expect(rows.first()).toBeVisible({ timeout: 20000 });
+
+		// The page column never overflows its own viewport width.
+		const overflow = await page.evaluate(() => {
+			const main = document.querySelector('main');
+			return main ? main.scrollWidth - main.clientWidth : 0;
+		});
+		expect(overflow).toBeLessThanOrEqual(1);
+
+		// Scrolled to the bottom, the last row clears the chat launcher rather than
+		// passing under it. Asserted as a box intersection so it holds wherever the
+		// (draggable) launcher sits.
+		await page.evaluate(() => {
+			document.querySelector('main')?.scrollTo({ top: 999_999, behavior: 'instant' });
+		});
+		const launcher = page.getByTestId('chat-launcher');
+		await expect(launcher).toBeVisible();
+		const launcherBox = (await launcher.boundingBox())!;
+		const lastRowBox = (await rows.last().boundingBox())!;
+		const overlaps =
+			lastRowBox.x < launcherBox.x + launcherBox.width &&
+			lastRowBox.x + lastRowBox.width > launcherBox.x &&
+			lastRowBox.y < launcherBox.y + launcherBox.height &&
+			lastRowBox.y + lastRowBox.height > launcherBox.y;
+		expect(overlaps).toBe(false);
+	});
+});


### PR DESCRIPTION
The agent Executions row was a single desktop flex line. Below `sm` the title column collapsed to a sliver and wrapped six lines deep, the task identifier broke across two of them, and the trigger reason was squeezed out of the row entirely - while the fixed chat launcher sat on top of the last run.

## What changed

**Run row** (`executions/index.tsx`) - mobile-first, the row wraps into three bands:

- status badge + task id + relative time, the time pushed to the right edge
- the task title on its own full-width line, clamped to two
- a meta strip carrying trigger reason, duration, cost and exit code

The `w-full` on the title is what forces the band breaks (a full-width item shares a flex line with nothing); `order-*` lifts the timestamp beside the id, since its DOM position is the desktop one, after the trigger. DOM order stays the desktop order, so the accessible name reads status, task, trigger, timing at both sizes. The trigger is capped at `max-w-[55%]` on mobile rather than left to shrink, because a flex line only shrinks items once they overflow it - an untruncated long trigger would take the whole meta band and push the timing figures onto a fourth line.

Every override drops at `sm`. Desktop row height measured 54px in a real browser at 1280px both before and after this change.

**Header** (`route.tsx`) - the agent name gets `min-w-0 truncate` so a long name no longer orphans the status badge onto a line of its own, plus a `title` attribute for the full text.

**Page bottom** (`route.tsx`) - `pb-20 sm:pb-8` on the layout column, so the last row of any tab (a run, the infinite-scroll sentinel, the settings Save button) clears the chat launcher instead of passing under it.

Row height drops from roughly 200px to 90px at 390px, so a phone screen shows six runs instead of two and a half.

## Testing

New `test/browser/agent-executions.mobile.spec.ts` (mobile project, 390px), stubbing the runs list so the geometry is measured against pinned content:

- the three bands land where they should, the identifier never splits, the title gets >80% of the column and stays under two lines, the row stays under 120px tall
- `<main>` never scrolls sideways, and the last row's box does not intersect the chat launcher's

Both pass locally. Existing `agent-executions-list`, `agent-executions-project` and `agent-detail` component tests stay green (25 tests), and desktop geometry was verified unchanged against a stashed baseline.

No user-facing strings added or changed, so no catalog work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016q1xzPkYM9KMP25L9FLzG4

---
_Generated by [Claude Code](https://claude.ai/code/session_016q1xzPkYM9KMP25L9FLzG4)_