### PR TITLE
fix(connectors): update the row live once a reconnect completes

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -4340,6 +4340,18 @@ the event (an unresolved row invalidates nothing):
   project's high-frequency activity to another and storm its caches.
 - **Everything else** resolves `project_id` first, then falls back to `team_id`.
 
+**A partial row must still carry the ids the resolver reads.** Most broadcasts send the
+full DB row, so `project_id`/`team_id` come for free; a hand-built payload (`{ id, status }`)
+resolves to nothing and the event is silently dropped. Two helpers exist so those payloads
+cannot drift: `broadcastCommentFamilyChange` stamps `project_id` on comment-family rows
+(whose tables have no such column), and `broadcastConnectorChange` stamps `team_id` +
+`project_id` on every `mcp_connections` row. The connector case is the one where the drop
+was visible: an OAuth (re)connection is written from the popup's callback, so this
+broadcast and the popup's own `hezo-oauth-success` postMessage
+(`useOAuthSuccessRefetch`) are the open Connectors page's only two update channels, and
+with the broadcast unresolvable a reconnected connector kept its amber "Needs reconnect"
+badge until a reload.
+
 **Container-state convergence.** The container status banner
 (`components/container-status-banner.tsx`), the CEO chat's HQ gate, and the create-project
 gate all derive from one `useContainerHealth(project)` reading `container_status` off the

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -279,7 +279,9 @@ Hezo surfaces it three ways instead:
 
 Press **Reconnect** and complete the provider's authorization exactly as you did the first
 time. The connector is repaired in place - you keep its method allowlist, its credential
-record, and its history, and every agent picks it up again on its next run.
+record, and its history, and every agent picks it up again on its next run. The row updates
+itself as soon as the authorization window closes: the amber badge becomes **Connected** and
+the provider's error message clears, with no page reload.
 
 Until you do, the connector's tools may still appear in agent tool lists, but calls through
 them fail. That is deliberate: withdrawing the tools mid-task would look to an agent like

--- a/packages/server/src/lib/broadcast.ts
+++ b/packages/server/src/lib/broadcast.ts
@@ -53,6 +53,35 @@ export function broadcastCommentFamilyChange(
 	});
 }
 
+/**
+ * Broadcast an `mcp_connections` row change enriched with `team_id` +
+ * `project_id`.
+ *
+ * The web client resolves the project slug whose caches a row_change
+ * invalidates from `row.project_id` (falling back to `row.team_id`), and every
+ * connector broadcast used to carry a partial row — `{ id, status }` — with
+ * neither. So none of them resolved, all of them were dropped client-side, and
+ * a connector's card only picked up its new state on a page reload. That is
+ * most visible on the reconnect path, where the write happens in the OAuth
+ * popup and this broadcast is the tab's only signal.
+ *
+ * `projectId` is the project the change was made from, or null for the global
+ * admin surface (whose page refetches off the popup's postMessage instead).
+ * `teamId` still selects the WS room.
+ */
+export function broadcastConnectorChange(
+	c: Context<Env>,
+	ids: { teamId: string; projectId: string | null },
+	action: ChangeAction,
+	row: Record<string, unknown>,
+): void {
+	broadcastChange(c, wsRoom.team(ids.teamId), 'mcp_connections', action, {
+		...row,
+		team_id: ids.teamId,
+		project_id: ids.projectId ?? (typeof row.project_id === 'string' ? row.project_id : null),
+	});
+}
+
 export function broadcastEvent(
 	wsManager: WebSocketManager,
 	room: string,

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -3,12 +3,11 @@ import {
 	getConnectorCapability,
 	type McpMethodInfo,
 	summarizeMethodAccess,
-	wsRoom,
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { encrypt } from '../crypto/encryption';
 import { trackBackground } from '../lib/background';
-import { broadcastChange } from '../lib/broadcast';
+import { broadcastConnectorChange } from '../lib/broadcast';
 import { validateSecretName } from '../lib/credential-placeholder';
 import { buildMeta, parsePagination } from '../lib/pagination';
 import { resolveActor } from '../lib/resolve';
@@ -529,7 +528,7 @@ connectorsRoutes.patch('/projects/:projectId/connectors/:id/methods', async (c) 
 		[parsed.enabled === null ? null : JSON.stringify(parsed.enabled), id],
 	);
 
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', { id, status: 'updated' });
+	broadcastConnectorChange(c, { teamId, projectId }, 'UPDATE', { id, status: 'updated' });
 	const actor = await resolveActor(db, c.get('auth'), teamId);
 	c.get('events').emit({
 		type: 'mcp_connection.updated',
@@ -691,7 +690,7 @@ connectorsRoutes.post('/projects/:projectId/connectors/:id/revoke', async (c) =>
 				log.warn('failed to delete oauth_connection on revoke', { error: (e as Error).message }),
 			);
 	}
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+	broadcastConnectorChange(c, { teamId, projectId }, 'UPDATE', {
 		id,
 		status: 'revoked',
 	});
@@ -858,7 +857,7 @@ connectorsRoutes.post('/projects/:projectId/connectors/:id/api-key', async (c) =
 	invalidateSecretsVault();
 	if (!updated) return err(c, 'NOT_FOUND', 'connector not found', 404);
 
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+	broadcastConnectorChange(c, { teamId, projectId }, 'UPDATE', {
 		id: conn.id,
 		status: 'active',
 	});
@@ -982,7 +981,7 @@ connectorsRoutes.post('/projects/:projectId/connectors', async (c) => {
 	);
 
 	const inserted = result.rows[0] as Record<string, unknown>;
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'INSERT', inserted);
+	broadcastConnectorChange(c, { teamId, projectId }, 'INSERT', inserted);
 
 	const createActor = await resolveActor(db, c.get('auth'), teamId);
 	c.get('events').emit({
@@ -1029,7 +1028,7 @@ async function kickoffLocalInstall(
 				rowId,
 			);
 			if (result) {
-				broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+				broadcastConnectorChange(c, { teamId, projectId: project.id }, 'UPDATE', {
 					id: rowId,
 					install_status: result.status,
 					install_error: result.error ?? null,
@@ -1074,7 +1073,7 @@ connectorsRoutes.post('/projects/:projectId/connectors/ensure', async (c) => {
 		projectId,
 	});
 	if (!alreadyExisted) {
-		broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'INSERT', { id: row.id });
+		broadcastConnectorChange(c, { teamId, projectId }, 'INSERT', { id: row.id });
 		const ensureActor = await resolveActor(db, c.get('auth'), teamId);
 		c.get('events').emit({
 			type: 'mcp_connection.created',
@@ -1103,7 +1102,7 @@ connectorsRoutes.delete('/projects/:projectId/connectors/:id', async (c) => {
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'MCP connection not found', 404);
 	}
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'DELETE', { id });
+	broadcastConnectorChange(c, { teamId, projectId }, 'DELETE', { id });
 	const deleteActor = await resolveActor(db, c.get('auth'), teamId);
 	c.get('events').emit({
 		type: 'mcp_connection.deleted',

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -7,7 +7,7 @@ import {
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
-import { broadcastChange } from '../lib/broadcast';
+import { broadcastChange, broadcastConnectorChange } from '../lib/broadcast';
 import { requestOrigin } from '../lib/request-origin';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
@@ -185,10 +185,12 @@ oauthRoutes.get('/oauth/callback', async (c) => {
 		// This flow only starts from the project-scoped auth-code route, so a
 		// team is always present; the guard narrows the now-nullable state type.
 		if (payload.teamId) {
-			broadcastChange(c, wsRoom.team(payload.teamId), 'mcp_connections', 'UPDATE', {
-				id: payload.mcpConnectionId,
-				oauth_connection_id: conn.id,
-			});
+			broadcastConnectorChange(
+				c,
+				{ teamId: payload.teamId, projectId: payload.projectId },
+				'UPDATE',
+				{ id: payload.mcpConnectionId, oauth_connection_id: conn.id },
+			);
 		}
 	}
 
@@ -355,7 +357,7 @@ async function startConnectorAuthCode(
 	if (connector.revoked_at) {
 		connector = (await restoreRevokedConnector(db, connector.id)) ?? connector;
 		if (opts.teamId) {
-			broadcastChange(c, wsRoom.team(opts.teamId), 'mcp_connections', 'UPDATE', {
+			broadcastConnectorChange(c, { teamId: opts.teamId, projectId: opts.projectId }, 'UPDATE', {
 				id: connector.id,
 				status: 'pending',
 			});
@@ -1021,7 +1023,7 @@ oauthRoutes.post('/projects/:projectId/connectors/:connectorId/oauth-device/poll
 		[conn.id, connector.id],
 	);
 
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+	broadcastConnectorChange(c, { teamId, projectId: entry.projectId }, 'UPDATE', {
 		id: connector.id,
 		oauth_connection_id: conn.id,
 		status: 'active',
@@ -1282,7 +1284,7 @@ async function finalizeConnectorConnection(
 	// The instance-admin flow has no team room to target; the settings page
 	// refetches off the popup's hezo-oauth-success postMessage instead.
 	if (teamId) {
-		broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+		broadcastConnectorChange(c, { teamId, projectId: opts.projectId }, 'UPDATE', {
 			id: connector.id,
 			oauth_connection_id: conn.id,
 			status: 'active',

--- a/packages/server/test/connector-realtime-broadcast.test.ts
+++ b/packages/server/test/connector-realtime-broadcast.test.ts
@@ -1,0 +1,181 @@
+import { WsMessageType, wsRoom } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { WebSocketManager, type WsEvent } from '../src/services/ws';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
+
+interface CapturedBroadcast {
+	room: string;
+	event: WsEvent;
+}
+
+/**
+ * `mcp_connections` realtime broadcasts must carry `team_id` + `project_id`.
+ *
+ * The web client resolves the project slug whose caches a row_change
+ * invalidates from `row.project_id` (falling back to `row.team_id`), so a
+ * partial `{ id, status }` row resolves to nothing and is dropped client-side.
+ * That is what left a reconnected connector's card showing "Needs reconnect"
+ * until a page reload: the OAuth popup does the write, so this broadcast is the
+ * open Connectors page's only other update channel.
+ */
+describe('mcp_connections realtime broadcasts carry team_id + project_id', () => {
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let sim: GitHubSim;
+	let teamId: string;
+	let projectId: string;
+	let projectSlug: string;
+	let captured: CapturedBroadcast[];
+	let broadcastSpy: ReturnType<typeof vi.spyOn>;
+	let prevApi: string | undefined;
+	let prevOAuth: string | undefined;
+	const issuedToken = 'gho_broadcast_test_token';
+
+	/** Every `mcp_connections` row this test's actions broadcast. */
+	function connectorRows(): Record<string, unknown>[] {
+		return captured
+			.filter(
+				(b) =>
+					b.room === wsRoom.team(teamId) &&
+					(b.event as { type: string; table?: string }).type === WsMessageType.RowChange &&
+					(b.event as { table?: string }).table === 'mcp_connections',
+			)
+			.map((b) => (b.event as unknown as { row: Record<string, unknown> }).row);
+	}
+
+	beforeAll(async () => {
+		sim = await createGitHubSim();
+		prevApi = process.env.GITHUB_API_BASE_URL;
+		prevOAuth = process.env.GITHUB_OAUTH_BASE_URL;
+		process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+		process.env.GITHUB_OAUTH_BASE_URL = sim.baseUrl;
+		sim.seed({
+			token: issuedToken,
+			user: { id: 11, login: 'octo-broadcast', avatar_url: 'http://av/o.png', email: 'o@e' },
+			signingKeys: [],
+			authKeys: [],
+		});
+
+		ctx = await createTestApp();
+
+		const typesRes = await ctx.app.request('/api/team-templates', {
+			headers: authHeader(ctx.token),
+		});
+		const typeId = (await typesRes.json()).data.find(
+			(t: { name: string }) => t.name === 'App Team',
+		).id;
+		const teamRes = await createTestTeam(ctx.db, {
+			name: 'Connector Realtime Co',
+			template_id: typeId,
+		});
+		teamId = (await teamRes.json()).data.id;
+
+		const projectRes = await createTestProject(ctx.db, teamId, { name: 'Connector Realtime' });
+		const project = (await projectRes.json()).data;
+		projectId = project.id;
+		projectSlug = project.slug;
+
+		captured = [];
+		broadcastSpy = vi.spyOn(WebSocketManager.prototype, 'broadcast').mockImplementation(function (
+			this: WebSocketManager,
+			room: string,
+			event: WsEvent,
+		) {
+			captured.push({ room, event });
+		});
+	});
+
+	afterAll(async () => {
+		broadcastSpy?.mockRestore();
+		process.env.GITHUB_API_BASE_URL = prevApi;
+		process.env.GITHUB_OAUTH_BASE_URL = prevOAuth;
+		await sim.destroy();
+		await safeClose(ctx.db);
+	});
+
+	it('stamps both ids on the create / api-key / revoke / delete broadcasts', async () => {
+		captured = [];
+
+		const createRes = await ctx.app.request(`/api/projects/${projectSlug}/connectors`, {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'linear',
+				kind: 'saas',
+				config: { url: 'https://mcp.linear.example/mcp' },
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const connectorId = (await createRes.json()).data.id as string;
+
+		// Attaching an API key is the non-OAuth way a connector goes active.
+		const keyRes = await ctx.app.request(
+			`/api/projects/${projectSlug}/connectors/${connectorId}/api-key`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: 'sk-test-value' }),
+			},
+		);
+		expect(keyRes.status).toBe(200);
+
+		const revokeRes = await ctx.app.request(
+			`/api/projects/${projectSlug}/connectors/${connectorId}/revoke`,
+			{ method: 'POST', headers: authHeader(ctx.token) },
+		);
+		expect(revokeRes.status).toBe(200);
+
+		const deleteRes = await ctx.app.request(
+			`/api/projects/${projectSlug}/connectors/${connectorId}`,
+			{ method: 'DELETE', headers: authHeader(ctx.token) },
+		);
+		expect(deleteRes.status).toBe(200);
+
+		const rows = connectorRows();
+		expect(rows.length).toBe(4);
+		for (const row of rows) {
+			expect(row.team_id).toBe(teamId);
+			expect(row.project_id).toBe(projectId);
+		}
+	});
+
+	it('stamps both ids on the connection-completed broadcast the reconnect path emits', async () => {
+		captured = [];
+
+		const ensureRes = await ctx.app.request(`/api/projects/${projectSlug}/connectors/ensure`, {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ provider_id: 'github' }),
+		});
+		expect(ensureRes.status).toBe(200);
+		const connectorId = (await ensureRes.json()).data.id as string;
+
+		const startRes = await ctx.app.request(
+			`/api/projects/${projectSlug}/connectors/${connectorId}/device/start`,
+			{ method: 'POST', headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' } },
+		);
+		expect(startRes.status).toBe(200);
+		const start = (await startRes.json()).data as { flow_id: string; user_code: string };
+
+		sim.approveDeviceFlow(start.user_code, issuedToken);
+
+		const pollRes = await ctx.app.request(
+			`/api/projects/${projectSlug}/connectors/${connectorId}/device/poll`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ flow_id: start.flow_id }),
+			},
+		);
+		expect(pollRes.status).toBe(200);
+
+		// The `status: 'active'` row is the one the open Connectors page needs to
+		// flip its card out of "Needs reconnect".
+		const activated = connectorRows().find((row) => row.status === 'active');
+		expect(activated).toBeDefined();
+		expect(activated?.id).toBe(connectorId);
+		expect(activated?.team_id).toBe(teamId);
+		expect(activated?.project_id).toBe(projectId);
+	});
+});

--- a/packages/web/src/components/connector-completion.tsx
+++ b/packages/web/src/components/connector-completion.tsx
@@ -1,9 +1,10 @@
 import { getConnectorCapability } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { KeyRound, Plug } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Connector } from '../hooks/use-connectors';
 import { useAuthStart } from '../hooks/use-oauth-connections';
+import { useOAuthSuccessRefetch } from '../hooks/use-oauth-success';
 import { queryKeys } from '../lib/query-keys';
 import { apiKeyGuideFor, ConnectorApiKeyForm } from './connector-api-key-form';
 import { ConnectorDeviceFlowDialog } from './connector-device-flow-dialog';
@@ -73,18 +74,9 @@ export function ConnectorCompletion({
 		onDone?.();
 	};
 
-	// Refetch immediately when the OAuth popup signals success via postMessage from
-	// the callback success page, without waiting for the WebSocket round-trip. The
-	// payload is just a type tag (not credentials), so we can't require same-origin.
-	useEffect(() => {
-		const onMessage = (e: MessageEvent) => {
-			if (!e.data || typeof e.data !== 'object') return;
-			if ((e.data as { type?: string }).type !== 'hezo-oauth-success') return;
-			queryClient.invalidateQueries({ queryKey: queryKeys.projects.connectors(projectId) });
-		};
-		window.addEventListener('message', onMessage);
-		return () => window.removeEventListener('message', onMessage);
-	}, [projectId, queryClient]);
+	// Refetch immediately when the OAuth popup signals success, without waiting
+	// for the WebSocket round-trip.
+	useOAuthSuccessRefetch(queryKeys.projects.connectors(projectId));
 
 	const openConnect = () => {
 		setError(null);

--- a/packages/web/src/hooks/use-oauth-success.ts
+++ b/packages/web/src/hooks/use-oauth-success.ts
@@ -1,0 +1,32 @@
+import { type QueryKey, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Refetch `queryKey` when the OAuth popup reports it finished.
+ *
+ * Every surface that opens the authorize popup needs this: the write happens in
+ * the popup, so nothing in this tab's own mutation lifecycle knows the connector
+ * changed, and without it a completed (re)connection only shows up on a reload.
+ *
+ * The popup posts `{type: 'hezo-oauth-success'}` via `window.opener.postMessage`
+ * from the callback page (`routes/oauth.ts:buildCallbackPage`), which lives on
+ * the server origin while the app is on the web origin — so this can't require
+ * `e.origin === window.location.origin` and gates on the message type instead.
+ * The payload is a type tag, not credentials.
+ */
+export function useOAuthSuccessRefetch(queryKey: QueryKey): void {
+	const queryClient = useQueryClient();
+	// Read through a ref so an inline-built key doesn't re-subscribe every render.
+	const keyRef = useRef(queryKey);
+	keyRef.current = queryKey;
+
+	useEffect(() => {
+		const onMessage = (e: MessageEvent) => {
+			if (!e.data || typeof e.data !== 'object') return;
+			if ((e.data as { type?: string }).type !== 'hezo-oauth-success') return;
+			queryClient.invalidateQueries({ queryKey: keyRef.current });
+		};
+		window.addEventListener('message', onMessage);
+		return () => window.removeEventListener('message', onMessage);
+	}, [queryClient]);
+}

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -29,6 +29,7 @@ import {
 	useEnsureConnector,
 	useOAuthConnections,
 } from '../../../hooks/use-oauth-connections';
+import { useOAuthSuccessRefetch } from '../../../hooks/use-oauth-success';
 import { useProject } from '../../../hooks/use-projects';
 import { useI18n } from '../../../lib/i18n';
 import { queryKeys } from '../../../lib/query-keys';
@@ -58,6 +59,12 @@ function ConnectorsPage() {
 		[connectorPages],
 	);
 	const { data: oauthConnections = [] } = useOAuthConnections(projectId);
+
+	// A (re)connection completes inside the OAuth popup, so this tab learns about
+	// it either from the popup's postMessage or from the connector's row-change
+	// broadcast. Listen for the first: it lands as soon as the popup closes,
+	// without waiting on the WebSocket round trip.
+	useOAuthSuccessRefetch(queryKeys.projects.connectors(projectId));
 
 	// Ref callback fires when the focused <li> mounts (which can happen after
 	// the initial render once the connectors query resolves). Scrolls into view

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,8 +1,7 @@
 import { summarizeMethodAccess } from '@hezo/shared';
-import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ChevronDown, Plus, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ConnectorMethodsDialog } from '../../components/connector-methods-dialog';
 import { InfiniteScrollSentinel } from '../../components/infinite-scroll-sentinel';
 import { RelatedItemsList } from '../../components/related-items-list';
@@ -31,6 +30,7 @@ import {
 	useUpdateInstanceConnectorScope,
 } from '../../hooks/use-instance-connectors';
 import { useMe } from '../../hooks/use-me';
+import { useOAuthSuccessRefetch } from '../../hooks/use-oauth-success';
 import { useAllVisibleProjects } from '../../hooks/use-projects';
 import { useI18n } from '../../lib/i18n';
 
@@ -59,7 +59,6 @@ function InstanceConnectorsPage() {
 	const { projects } = useAllVisibleProjects();
 	const createConnector = useCreateInstanceConnector();
 	const authStart = useInstanceAuthStart();
-	const queryClient = useQueryClient();
 
 	// Ref callback fires when the focused row mounts (which can happen after the
 	// initial render once the connectors query resolves). Scrolls into view then.
@@ -93,21 +92,10 @@ function InstanceConnectorsPage() {
 		setError(null);
 	}
 
-	// Refetch the list when the OAuth popup signals success. The popup posts
-	// {type: 'hezo-oauth-success'} via window.opener.postMessage from the
-	// callback page (routes/oauth.ts:buildCallbackPage), which lives on the
-	// server origin while we're on the web origin — so we can't require
-	// e.origin === window.location.origin and gate on message type instead.
-	// The payload is just a type tag, not credentials.
-	useEffect(() => {
-		const onMessage = (e: MessageEvent) => {
-			if (!e.data || typeof e.data !== 'object') return;
-			if ((e.data as { type?: string }).type !== 'hezo-oauth-success') return;
-			queryClient.invalidateQueries({ queryKey: INSTANCE_CONNECTORS_KEY });
-		};
-		window.addEventListener('message', onMessage);
-		return () => window.removeEventListener('message', onMessage);
-	}, [queryClient]);
+	// Refetch the list when the OAuth popup signals success. The admin connect
+	// flow carries no team, so it emits no row-change broadcast — this is the
+	// only update channel here.
+	useOAuthSuccessRefetch(INSTANCE_CONNECTORS_KEY);
 
 	async function handleCreate(e: React.FormEvent) {
 		e.preventDefault();

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -653,6 +653,70 @@ test('an active connector still surfaces a recorded auth error', async () => {
 	await findByText(/token refresh: generic refresh needs token_url/);
 });
 
+test('a degraded connector flips to Connected when the OAuth popup reports success', async () => {
+	// Reconnect opens the authorize popup, so the write that clears `auth_error`
+	// happens outside this tab entirely - no mutation here ever settles. Without
+	// the postMessage listener the row kept its amber "Needs reconnect" badge
+	// until a page reload, which is exactly the moment the operator is watching.
+	let slug = '';
+	let connectorId = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			const connector = await seedSaasConnector(ws, {
+				name: 'linear',
+				url: 'https://mcp.linear.example/mcp',
+			});
+			connectorId = connector.id;
+			const oauth = await seedGithubOAuth(['repo']);
+			await markConnectorActive(connector.id, oauth.id);
+			// Activated + auth_error = the `degraded` rung: it worked, its grant died.
+			const { db } = getTestContext();
+			await db.query(`UPDATE mcp_connections SET auth_error = $2 WHERE id = $1`, [
+				connector.id,
+				'token refresh: token endpoint error: invalid_grant',
+			]);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('linear');
+	const degradedRow = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id') === connectorId);
+	if (!degradedRow) throw new Error('degraded connector row not found');
+	expect(degradedRow.getAttribute('data-status')).toBe('degraded');
+	within(degradedRow).getByTestId('connector-reconnect');
+	within(degradedRow).getByText(/token refresh: token endpoint error/);
+
+	// The popup completed the re-authorization server-side (simulated directly in
+	// the DB, as the callback's markActive does) …
+	const { db } = getTestContext();
+	await db.query(
+		`UPDATE mcp_connections SET auth_error = NULL, activated_at = now() WHERE id = $1`,
+		[connectorId],
+	);
+
+	// … then posts hezo-oauth-success to its opener, which refetches the list.
+	window.dispatchEvent(new MessageEvent('message', { data: { type: 'hezo-oauth-success' } }));
+
+	await waitFor(() => {
+		const row = within(getByTestId('connectors-list'))
+			.getAllByTestId('connector-row')
+			.find((li) => li.getAttribute('data-connector-id') === connectorId);
+		expect(row?.getAttribute('data-status')).toBe('active');
+	});
+	const reconnected = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id') === connectorId);
+	if (!reconnected) throw new Error('reconnected connector row not found');
+	within(reconnected).getByText('Connected');
+	expect(within(reconnected).queryByTestId('connector-reconnect')).toBeNull();
+	expect(within(reconnected).queryByText(/token refresh: token endpoint error/)).toBeNull();
+});
+
 test('a pending connector offers Remove, which deletes it from the project', async () => {
 	let slug = '';
 	const { findByText, getByTestId, router } = await renderApp({


### PR DESCRIPTION
A degraded connector kept its amber **Needs reconnect** badge and the provider's error message until the operator reloaded the page, even though the reconnect had already succeeded server-side.

## Why it happened

The reconnect is written from inside the OAuth popup, so the project Connectors page has exactly two ways to learn about it. Neither worked.

**1. The row-change broadcast was unresolvable.** Every `mcp_connections` broadcast sent a hand-built partial row (`{ id, status }`). The web client's `resolveProjectSlugForChange` resolves the project whose caches to invalidate from `row.project_id`, falling back to `row.team_id` - so with neither present, every connector broadcast resolved to nothing and was dropped client-side. That silently affected revoke, api-key, method updates, install status and delete too; those paths only appeared to work because the acting tab's own mutation invalidated locally.

**2. The page never listened for the popup's postMessage.** The global settings page and the task-thread completion card both listen for `hezo-oauth-success`; the project Connectors page did not.

## Changes

- **`broadcastConnectorChange`** (`lib/broadcast.ts`) stamps `team_id` + `project_id` on every `mcp_connections` row change, mirroring the existing `broadcastCommentFamilyChange`. All 11 call sites across `routes/connectors.ts` and `routes/oauth.ts` now go through it.
- **`useOAuthSuccessRefetch`** extracts the postMessage listener that the settings page and the completion card each had inline, and adds it to the project Connectors page - so the row refetches the moment the popup closes, without waiting on the WebSocket round trip.

## Tests

- `packages/server/test/connector-realtime-broadcast.test.ts` (new): asserts the create / api-key / revoke / delete broadcasts carry both ids, and drives the GitHub device flow through `github-sim` to assert the connection-completed broadcast does too.
- `packages/web/test/connectors-page.test.tsx`: a degraded row flips to **Connected**, drops its Reconnect button and clears its error when `hezo-oauth-success` arrives. Verified it fails without the listener.

Full `connector`, `oauth`, `broadcast`, `websocket` and `docs` patterns pass locally; `typecheck` and `biome check` clean.

## Docs

- `.dev/architecture.md` - the partial-row broadcast rule under row-change → project-slug resolution.
- `docs/mcp/connecting-mcp-servers.md` - one sentence that the row updates itself with no page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD1bvxUcwiRyRyTus979XS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD1bvxUcwiRyRyTus979XS)_