### PR TITLE
fix(web): drop the subscription hint under the agent model override

### DIFF
--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -442,16 +442,10 @@ function ModelOverride({ provider, model, onProviderChange, onModelChange }: Mod
 							</option>
 						))}
 					</select>
-					{isSubscription ? (
-						<span className="text-xs text-text-2">
-							Subscription sign-in — the provider's default model is used.
+					{models.error && (
+						<span className="text-xs text-danger">
+							{(models.error as { message?: string }).message || 'Failed to load models'}
 						</span>
-					) : (
-						models.error && (
-							<span className="text-xs text-danger">
-								{(models.error as { message?: string }).message || 'Failed to load models'}
-							</span>
-						)
 					)}
 				</label>
 			</div>


### PR DESCRIPTION
Removes the "Subscription sign-in - the provider's default model is used." line rendered beneath the Model select in an agent's Model override card (`packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx`).

The select is already disabled and pinned to "Provider default" when the chosen provider is a subscription sign-in, so the hint restated what the control showed.

The error branch is now unconditional instead of being the `else` of the subscription ternary: the models query is disabled for a subscription config (`enabled: ... && !isSubscription`), so `models.error` can never be set in that state. `isSubscription` is still read for the query gate and the select's `disabled` prop.

## Testing

- `bun run typecheck` - clean
- `bunx biome check` on the changed file - clean
- `packages/web` `agent-detail.test.tsx` (12 tests) - passing; no test asserted on the removed string

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvt2cxnN3hSEiAJBMybFuL)_