### PR TITLE
fix(runs): stop idle agents re-running themselves every container start

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2194,6 +2194,51 @@ countdown matches the enforced cadence. Alongside it the API derives `has_action
 (mirrors the scheduler's task selection: a non-terminal, unblocked assigned task); when
 false the next heartbeat would no-op, so the UI shows a dash rather than a countdown.
 
+**The no-work backoff, and why the cadence needs one.** The configured interval is honoured
+by exactly two code paths - `processScheduledHeartbeats` and `chainNextTaskWakeup`. Every
+other source dispatches on arrival, which is correct for a mention and wrong for a system
+event: a daily agent could be re-run every few minutes by `automation` wakeups while the UI
+counted down 23 hours to its next heartbeat. `report_no_work` made that visible - the
+verdict was recorded on the run row and never read again, so each system wakeup bought a
+container, a model call and a bill to re-derive "nothing to do".
+
+`noWorkCooldownActive` (`services/no-work-backoff.ts`) applies that verdict at dispatch. It
+sits in `activateAgent` **after task resolution** - the one point every source passes through
+holding a concrete task, so a new source cannot forget it. It suppresses when all three hold:
+the agent's most recent *finished* run on this task ended `reported_no_work`; that run
+finished within `max(heartbeat_interval_min, floor)` (so the backoff expires exactly when a
+scheduled heartbeat would have come round anyway); and no `task_comments` row has landed
+since, excluding ones that run authored. Comments are the signal rather than `tasks.updated_at`
+because every mutation that could give the agent work - status, assignee, title, unblock -
+writes one through `task-events.ts`, whereas `updated_at` is bumped by the run's own
+in-progress flip and would report "changed" on the quietest run. Conversational sources
+(`mention`, `comment`, `reply`, `on_demand`, `credential_provided`, `asset_deletion_resolved`)
+are exempt: each is somebody asking for something the last pass could not have served. A
+suppressed wakeup is marked `completed` with `last_skipped_reason = no_work_cooldown` -
+answered, not re-queued to ask again, and not left dangling in `claimed`.
+
+**The container-start fan-out, and the loop it used to close.** `provisionContainer` ends by
+nudging the project's agents (`wakeAgentsWithPendingWork`) so work queued while the container
+was still coming up starts without waiting for a heartbeat. That is right for a provision
+nobody is waiting on - startup self-heal, project creation - and wrong for one the run path
+asked for: `acquireRunContainer`'s pool ladder provisions on its `create` rung, so a run is
+already starting and will do the work. Waking then billed a second run for it, which on a cold
+pool provisioned again and woke again, sustaining itself at container-start cadence no matter
+what the agent's heartbeat said. The policy is therefore the caller's to state
+(`ProvisionWakePolicy`), since only the caller knows whether a run is in flight.
+
+Two things keep the fan-out honest wherever it does fire. It **names the task** on each wakeup:
+a task-less payload slips past every dedup guard in the dispatch path - `shouldDeferWakeupForBlockers`
+returns early without one, `processWakeups`' busy/capacity pre-checks are all inside
+`if (wakeupTaskId)`, and `chainNextTaskWakeup` reads `payload->>'task_id'` - so it queued a run per
+container start regardless of what was already in flight. And it **skips agents already covered**
+by a queued or claimed wakeup for that task, rather than leaning on `createWakeup`'s coalescing,
+which merges payloads and would overwrite a more specific sibling's `reason` (the container-recovery
+wakeup queued moments earlier in the same provision is exactly that case). The payload carries
+`reason`, not `trigger`: `trigger` marks a wakeup with its own dispatch path, and `createWakeup`
+refuses to coalesce onto one, so the marker both blocked coalescing and left the run list showing a
+bare "Automation" for a wakeup that can now name itself.
+
 **Dispatch.** `JobManager` runs a ~1 Hz cron that also does container sync, container
 health, and orphan recovery. Container sync separates its two costs: liveness
 (`inspectContainer`) runs every pass, while the working-set **memory sample**
@@ -3243,6 +3288,16 @@ summing cumulative session totals). `recoverOffStreamRunUsage` dispatches both a
 file afterwards — Grok's holds the `XAI_API_KEY`, and a wire log plausibly captures the
 Moonshot bearer.
 
+**Grok's text buffer flushes at every turn boundary, not just at `end`.** Its stream carries
+assistant text as `text` deltas with no `result` event, so the parser accumulates them and the
+flush is the only place `finalMessage` can be captured. Consecutive `text` events are deltas of
+one message, but a run has many: the next turn opens with `thought`, and tool activity arrives as
+event types this parser renders nothing for. Flushing only on `end` therefore ran the whole run's
+narration into one buffer and made `finalMessage` the concatenation of every turn - sentences
+abutting with no separator, since deltas are appended raw. The handoff net posts that value
+verbatim, so an entire run's thinking went out as one comment. Anything that is not another
+`text` delta now ends the message.
+
 **Runtime timeout hardening.** Each CLI ships default timeouts that would cut off Hezo's
 legitimately long agent/background work; every runtime is relaxed at its own config surface
 (no exact cross-runtime env analog exists for Claude Code's `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`).
@@ -3361,7 +3416,17 @@ and the handoff-delivery net are:
 blocks at most once per run (the `stop_hook_active` ceiling) — so a stranded handoff is *also*
 caught **deterministically** at run completion, independent of any judge. In `agent-runner.ts`,
 when a run exits cleanly, the runner reads the run's final assistant message from the stream
-parser (`getFinalAssistantMessage()`). Three stranded forms are handled, differently:
+parser (`getFinalAssistantMessage()`).
+
+**A run that called `report_no_work` is excluded outright.** Every form below is a *handoff* the
+run failed to deliver, and an agent that declared it had nothing to do handed nothing over - its
+final message is a status note, and an `@admin` inside it is narration, not an ask. Delivering it
+anyway posted a comment the agent had explicitly decided not to write, fanned it to the admin
+inbox on every idle wake, and set `produced_output`, which graded the no-op a productive run and
+hid it from the no-work backoff above. On Grok that fired on every idle tick, because Grok has no
+judge and the net is its only guardrail.
+
+Three stranded forms are handled, differently:
 (1) an **active `@`-mention** (`extractMentionSlugs`) the run never posted as a comment is
 delivered verbatim via `postAgentComment` — the same insert + broadcast + `fireCommentWakeups`
 path `create_comment` uses — so it fans out to the admin inbox / agent wakeup instead of

--- a/packages/server/migrations/061_no_work_backoff_index.sql
+++ b/packages/server/migrations/061_no_work_backoff_index.sql
@@ -1,0 +1,20 @@
+-- Index for the no-work backoff, which runs once per agent dispatch.
+--
+-- `heartbeat_runs (member_id, task_id, finished_at DESC)`
+--    `noWorkCooldownActive` asks for one row: this agent's most recent finished
+--    run on this task. That is filter-then-sort-then-limit on exactly these
+--    three columns, so the composite serves it as a single index seek.
+--
+--    The nearest existing indexes cannot. `idx_runs_member_finished`
+--    (member_id, finished_at DESC) from 047 has the right shape but no task
+--    column, so it walks every run the agent has ever finished, newest first,
+--    discarding the ones on other tasks until it reaches this task's - and an
+--    agent that works many tasks pays for all of them on every dispatch.
+--    `idx_runs_task_started` is keyed on started_at, which is not the ordering
+--    this asks for. `heartbeat_runs` is never pruned, so both degrade with the
+--    instance's whole run history rather than with anything bounded.
+--
+-- Additive. No row is read, moved or dropped, and the indexes beside it stay.
+
+CREATE INDEX IF NOT EXISTS idx_runs_member_task_finished
+    ON heartbeat_runs (member_id, task_id, finished_at DESC);

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -2121,7 +2121,15 @@ export async function runAgent(
 			//       delivery non-looping (see the branch itself).
 			// Best-effort: a failure here must never throw out of the run-completion path.
 			// Runs on every runtime, including OpenCode, which has no stop-hook judge.
-			if (exitedClean && task) {
+			//
+			// A run that called `report_no_work` is excluded outright. Every form above
+			// is a HANDOFF the agent failed to deliver, and an agent that declared it
+			// had nothing to do handed nothing over - its final message is a status
+			// note. Delivering it posts a comment the agent decided not to write, fans
+			// it out to the @admin inbox on every idle wake, and flips
+			// `produced_output`, grading the no-op as productive work and hiding it
+			// from the no-work backoff that damps the next dispatch.
+			if (exitedClean && task && !reportedNoWork) {
 				try {
 					const finalMessage = parser.getFinalAssistantMessage();
 					if (finalMessage?.trim()) {

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -1328,6 +1328,13 @@ function createGrokParser(): AgentStreamParser {
 			// — and it matters more on Grok than anywhere else, because Grok is
 			// also one of the two runtimes whose hooks cannot host the
 			// completeness judge, so the net is its only guardrail.
+			//
+			// Which makes flushing at every turn boundary load-bearing, not
+			// cosmetic: `finalMessage` is overwritten per flush, so a buffer that
+			// only emptied at `end` made it the concatenation of every turn in the
+			// run rather than the last message. The net then posted a whole run's
+			// narration as one comment - sentences run together with no separator,
+			// since the deltas were simply appended.
 			finalMessage = t;
 		}
 		textBuf = '';
@@ -1337,16 +1344,16 @@ function createGrokParser(): AgentStreamParser {
 		const event = raw as GrokEvent;
 		const type = event.type ?? '';
 
-		if (type === 'thought') {
-			thoughtBuf += event.data ?? '';
-			return [];
-		}
+		// Consecutive `text` events are deltas of ONE message, so they accumulate.
+		// Anything else ends that message: the next turn opens with `thought`, a
+		// tool call arrives as a type this parser drops, or the run reaches `end`.
 		if (type === 'text') {
 			const out: string[] = [];
 			flushThought(out);
 			textBuf += event.data ?? '';
 			return out;
 		}
+
 		if (type === 'end') {
 			const out: string[] = [];
 			flushThought(out);
@@ -1356,12 +1363,21 @@ function createGrokParser(): AgentStreamParser {
 			out.push(`[done] ${status}`);
 			return out;
 		}
+
+		const out: string[] = [];
+		flushText(out);
+
+		if (type === 'thought') {
+			thoughtBuf += event.data ?? '';
+			return out;
+		}
 		if (type === 'error') {
 			const msg = extractErrorMessage(undefined, event.message);
 			if (msg) terminalError = classifyRuntimeError(msg) ?? terminalError;
-			return msg ? [`[tool-error] ${msg.replace(/\s+/g, ' ').trim()}`] : [];
+			if (msg) out.push(`[tool-error] ${msg.replace(/\s+/g, ' ').trim()}`);
+			return out;
 		}
-		return [];
+		return out;
 	};
 
 	return createJsonlParser(

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -7,10 +7,12 @@ import {
 	CONTAINER_RECLAIM_MIN_IDLE_SEC,
 	ContainerStatus,
 	HeartbeatRunStatus,
+	TaskPriority,
 	TEST_CONTAINER_LABEL_KEY,
 	TEST_CONTAINER_LABEL_VALUE,
 	TEST_CONTAINERS_ENV,
 	WakeupSource,
+	WakeupStatus,
 	WsMessageType,
 	wsRoom,
 } from '@hezo/shared';
@@ -390,10 +392,28 @@ export async function captureContainerLogs(
 	}
 }
 
+/**
+ * Whether a finished provision should nudge the project's agents.
+ *
+ * `wakeAgentsWithPendingWork` exists for the provisions nobody is waiting on -
+ * startup self-heal, project creation - where pending work would otherwise sit
+ * until the next scheduled heartbeat. A provision the run path itself asked for
+ * is the opposite case: a run is already starting on this project and will do
+ * the work, so waking every agent that holds a task here bills a second run for
+ * work the first one is mid-way through. That second run provisions again on a
+ * cold pool, wakes again, and the loop sustains itself at container-start
+ * cadence rather than at the agent's configured heartbeat.
+ *
+ * Stated by the caller rather than inferred here, because the caller is the only
+ * one that knows whether a run is already in flight.
+ */
+export type ProvisionWakePolicy = 'wake-pending-agents' | 'caller-runs-the-work';
+
 export async function provisionContainer(
 	deps: ContainerDeps,
 	project: ProjectRow,
 	teamSlug: string,
+	wakePolicy: ProvisionWakePolicy = 'wake-pending-agents',
 ): Promise<string> {
 	const { db, docker, dataDir, wsManager, masterKeyManager, logs } = deps;
 	const teamId = project.team_id;
@@ -759,10 +779,13 @@ export async function provisionContainer(
 		// run (container_status !== running). Now that it's up, nudge every agent
 		// holding pending work so freshly-created tasks (e.g. the CEO's coherence
 		// pass) start without waiting for the next scheduled heartbeat. Mirrors the
-		// container start/rebuild routes.
-		await wakeAgentsWithPendingWork(db, project.id, teamId).catch((e) =>
-			log.error('Failed to wake agents with pending work after provision:', e),
-		);
+		// container start/rebuild routes. Skipped when the caller is itself a run
+		// that provisioned this container to execute on - see ProvisionWakePolicy.
+		if (wakePolicy === 'wake-pending-agents') {
+			await wakeAgentsWithPendingWork(db, project.id, teamId).catch((e) =>
+				log.error('Failed to wake agents with pending work after provision:', e),
+			);
+		}
 
 		return Id;
 	} catch (error) {
@@ -1226,7 +1249,10 @@ export async function acquireRunContainer(
 
 			if (decision.kind === 'create') {
 				const proj = await loadProjectRow(db, projectId);
-				const id = await provisionContainer(deps, proj, proj.team_slug);
+				// The caller is acquiring this container to run on it right now, so
+				// the post-provision fan-out would wake agents for work this run is
+				// about to do - including the agent whose run is provisioning.
+				const id = await provisionContainer(deps, proj, proj.team_slug, 'caller-runs-the-work');
 				if (await takeMember(deps, projectId, id, taskId, workload)) {
 					return { kind: 'acquired' as const, containerId: id };
 				}
@@ -2409,6 +2435,15 @@ export async function requeueContainerKilledRuns(
  * in this project. Used after a container transitions to running (initial
  * provision, start, rebuild) so pending work is picked up promptly instead of
  * waiting for the next scheduled heartbeat.
+ *
+ * **Each wakeup names the task it is for.** A task-less wakeup slips past every
+ * dedup guard in the dispatch path - `shouldDeferWakeupForBlockers` returns
+ * early without a task, `processWakeups`' busy/capacity pre-checks are all
+ * inside `if (wakeupTaskId)`, and `chainNextTaskWakeup`'s already-covered clause
+ * reads `payload->>'task_id'` - so a fan-out that omitted it queued a run per
+ * container start no matter what was already in flight. The task chosen is the
+ * one `activateAgent` would select anyway (priority, then oldest, blockers
+ * clear), so naming it changes which guards fire, not which work runs.
  */
 export async function wakeAgentsWithPendingWork(
 	db: Db,
@@ -2416,20 +2451,61 @@ export async function wakeAgentsWithPendingWork(
 	teamId: string,
 ): Promise<void> {
 	const { placeholders, values } = terminalStatusParams(3);
-	const pending = await db.query<{ agent_id: string }>(
-		`SELECT DISTINCT i.assignee_id AS agent_id
+	const pr = 3 + values.length;
+	const wu = pr + 4;
+	const pending = await db.query<{ agent_id: string; task_id: string }>(
+		`SELECT DISTINCT ON (i.assignee_id) i.assignee_id AS agent_id, i.id AS task_id
 		 FROM tasks i
 		 JOIN member_agents ma ON ma.id = i.assignee_id
 		 WHERE i.project_id = $1 AND i.team_id = $2
 		   AND i.status NOT IN (${placeholders})
-		   AND ma.admin_status = 'enabled'`,
-		[projectId, teamId, ...values],
+		   AND ma.admin_status = 'enabled'
+		   AND NOT EXISTS (
+		     SELECT 1 FROM task_dependencies d
+		     JOIN tasks b ON b.id = d.blocked_by_task_id
+		     WHERE d.task_id = i.id
+		       AND b.status NOT IN (${placeholders})
+		   )
+		   -- Already covered: a pending wakeup for this agent and task will run the
+		   -- work, so a nudge adds nothing. Skipping beats relying on createWakeup's
+		   -- coalescing, which merges payloads and would overwrite a more specific
+		   -- sibling's reason - the container-recovery wakeup queued moments earlier
+		   -- in this same provision is exactly that case.
+		   AND NOT EXISTS (
+		     SELECT 1 FROM agent_wakeup_requests w
+		     WHERE w.member_id = i.assignee_id
+		       AND w.status IN ($${wu}::wakeup_status, $${wu + 1}::wakeup_status)
+		       AND w.payload->>'task_id' = i.id::text
+		   )
+		 ORDER BY i.assignee_id,
+		   CASE i.priority WHEN $${pr} THEN 0 WHEN $${pr + 1} THEN 1 WHEN $${pr + 2} THEN 2 WHEN $${pr + 3} THEN 3 END,
+		   i.created_at ASC`,
+		[
+			projectId,
+			teamId,
+			...values,
+			TaskPriority.Urgent,
+			TaskPriority.High,
+			TaskPriority.Medium,
+			TaskPriority.Low,
+			WakeupStatus.Queued,
+			WakeupStatus.Claimed,
+		],
 	);
 	for (const row of pending.rows) {
 		trackBackground(
 			createWakeup(db, row.agent_id, teamId, WakeupSource.Automation, {
-				trigger: 'container_start',
+				// `reason`, not `trigger`. `trigger` marks a wakeup with its own
+				// dispatch path (the Captain's `progress_update_now`), and `createWakeup`
+				// deliberately refuses to coalesce onto one so the marker cannot be
+				// absorbed - which meant every container start stacked another row for
+				// the same agent and task. This wakeup has no special dispatch, so it
+				// wants ordinary coalescing. `reason` is also the key the run list reads
+				// (`formatTriggerReason`), so runs now name themselves "Automation:
+				// container_start" instead of a bare "Automation".
+				reason: 'container_start',
 				project_id: projectId,
+				task_id: row.task_id,
 			}).catch((e) => log.error('Failed to create wakeup on container start:', e)),
 		);
 	}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -76,6 +76,7 @@ import { getDueGoals } from './goals';
 import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
 import { refreshModelPins } from './model-pins';
+import { noWorkCooldownActive } from './no-work-backoff';
 import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
 import { collectCandidateRunIds, decideSweepKills } from './process-sweeper';
@@ -2188,6 +2189,41 @@ export class JobManager {
 				return;
 			}
 			task = tasks.rows[0];
+		}
+
+		// No-work backoff. Placed here, after task resolution, because it is the one
+		// point every wakeup source passes through holding a concrete task - both the
+		// payload-targeted wakeups and the ones that select a task above. A gate per
+		// source would have to be re-added to each new source; this cannot be missed.
+		//
+		// Skipped rather than re-queued: the last run answered this exact question and
+		// nothing has changed since, so there is nothing to retry. New input lifts it
+		// immediately (see noWorkCooldownActive), and it expires on its own at the
+		// agent's configured cadence.
+		if (await noWorkCooldownActive(db, memberId, task.id, wakeupSource)) {
+			log.debug(
+				`Agent ${ref(agent.rows[0].slug, memberId)} reported no work on ${ref(task.identifier, task.id)} within its heartbeat interval and nothing has changed since — skipping wakeup`,
+			);
+			await this.markWakeupSkipped(
+				wakeupId,
+				WakeupSkipReason.NoWorkCooldown,
+				task.id,
+				teamId,
+				null,
+			);
+			// Completed, not left claimed: the wakeup was considered and answered -
+			// there is nothing to do - which is the same outcome as the "no actionable
+			// tasks" branch above, and it must not sit in `claimed` forever. Not
+			// re-queued either: retrying would re-ask a question already answered, and
+			// the next container start or scheduled heartbeat raises a fresh wakeup
+			// once the window has passed.
+			if (wakeupId) {
+				await db.query(
+					`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
+					[WakeupStatus.Completed, wakeupId],
+				);
+			}
+			return;
 		}
 
 		// Per-task serialisation plus the per-project concurrency ceiling: only one

--- a/packages/server/src/services/no-work-backoff.ts
+++ b/packages/server/src/services/no-work-backoff.ts
@@ -1,0 +1,96 @@
+import { WakeupSource } from '@hezo/shared';
+import type { Db } from '../db/database';
+import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
+
+/**
+ * Wakeup sources the no-work backoff never suppresses.
+ *
+ * Each is somebody asking this agent for something it could not have served on
+ * its last pass: a human or teammate addressing it, an operator pressing "Run
+ * now", a credential or asset decision it was parked on. The backoff exists to
+ * stop the system re-asking a question it already answered, never to delay an
+ * answer to a new one.
+ *
+ * The complement - `heartbeat`, `assignment`, `timer`, `automation` - is
+ * everything the system raises on its own behalf, which is exactly what a
+ * "nothing to do" verdict is about.
+ */
+export const NO_WORK_BACKOFF_EXEMPT_SOURCES: ReadonlySet<string> = new Set([
+	WakeupSource.Mention,
+	WakeupSource.Comment,
+	WakeupSource.Reply,
+	WakeupSource.OnDemand,
+	WakeupSource.CredentialProvided,
+	WakeupSource.AssetDeletionResolved,
+]);
+
+/**
+ * Would dispatching this agent onto this task re-run a no-op it just finished?
+ *
+ * `report_no_work` is the agent stating that this task has nothing for it yet.
+ * That verdict was recorded on the run row and then never read again, so any
+ * wakeup arriving afterwards - and four of the ten sources fire on system state
+ * changes nobody chose - dispatched a fresh container, a fresh model call and a
+ * fresh bill to reach the identical conclusion. The agent's configured cadence
+ * did not help: it is honoured only by `processScheduledHeartbeats` and
+ * `chainNextTaskWakeup`, so a 24-hour agent could still run every few minutes.
+ *
+ * This is the missing half - the verdict applied at dispatch, for every source.
+ * Three conditions, all required:
+ *
+ * 1. The agent's most recent finished run on this task ended in `report_no_work`.
+ *    A run that did work, failed, or timed out says nothing about whether there
+ *    is work now.
+ * 2. That run finished within the agent's own heartbeat interval (floored the
+ *    same way the scheduler floors it). The window is the cadence the operator
+ *    chose, so the backoff expires exactly when a scheduled heartbeat would have
+ *    come round anyway - it delays nothing that was going to happen sooner.
+ * 3. Nothing has landed on the task since. Every change that could give the
+ *    agent something to do - a human or teammate comment, a status flip, a
+ *    reassignment, a retitle, an unblock - writes a `task_comments` row through
+ *    `services/task-events.ts`, so one check covers all of them. Comments the
+ *    run itself authored are excluded; they are the run reporting, not new input.
+ *
+ * Deliberately reads comments rather than `tasks.updated_at`: a run bumps its
+ * own task's `updated_at` when it flips the status to in_progress, so that
+ * column reports "changed" on the quietest possible run and the backoff would
+ * never engage.
+ *
+ * One round trip. Returns false for a task-less wakeup (nothing to be idle
+ * about) and for every exempt source.
+ */
+export async function noWorkCooldownActive(
+	db: Db,
+	memberId: string,
+	taskId: string | null | undefined,
+	source: string,
+): Promise<boolean> {
+	if (!taskId) return false;
+	if (NO_WORK_BACKOFF_EXEMPT_SOURCES.has(source)) return false;
+
+	const r = await db.query<{ cooldown: boolean }>(
+		`WITH last_run AS (
+		   SELECT hr.id, hr.finished_at, hr.reported_no_work
+		   FROM heartbeat_runs hr
+		   WHERE hr.member_id = $1 AND hr.task_id = $2 AND hr.finished_at IS NOT NULL
+		   ORDER BY hr.finished_at DESC
+		   LIMIT 1
+		 )
+		 SELECT (
+		   lr.reported_no_work
+		   AND lr.finished_at
+		       + (GREATEST(ma.heartbeat_interval_min, $3::int) || ' minutes')::interval > now()
+		   AND NOT EXISTS (
+		     SELECT 1 FROM task_comments c
+		     WHERE c.task_id = $2
+		       AND c.created_at > lr.finished_at
+		       AND (c.created_by_run_id IS NULL OR c.created_by_run_id <> lr.id)
+		   )
+		 ) AS cooldown
+		 FROM last_run lr
+		 JOIN member_agents ma ON ma.id = $1`,
+		[memberId, taskId, HEARTBEAT_INTERVAL_FLOOR_MIN],
+	);
+
+	return r.rows[0]?.cooldown === true;
+}

--- a/packages/server/test/agent-runner-handoff-delivery.test.ts
+++ b/packages/server/test/agent-runner-handoff-delivery.test.ts
@@ -101,11 +101,13 @@ function createMockDocker(overrides: Record<string, unknown> = {}): ContainerEng
 	const {
 		execStart: execStartOverride,
 		producesOutput = false,
+		reportsNoWork = false,
 		execInspect,
 		...rest
 	} = overrides as Record<string, unknown> & {
 		execStart?: (...a: unknown[]) => unknown;
 		producesOutput?: boolean;
+		reportsNoWork?: boolean;
 		execInspect?: () => Promise<unknown>;
 	};
 	const innerExecStart =
@@ -138,6 +140,13 @@ function createMockDocker(overrides: Record<string, unknown> = {}): ContainerEng
 				await db.query(
 					`UPDATE heartbeat_runs SET produced_output = true WHERE task_id = $1 AND status = 'running'`,
 					[taskId],
+				);
+			}
+			// What the `report_no_work` MCP tool sets mid-run.
+			if (reportsNoWork) {
+				await db.query(
+					`UPDATE heartbeat_runs SET reported_no_work = true, no_work_reason = $2 WHERE task_id = $1 AND status = 'running'`,
+					[taskId, 'nothing due today'],
 				);
 			}
 			return innerExecStart(...args);
@@ -297,6 +306,58 @@ describe('runAgent handoff-delivery guardrail', () => {
 			[taskId, comments.rows[0].id],
 		);
 		expect(mentions.rows.length).toBeGreaterThan(0);
+	});
+
+	it('delivers nothing when the run called report_no_work, however its final message reads', async () => {
+		// Every form this net handles is a HANDOFF the run failed to deliver. A run
+		// that declared it had nothing to do handed nothing over - its final message
+		// is a status note, and the @admin in it is the agent narrating, not asking.
+		//
+		// Delivering it anyway is what turned an idle daily agent into an inbox
+		// flood: each no-op wake posted a comment the agent had explicitly decided
+		// not to write, fanned it to the admin inbox, and set produced_output, which
+		// graded the no-op a productive run and hid it from the no-work backoff.
+		const deps = makeDeps(
+			createMockDocker({
+				producesOutput: false,
+				reportsNoWork: true,
+				execStart: streamResult(
+					'HM-345 heartbeat — intentional no-op. Nothing new since yesterday; parking with report_no_work only. @admin no action needed.',
+				),
+			}),
+		);
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		const runId = runIdOf(result);
+
+		// Still a success - report_no_work is a legitimate idle wake.
+		const run = await db.query<{
+			status: string;
+			produced_output: boolean;
+			reported_no_work: boolean;
+			log_text: string;
+		}>(
+			`SELECT status, produced_output, reported_no_work, ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
+		expect(run.rows[0].reported_no_work).toBe(true);
+		// ...but a silent one. No comment, no delivery log line, and the no-op is
+		// still recorded as a no-op.
+		expect(run.rows[0].produced_output).toBe(false);
+		expect(run.rows[0].log_text).not.toContain('auto-delivered');
+
+		const comments = await textComments(runId);
+		expect(comments.rows.length).toBe(0);
+
+		// Nothing reached the admin inbox for this run.
+		const mentions = await db.query(
+			`SELECT 1 FROM admin_mentions m
+			 JOIN task_comments c ON c.id = m.comment_id
+			 WHERE c.created_by_run_id = $1`,
+			[runId],
+		);
+		expect(mentions.rows.length).toBe(0);
 	});
 
 	it('does not double-post when the handoff was already posted via create_comment this run', async () => {

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -776,6 +776,45 @@ describe('getFinalAssistantMessage', () => {
 		parser.onStdout(`${JSON.stringify({ type: 'end', stopReason: 'stop' })}\n`);
 		expect(parser.getFinalAssistantMessage()).toBe('done — over to you @admin');
 	});
+
+	it('keeps the Grok final message to the LAST turn across a multi-turn run', () => {
+		// Consecutive `text` events are deltas of one message, but a run has many
+		// messages: each turn opens with `thought` and the tool activity between
+		// them arrives as event types this parser drops. Flushing only on `end`
+		// therefore ran the whole run's narration together into one buffer, and
+		// `finalMessage` became that concatenation - sentences abutting with no
+		// separator, since deltas are appended raw. The runner's delivery net posts
+		// this value verbatim, so on Grok (no completeness judge, net is the only
+		// guardrail) an entire run's thinking was posted as one comment.
+		const parser = createAgentStreamParser(AgentRuntime.Grok);
+		parser.onStdout(`${JSON.stringify({ type: 'thought', data: 'checking status' })}\n`);
+		parser.onStdout(`${JSON.stringify({ type: 'text', data: 'Checking the task.' })}\n`);
+		// A tool call: an event type this parser renders nothing for, but which
+		// still ends the assistant message before it.
+		parser.onStdout(`${JSON.stringify({ type: 'tool_use', data: 'get_task' })}\n`);
+		parser.onStdout(`${JSON.stringify({ type: 'thought', data: 'nothing due' })}\n`);
+		parser.onStdout(`${JSON.stringify({ type: 'text', data: 'Nothing to do ' })}\n`);
+		parser.onStdout(`${JSON.stringify({ type: 'text', data: 'today.' })}\n`);
+		parser.onStdout(`${JSON.stringify({ type: 'end', stopReason: 'stop' })}\n`);
+
+		expect(parser.getFinalAssistantMessage()).toBe('Nothing to do today.');
+		// The specific regression: the earlier turn must not be glued to the front.
+		expect(parser.getFinalAssistantMessage()).not.toContain('Checking the task.');
+	});
+
+	it('renders each Grok turn as its own log line rather than one blob at the end', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Grok);
+		let out = '';
+		out += parser.onStdout(`${JSON.stringify({ type: 'text', data: 'First message.' })}\n`);
+		out += parser.onStdout(`${JSON.stringify({ type: 'thought', data: 'now the second' })}\n`);
+		out += parser.onStdout(`${JSON.stringify({ type: 'text', data: 'Second message.' })}\n`);
+		out += parser.onStdout(`${JSON.stringify({ type: 'end', stopReason: 'stop' })}\n`);
+
+		expect(out).toContain('First message.');
+		expect(out).toContain('Second message.');
+		// Run together, this would read `First message.Second message.`
+		expect(out).not.toContain('First message.Second message.');
+	});
 });
 
 describe('grok stream parser', () => {

--- a/packages/server/test/containers-provision-branches.test.ts
+++ b/packages/server/test/containers-provision-branches.test.ts
@@ -250,7 +250,7 @@ describe('provisionContainer', () => {
 		expect(stored.rows[0].container_status).toBe('running');
 	});
 
-	it('requeues container-killed runs and wakes agents with pending work after provisioning', async () => {
+	it('requeues container-killed runs, and does not double-queue the fan-out behind them', async () => {
 		await resetContainerRow();
 		await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
 		await db.query('DELETE FROM agent_wakeup_requests WHERE team_id = $1', [teamId]);
@@ -270,20 +270,46 @@ describe('provisionContainer', () => {
 			 WHERE member_id = $1 AND status = $2::wakeup_status ORDER BY created_at ASC`,
 			[agentId, WakeupStatus.Queued],
 		);
-		const reasons = wakeups.rows.map(
-			(w) =>
-				(w.payload as Record<string, unknown>).reason ??
-				(w.payload as Record<string, unknown>).trigger,
-		);
-		expect(reasons).toContain('container_recovery');
-		expect(reasons).toContain('container_start');
-		const recovery = wakeups.rows.find(
-			(w) => (w.payload as Record<string, unknown>).reason === 'container_recovery',
-		);
-		expect((recovery?.payload as Record<string, unknown>).previous_run_id).toBe(killed.rows[0].id);
-		expect((recovery?.payload as Record<string, unknown>).task_id).toBe(planningTaskId);
+		// One wakeup, not two. The recovery wakeup already names this agent and this
+		// task, so the pending-work fan-out that follows it in the same provision
+		// has nothing to add and stands down. It must not queue a second row: both
+		// now carry a task_id, so createWakeup would coalesce them and mergePayloads
+		// would overwrite `container_recovery` - losing the specific reason, and the
+		// recovery label with it - to say `container_start` instead.
+		expect(wakeups.rows.length).toBe(1);
+		const recovery = wakeups.rows[0];
+		expect((recovery.payload as Record<string, unknown>).reason).toBe('container_recovery');
+		expect((recovery.payload as Record<string, unknown>).previous_run_id).toBe(killed.rows[0].id);
+		expect((recovery.payload as Record<string, unknown>).task_id).toBe(planningTaskId);
 
 		await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+	});
+
+	it('wakes nobody when the caller provisioned this container to run on it', async () => {
+		await resetContainerRow();
+		await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE team_id = $1', [teamId]);
+
+		const { docker } = recordingDocker();
+		await provisionContainer(
+			baseDeps(docker),
+			await projectRow(),
+			teamSlug,
+			'caller-runs-the-work',
+		);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		// The pool ladder reaches provisionContainer from acquireRunContainer, so a
+		// run is already starting on this project. Fanning out here woke that same
+		// agent for the work its own run was about to do; the extra run provisioned
+		// again on a cold pool, woke again, and the loop sustained itself at
+		// container-start cadence regardless of the agent's heartbeat interval.
+		expect(wakeups.rows.some((w) => w.payload.reason === 'container_start')).toBe(false);
 	});
 
 	it('streams provisioning lines and serves a replace-snapshot through the log broker', async () => {

--- a/packages/server/test/containers-recovery.test.ts
+++ b/packages/server/test/containers-recovery.test.ts
@@ -259,7 +259,83 @@ describe('wakeAgentsWithPendingWork', () => {
 		);
 		expect(wakeups.rows.length).toBe(1);
 		expect(wakeups.rows[0].source).toBe('automation');
-		expect((wakeups.rows[0].payload as Record<string, unknown>).trigger).toBe('container_start');
+		expect((wakeups.rows[0].payload as Record<string, unknown>).reason).toBe('container_start');
+	});
+
+	it('names the task on the wakeup so the dispatch-path dedup guards can see it', async () => {
+		await clearState();
+		await db.query(`UPDATE member_agents SET admin_status = 'enabled' WHERE id = $1`, [agentId]);
+
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status
+			 ORDER BY created_at DESC LIMIT 1`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(wakeups.rows.length).toBe(1);
+		// Without this the wakeup slips past every guard keyed on `payload->>'task_id'`
+		// - the blocker deferral, processWakeups' busy/capacity pre-checks, and
+		// chainNextTaskWakeup's already-covered clause - so each container start
+		// queued a run regardless of what was already in flight.
+		expect(wakeups.rows[0].payload.task_id).toBe(taskId);
+	});
+
+	it('coalesces onto an already-queued wakeup for the same task instead of stacking runs', async () => {
+		await clearState();
+		await db.query(`UPDATE member_agents SET admin_status = 'enabled' WHERE id = $1`, [agentId]);
+
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ id: string }>(
+			`SELECT id FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		// Two container starts, one pending run. `createWakeup` coalesces on
+		// (member, task_id), which a task-less payload could only ever do against
+		// other task-less rows.
+		expect(wakeups.rows.length).toBe(1);
+	});
+
+	it('names an actionable task, never one parked behind an open blocker', async () => {
+		await db.query(`UPDATE member_agents SET admin_status = 'enabled' WHERE id = $1`, [agentId]);
+
+		const blocker = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projectId, title: 'Blocker', assignee_id: agentId }),
+		});
+		const blockerId = (await blocker.json()).data.id;
+		await db.query(`INSERT INTO task_dependencies (task_id, blocked_by_task_id) VALUES ($1, $2)`, [
+			taskId,
+			blockerId,
+		]);
+		// After the dependency exists, so the assignment wakeups both tasks queued on
+		// creation don't count towards the assertion below.
+		await clearState();
+
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		// Both tasks are this agent's, but only the blocker is actionable. Naming the
+		// blocked one would queue a run `activateAgent` cannot act on - the mismatch
+		// a task-less payload made unfalsifiable.
+		expect(wakeups.rows.length).toBe(1);
+		expect(wakeups.rows[0].payload.task_id).toBe(blockerId);
+
+		await db.query('DELETE FROM task_dependencies WHERE task_id = $1', [taskId]);
+		await db.query('DELETE FROM tasks WHERE id = $1', [blockerId]);
 	});
 
 	it('does not wake an agent whose only task is in a terminal status', async () => {

--- a/packages/server/test/job-manager-recovery.test.ts
+++ b/packages/server/test/job-manager-recovery.test.ts
@@ -303,7 +303,7 @@ describe('JobManager recovery & maintenance', () => {
 				'SELECT payload FROM agent_wakeup_requests WHERE member_id = $1',
 				[agentId],
 			);
-			expect(wakeups.rows.some((w) => w.payload.trigger === 'container_start')).toBe(true);
+			expect(wakeups.rows.some((w) => w.payload.reason === 'container_start')).toBe(true);
 			manager.shutdown();
 		});
 

--- a/packages/server/test/job-manager-scheduling.test.ts
+++ b/packages/server/test/job-manager-scheduling.test.ts
@@ -464,6 +464,110 @@ describe('JobManager scheduling & dispatch', () => {
 		});
 	});
 
+	describe('no-work backoff', () => {
+		/**
+		 * A finished no-work run for the shared agent+task, `minutesAgo` back.
+		 *
+		 * Clears the task's comments first. The backoff lifts on any comment newer
+		 * than the run, and earlier tests in this file leave text comments on the
+		 * shared task at real `now()` - which is newer than a backdated run, so they
+		 * would lift it before the assertion ran. (afterEach only sweeps `system`.)
+		 */
+		async function seedNoWorkRun(minutesAgo: number): Promise<void> {
+			await ctx.db.query('DELETE FROM task_comments WHERE task_id = $1', [taskId]);
+			await ctx.db.query(
+				`INSERT INTO heartbeat_runs
+				   (team_id, member_id, task_id, status, started_at, finished_at, reported_no_work)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status,
+				         now() - ($5 || ' minutes')::interval - interval '1 minute',
+				         now() - ($5 || ' minutes')::interval, true)`,
+				[teamId, agentId, taskId, HeartbeatRunStatus.Succeeded, String(minutesAgo)],
+			);
+		}
+
+		it('skips a container_start dispatch minutes after the agent reported no work', async () => {
+			// The incident, end to end. A daily agent finishes a run having called
+			// report_no_work; the container_start automation fires minutes later and
+			// used to dispatch a full billed run to reach the same conclusion, over
+			// and over, while the UI showed the next heartbeat a day away.
+			await ctx.db.query('UPDATE member_agents SET heartbeat_interval_min = 1440 WHERE id = $1', [
+				agentId,
+			]);
+			await seedNoWorkRun(5);
+			const wakeupId = await insertQueuedWakeup(agentId, 'automation', {
+				task_id: taskId,
+				reason: 'container_start',
+			});
+
+			const manager = createJobManager();
+			await internals(manager).processWakeups();
+			await waitForBackground();
+
+			const row = await wakeupRow(wakeupId);
+			// Completed, with the reason recorded: answered, not left dangling and not
+			// re-queued to ask again.
+			expect(row.status).toBe(WakeupStatus.Completed);
+			expect(row.last_skipped_reason).toBe(WakeupSkipReason.NoWorkCooldown);
+			// The point of the whole change: no second run, so no second bill.
+			const runs = await ctx.db.query<{ id: string }>(
+				`SELECT id FROM heartbeat_runs
+				 WHERE member_id = $1 AND task_id = $2 AND reported_no_work = false`,
+				[agentId, taskId],
+			);
+			expect(runs.rows.length).toBe(0);
+			manager.shutdown();
+		});
+
+		it('dispatches anyway once new input lands on the task', async () => {
+			await ctx.db.query('UPDATE member_agents SET heartbeat_interval_min = 1440 WHERE id = $1', [
+				agentId,
+			]);
+			await seedNoWorkRun(5);
+			// A human comment after the run - the backoff must not sit on this.
+			await ctx.db.query(
+				`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+				 VALUES ($1, NULL, 'text'::comment_content_type, $2::jsonb)`,
+				[taskId, JSON.stringify({ text: 'actually, there is something' })],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId, 'automation', {
+				task_id: taskId,
+				reason: 'container_start',
+			});
+
+			const manager = createJobManager();
+			await internals(manager).processWakeups();
+			await waitForBackground();
+
+			const row = await wakeupRow(wakeupId);
+			expect(row.last_skipped_reason).not.toBe(WakeupSkipReason.NoWorkCooldown);
+			// It really ran (and failed on the absent AI provider, as everything in
+			// this file does) rather than merely avoiding the skip.
+			const runs = await ctx.db.query<{ id: string }>(
+				`SELECT id FROM heartbeat_runs
+				 WHERE member_id = $1 AND task_id = $2 AND reported_no_work = false`,
+				[agentId, taskId],
+			);
+			expect(runs.rows.length).toBe(1);
+			manager.shutdown();
+		});
+
+		it('never sits on a mention, however recent the no-work verdict', async () => {
+			await ctx.db.query('UPDATE member_agents SET heartbeat_interval_min = 1440 WHERE id = $1', [
+				agentId,
+			]);
+			await seedNoWorkRun(1);
+			const wakeupId = await insertQueuedWakeup(agentId, 'mention', { task_id: taskId });
+
+			const manager = createJobManager();
+			await internals(manager).processWakeups();
+			await waitForBackground();
+
+			const row = await wakeupRow(wakeupId);
+			expect(row.last_skipped_reason).not.toBe(WakeupSkipReason.NoWorkCooldown);
+			manager.shutdown();
+		});
+	});
+
 	describe('processBudgetResumes', () => {
 		it('lifts a reactive budget pause once the agent is back within budget', async () => {
 			const manager = createJobManager();

--- a/packages/server/test/migrate-061-no-work-backoff-index.test.ts
+++ b/packages/server/test/migrate-061-no-work-backoff-index.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '061_no_work_backoff_index.sql';
+
+describe('061_no_work_backoff_index migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let memberId: string;
+	let taskId: string;
+	let noWorkRunId: string;
+	let workingRunId: string;
+	let otherTaskRunId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema before 061
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Acme', 'acme', 'AC') RETURNING id`,
+			[teamId],
+		);
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		memberId = member.rows[0].id;
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+			 VALUES ($1, $2, 1, 'AC-1', 'Daily check') RETURNING id`,
+			[teamId, project.rows[0].id],
+		);
+		taskId = task.rows[0].id;
+		const otherTask = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+			 VALUES ($1, $2, 2, 'AC-2', 'Something else') RETURNING id`,
+			[teamId, project.rows[0].id],
+		);
+
+		// An older no-work run and a newer working one on the SAME task: the query
+		// this index serves must return the newer, so a pair is the minimum that
+		// proves it orders rather than merely filters.
+		const noWork = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at, reported_no_work)
+			 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status,
+			         TIMESTAMPTZ '2026-01-02 09:00:00Z', TIMESTAMPTZ '2026-01-02 09:05:00Z', true)
+			 RETURNING id`,
+			[teamId, memberId, taskId],
+		);
+		noWorkRunId = noWork.rows[0].id;
+		const working = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at, reported_no_work)
+			 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status,
+			         TIMESTAMPTZ '2026-01-02 11:00:00Z', TIMESTAMPTZ '2026-01-02 11:20:00Z', false)
+			 RETURNING id`,
+			[teamId, memberId, taskId],
+		);
+		workingRunId = working.rows[0].id;
+		// A newer run on a DIFFERENT task. Without the task column in the key this
+		// is the row a (member_id, finished_at DESC) walk reaches first.
+		const otherRun = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at, reported_no_work)
+			 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status,
+			         TIMESTAMPTZ '2026-01-02 12:00:00Z', TIMESTAMPTZ '2026-01-02 12:10:00Z', true)
+			 RETURNING id`,
+			[teamId, memberId, otherTask.rows[0].id],
+		);
+		otherTaskRunId = otherRun.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the member/task/finished index', async () => {
+		const r = await h.db.query<{ indexdef: string }>(
+			`SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_runs_member_task_finished'`,
+		);
+		expect(r.rows.length).toBe(1);
+		const def = r.rows[0].indexdef.toLowerCase();
+		expect(def).toContain('member_id');
+		expect(def).toContain('task_id');
+		expect(def).toContain('finished_at');
+		// Partial would silently exclude runs the backoff has to reason about.
+		expect(def).not.toContain('where');
+	});
+
+	it('preserves every pre-existing run row and its no-work verdict', async () => {
+		const kept = await h.db.query<{ id: string; reported_no_work: boolean }>(
+			`SELECT id, reported_no_work FROM heartbeat_runs WHERE team_id = $1 ORDER BY finished_at`,
+			[teamId],
+		);
+		expect(kept.rows.length).toBe(3);
+		expect(kept.rows.map((r) => r.id)).toEqual([noWorkRunId, workingRunId, otherTaskRunId]);
+		expect(kept.rows.map((r) => r.reported_no_work)).toEqual([true, false, true]);
+	});
+
+	it('serves the backoff lookup the index was added for, scoped to one task', async () => {
+		const r = await h.db.query<{ id: string; reported_no_work: boolean }>(
+			`SELECT hr.id, hr.reported_no_work
+			 FROM heartbeat_runs hr
+			 WHERE hr.member_id = $1 AND hr.task_id = $2 AND hr.finished_at IS NOT NULL
+			 ORDER BY hr.finished_at DESC
+			 LIMIT 1`,
+			[memberId, taskId],
+		);
+		expect(r.rows.length).toBe(1);
+		// The newer run on this task, not the newer run on the other one.
+		expect(r.rows[0].id).toBe(workingRunId);
+		expect(r.rows[0].reported_no_work).toBe(false);
+	});
+});

--- a/packages/server/test/no-work-backoff.test.ts
+++ b/packages/server/test/no-work-backoff.test.ts
@@ -1,0 +1,232 @@
+import { CommentContentType, HeartbeatRunStatus, TaskStatus, WakeupSource } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { noWorkCooldownActive } from '../src/services/no-work-backoff';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let taskId: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'App Team',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Backoff Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Backoff Project',
+		description: 'Test project.',
+	});
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const agentsRes = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/agents`, {
+		headers: authHeader(token),
+	});
+	agentId = (await agentsRes.json()).data[0].id;
+	// The cadence the incident ran at: a daily agent that was still being
+	// dispatched every few minutes.
+	await db.query('UPDATE member_agents SET heartbeat_interval_min = 1440 WHERE id = $1', [agentId]);
+
+	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title: 'Daily check', assignee_id: agentId }),
+	});
+	taskId = (await taskRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function clearRuns(): Promise<void> {
+	await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+	await db.query('DELETE FROM task_comments WHERE task_id = $1', [taskId]);
+}
+
+/** A finished run on the shared task, `minutesAgo` in the past. */
+async function insertRun(opts: {
+	reportedNoWork: boolean;
+	minutesAgo: number;
+	status?: HeartbeatRunStatus;
+}): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs
+		   (team_id, member_id, task_id, status, started_at, finished_at, reported_no_work)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status,
+		         now() - ($5 || ' minutes')::interval - interval '1 minute',
+		         now() - ($5 || ' minutes')::interval,
+		         $6)
+		 RETURNING id`,
+		[
+			teamId,
+			agentId,
+			taskId,
+			opts.status ?? HeartbeatRunStatus.Succeeded,
+			String(opts.minutesAgo),
+			opts.reportedNoWork,
+		],
+	);
+	return r.rows[0].id;
+}
+
+async function insertComment(minutesAgo: number, runId: string | null): Promise<void> {
+	await db.query(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content, created_at, created_by_run_id)
+		 VALUES ($1, NULL, $2::comment_content_type, $3::jsonb, now() - ($4 || ' minutes')::interval, $5)`,
+		[
+			taskId,
+			CommentContentType.Text,
+			JSON.stringify({ text: 'anything' }),
+			String(minutesAgo),
+			runId,
+		],
+	);
+}
+
+describe('noWorkCooldownActive', () => {
+	it('suppresses a re-dispatch after report_no_work within the heartbeat interval', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 5 });
+
+		// The incident exactly: a 1440-minute agent, five minutes after it said it
+		// had nothing to do, woken by the container_start automation.
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(true);
+	});
+
+	it('lets the dispatch through once the heartbeat interval has elapsed', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 1441 });
+
+		// The window is the operator's own cadence, so it expires exactly when a
+		// scheduled heartbeat would have come round anyway.
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(false);
+	});
+
+	it('lifts the moment new input lands on the task', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 10 });
+		await insertComment(2, null);
+
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(false);
+	});
+
+	it('ignores comments the no-work run itself authored', async () => {
+		await clearRuns();
+		const runId = await insertRun({ reportedNoWork: true, minutesAgo: 10 });
+		// Backdated behind finished_at is the honest case, but a run's own comment
+		// landing after it is what the created_by_run_id exclusion is for: the run
+		// reporting is not new input.
+		await insertComment(2, runId);
+
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(true);
+	});
+
+	it('does not suppress when the last run actually did work', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: false, minutesAgo: 5 });
+
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(false);
+	});
+
+	it('reads the most recent run, not any no-work run in history', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 30 });
+		await insertRun({ reportedNoWork: false, minutesAgo: 3 });
+
+		// A later run that did work says the task is live again.
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(false);
+	});
+
+	it('never suppresses a conversational source', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 1 });
+
+		for (const source of [
+			WakeupSource.Mention,
+			WakeupSource.Comment,
+			WakeupSource.Reply,
+			WakeupSource.OnDemand,
+			WakeupSource.CredentialProvided,
+			WakeupSource.AssetDeletionResolved,
+		]) {
+			expect(await noWorkCooldownActive(db, agentId, taskId, source)).toBe(false);
+		}
+	});
+
+	it('suppresses every system-raised source, not just the automation that caused this', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 5 });
+
+		for (const source of [
+			WakeupSource.Heartbeat,
+			WakeupSource.Assignment,
+			WakeupSource.Timer,
+			WakeupSource.Automation,
+		]) {
+			expect(await noWorkCooldownActive(db, agentId, taskId, source)).toBe(true);
+		}
+	});
+
+	it('is inert for a task-less wakeup and when the agent has never run the task', async () => {
+		await clearRuns();
+		expect(await noWorkCooldownActive(db, agentId, null, WakeupSource.Heartbeat)).toBe(false);
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Heartbeat)).toBe(false);
+	});
+
+	it('ignores an unfinished run so an in-flight one cannot park the task', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 5 });
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, reported_no_work)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now(), false)`,
+			[teamId, agentId, taskId, HeartbeatRunStatus.Running],
+		);
+
+		// The running row has a null finished_at, so the no-work verdict still stands.
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(true);
+	});
+
+	it('lifts on a status change, which reaches it as a system comment', async () => {
+		await clearRuns();
+		await insertRun({ reportedNoWork: true, minutesAgo: 10 });
+		// What `recordStatusChange` writes. Every task mutation that could give the
+		// agent something to do goes through task-events.ts and lands here, which is
+		// why one comment check covers status, assignee, title and unblock alike.
+		await db.query(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, $2::comment_content_type, $3::jsonb)`,
+			[
+				taskId,
+				CommentContentType.System,
+				JSON.stringify({ kind: 'status_change', from: TaskStatus.Backlog, to: TaskStatus.Review }),
+			],
+		);
+
+		expect(await noWorkCooldownActive(db, agentId, taskId, WakeupSource.Automation)).toBe(false);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -905,6 +905,13 @@ export const WakeupSkipReason = {
 	InstanceAtCapacity: 'instance_at_capacity',
 	AgentRunning: 'agent_running',
 	OverBudget: 'over_budget',
+	/**
+	 * The agent's last run on this task ended in `report_no_work` and nothing has
+	 * landed on the task since, so re-dispatching would bill an identical no-op.
+	 * Lifts on its own once the agent's heartbeat interval elapses, or immediately
+	 * on new input. See `services/no-work-backoff.ts`.
+	 */
+	NoWorkCooldown: 'no_work_cooldown',
 } as const;
 export type WakeupSkipReason = (typeof WakeupSkipReason)[keyof typeof WakeupSkipReason];
 


### PR DESCRIPTION
An agent configured with a **1440-minute heartbeat was running every few minutes**, each run calling `report_no_work`, each one billed, and each one posting a comment that pinged the `@admin` inbox. The UI meanwhile showed `Next heartbeat in 23h59m`.

## The loop

`provisionContainer` ends by nudging every agent in the project holding a non-terminal task (`wakeAgentsWithPendingWork`, containers.ts:763). That is right for a provision nobody is waiting on - startup self-heal, project creation - and wrong for one the run path asked for: `acquireRunContainer`'s pool ladder provisions on its `create` rung (containers.ts:1229), so a run is already starting and will do the work.

```
run starts -> pool must create a member -> provisionContainer
           -> wakes every agent with pending work, including this one
           -> run ends -> that wakeup dispatches -> activateAgent re-picks the task
           -> new billed run -> ...
```

Two independent reasons nothing stopped it:

- **The wakeup carried no `task_id`**, which disarms every dedup guard in the dispatch path - `shouldDeferWakeupForBlockers` returns early without one, `processWakeups`' busy/capacity pre-checks are all inside `if (wakeupTaskId)`, and `chainNextTaskWakeup` reads `payload->>'task_id'`.
- **The configured cadence is honoured by only two code paths** - `processScheduledHeartbeats` and `chainNextTaskWakeup`. Every other source dispatches on arrival.

## Changes

**Origin.** `provisionContainer` takes a `ProvisionWakePolicy`; the pool ladder passes `caller-runs-the-work`. Stated by the caller, which is the only one that knows whether a run is in flight.

**Fan-out hardening.** It now names the task, skips agents already covered by a queued or claimed wakeup for it, and carries `reason` rather than `trigger`. `trigger` marks a wakeup with its own dispatch path, so `createWakeup` refuses to coalesce onto one - which both stacked rows and left the run list showing a bare `Automation` for a wakeup that can now name itself.

**Source-agnostic gate.** `noWorkCooldownActive` (`services/no-work-backoff.ts`) applies a `report_no_work` verdict at dispatch, called from `activateAgent` after task resolution - the one point every source passes through holding a concrete task, so a new source cannot forget it. Suppresses only when the last finished run on that task reported no work, within `max(heartbeat_interval_min, floor)`, and no comment has landed since. Conversational sources are exempt. Suppressed wakeups are marked `completed` with `last_skipped_reason = no_work_cooldown`.

**Inbox spam.** The handoff-delivery net no longer fires on a `report_no_work` run. Every form it handles is a *handoff*; an agent that declared it had nothing to do handed nothing over. Delivering its final message posted a comment the agent explicitly decided not to write, fanned it to the admin inbox on every idle wake, and set `produced_output` - grading the no-op as productive work and hiding it from the backoff above.

**Parser.** Grok flushed its text buffer only on `end`, so `getFinalAssistantMessage` returned every turn concatenated (`"...due.Still 2026-08-16 UTC. Checking..."`) - and that blob is what the net was posting. Anything that is not another `text` delta now ends the message. Grok has no stop-hook judge, so the net is its only guardrail.

## Migration

`061_no_work_backoff_index.sql` - additive index only, `heartbeat_runs (member_id, task_id, finished_at DESC)` for the once-per-dispatch lookup. No row read, moved or dropped.

## Tests

- `no-work-backoff.test.ts` (11) - the window, new-input lift, self-authored comments, exempt vs suppressed sources, unfinished runs, status changes via system comments
- `job-manager-scheduling.test.ts` - the incident end to end: a 1440-min agent, a `container_start` wakeup five minutes after a no-work run, skipped with no second run; dispatches anyway after a new comment; never sits on a mention
- `containers-provision-branches.test.ts` - the run-path provision wakes nobody; the fan-out does not double-queue behind a recovery wakeup
- `containers-recovery.test.ts` - the wakeup names its task, dedups, and never names a blocked one
- `agent-runner-handoff-delivery.test.ts` - a `report_no_work` run posts nothing, logs no delivery, keeps `produced_output` false, and reaches no admin inbox
- `agent-stream-parser.test.ts` - Grok's final message is the last turn, and each turn is its own log line
- `migrate-061-no-work-backoff-index.test.ts` - data preservation plus the lookup the index serves

779 server tests pass. `bun run typecheck`, `biome check` and `bun run build` are clean.

## Note for reviewers

One behaviour change worth a look: when a container-recovery wakeup already covers an agent+task, the fan-out now stands down instead of queueing a second row. Previously both rows existed because `trigger` blocked coalescing; with `reason` they would coalesce and `mergePayloads` would overwrite `container_recovery`. `containers-provision-branches.test.ts` asserts the recovery wakeup survives intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5kq7rHEFkNGn1QYyLtsHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5kq7rHEFkNGn1QYyLtsHr)_