### PR TITLE
fix(runs): show every run by default, and stop calling a never-started run a failure

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2296,6 +2296,21 @@ consequences elsewhere: the idle-stop scan's busy set excludes a parked run
 scan feeds; and the run reads honestly while parked, the run comment and run detail page
 both rendering "Queued - waiting for container capacity" from `queued_reason`.
 
+The registry is in-memory, so it protects a park only for as long as the process lives.
+`CAPACITY_PARK_MAX_MS` (180 s) deliberately exceeds `STALE_STATE_GRACE_SECONDS` (120 s), so
+a restart mid-park hands every parked row straight to the orphan pass with no driver to
+vouch for it - and a restart is exactly when the pool is cold and capacity tightest, so the
+two coincide rather than being independent. That pairing is only tolerable because the
+orphan pass's verdict for a run that never started is itself non-destructive: it finalizes
+the row `Cancelled`, hands the *original* wakeup back to the queue (`claimed` → `queued`,
+mirroring `settleWakeupForRun`) and spends no strike of the lost-run escalation, so the
+work is redispatched rather than lost or reported as a failure the operator must act on.
+The `running` arm is unchanged and still `Failed` - a process that vanished mid-flight did
+lose work. `capacity-park-grace` in `orphan-detector.test.ts` pins the constant
+relationship so neither can be moved without meeting the assumption. The run's `error`
+carries the tail of its own log, so the detail page says *why* it never started rather than
+only that it did not.
+
 **Run.** `agent-runner.ts` builds the run context (provider/runtime resolution, MCP
 descriptors, egress proxy, ssh-agent socket, container env), starts a `heartbeat_runs`
 row, and drives a streaming `docker exec` of the runtime CLI. The long-lived Docker streams

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -89,15 +89,17 @@ manager.)
 ## Reviewing an agent's runs
 
 Every agent has an **Executions** tab listing its runs - what triggered each one, how long
-it took, what it cost, and the full log. The list opens on the runs that did work: runs
-that ended in an error are filtered out by default, because a busy agent accumulates more
-of them than you are usually looking for. The filter above the list switches between
-**Runs**, **Errored** and **All**, and the choice is part of the page address, so a
-filtered view can be bookmarked or shared. Runs that are still queued or running are never
-hidden, whichever filter is selected.
+it took, what it cost, and the full log. The list opens on every run, newest first. The
+filter above it narrows to a single outcome: **All**, **Succeeded** (runs that finished
+cleanly) or **Errored** (runs that failed or timed out). A run that is still queued or
+running, or one that was cancelled, belongs to neither narrow view and appears under All.
+The choice is part of the page address, so a filtered view can be bookmarked or shared,
+and opening a run and coming back returns you to the view you were in.
 
 A run waiting for a container to free up shows as queued, not as an error - it keeps its
-place and starts as soon as memory is available. See
+place and starts as soon as memory is available. If the wait outlasts its patience the run
+is recorded as cancelled and the work goes back on the queue to be picked up again; that
+is not a failure, and it is why cancelled runs are their own thing rather than errors. See
 [how much can run at once](/docs/containers/overview#how-much-can-run-at-once).
 
 ## Per-agent model override

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -127,7 +127,9 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
  * is a cheap aggregate over lengths.
  */
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id, hr.kind,
-	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
+	-- created_at, not just started_at: a run that ended before it ever started has
+	-- no started_at, and created_at is the only clock it has to be placed by.
+	hr.status, hr.queued_reason, hr.created_at, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
 	hr.input_tokens, hr.output_tokens, hr.cost_cents, hr.usage_partial,
 	hr.invocation_command, hr.working_dir,
 	hr.process_pid, hr.retry_of_run_id, hr.process_loss_retry_count,
@@ -1352,17 +1354,24 @@ agentsRoutes.get('/projects/:projectId/agents/:agentId/heartbeat-runs', async (c
 	// One predicate, both queries: a count that disagrees with the page makes
 	// `meta.total` promise rows the caller can never reach, so infinite scroll
 	// keeps asking for a page that comes back empty. The two carry the status
-	// array at different positions, so the predicate takes its param index.
-	// `= ANY` to include, `<> ALL` to exclude — `<> ANY` would read "differs from
-	// at least one of them", which is true of every status once the array holds
-	// more than one.
-	const whereFor = (statusIdx: number) =>
+	// parameter at different positions, so the predicate takes its param index.
+	//
+	// Each narrow option is an include, never an exclude: `Succeeded` is the one
+	// status (a scalar), `Errored` is the {failed, timed_out} set (`= ANY`).
+	// Neither covers a live or cancelled run - only `All` does, which is why it is
+	// the default rather than a way to see extra rows.
+	const whereFor = (statusIdx: number) => {
+		if (filter === RunOutcomeFilter.All) return 'hr.member_id = $1';
+		if (filter === RunOutcomeFilter.Succeeded)
+			return `hr.member_id = $1 AND hr.status = $${statusIdx}::heartbeat_run_status`;
+		return `hr.member_id = $1 AND hr.status = ANY($${statusIdx}::heartbeat_run_status[])`;
+	};
+	const filterParams: unknown[] =
 		filter === RunOutcomeFilter.All
-			? 'hr.member_id = $1'
-			: `hr.member_id = $1 AND hr.status ${
-					filter === RunOutcomeFilter.Errored ? '= ANY' : '<> ALL'
-				}($${statusIdx}::heartbeat_run_status[])`;
-	const filterParams = filter === RunOutcomeFilter.All ? [] : [[...ERRORED_RUN_STATUSES]];
+			? []
+			: filter === RunOutcomeFilter.Succeeded
+				? [HeartbeatRunStatus.Succeeded]
+				: [[...ERRORED_RUN_STATUSES]];
 
 	const countResult = await db.query<{ total: number }>(
 		`SELECT count(*)::int AS total FROM heartbeat_runs hr WHERE ${whereFor(2)}`,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -120,7 +120,7 @@ import {
 	type McpDescriptor,
 	validateInjection,
 } from './mcp-injectors';
-import { retryOrEscalateLostRun } from './orphan-detector';
+import { retryOrEscalateLostRun, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
 import type { ProgressActivityCandidates, ProgressActivityKind } from './project-activity';
 import { loadReactionsForTask, type ReactionGroup } from './reactions';
@@ -1142,8 +1142,16 @@ const CAPACITY_PARK_POLL_MS = 5_000;
  * trading one errored row for another. The dispatcher's pre-flight gate already
  * refuses to dispatch while at capacity, so a run that reaches the ladder and
  * finds nothing lost a race, and a race resolves in seconds or was never one.
+ *
+ * This exceeds {@link STALE_STATE_GRACE_SECONDS}, so a parked run outlives the
+ * age at which the orphan pass would consider its row. That is safe only because
+ * the pass skips any run id in the live-run registry, and this park stays inside
+ * `runAgent` precisely to keep it there. The registry is in-memory, so a restart
+ * mid-park drops the row to the pass anyway — which is why the never-started
+ * verdict has to be survivable rather than a failure. `capacity-park-grace`
+ * in `orphan-detector.test.ts` pins the relationship.
  */
-const CAPACITY_PARK_MAX_MS = 3 * 60_000;
+export const CAPACITY_PARK_MAX_MS = 3 * 60_000;
 
 /**
  * Sleep that returns early when the run is aborted, so a cancel or a shutdown

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -2,6 +2,7 @@ import {
 	AgentRuntimeStatus,
 	ApprovalType,
 	HeartbeatRunStatus,
+	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
 	wsRoom,
@@ -44,6 +45,50 @@ export interface DetectOrphansOpts {
 	killProcesses?: (containerId: string, runId: string) => Promise<void>;
 }
 
+/**
+ * How much of the log tail rides along in the run's `error`.
+ *
+ * Shorter than the excerpt handed to a retry wakeup: this one is rendered in a
+ * fixed-height block on the run detail page, and the point is to say *why*
+ * without the reader having to go and read the log themselves.
+ */
+const ORPHAN_ERROR_TAIL_CHARS = 400;
+
+/**
+ * The run's `error`, carrying the actual cause where the log has one.
+ *
+ * The bare verdict on its own ("run never started") named the symptom and left
+ * the reason - almost always the instance being at its container-memory budget -
+ * sitting in a log the reader had to open separately.
+ */
+function orphanErrorMessage(neverStarted: boolean, logTail: string): string {
+	const verdict = neverStarted
+		? 'Never started: no host process was driving this run, so it was returned to the queue.'
+		: 'Orphaned: process no longer running';
+	const excerpt = logTail.trim().slice(-ORPHAN_ERROR_TAIL_CHARS).trim();
+	return excerpt ? `${verdict}\n\nLast log output:\n${excerpt}` : verdict;
+}
+
+/**
+ * Hand a claimed wakeup back to the queue. Returns whether it was still claimed.
+ *
+ * The status guard is load-bearing: another path may have settled this wakeup
+ * already, and returning a completed one to the queue dispatches its work a
+ * second time. The boolean is how the caller knows whether the work was handed
+ * back or still needs a retry raised for it.
+ */
+async function requeueWakeup(db: Db, wakeupId: string): Promise<boolean> {
+	const res = await db.query(
+		`UPDATE agent_wakeup_requests
+		 SET status = $1::wakeup_status, claimed_at = NULL,
+		     last_skipped_at = now(), last_skipped_reason = $2
+		 WHERE id = $3 AND status = $4::wakeup_status
+		 RETURNING id`,
+		[WakeupStatus.Queued, WakeupSkipReason.InstanceAtCapacity, wakeupId, WakeupStatus.Claimed],
+	);
+	return res.rows.length > 0;
+}
+
 export async function detectOrphans(
 	db: Db,
 	liveRunIds: Set<string>,
@@ -65,13 +110,24 @@ export async function detectOrphans(
 		member_id: string;
 		team_id: string;
 		task_id: string | null;
+		wakeup_id: string | null;
 		project_id: string | null;
 		container_id: string | null;
 		process_loss_retry_count: number;
 		status: HeartbeatRunStatus;
 	}>(
-		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.process_loss_retry_count, hr.status,
-		        (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id) AS project_id,
+		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.wakeup_id,
+		        hr.process_loss_retry_count, hr.status,
+		        -- The team fallback is load-bearing for the broadcast, not a nicety.
+		        -- A progress-update run carries no task, so the task lookup alone
+		        -- left project_id NULL - and the client skips a heartbeat_runs
+		        -- change it cannot map to a project (PROJECT_STRICT_TABLES), so
+		        -- those reaps reached no open page at all. A team owns exactly one
+		        -- project (UNIQUE(projects.team_id)), so this is unambiguous.
+		        COALESCE(
+		          (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id),
+		          (SELECT p.id FROM projects p WHERE p.team_id = hr.team_id)
+		        ) AS project_id,
 		        (SELECT p.container_id FROM projects p JOIN tasks t ON t.project_id = p.id
 		         WHERE t.id = hr.task_id) AS container_id
 		 FROM heartbeat_runs hr
@@ -101,19 +157,38 @@ export async function detectOrphans(
 
 		orphanCount++;
 
-		const error =
-			run.status === HeartbeatRunStatus.Queued
-				? 'Orphaned: run never started'
-				: 'Orphaned: process no longer running';
+		// The two arms are not the same event, and giving them one verdict was the
+		// bug. A `running` run had a process doing work that vanished mid-flight:
+		// output may be half-written, the container may hold a wedged tree, and the
+		// agent's turn was spent - a failure. A `queued` one never started, so
+		// nothing was produced and nothing was lost; the honest record is the one
+		// the capacity park already writes when it gives up, `Cancelled` with the
+		// work handed back. Failing it instead filled the Errored view with rows
+		// nobody could act on, and minted a fresh retry wakeup on every pass rather
+		// than returning the one already sitting there claimed.
+		const neverStarted = run.status === HeartbeatRunStatus.Queued;
+
+		// Read once and use twice - the message below and, on the failure arm, the
+		// retry wakeup's excerpt. This runs on a 30s cron, so a second read per
+		// orphan is a cost with nothing to show for it.
+		const tail = await readRunLogTail(db, run.id, ORPHAN_LOG_TAIL_CHARS);
+		const error = orphanErrorMessage(neverStarted, tail.text);
 
 		await db.query(
 			`UPDATE heartbeat_runs
 			 SET status = $2::heartbeat_run_status,
 			     finished_at = now(),
 			     error = $3,
-			     process_loss_retry_count = process_loss_retry_count + 1
+			     -- Only a real process loss counts toward the escalation. A run that
+			     -- never started is being handed back, not retried after a failure.
+			     process_loss_retry_count = process_loss_retry_count + $4::int
 			 WHERE id = $1`,
-			[run.id, HeartbeatRunStatus.Failed, error],
+			[
+				run.id,
+				neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed,
+				error,
+				neverStarted ? 0 : 1,
+			],
 		);
 
 		// Task-less runs can't resolve a container here; the startup sweep is
@@ -136,16 +211,30 @@ export async function detectOrphans(
 			member_id: run.member_id,
 			task_id: run.task_id,
 			project_id: run.project_id,
-			status: HeartbeatRunStatus.Failed,
+			status: neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed,
 			error,
 		});
 
-		await retryOrEscalateLostRun(db, {
-			runId: run.id,
-			memberId: run.member_id,
-			teamId: run.team_id,
-			priorRetries: run.process_loss_retry_count,
-		});
+		// A run that never started is put back rather than retried: the original
+		// wakeup returns to the queue for the dispatcher to pick up, exactly as
+		// `JobManager.settleWakeupForRun` does for the capacity park's own give-up
+		// path. Guarded on `claimed` so a wakeup already settled by another path is
+		// not resurrected. With no wakeup to return (a run started by something
+		// else) there is nothing to hand back, so fall through to the retry path
+		// rather than dropping the work.
+		const requeued = neverStarted && run.wakeup_id ? await requeueWakeup(db, run.wakeup_id) : false;
+		if (requeued) continue;
+
+		await retryOrEscalateLostRun(
+			db,
+			{
+				runId: run.id,
+				memberId: run.member_id,
+				teamId: run.team_id,
+				priorRetries: run.process_loss_retry_count,
+			},
+			tail.text,
+		);
 	}
 
 	return orphanCount;
@@ -170,6 +259,8 @@ export async function detectOrphans(
 export async function retryOrEscalateLostRun(
 	db: Db,
 	run: { runId: string; memberId: string; teamId: string; priorRetries: number },
+	/** Log excerpt the caller has already read, to save reading it twice. */
+	knownLogTail?: string,
 ): Promise<void> {
 	if (run.priorRetries + 1 < MAX_RETRIES) {
 		const failedRun = await db.query<{ exit_code: number | null }>(
@@ -178,7 +269,8 @@ export async function retryOrEscalateLostRun(
 		);
 		// Read the excerpt from storage; this used to aggregate the run's whole
 		// log (up to 10 MB) to keep its last 1000 characters, on a 30s cron.
-		const tail = await readRunLogTail(db, run.runId, ORPHAN_LOG_TAIL_CHARS);
+		const tailText =
+			knownLogTail ?? (await readRunLogTail(db, run.runId, ORPHAN_LOG_TAIL_CHARS)).text;
 
 		await createWakeup(db, run.memberId, run.teamId, WakeupSource.Timer, {
 			reason: 'orphan_retry',
@@ -187,7 +279,7 @@ export async function retryOrEscalateLostRun(
 			previous_failure: {
 				run_id: run.runId,
 				exit_code: failedRun.rows[0]?.exit_code ?? null,
-				log_tail: tail.text.length > 0 ? tail.text : null,
+				log_tail: tailText.length > 0 ? tailText : null,
 			},
 		});
 	} else {

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -756,14 +756,16 @@ describe('run-outcome filter on the runs list', () => {
 		});
 		filterAgentId = (await agentRes.json()).data.id as string;
 
-		// One of each interesting shape: a clean finish, both errored statuses, and
-		// a live run that has not started (started_at NULL) so the filter can be
-		// shown never to hide one.
+		// One of each interesting shape: a clean finish, both errored statuses, a
+		// live run that has not started (started_at NULL), and a cancelled one.
+		// The last two are what prove the narrow options are strict - each belongs
+		// to neither Succeeded nor Errored, so only All returns them.
 		const shapes: [string, string, boolean][] = [
 			['ok', 'succeeded', true],
 			['failed', 'failed', true],
 			['timedOut', 'timed_out', true],
 			['live', 'queued', false],
+			['cancelled', 'cancelled', false],
 		];
 		for (const [key, status, started] of shapes) {
 			const r = await db.query<{ id: string }>(
@@ -790,25 +792,30 @@ describe('run-outcome filter on the runs list', () => {
 	}
 
 	it('returns every run when no filter is given', async () => {
+		// The default view, and the one the Executions page opens on: nothing is
+		// hidden, so a reader looking for a failure does not have to find a control
+		// first.
 		const { ids, total } = await list('');
 		expect(new Set(ids)).toEqual(new Set(Object.values(seeded)));
-		expect(total).toBe(4);
+		expect(total).toBe(5);
 	});
 
-	it('filter=runs drops both errored statuses, and the count drops with them', async () => {
-		const { ids, total } = await list('?filter=runs');
-		expect(new Set(ids)).toEqual(new Set([seeded.ok, seeded.live]));
+	it('filter=succeeded returns only the succeeded run, and the count drops with it', async () => {
+		const { ids, total } = await list('?filter=succeeded');
+		expect(new Set(ids)).toEqual(new Set([seeded.ok]));
 		// The count must carry the same predicate as the page: a total that
 		// promises rows the caller can never reach makes infinite scroll ask for a
 		// page that comes back empty.
-		expect(total).toBe(2);
+		expect(total).toBe(1);
 	});
 
-	it('filter=runs keeps a live run that has not started', async () => {
-		// The filter is on the outcome, not on whether the run got going - a run
-		// still waiting to start is the most interesting row on the page.
-		const { ids } = await list('?filter=runs');
-		expect(ids).toContain(seeded.live);
+	it('filter=succeeded is strict - it excludes a live run and a cancelled one', async () => {
+		// Not "everything that did not error". A run still queued has not
+		// succeeded, and a run handed back to the queue for capacity was cancelled;
+		// neither belongs under a tab called Succeeded. All is where they live.
+		const { ids } = await list('?filter=succeeded');
+		expect(ids).not.toContain(seeded.live);
+		expect(ids).not.toContain(seeded.cancelled);
 	});
 
 	it('filter=errored returns exactly the failed and timed-out runs', async () => {
@@ -817,10 +824,27 @@ describe('run-outcome filter on the runs list', () => {
 		expect(total).toBe(2);
 	});
 
+	it('filter=errored does not claim a cancelled run', async () => {
+		// A run the instance handed back for capacity is not the agent failing.
+		const { ids } = await list('?filter=errored');
+		expect(ids).not.toContain(seeded.cancelled);
+	});
+
 	it('an unrecognised filter falls back to returning everything', async () => {
 		const { ids, total } = await list('?filter=nonsense');
 		expect(new Set(ids)).toEqual(new Set(Object.values(seeded)));
-		expect(total).toBe(4);
+		expect(total).toBe(5);
+	});
+
+	it('sends created_at, the only clock a run that never started has', async () => {
+		const res = await app.request(
+			`/api/projects/${projectSlug}/agents/${filterAgentId}/heartbeat-runs?filter=all`,
+			{ headers: authHeader(token) },
+		);
+		const body = await res.json();
+		const live = body.data.find((r: { id: string }) => r.id === seeded.live);
+		expect(live.started_at).toBeNull();
+		expect(live.created_at).toBeTruthy();
 	});
 
 	it('pages a filtered set without repeating or dropping a row', async () => {

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -8,8 +8,14 @@ import {
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
-import { detectOrphans, healStaleRunState } from '../src/services/orphan-detector';
+import { CAPACITY_PARK_MAX_MS } from '../src/services/agent-runner';
+import {
+	detectOrphans,
+	healStaleRunState,
+	STALE_STATE_GRACE_SECONDS,
+} from '../src/services/orphan-detector';
 import { safeClose } from './helpers';
 import {
 	authHeader,
@@ -253,7 +259,7 @@ describe('detectOrphans for runs stranded before they started', () => {
 		);
 	}
 
-	it('fails a queued run whose driver never started it, and frees the state it pinned', async () => {
+	it('cancels a queued run whose driver never started it, and frees the state it pinned', async () => {
 		await clearRuns();
 		const taskId = await createTask(teamId);
 		const lockId = await insertLock(agentId, taskId);
@@ -263,13 +269,23 @@ describe('detectOrphans for runs stranded before they started', () => {
 		const count = await detectOrphans(db, new Set());
 		expect(count).toBe(1);
 
-		const run = await db.query<{ status: string; error: string; finished_at: string | null }>(
-			'SELECT status, error, finished_at FROM heartbeat_runs WHERE id = $1',
+		const run = await db.query<{
+			status: string;
+			error: string;
+			finished_at: string | null;
+			process_loss_retry_count: number;
+		}>(
+			'SELECT status, error, finished_at, process_loss_retry_count FROM heartbeat_runs WHERE id = $1',
 			[runId],
 		);
-		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
-		expect(run.rows[0].error).toBe('Orphaned: run never started');
+		// Cancelled, not failed: the run never started, so nothing ran and nothing
+		// was lost. Failing it filled the Errored view with unactionable rows.
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
+		expect(run.rows[0].error).toContain('Never started');
 		expect(run.rows[0].finished_at).not.toBeNull();
+		// And it spends none of the three strikes that raise "manual intervention
+		// required" - those are for a run that got a fair attempt and lost it.
+		expect(run.rows[0].process_loss_retry_count).toBe(0);
 
 		// The point of the reap: the task stops reading as having an active run,
 		// which is what blocks reassignment and shows the agent as busy.
@@ -293,6 +309,103 @@ describe('detectOrphans for runs stranded before they started', () => {
 			[agentId],
 		);
 		expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.Idle);
+	});
+
+	it('hands the original wakeup back to the queue instead of minting a retry', async () => {
+		await clearRuns();
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at)
+			 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, now())
+			 RETURNING id`,
+			[agentId, teamId, WakeupSource.Timer, WakeupStatus.Claimed],
+		);
+		const wakeupId = wakeup.rows[0].id;
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, wakeup_id, status, created_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '10 minutes')`,
+			[teamId, agentId, wakeupId, HeartbeatRunStatus.Queued],
+		);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		// The work is put back on the row that already carries it - the dispatcher
+		// picks it up on the next tick.
+		const settled = await db.query<{ status: string; claimed_at: string | null }>(
+			'SELECT status, claimed_at FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(settled.rows[0].status).toBe(WakeupStatus.Queued);
+		expect(settled.rows[0].claimed_at).toBeNull();
+
+		// And no second wakeup was created for the same work.
+		const all = await db.query<{ count: string }>(
+			'SELECT count(*)::text AS count FROM agent_wakeup_requests WHERE member_id = $1',
+			[agentId],
+		);
+		expect(all.rows[0].count).toBe('1');
+	});
+
+	it('carries the real cause into the error so the run page does not just say it never started', async () => {
+		await clearRuns();
+		const runId = await insertQueuedRun('10 minutes');
+		await appendRunLogChunks(
+			db,
+			runId,
+			'[runner] no container available for project abc: its next container does not fit ' +
+				'the instance memory budget - returning this run to the queue.\n',
+		);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const run = await db.query<{ error: string }>(
+			'SELECT error FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].error).toContain('Never started');
+		expect(run.rows[0].error).toContain('no container available');
+	});
+
+	it('broadcasts a project even for a task-less run, so an open page can map the change', async () => {
+		// The client resolves a heartbeat_runs change by project_id alone and skips
+		// a row without one (PROJECT_STRICT_TABLES). A progress-update run carries
+		// no task, so deriving the project from the task left these reaps reaching
+		// no open page - the reader watched a queued run that had already ended.
+		await clearRuns();
+		const runId = await insertQueuedRun('10 minutes');
+		const sent: Record<string, unknown>[] = [];
+		const wsManager = {
+			broadcast: (_room: string, msg: { row: Record<string, unknown> }) => {
+				sent.push(msg.row);
+			},
+		} as unknown as Parameters<typeof detectOrphans>[2];
+
+		expect(await detectOrphans(db, new Set(), wsManager)).toBe(1);
+
+		const row = sent.find((r) => r.id === runId);
+		expect(row).toBeDefined();
+		expect(row?.project_id).toBeTruthy();
+		expect(row?.status).toBe(HeartbeatRunStatus.Cancelled);
+	});
+
+	it('capacity-park-grace: a park outliving the grace window is survivable, not a failure', async () => {
+		// The park deliberately runs past the age at which this pass would consider
+		// its row, and is kept safe only by the live-run registry. That registry is
+		// in-memory, so a restart mid-park hands every parked row straight to this
+		// pass. The pairing is only tolerable while the verdict for a run that
+		// never started is non-terminal for the *work* - cancel the row, hand the
+		// wakeup back. If someone shortens the grace or lengthens the park, this is
+		// the assumption they are leaning on.
+		expect(CAPACITY_PARK_MAX_MS).toBeGreaterThan(STALE_STATE_GRACE_SECONDS * 1000);
+
+		await clearRuns();
+		const runId = await insertQueuedRun('10 minutes');
+		expect(await detectOrphans(db, new Set())).toBe(1);
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
 	});
 
 	it('leaves a queued run alone while its driver still holds it (waiting on a credential lock)', async () => {
@@ -325,20 +438,24 @@ describe('detectOrphans for runs stranded before they started', () => {
 		await clearRuns();
 	});
 
-	it('reports the two stranded kinds with distinct errors in one pass', async () => {
+	it('reports the two stranded kinds with distinct verdicts in one pass', async () => {
 		await clearRuns();
 		const queuedId = await insertQueuedRun('10 minutes');
 		const runningId = await insertOrphanRun(agentId, teamId);
 
 		expect(await detectOrphans(db, new Set())).toBe(2);
 
-		const runs = await db.query<{ id: string; error: string }>(
-			'SELECT id, error FROM heartbeat_runs WHERE id = ANY($1::uuid[])',
+		const runs = await db.query<{ id: string; error: string; status: string }>(
+			'SELECT id, error, status FROM heartbeat_runs WHERE id = ANY($1::uuid[])',
 			[[queuedId, runningId]],
 		);
-		const errorById = new Map(runs.rows.map((r) => [r.id, r.error]));
-		expect(errorById.get(queuedId)).toBe('Orphaned: run never started');
-		expect(errorById.get(runningId)).toBe('Orphaned: process no longer running');
+		const byId = new Map(runs.rows.map((r) => [r.id, r]));
+		// Never started is not a failure: nothing ran, so nothing failed.
+		expect(byId.get(queuedId)?.status).toBe(HeartbeatRunStatus.Cancelled);
+		expect(byId.get(queuedId)?.error).toContain('Never started');
+		// A process that vanished mid-run is.
+		expect(byId.get(runningId)?.status).toBe(HeartbeatRunStatus.Failed);
+		expect(byId.get(runningId)?.error).toContain('Orphaned: process no longer running');
 	});
 });
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1324,17 +1324,20 @@ export function isErroredRunStatus(status: HeartbeatRunStatus): boolean {
 /**
  * List-view filter for an agent's run history.
  *
- * An agent accumulates far more errored runs than a reader is usually looking
- * for, and they crowd out the runs that did work, so the Executions list defaults
- * to hiding them. Live `queued`/`running` runs are never hidden by any option -
- * only finished-badly ones.
+ * `All` is the default: a reader looking for what went wrong should not have to
+ * discover a control first, and the back link from a run detail page has to land
+ * somewhere that can show the run it came from whatever its outcome. The other
+ * two narrow to a single outcome each, so every option is exactly what its label
+ * says - `Succeeded` is the `succeeded` status alone, not "everything that did
+ * not error", which would put a cancelled run under a tab called Succeeded.
  */
 export const RunOutcomeFilter = {
-	/** Default: every run except the errored ones. */
-	Runs: 'runs',
+	/** Default: every run, whatever its status. */
+	All: 'all',
+	/** Only runs that finished cleanly. */
+	Succeeded: 'succeeded',
 	/** Only the errored runs. */
 	Errored: 'errored',
-	All: 'all',
 } as const;
 export type RunOutcomeFilter = (typeof RunOutcomeFilter)[keyof typeof RunOutcomeFilter];
 
@@ -1347,9 +1350,9 @@ export function matchesRunOutcomeFilter(
 	status: HeartbeatRunStatus,
 	filter: RunOutcomeFilter,
 ): boolean {
-	if (filter === RunOutcomeFilter.All) return true;
-	const errored = isErroredRunStatus(status);
-	return filter === RunOutcomeFilter.Errored ? errored : !errored;
+	if (filter === RunOutcomeFilter.Errored) return isErroredRunStatus(status);
+	if (filter === RunOutcomeFilter.Succeeded) return status === HeartbeatRunStatus.Succeeded;
+	return true;
 }
 
 /**

--- a/packages/shared/test/run-outcome-filter.test.ts
+++ b/packages/shared/test/run-outcome-filter.test.ts
@@ -48,11 +48,39 @@ describe('matchesRunOutcomeFilter', () => {
 			expect(matchesRunOutcomeFilter(s, RunOutcomeFilter.All)).toBe(true);
 	});
 
-	it('Runs and Errored partition the statuses exactly', () => {
-		for (const s of ALL_STATUSES) {
-			const inRuns = matchesRunOutcomeFilter(s, RunOutcomeFilter.Runs);
-			const inErrored = matchesRunOutcomeFilter(s, RunOutcomeFilter.Errored);
-			expect(inRuns).toBe(!inErrored);
-		}
+	it('Succeeded admits the succeeded status and nothing else', () => {
+		// Strict, not "everything that did not error": a cancelled or still-queued
+		// run under a tab called Succeeded is a lie about what happened.
+		for (const s of ALL_STATUSES)
+			expect(matchesRunOutcomeFilter(s, RunOutcomeFilter.Succeeded)).toBe(
+				s === HeartbeatRunStatus.Succeeded,
+			);
+	});
+
+	it('Errored admits exactly the errored statuses', () => {
+		for (const s of ALL_STATUSES)
+			expect(matchesRunOutcomeFilter(s, RunOutcomeFilter.Errored)).toBe(isErroredRunStatus(s));
+	});
+
+	it('Succeeded and Errored are disjoint, and All is the only option covering the rest', () => {
+		// The three narrow options no longer partition the statuses - a live or
+		// cancelled run belongs to neither, which is why All is the default.
+		const uncovered = ALL_STATUSES.filter(
+			(s) =>
+				!matchesRunOutcomeFilter(s, RunOutcomeFilter.Succeeded) &&
+				!matchesRunOutcomeFilter(s, RunOutcomeFilter.Errored),
+		);
+		expect(new Set(uncovered)).toEqual(
+			new Set([
+				HeartbeatRunStatus.Queued,
+				HeartbeatRunStatus.Running,
+				HeartbeatRunStatus.Cancelled,
+			]),
+		);
+		for (const s of ALL_STATUSES)
+			expect(
+				matchesRunOutcomeFilter(s, RunOutcomeFilter.Succeeded) &&
+					matchesRunOutcomeFilter(s, RunOutcomeFilter.Errored),
+			).toBe(false);
 	});
 });

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -17,6 +17,8 @@ export interface HeartbeatRun {
 	project_name: string | null;
 	status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'timed_out';
 	queued_reason: string | null;
+	created_at: string;
+	/** Null until the run goes running - a run that ended before that never gets one. */
 	started_at: string | null;
 	finished_at: string | null;
 	exit_code: number | null;
@@ -81,6 +83,7 @@ export function useHeartbeatRuns(
 	options?: { perPage?: number; filter?: RunOutcomeFilter },
 ) {
 	const perPage = options?.perPage ?? 50;
+	// Same default as the route and the server: nothing hidden unless asked.
 	const filter = options?.filter ?? RunOutcomeFilter.All;
 	return useInfiniteQuery({
 		// `filter` has to be in the key: the poll below refetches every loaded

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Keine Läufe entsprechen diesem Filter.",
 	"executions.filter.all": "Alle",
 	"executions.filter.errored": "Fehlgeschlagen",
-	"executions.filter.runs": "Läufe",
+	"executions.filter.succeeded": "Erfolgreich",
 	"executions.loading": "Läufe werden geladen...",
 	"goals.archive.action": "Ziel archivieren",
 	"goals.archive.confirmAction": "Archivieren",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "No executions match this filter.",
 	"executions.filter.all": "All",
 	"executions.filter.errored": "Errored",
-	"executions.filter.runs": "Runs",
+	"executions.filter.succeeded": "Succeeded",
 	"executions.loading": "Loading executions...",
 	"goals.archive.action": "Archive goal",
 	"goals.archive.confirmAction": "Archive",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Ninguna ejecución coincide con este filtro.",
 	"executions.filter.all": "Todas",
 	"executions.filter.errored": "Con errores",
-	"executions.filter.runs": "Ejecuciones",
+	"executions.filter.succeeded": "Exitosas",
 	"executions.loading": "Cargando ejecuciones...",
 	"goals.archive.action": "Archivar objetivo",
 	"goals.archive.confirmAction": "Archivar",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Aucune exécution ne correspond à ce filtre.",
 	"executions.filter.all": "Toutes",
 	"executions.filter.errored": "En erreur",
-	"executions.filter.runs": "Exécutions",
+	"executions.filter.succeeded": "Réussies",
 	"executions.loading": "Chargement des exécutions...",
 	"goals.archive.action": "Archiver l'objectif",
 	"goals.archive.confirmAction": "Archiver",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Nessuna esecuzione corrisponde a questo filtro.",
 	"executions.filter.all": "Tutte",
 	"executions.filter.errored": "Con errori",
-	"executions.filter.runs": "Esecuzioni",
+	"executions.filter.succeeded": "Riuscite",
 	"executions.loading": "Caricamento delle esecuzioni...",
 	"goals.archive.action": "Archivia obiettivo",
 	"goals.archive.confirmAction": "Archivia",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "このフィルターに一致する実行はありません。",
 	"executions.filter.all": "すべて",
 	"executions.filter.errored": "エラー",
-	"executions.filter.runs": "実行",
+	"executions.filter.succeeded": "成功",
 	"executions.loading": "実行を読み込んでいます...",
 	"goals.archive.action": "ゴールをアーカイブ",
 	"goals.archive.confirmAction": "アーカイブ",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "이 필터와 일치하는 실행이 없습니다.",
 	"executions.filter.all": "전체",
 	"executions.filter.errored": "오류",
-	"executions.filter.runs": "실행",
+	"executions.filter.succeeded": "성공",
 	"executions.loading": "실행을 불러오는 중...",
 	"goals.archive.action": "목표 보관",
 	"goals.archive.confirmAction": "보관",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Geen uitvoeringen komen overeen met dit filter.",
 	"executions.filter.all": "Alle",
 	"executions.filter.errored": "Mislukt",
-	"executions.filter.runs": "Uitvoeringen",
+	"executions.filter.succeeded": "Geslaagd",
 	"executions.loading": "Uitvoeringen laden...",
 	"goals.archive.action": "Doel archiveren",
 	"goals.archive.confirmAction": "Archiveren",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Żadne uruchomienie nie pasuje do tego filtra.",
 	"executions.filter.all": "Wszystkie",
 	"executions.filter.errored": "Błędy",
-	"executions.filter.runs": "Uruchomienia",
+	"executions.filter.succeeded": "Udane",
 	"executions.loading": "Ładowanie uruchomień...",
 	"goals.archive.action": "Zarchiwizuj cel",
 	"goals.archive.confirmAction": "Zarchiwizuj",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Nenhuma execução corresponde a este filtro.",
 	"executions.filter.all": "Todas",
 	"executions.filter.errored": "Com erros",
-	"executions.filter.runs": "Execuções",
+	"executions.filter.succeeded": "Bem-sucedidas",
 	"executions.loading": "Carregando execuções...",
 	"goals.archive.action": "Arquivar meta",
 	"goals.archive.confirmAction": "Arquivar",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "Inga körningar matchar det här filtret.",
 	"executions.filter.all": "Alla",
 	"executions.filter.errored": "Misslyckade",
-	"executions.filter.runs": "Körningar",
+	"executions.filter.succeeded": "Lyckade",
 	"executions.loading": "Laddar körningar...",
 	"goals.archive.action": "Arkivera mål",
 	"goals.archive.confirmAction": "Arkivera",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -257,7 +257,7 @@
 	"executions.emptyFiltered": "没有符合此筛选条件的运行记录。",
 	"executions.filter.all": "全部",
 	"executions.filter.errored": "出错",
-	"executions.filter.runs": "运行",
+	"executions.filter.succeeded": "成功",
 	"executions.loading": "正在加载运行记录...",
 	"goals.archive.action": "归档目标",
 	"goals.archive.confirmAction": "归档",

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -1,4 +1,4 @@
-import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
+import { INSTANCE_AGENT_SLUGS, isRunOutcomeFilter, RunOutcomeFilter } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { format } from 'date-fns';
 import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react';
@@ -52,6 +52,7 @@ function statusColor(status: string): string {
 
 function ExecutionDetailPage() {
 	const { projectId, agentId, runId } = Route.useParams();
+	const { filter } = Route.useSearch();
 	const { data: run, isLoading } = useHeartbeatRun(projectId, agentId, runId);
 	const { data: agent } = useAgent(projectId, agentId);
 
@@ -115,9 +116,16 @@ function ExecutionDetailPage() {
 
 	return (
 		<div>
+			{/* Carries the filter the reader arrived with, so going back returns them
+			    to the view they left rather than to the default one - which need not
+			    contain the run they were just looking at. Absent (a deep link, or a
+			    run reached from a goal or a comment) falls through to All, which
+			    always contains it. */}
 			<Link
 				to="/projects/$projectId/agents/$agentId/executions"
 				params={{ projectId, agentId }}
+				search={filter ? { filter } : {}}
+				data-testid="run-back-link"
 				className="inline-flex items-center gap-1 text-xs text-text-2 hover:text-text-1 mb-4"
 			>
 				<ArrowLeft className="w-3 h-3" /> Executions
@@ -277,6 +285,23 @@ function ExecutionDetailPage() {
 	);
 }
 
+interface ExecutionDetailSearch {
+	/**
+	 * The list filter the reader came from, carried only so the back link can
+	 * restore it. Absent means they arrived from somewhere with no view to return
+	 * to, and back goes to the default All.
+	 */
+	filter?: RunOutcomeFilter;
+}
+
 export const Route = createFileRoute('/projects/$projectId/agents/$agentId/executions/$runId')({
+	// Mirrors the list route: the default is dropped rather than written, so one
+	// view cannot be addressed two ways.
+	validateSearch: (search: Record<string, unknown>): ExecutionDetailSearch => ({
+		filter:
+			isRunOutcomeFilter(search.filter) && search.filter !== RunOutcomeFilter.All
+				? search.filter
+				: undefined,
+	}),
 	component: ExecutionDetailPage,
 });

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
@@ -8,7 +8,11 @@ import { RelativeTime } from '../../../../../../components/ui/relative-time';
 import { Tooltip } from '../../../../../../components/ui/tooltip';
 import { useAgent } from '../../../../../../hooks/use-agents';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
-import { type HeartbeatRun, useHeartbeatRuns } from '../../../../../../hooks/use-heartbeat-runs';
+import {
+	type HeartbeatRun,
+	isActiveRunStatus,
+	useHeartbeatRuns,
+} from '../../../../../../hooks/use-heartbeat-runs';
 import { useI18n } from '../../../../../../lib/i18n';
 import { formatTriggerReason } from '../../../../../../lib/run-trigger';
 
@@ -34,11 +38,13 @@ function ExecutionRow({
 	projectId,
 	agentId,
 	isInstanceAgent,
+	filter,
 }: {
 	run: HeartbeatRun;
 	projectId: string;
 	agentId: string;
 	isInstanceAgent: boolean;
+	filter: RunOutcomeFilter;
 }) {
 	const elapsed = useElapsedDuration(run.started_at ?? '', run.finished_at);
 	const trigger = formatTriggerReason(run, projectId);
@@ -61,6 +67,10 @@ function ExecutionRow({
 		<Link
 			to="/projects/$projectId/agents/$agentId/executions/$runId"
 			params={{ projectId, agentId, runId: run.id }}
+			// Carried so the detail page's back link can put the reader back in the
+			// view they left. Without it, returning from an errored run landed on a
+			// view that may not contain it.
+			search={filter === RunOutcomeFilter.All ? {} : { filter }}
 			data-testid="execution-row"
 			className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border-subtle bg-surface px-3 py-2.5 text-xs hover:bg-surface-2 transition-colors sm:flex-nowrap sm:gap-2"
 		>
@@ -100,13 +110,18 @@ function ExecutionRow({
 				</span>
 			</Tooltip>
 
-			{run.started_at ? (
+			{/* A run only stamps started_at when it goes running, so this slot keyed
+			    on it alone read "queued" for every run that ended before it started -
+			    an orphaned or capacity-cancelled row said `failed … queued`. The word
+			    belongs to a genuinely live run; everything else is placed by the
+			    clock it does have, created_at. */}
+			{isActiveRunStatus(run.status) && !run.started_at ? (
+				<span className="order-3 text-text-2 ml-auto whitespace-nowrap sm:order-none">queued</span>
+			) : (
 				<RelativeTime
-					iso={run.started_at}
+					iso={run.started_at ?? run.created_at}
 					className="order-3 text-text-2 ml-auto whitespace-nowrap sm:order-none"
 				/>
-			) : (
-				<span className="order-3 text-text-2 ml-auto whitespace-nowrap sm:order-none">queued</span>
 			)}
 
 			<span className="order-6 text-text-3 whitespace-nowrap sm:order-none">{elapsed}</span>
@@ -128,7 +143,7 @@ function ExecutionRow({
 
 function ExecutionListPage() {
 	const { projectId, agentId } = Route.useParams();
-	const { filter = RunOutcomeFilter.Runs } = Route.useSearch();
+	const { filter = RunOutcomeFilter.All } = Route.useSearch();
 	const navigate = Route.useNavigate();
 	const { t } = useI18n();
 	const {
@@ -162,7 +177,7 @@ function ExecutionListPage() {
 		navigate({
 			search: (prev) => ({
 				...(prev as ExecutionsSearch),
-				filter: next === RunOutcomeFilter.Runs ? undefined : next,
+				filter: next === RunOutcomeFilter.All ? undefined : next,
 			}),
 			replace: true,
 		});
@@ -175,9 +190,9 @@ function ExecutionListPage() {
 			<FilterPills
 				className="mb-3"
 				options={[
-					{ value: RunOutcomeFilter.Runs, label: t('executions.filter.runs') },
-					{ value: RunOutcomeFilter.Errored, label: t('executions.filter.errored') },
 					{ value: RunOutcomeFilter.All, label: t('executions.filter.all') },
+					{ value: RunOutcomeFilter.Succeeded, label: t('executions.filter.succeeded') },
+					{ value: RunOutcomeFilter.Errored, label: t('executions.filter.errored') },
 				]}
 				value={filter}
 				onChange={setFilter}
@@ -200,6 +215,7 @@ function ExecutionListPage() {
 							projectId={projectId}
 							agentId={agentId}
 							isInstanceAgent={isInstanceAgent}
+							filter={filter}
 						/>
 					))}
 					<InfiniteScrollSentinel
@@ -215,16 +231,16 @@ function ExecutionListPage() {
 }
 
 interface ExecutionsSearch {
-	/** Run-outcome filter - absent means the default Runs view. */
+	/** Run-outcome filter - absent means the default All view. */
 	filter?: RunOutcomeFilter;
 }
 
 export const Route = createFileRoute('/projects/$projectId/agents/$agentId/executions/')({
-	// The default is dropped rather than written, so `?filter=runs` and no param
+	// The default is dropped rather than written, so `?filter=all` and no param
 	// cannot become two cache entries holding the same rows.
 	validateSearch: (search: Record<string, unknown>): ExecutionsSearch => ({
 		filter:
-			isRunOutcomeFilter(search.filter) && search.filter !== RunOutcomeFilter.Runs
+			isRunOutcomeFilter(search.filter) && search.filter !== RunOutcomeFilter.All
 				? search.filter
 				: undefined,
 	}),

--- a/packages/web/test/agent-executions-list.test.tsx
+++ b/packages/web/test/agent-executions-list.test.tsx
@@ -14,6 +14,7 @@ import {
 	matchesRunOutcomeFilter,
 	RunOutcomeFilter,
 } from '@hezo/shared';
+import { waitFor } from '@testing-library/react';
 import { afterEach, expect, test } from 'vitest';
 import type { HeartbeatRun } from '../src/hooks/use-heartbeat-runs';
 import { renderApp } from './helpers/render';
@@ -40,6 +41,7 @@ function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		project_name: 'Demo Project',
 		status: 'succeeded',
 		queued_reason: null,
+		created_at: '2024-01-01T00:00:00.000Z',
 		started_at: '2026-06-07T20:58:30Z',
 		finished_at: '2026-06-07T20:59:50Z',
 		exit_code: 0,
@@ -277,10 +279,11 @@ test('shows the empty state when the agent has no runs', async () => {
 	// Only the unfiltered view may claim the agent has never run. Every other
 	// view is hiding something by definition, so it says so instead - an agent
 	// whose runs all errored must not be described as having no runs at all.
-	const { findByText } = await renderExecutions([], { filter: RunOutcomeFilter.All });
+	// All is now the default, so the honest claim is the one the bare view makes.
+	const { findByText } = await renderExecutions([]);
 	await findByText('No executions yet.', undefined, { timeout: 20_000 });
 
-	const filtered = await renderExecutions([]);
+	const filtered = await renderExecutions([], { filter: RunOutcomeFilter.Errored });
 	await filtered.findByText('No executions match this filter.', undefined, { timeout: 20_000 });
 });
 
@@ -341,40 +344,44 @@ test('a cancelled run renders with the neutral status (no exit/cost suffixes)', 
 	expect(row.textContent).not.toContain('$');
 });
 
-test('the default view hides errored runs, and the pills reveal them', async () => {
+test('the default view shows every run, and the pills narrow to one outcome each', async () => {
 	const { findByRole, queryByRole, user, router } = await renderExecutions([
 		makeRun({ id: 'run-ok', status: 'succeeded', task_identifier: 'DEMO-OK' }),
 		makeRun({ id: 'run-bad', status: 'failed', exit_code: 1, task_identifier: 'DEMO-BAD' }),
 		makeRun({ id: 'run-slow', status: 'timed_out', task_identifier: 'DEMO-SLOW' }),
 	]);
 
-	// Default: the succeeded run only. `failed` and `timed_out` are both errored.
+	// Default: nothing hidden. A reader looking for a failure should not have to
+	// find a control first, and the back link from a run has to land somewhere
+	// that contains the run it came from whatever its outcome.
 	await findByRole('link', { name: /DEMO-OK/ }, { timeout: 20_000 });
-	expect(queryByRole('link', { name: /DEMO-BAD/ })).toBeNull();
-	expect(queryByRole('link', { name: /DEMO-SLOW/ })).toBeNull();
+	await findByRole('link', { name: /DEMO-BAD/ }, { timeout: 20_000 });
+	await findByRole('link', { name: /DEMO-SLOW/ }, { timeout: 20_000 });
+	expect(router.state.location.search).toEqual({});
 
 	await user.click(await findByRole('button', { name: 'Errored' }));
 	await findByRole('link', { name: /DEMO-BAD/ }, { timeout: 20_000 });
 	await findByRole('link', { name: /DEMO-SLOW/ }, { timeout: 20_000 });
-	// The complement: the clean run is the one hidden now.
 	expect(queryByRole('link', { name: /DEMO-OK/ })).toBeNull();
 	expect(router.state.location.search).toEqual({ filter: 'errored' });
 
-	await user.click(await findByRole('button', { name: 'All' }));
+	await user.click(await findByRole('button', { name: 'Succeeded' }));
 	await findByRole('link', { name: /DEMO-OK/ }, { timeout: 20_000 });
-	await findByRole('link', { name: /DEMO-BAD/ }, { timeout: 20_000 });
+	expect(queryByRole('link', { name: /DEMO-BAD/ })).toBeNull();
+	expect(router.state.location.search).toEqual({ filter: 'succeeded' });
 
 	// Back to the default, which is dropped from the URL rather than written -
-	// otherwise `?filter=runs` and no param are two cache entries of one view.
-	await user.click(await findByRole('button', { name: 'Runs' }));
-	await findByRole('link', { name: /DEMO-OK/ }, { timeout: 20_000 });
+	// otherwise `?filter=all` and no param are two cache entries of one view.
+	await user.click(await findByRole('button', { name: 'All' }));
+	await findByRole('link', { name: /DEMO-BAD/ }, { timeout: 20_000 });
 	expect(router.state.location.search).toEqual({});
 });
 
-test('a live queued run is never hidden by the default filter', async () => {
-	// The whole point of filtering on the outcome rather than on "did it start":
-	// a run that has not started yet is the most interesting row on the page.
-	const { findByRole } = await renderExecutions([
+test('Succeeded is strict - a live run and a cancelled one belong only to All', async () => {
+	// Not "everything that did not error". A run still queued has not succeeded,
+	// and one handed back for capacity was cancelled; neither belongs under a tab
+	// called Succeeded. Both are visible by default, which is the point of All.
+	const { findByRole, queryByRole, user } = await renderExecutions([
 		makeRun({
 			id: 'run-live',
 			status: 'queued',
@@ -383,10 +390,45 @@ test('a live queued run is never hidden by the default filter', async () => {
 			queued_reason: 'waiting for container capacity',
 			task_identifier: 'DEMO-LIVE',
 		}),
+		makeRun({ id: 'run-cx', status: 'cancelled', task_identifier: 'DEMO-CX' }),
 	]);
 
 	const row = await findByRole('link', { name: /DEMO-LIVE/ }, { timeout: 20_000 });
 	expect(row.textContent).toContain('queued');
+	await findByRole('link', { name: /DEMO-CX/ }, { timeout: 20_000 });
+
+	await user.click(await findByRole('button', { name: 'Succeeded' }));
+	await waitFor(() => expect(queryByRole('link', { name: /DEMO-LIVE/ })).toBeNull());
+	expect(queryByRole('link', { name: /DEMO-CX/ })).toBeNull();
+});
+
+test('a terminal run that never started is placed by its created_at, not labelled queued', async () => {
+	// The timestamp slot keyed on started_at alone read "queued" for every run
+	// that ended before it started, so an orphaned row said `failed … queued`.
+	const { findByRole } = await renderExecutions([
+		makeRun({
+			id: 'run-orphan',
+			status: 'cancelled',
+			started_at: null,
+			finished_at: '2024-01-02T00:00:00.000Z',
+			task_identifier: 'DEMO-ORPH',
+		}),
+	]);
+
+	const row = await findByRole('link', { name: /DEMO-ORPH/ }, { timeout: 20_000 });
+	expect(row.textContent).toContain('cancelled');
+	expect(row.textContent).not.toContain('queued');
+});
+
+test('a row carries the active filter through to the run detail link', async () => {
+	// So the detail page's back link can put the reader back where they were.
+	const { findByRole, user } = await renderExecutions([
+		makeRun({ id: 'run-bad', status: 'failed', task_identifier: 'DEMO-BAD' }),
+	]);
+
+	await user.click(await findByRole('button', { name: 'Errored' }));
+	const row = await findByRole('link', { name: /DEMO-BAD/ }, { timeout: 20_000 });
+	expect(row.getAttribute('href')).toContain('filter=errored');
 });
 
 test('the filter pills stay on screen when the filtered view is empty', async () => {
@@ -402,5 +444,5 @@ test('the filter pills stay on screen when the filtered view is empty', async ()
 	await findByText('No executions match this filter.', undefined, { timeout: 20_000 });
 	expect(queryByText('No executions yet.')).toBeNull();
 	// Still escapable.
-	await findByRole('button', { name: 'Runs' });
+	await findByRole('button', { name: 'All' });
 });

--- a/packages/web/test/agent-run-detail-realtime.test.tsx
+++ b/packages/web/test/agent-run-detail-realtime.test.tsx
@@ -1,0 +1,180 @@
+import { HeartbeatRunKind, RunOutcomeFilter } from '@hezo/shared';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { afterEach, expect, test } from 'vitest';
+import type { HeartbeatRun } from '../src/hooks/use-heartbeat-runs';
+import { invalidateQueriesForRowChange } from '../src/hooks/use-websocket';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+/**
+ * The run detail page has to reflect a run going terminal while it is open.
+ *
+ * A run parked waiting for container capacity sits `queued` for minutes, and the
+ * thing that ends it is a server-side sweep, not anything the reader did. If the
+ * page does not pick that up, the operator is left staring at "Waiting to
+ * start…" for a run that already finished, and has to reload to find out what
+ * happened - which is exactly what was reported.
+ */
+
+let restoreFetch: (() => void) | null = null;
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+});
+
+function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
+	return {
+		id: 'run-1',
+		member_id: 'm-1',
+		team_id: 't-1',
+		wakeup_id: null,
+		task_id: 'task-1',
+		kind: HeartbeatRunKind.Task,
+		task_identifier: 'INV-8',
+		task_title: 'Standing watch',
+		project_id: 'p-1',
+		project_slug: 'demo',
+		project_name: 'Demo',
+		status: 'queued',
+		queued_reason: null,
+		created_at: '2024-01-01T00:00:00.000Z',
+		started_at: null,
+		finished_at: null,
+		exit_code: null,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: null,
+		usage_partial: false,
+		invocation_command: null,
+		log_text: null,
+		working_dir: null,
+		trigger_source: null,
+		trigger_payload: null,
+		trigger_comment_id: null,
+		trigger_comment_public_id: null,
+		trigger_actor_member_id: null,
+		trigger_actor_slug: null,
+		trigger_actor_title: null,
+		trigger_comment_task_id: null,
+		trigger_comment_task_identifier: null,
+		trigger_comment_project_slug: null,
+		run_comment_id: null,
+		run_comment_public_id: null,
+		created_tasks: [],
+		created_docs: [],
+		created_skills: [],
+		proposed_skills: [],
+		...overrides,
+	};
+}
+
+/** Serves whatever `current.run` holds, so a test can flip it mid-render. */
+function installRunDetailMock(agentId: string, current: { run: HeartbeatRun }) {
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+		if (
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/${agentId}/heartbeat-runs/[^/?]+`).test(url)
+		) {
+			return new Response(JSON.stringify({ data: current.run }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return original(input as RequestInfo, init);
+	}) as typeof fetch;
+}
+
+test('a run going terminal server-side reaches the open detail page without a reload', async () => {
+	const current = { run: makeRun({}) };
+	const seeded = { projectSlug: '', agentId: '', memberId: '' };
+
+	const { router, findByText } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Realtime Project' });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			seeded.memberId = captain.id;
+			current.run = makeRun({ member_id: captain.id, project_slug: project.slug });
+			installRunDetailMock(captain.id, current);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions/$runId',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId, runId: 'run-1' },
+		search: { filter: RunOutcomeFilter.Errored },
+	});
+
+	// Parked: no start time, so the page says so and shows no error.
+	await findByText('Waiting to start…', undefined, { timeout: 20_000 });
+
+	// The sweep runs. The row goes terminal and the server broadcasts the change
+	// with the payload the orphan detector actually sends.
+	current.run = makeRun({
+		member_id: seeded.memberId,
+		project_slug: seeded.projectSlug,
+		status: 'cancelled',
+		finished_at: '2024-01-01T00:05:00.000Z',
+		error: 'Never started: no host process was driving this run.',
+	});
+	invalidateQueriesForRowChange(queryClient, seeded.projectSlug, 'heartbeat_runs', {
+		id: 'run-1',
+		member_id: seeded.memberId,
+		task_id: 'task-1',
+		project_id: 'p-1',
+		status: 'cancelled',
+	});
+
+	await findByText(/Never started/, undefined, { timeout: 20_000 });
+});
+
+test('the back link returns to the filtered view the reader came from', async () => {
+	const current = { run: makeRun({ status: 'failed', error: 'Boom' }) };
+	const seeded = { projectSlug: '', agentId: '' };
+
+	const { router, container, findByText } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Back Link Project' });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			current.run = makeRun({
+				member_id: captain.id,
+				project_slug: project.slug,
+				status: 'failed',
+				error: 'Boom',
+			});
+			installRunDetailMock(captain.id, current);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions/$runId',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId, runId: 'run-1' },
+		search: { filter: RunOutcomeFilter.Errored },
+	});
+
+	// Wait for the run itself to land, so the back link is the rendered one.
+	await findByText(/Boom/, undefined, { timeout: 20_000 });
+
+	// Targeted by testid, not by name: the agent layout renders its own
+	// "Executions" folder tab, which points at the unfiltered list and would
+	// satisfy a name-based query while telling us nothing about this link.
+	//
+	// Without the carried filter this href drops `?filter=errored`, landing the
+	// reader on a view that need not contain the run they just left.
+	const back = container.querySelector('[data-testid="run-back-link"]');
+	expect(back?.getAttribute('href')).toContain('filter=errored');
+});

--- a/packages/web/test/run-trigger.test.ts
+++ b/packages/web/test/run-trigger.test.ts
@@ -22,6 +22,7 @@ function run(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		project_name: 'Web App',
 		status: 'succeeded',
 		queued_reason: null,
+		created_at: '2024-01-01T00:00:00.000Z',
 		started_at: null,
 		finished_at: null,
 		exit_code: 0,

--- a/test/browser/run-trigger-reason.spec.ts
+++ b/test/browser/run-trigger-reason.spec.ts
@@ -241,11 +241,11 @@ test('run list row shows the trigger reason summary', async ({ page }) => {
 		(r) => r.trigger_source !== null,
 	);
 
-	// `filter=all`: the list hides errored runs by default, and a run in this
-	// environment has no real model provider to reach, so it ends `failed`. What
-	// this test is about is the trigger-reason summary on a row, not which rows
-	// the default view shows.
-	await page.goto(`/projects/${project.slug}/agents/${captain.id}/executions?filter=all`);
+	// The default view is All, so no filter is needed to reach the row: a run in
+	// this environment has no real model provider to reach and ends `failed`.
+	// What this test is about is the trigger-reason summary on a row, not which
+	// rows a given view shows.
+	await page.goto(`/projects/${project.slug}/agents/${captain.id}/executions`);
 
 	const firstRow = page.locator('a[href*="/executions/"]').first();
 	await expect(firstRow).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## What

The Executions list opened on a view that **hid errored runs**, and the run detail page's back link carried no filter - so opening a failed run and coming back landed on a view that did not contain it.

- The list now opens on **All**, with pills **All / Succeeded / Errored**.
- **Succeeded is strict** - the `succeeded` status alone, not "everything that did not error", which had put a cancelled run under a tab called Succeeded. A live or cancelled run belongs to neither narrow view, which is why All is the default rather than a way to see extra rows.
- A row carries the active filter into the detail link, and the back link restores it - falling through to All when absent (a deep link, or a run reached from a goal or a comment).

## The `failed … queued` row

The timestamp slot keyed on `started_at` alone, and a run that ended before it started has none, so the word meant to mark a live run appeared on terminal ones. It is now placed by `created_at` - which the list route never selected, though its `ORDER BY` already relied on it - and `queued` is reserved for a genuinely live run.

## Orphaned runs

The orphan pass gave one verdict to two different events:

| | Before | After |
|---|---|---|
| `running`, process vanished mid-flight | `Failed` | `Failed` (unchanged - work was lost) |
| `queued`, never started | `Failed`, fresh retry wakeup each pass | `Cancelled`, **original wakeup handed back** |

A run that never started produced nothing and lost nothing. Failing it filled the Errored view with rows nobody could act on, and minted a new wakeup on every pass rather than returning the one already sitting there claimed. It is now finalized `Cancelled` with the wakeup returned (`claimed` → `queued`, mirroring `settleWakeupForRun`) and no strike spent against the lost-run escalation. The verdict also carries the tail of the run's own log, so the detail page says *why* it never started instead of only that it did not.

## Why that verdict matters for the capacity park

`CAPACITY_PARK_MAX_MS` (180s) deliberately exceeds `STALE_STATE_GRACE_SECONDS` (120s), safe only because the pass skips ids in the live-run registry - and that registry is **in-memory**, so a restart mid-park hands every parked row straight to it with no driver to vouch for it. A restart is also when the pool is cold and capacity tightest, so the two coincide rather than being independent. The park ceiling is unchanged; a new `capacity-park-grace` test pins the constant relationship so neither can move without meeting the assumption.

## Realtime

The pass broadcast a project derived from the run's task, so a **task-less** run (a progress-update run) emitted a row the client cannot map to a project and skips wholesale (`PROJECT_STRICT_TABLES`) - those reaps reached no open page at all. It now falls back to the run's own team, which owns exactly one project. A new component test drives a row-change at an open detail page and asserts the error appears without a remount.

## Tests

- `run-outcome-filter.test.ts` - Succeeded is strict; the three options no longer partition the statuses
- `heartbeat-runs.test.ts` - `filter=succeeded` excludes live and cancelled; the predicate stays on both the count and the page; `created_at` is sent
- `orphan-detector.test.ts` - split verdicts, wakeup handed back rather than duplicated, retry counter untouched, real cause in the error, task-less broadcast carries a project, park-vs-grace pin
- `agent-executions-list.test.tsx` - All default, three pills, strict Succeeded, terminal-never-started row shows a time, row carries the filter
- `agent-run-detail-realtime.test.tsx` (new) - terminal transition reaches the open page; back link restores the filter

Verified locally: `typecheck`, `biome`, `build`, shared tier (367), the affected server suites (104), and the executions/run web suites (63). Full browser tier and the gated Postgres/S3 legs left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_0195i7upG2mT5h8ujRCtfMmx)_