### PR TITLE
fix(runs): stop a config error becoming an unbounded retry storm

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2277,8 +2277,12 @@ against `created_at` (the 120 s grace window, which spans the whole not-yet-star
 Both arms are guarded by the in-process live-run registry — the run id is registered the
 moment the row is inserted, so a run whose host-side driver still owns it (waiting on the
 credential lock, say) is skipped and only a row whose driver has vanished is failed. The two
-kinds are distinguished only by their recorded `error` (`Orphaned: run never started` vs
-`Orphaned: process no longer running`); the retry/approval escalation is shared.
+kinds are distinguished only by their recorded `error` (`Never started: …` vs
+`Orphaned: nothing was driving this run any more …`); the retry/approval escalation is
+shared. Neither verdict claims a process check - there is none to make, since `process_pid`
+is written nowhere and liveness is the in-process registry alone. The reap `UPDATE` is
+guarded on a non-terminal status, so a row that settled between the scan and the write keeps
+the cause its own writer recorded rather than being overwritten with the generic one.
 `healStaleRunState` is the inverse pass and deliberately counts `queued` as active, so it
 repairs the *surroundings* (execution locks, agent `runtime_status`, claimed wakeups) but
 never the run row itself.

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2292,8 +2292,8 @@ moment the row is inserted, so a run whose host-side driver still owns it (waiti
 credential lock, say) is skipped and only a row whose driver has vanished is failed. The two
 kinds are distinguished only by their recorded `error` (`Never started: …` vs
 `Orphaned: nothing was driving this run any more …`); the retry/approval escalation is
-shared. Neither verdict claims a process check - there is none to make, since `process_pid`
-is written nowhere and liveness is the in-process registry alone. The reap `UPDATE` is
+shared. Neither verdict claims a process check - there is none to make, since a run's work
+happens inside a container and liveness is the in-process registry alone. The reap `UPDATE` is
 guarded on a non-terminal status, so a row that settled between the scan and the write keeps
 the cause its own writer recorded rather than being overwritten with the generic one.
 `healStaleRunState` is the inverse pass and deliberately counts `queued` as active, so it
@@ -3039,9 +3039,12 @@ gate that blocks the agent from ending its turn with unfinished work.
 
 **Sessions & recovery.** `agent_task_sessions` persists per-task session state; each
 heartbeat spawns a fresh subprocess and injects handoff markdown from the prior session,
-with compaction policies rotating on token/run/age thresholds. The orphan detector uses
-`heartbeat_runs.process_pid`/`retry_of_run_id`/`process_loss_retry_count` to recover runs
-whose process disappeared. A ~30 s sweep (`processBudgetResumes`) lifts budget-paused
+with compaction policies rotating on token/run/age thresholds. The orphan detector recovers
+runs whose driver disappeared, bounded by `heartbeat_runs.process_loss_retry_count` - which
+a retried run inherits from the run named in `retry_of_run_id`, so the chain reaches its
+ceiling instead of restarting at zero every lap. `process_pid` was dropped in migration 062:
+it was never written, because a run's work happens in a container and there is no host pid
+to record. A ~30 s sweep (`processBudgetResumes`) lifts budget-paused
 agents back to `idle` once a window rolls over or a limit is raised.
 
 ---

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1877,17 +1877,30 @@ and a fresh one be built.
   wedged instance, not a slow one. `findStaleIdleMembers` asks the member-shaped question
   instead, clocked on `last_released_at` (made total and indexed by migration 053; the old
   clock was `projects.container_last_started_at`, so starting any container reset the timer
-  for every idle sibling). It fires only for projects that have a `busy` member - a fully
-  idle project still belongs to the whole-project pass, which keeps one member suspended for
-  a warm restart.
+  for every idle sibling). It fires for **every** project. It used to require a `busy`
+  member, leaving a fully idle project to the whole-project pass and its warm-start
+  guarantee - but the two preconditions did not partition the space: a project whose runs
+  last seconds is never quiet (queued wakeups and recent finishes keep it out of the
+  project-shaped pass) and rarely busy when the once-a-minute cron samples it, so its idle
+  members matched neither and pinned the budget indefinitely. The warm-start floor now lives
+  in the planner, where it is a property of the plan rather than of which pass ran: one
+  member is held back and suspended only when nothing else - a busy, suspended or pinned
+  member - could serve the project's next run.
 - **Cross-project reclaim** (`planCrossProjectReclaim`, the `reclaim` rung of
   `selectPoolMember`). Closes the gap in between: rather than queue behind memory a
   neighbour is demonstrably not using, a blocked acquire retires enough of other projects'
   idle members to cover its shortfall. All-or-nothing (freeing part of the shortfall helps
   nobody and has destroyed a warm container to do it), only as much as the shortfall,
-  hoarder-first then longest-idle, and floored at `CONTAINER_RECLAIM_MIN_IDLE_SEC` so a
-  project mid-burst is not stripped of a container it is about to reuse - which is also what
-  stops two starved projects reclaiming from each other in a loop.
+  hoarder-first then longest-idle, and floored on two clocks:
+  `CONTAINER_RECLAIM_MIN_IDLE_SEC` so a project mid-burst is not stripped of a container it
+  is about to reuse, and `CONTAINER_RECLAIM_MIN_AGE_SEC` so a container the instance only
+  just paid a cold provision for is not retired to fund another cold provision elsewhere.
+  Between them they stop two starved projects reclaiming from each other in a loop. A
+  candidate is **suspended rather than destroyed** whenever taking it would leave its
+  project with nothing resumable, as well as when it holds unpushed commits: both free
+  identical budget memory, since a suspended member is not counted, so destroying buys the
+  requester nothing and costs the victim a full cold provision. Bounded at one suspended
+  member per project by construction.
 
 **Both dispatch gates count reclaimable memory as headroom, and must.** The gate runs *before*
 the pool, so leaving it out meant the run was skipped as `InstanceAtCapacity` and the reclaim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | A chat platform | `ChatChannelAdapter` (`services/chat-channels/`) |
 | A host-side call to a repo's git host, with that repo's own credential | `resolveRepoGitHub` (`services/repo-github.ts`) - returns a verdict, never an upstream body |
 | "Did this execution strand a handoff?" | `detectNoWakeExits` (`services/comment-wakeups.ts`) |
+| "Is this run failure worth another attempt?" | `classifyRunFailure` (`services/run-failure-classification.ts`) - unrecognised is permanent, and no row may name a backend |
 | Waking the assignee after an assignment write | `wakeAgentIfAssigned` (`services/wakeup.ts`) |
 | "May this caller move this task's assignee?" | `assertNoBlockingRun` (`lib/reassign-guard.ts`) - not the one-run-per-task check, which is `isTaskBusyInDb` (`services/run-concurrency.ts`) |
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |

--- a/packages/server/migrations/062_drop_vestigial_process_pid.sql
+++ b/packages/server/migrations/062_drop_vestigial_process_pid.sql
@@ -1,0 +1,17 @@
+-- Drop `heartbeat_runs.process_pid`.
+--
+-- It has never been written. A run's work happens inside a container, exec'd
+-- through the engine seam, so there is no host pid to record - liveness is the
+-- in-process live-run registry plus the `HEZO_HEARTBEAT_RUN_ID` env marker every
+-- reap path keys on. The column was nonetheless selected into the agent-run API
+-- projection, so every row of a list of up to 200 shipped a permanently-null
+-- field that read like liveness tracking.
+--
+-- Fixed-width, so unlike migration 041's `log_text` there is no TOAST graveyard
+-- and no VACUUM follow-up.
+--
+-- `retry_of_run_id` is deliberately kept: it was equally unwritten until this
+-- release, and now records which run a retry replaces, which is what bounds the
+-- lost-run chain.
+
+ALTER TABLE heartbeat_runs DROP COLUMN IF EXISTS process_pid;

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -132,7 +132,7 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 	hr.status, hr.queued_reason, hr.created_at, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
 	hr.input_tokens, hr.output_tokens, hr.cost_cents, hr.usage_partial,
 	hr.invocation_command, hr.working_dir,
-	hr.process_pid, hr.retry_of_run_id, hr.process_loss_retry_count,
+	hr.retry_of_run_id, hr.process_loss_retry_count,
 	i.identifier AS task_identifier, i.title AS task_title,
 	i.project_id AS project_id, p.slug AS project_slug, p.name AS project_name,
 	aw.source AS trigger_source,

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -67,6 +67,15 @@ const MAX_BATCH_TASKS = 50;
  */
 const LATEST_RUN_LOG_TAIL_CHARS = 64 * 1024;
 
+/**
+ * Outer bound on `heartbeat_runs.error` in a task projection.
+ *
+ * The column has no schema ceiling - a runner failure can carry a stack, the
+ * orphan pass appends a log tail - and the client renders only its first line
+ * (`runErrorSummary`). The single-run read serves the whole value.
+ */
+const LAST_RUN_ERROR_MAX_CHARS = 400;
+
 async function buildCreateTaskCaller(c: Context<Env>, teamId: string): Promise<CreateTaskCaller> {
 	const auth = c.get('auth');
 	const actorMemberId = await resolveAuthActorMemberId(c.get('db'), auth, teamId);
@@ -319,6 +328,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
               'queued_reason', ar.queued_reason
             ) ELSE NULL END AS active_run,
             lr.status AS last_run_status,
+            left(lr.error, ${LAST_RUN_ERROR_MAX_CHARS}) AS last_run_error,
             lr.run_id AS last_run_id,
             lr.comment_id AS last_run_comment_id,
             lr.comment_public_id AS last_run_comment_public_id,
@@ -351,7 +361,8 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        LIMIT 1
      ) qw ON true
      LEFT JOIN LATERAL (
-       SELECT hr.id AS run_id, hr.status, hrc.id AS comment_id, hrc.public_id AS comment_public_id
+       SELECT hr.id AS run_id, hr.status, hr.error, hrc.id AS comment_id,
+              hrc.public_id AS comment_public_id
        FROM heartbeat_runs hr
        LEFT JOIN task_comments hrc
          ON hrc.task_id = hr.task_id

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -140,6 +140,9 @@ export function buildUpdatesRoutes(opts: { autoUnlock: boolean }): Hono<Env> {
 			// the unlock after the update restart.
 			autoUnlock: opts.autoUnlock || (isSupervisedWorker() && typeof process.send === 'function'),
 			canApply: isSupervisedWorker(),
+			// The same count the auto-install cron defers on, so the banner and the
+			// scheduler agree on what "busy" means.
+			runsInFlight: c.get('jobManager')?.inFlightRunCount() ?? 0,
 		});
 	});
 
@@ -175,6 +178,16 @@ export function buildUpdatesRoutes(opts: { autoUnlock: boolean }): Hono<Env> {
 		const state = await readUpdateState(dataDir);
 		if (state.state !== UpdateState.Staged) {
 			return err(c, 'NO_STAGED_UPDATE', 'No staged update to apply', 409);
+		}
+		// Deliberately does not refuse. The auto-install cron defers on in-flight
+		// work because nobody asked it to restart now; an operator pressing the
+		// button did, and the drain in `shutdownRuntime` is what makes that safe.
+		// Logged so an operator restart is attributable in the journal.
+		const inFlight = c.get('jobManager')?.inFlightRunCount() ?? 0;
+		if (inFlight > 0) {
+			log.warn(
+				`Applying update with ${inFlight} agent run(s) in flight; they will be drained, then re-queued`,
+			);
 		}
 		setTimeout(() => {
 			void exitToApplyUpdate();

--- a/packages/server/src/runtime-control.ts
+++ b/packages/server/src/runtime-control.ts
@@ -13,6 +13,16 @@ const log = logger.child('runtime');
 let active: StartupResult | null = null;
 let shuttingDown = false;
 
+/**
+ * How long shutdown waits for in-flight runs to write a terminal row.
+ *
+ * Sized against the documented systemd `TimeoutStopSec=30`: the in-container
+ * reap above it is bounded at 8s, and the closes below it need room too, so this
+ * plus both must fit inside that budget or the supervisor SIGKILLs mid-write.
+ * Lowering one without the other is what breaks it.
+ */
+const RUN_DRAIN_DEADLINE_MS = 10_000;
+
 export function setActiveRuntime(result: StartupResult): void {
 	active = result;
 }
@@ -33,9 +43,27 @@ export async function shutdownRuntime(result: StartupResult): Promise<void> {
 	// path's own kill is fire-and-forget and would race process.exit, stranding
 	// the agent CLIs in the warm containers until the next boot sweep. Bounded
 	// internally so a dead Docker socket can't wedge shutdown.
+	// Stop scheduling first, or the 5s wakeup cron keeps handing fresh runs to a
+	// process on its way out and the drain below never converges.
+	result.jobManager.stopAcceptingWork();
 	await result.jobManager
 		.killLiveRunProcesses()
 		.catch((err) => log.warn('live-run process reap during shutdown failed', err));
+	// Then give the aborts somewhere to land. Without this the registries were
+	// cleared synchronously and the DB closed while the runs just cancelled were
+	// still writing their terminal rows, so a clean restart looked to the next
+	// boot exactly like a crash.
+	const stranded = await result.jobManager.drainRunningRuns(RUN_DRAIN_DEADLINE_MS).catch((err) => {
+		log.warn('run drain during shutdown failed', err);
+		return [];
+	});
+	if (stranded.length > 0) {
+		log.warn(
+			`Shutdown: ${stranded.length} run(s) still in flight after ${RUN_DRAIN_DEADLINE_MS}ms; ` +
+				`startup reconciliation will fail and re-queue them: ` +
+				stranded.map((r) => `${r.runId}${r.taskId ? ` (task ${r.taskId})` : ''}`).join(', '),
+		);
+	}
 	result.jobManager.shutdown();
 	await result.chatSessionManager.stop();
 	await result.egressProxy.releaseAll();

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1182,6 +1182,42 @@ function abortErrorMessage(reason: RunAbortReason | null): string | undefined {
 	return reason ?? undefined;
 }
 
+/**
+ * Where each recovery records the run it is replacing, and whether that
+ * recovery draws on the lost-run retry budget.
+ *
+ * Three paths mint a replacement run and each names the prior run under its own
+ * key. One reader, so a fourth spelling is a row here rather than a branch at
+ * the call site.
+ */
+const RUN_LINEAGE_SOURCES: readonly {
+	read: (p: Record<string, unknown>) => unknown;
+	inheritsLossBudget: boolean;
+}[] = [
+	// The orphan pass's retry - the only one bounded by the lost-run ceiling.
+	{
+		read: (p) => (p.previous_failure as Record<string, unknown> | undefined)?.run_id,
+		inheritsLossBudget: true,
+	},
+	// A container coming back, and startup recovery. One-shot.
+	{ read: (p) => p.previous_run_id, inheritsLossBudget: false },
+	// A human pressing Retry. Somebody is asking for another attempt.
+	{ read: (p) => p.source_run_id, inheritsLossBudget: false },
+];
+
+export function extractReplacedRun(
+	payload: Record<string, unknown> | undefined,
+): ReplacedRun | null {
+	if (!payload) return null;
+	for (const source of RUN_LINEAGE_SOURCES) {
+		const id = source.read(payload);
+		if (typeof id === 'string') {
+			return { runId: id, inheritsLossBudget: source.inheritsLossBudget };
+		}
+	}
+	return null;
+}
+
 function extractTriggeredBy(payload: Record<string, unknown> | undefined): TriggeredBy | null {
 	const raw = payload?.triggered_by;
 	if (!raw || typeof raw !== 'object') return null;
@@ -1256,6 +1292,7 @@ export async function runAgent(
 		effectiveWakeupId,
 		extractTriggeredBy(wakeupPayload),
 		progressUpdate ? HeartbeatRunKind.ProgressUpdate : HeartbeatRunKind.Task,
+		extractReplacedRun(wakeupPayload),
 	);
 	const onContainerAcquired = onRunRegistered?.(heartbeatRunId);
 	await emitRunStarted(deps, heartbeatRunId, agent, task, project, effectiveWakeupId);
@@ -1424,6 +1461,7 @@ export async function runAgent(
 				runId: heartbeatRunId,
 				memberId: agent.id,
 				teamId: runTeamId,
+				taskId: task?.id ?? null,
 				priorRetries: Math.max(0, (bumped.rows[0]?.process_loss_retry_count ?? 1) - 1),
 			});
 		} catch (e) {
@@ -4150,6 +4188,19 @@ export interface TriggeredBy {
 	name: string;
 }
 
+/**
+ * The run this one replaces, and whether it inherits that run's retry budget.
+ *
+ * Only the lost-run chain spends the budget. A container coming back, a server
+ * restart and a human pressing Retry are one-shot recoveries already bounded by
+ * their own guards - none can feed itself, so none may be throttled by a ceiling
+ * the lost-run chain filled.
+ */
+export interface ReplacedRun {
+	runId: string;
+	inheritsLossBudget: boolean;
+}
+
 export async function createHeartbeatRun(
 	db: Db,
 	agent: AgentInfo,
@@ -4159,13 +4210,38 @@ export async function createHeartbeatRun(
 	wakeupId: string,
 	triggeredBy: TriggeredBy | null = null,
 	kind: HeartbeatRunKind = HeartbeatRunKind.Task,
+	replaces: ReplacedRun | null = null,
 ): Promise<string> {
 	const { runId, statusFlippedToInProgress } = await withTransaction(db, async () => {
+		// The retry budget is read from the replaced **row**, not from the wakeup
+		// payload that named it. Both columns existed and neither was ever written:
+		// `retry_of_run_id` had no writer at all, and a retried run took the schema
+		// default of 0 for `process_loss_retry_count` - so `priorRetries` was always
+		// 0, `0 + 1 < MAX_RETRIES` was always true, and the escalation branch in
+		// `retryOrEscalateLostRun` could not be reached. The chain had no end.
+		//
+		// Reading the row rather than the payload is what makes the ceiling
+		// unforgeable: a coalesced or hand-edited `retry_count` cannot reset it, and
+		// the worst a wrong `run_id` can do is name a real run and inherit its count.
 		const runResult = await db.query<{ id: string }>(
-			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status, kind)
-			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status, $6::heartbeat_run_kind)
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status, kind,
+			                             retry_of_run_id, process_loss_retry_count)
+			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status, $6::heartbeat_run_kind, $7,
+			         CASE WHEN $8::boolean
+			              THEN COALESCE((SELECT prior.process_loss_retry_count
+			                               FROM heartbeat_runs prior WHERE prior.id = $7), 0)
+			              ELSE 0 END)
 			 RETURNING id`,
-			[agent.id, runTeamId, task?.id ?? null, wakeupId, HeartbeatRunStatus.Queued, kind],
+			[
+				agent.id,
+				runTeamId,
+				task?.id ?? null,
+				wakeupId,
+				HeartbeatRunStatus.Queued,
+				kind,
+				replaces?.runId ?? null,
+				replaces?.inheritsLossBudget ?? false,
+			],
 		);
 		const runId = runResult.rows[0].id;
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -2604,6 +2604,63 @@ export async function runAgent(
 				timedOut: reason === 'run_timeout',
 			};
 		}
+	} catch (error) {
+		// Every throw between the container claim and the exec lands here: the
+		// credential lock, `markHeartbeatRunRunning`, the run-user probe, the ssh and
+		// egress allocations, the connector load, the tunnel, `buildRunContext`.
+		//
+		// Before this the only handler was the `finally` below. It released the run's
+		// resources and let the error leave `runAgent`, so the row stayed `running`
+		// with no error on it - and nothing downstream could then tell the truth.
+		// `postFailurePing` reads the row and returns early on a non-terminal status,
+		// so the task thread said nothing at all, and 30s later the orphan pass
+		// recorded that the process was no longer running when the process was alive
+		// and had thrown. The row is the record of what happened, so it is written
+		// here, by the code that holds the actual error.
+		//
+		// Returning rather than rethrowing is load-bearing: it routes into the
+		// job manager's normal completion path, so the wakeup settles, the failure
+		// ping fires and the next task is chained - all against a terminal row.
+		//
+		// `cleanupRunArtifacts` is deliberately not called: it is declared inside the
+		// exec block and is not in scope. The `finally` below is what releases the
+		// tunnel, both host ports and the container claim on this path, which is the
+		// job it was written for.
+		const verdict = throwVerdict(error);
+		const durationMs = Date.now() - startTime;
+		log.error(`Run ${heartbeatRunId} failed before the agent could start:`, error);
+		emit('stderr', `\n[runner] ${verdict.message}\n`);
+		await deps.logs.end(streamId);
+		await updateHeartbeatRun(
+			deps.db,
+			heartbeatRunId,
+			{
+				status: verdict.status,
+				exitCode: -1,
+				durationMs,
+				error: verdict.message,
+			},
+			runBroadcast,
+		);
+		// Only a failure the infrastructure caused earns a recovery retry. A
+		// configuration error reproduces identically on every attempt, and the retry
+		// that used to be minted for one - by the orphan pass, on a row this path had
+		// abandoned - turned a single bad MCP injection into hundreds of failed runs
+		// on one task, each having claimed a container first.
+		if (
+			verdict.status === HeartbeatRunStatus.Failed &&
+			classifyRunFailure(error) === RunFailureClass.Transient
+		) {
+			await spendLostRunStrike();
+		}
+		return {
+			success: false,
+			exitCode: -1,
+			stderr: verdict.message,
+			durationMs,
+			heartbeatRunId,
+			timedOut: verdict.timedOut,
+		};
 	} finally {
 		releaseCredentialLock?.();
 		// These outlive every explicit cleanup path above, so this is the only
@@ -2621,6 +2678,23 @@ export async function runAgent(
 			[
 				'egress-proxy',
 				() => (egressProxyAllocated ? deps.egressProxy?.releaseRunProxy(heartbeatRunId) : null),
+			],
+			[
+				// A scrub, not tidiness: the per-run home carries the run CLI's own
+				// model-provider credential in plaintext, the one exception to the rule
+				// that no confidential value enters a run. `cleanupRunArtifacts` removes
+				// it on every path that reaches it, but it is declared inside the exec
+				// block and reads `context` - so a throw in setup, where the files are
+				// already written, left the credential on a container the pool hands to
+				// the next run. Derived rather than read off `context` for that reason;
+				// both home builders produce this same directory.
+				'per-run-home',
+				async () => {
+					if (!containerId) return;
+					const dir = getContainerSubscriptionRootImpl(provider, runtimeType, heartbeatRunId);
+					if (!dir) return;
+					await deps.docker.files(containerId, dir).removeDir('.');
+				},
 			],
 			['pool-container', () => releaseContainer()],
 		] as const) {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1096,14 +1096,29 @@ export type ContainerExitAbortReason = 'container_error' | 'container_stopped';
  * task, post a comment, or record anything at all. The container is still alive,
  * so no `container_*` transition fires and nothing else would notice.
  */
-export type RunAbortReason = ContainerExitAbortReason | 'run_timeout' | 'tunnel_lost';
+export type RunAbortReason =
+	| ContainerExitAbortReason
+	| 'run_timeout'
+	| 'tunnel_lost'
+	| 'server_shutdown';
 
 const RUN_ABORT_REASONS: readonly string[] = [
 	'container_error',
 	'container_stopped',
 	'run_timeout',
 	'tunnel_lost',
+	'server_shutdown',
 ];
+
+/**
+ * What a run killed by a clean shutdown records.
+ *
+ * Deliberately distinguishable from `reconcileOnStartup`'s "Server restarted
+ * while run in flight": this one means the drain saw it coming, that one means
+ * it did not. Which of the two a run wears says whether the shutdown was orderly.
+ */
+export const RUN_LOST_TO_SHUTDOWN_ERROR =
+	'Server shut down while this run was in flight; it will be re-queued when Hezo comes back.';
 
 function runAbortReason(signal?: AbortSignal): RunAbortReason | null {
 	const reason = signal?.reason as unknown;
@@ -1183,6 +1198,7 @@ function sleepUnlessAborted(ms: number, signal: AbortSignal): Promise<void> {
 /** Error string stamped on an aborted run row — a friendly line for a timeout, else the raw reason. */
 function abortErrorMessage(reason: RunAbortReason | null): string | undefined {
 	if (reason === 'run_timeout') return 'run reached its time limit';
+	if (reason === 'server_shutdown') return RUN_LOST_TO_SHUTDOWN_ERROR;
 	if (reason === 'tunnel_lost')
 		return (
 			'the run tunnel to the container closed mid-run, so the agent lost its Hezo tools, ' +

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -127,6 +127,7 @@ import { loadReactionsForTask, type ReactionGroup } from './reactions';
 import { checkRepoCommitMerged } from './repo-github';
 import { ensureProjectRepos } from './repo-sync';
 import { CAPACITY_PARK_QUEUED_REASON, projectContainerMemoryGb } from './run-concurrency';
+import { classifyRunFailure, RunFailureClass } from './run-failure-classification';
 import {
 	buildSubscriptionMount as buildSubscriptionMountImpl,
 	ensureRuntimeHomeDir,
@@ -142,7 +143,6 @@ import {
 import { resolveRuntimeForTask } from './runtime-resolver';
 import { createBundleVault } from './sandbox/bundle-vault';
 import type { RunEndpoints } from './sandbox/endpoints';
-import { ExecStreamLostError } from './sandbox/errors';
 import type { SandboxFiles } from './sandbox/files';
 import { dockerSandboxHandle } from './sandbox/handle';
 import { setPoolMemberDiskUsage, setPoolMemberUnpushedFlag } from './sandbox/pool-db';
@@ -1373,6 +1373,64 @@ export async function runAgent(
 		};
 	};
 
+	/**
+	 * The terminal verdict for a thrown run failure.
+	 *
+	 * The **signal** decides the status, not the shape of the thrown error. Only
+	 * Docker's exec reliably rejects with an `AbortError` when its attach is torn
+	 * down; a managed backend's exec may reject with anything or resolve outright,
+	 * and keying on the error name there recorded a timed-out run as `failed` while
+	 * still stamping it with the timeout's own message - measured against the live
+	 * Daytona API. An error with no abort reason behind it is a genuine failure; a
+	 * bare abort (user cancel, shutdown) is still `cancelled`.
+	 *
+	 * Shared with the setup window, which needs the same answer: a shutdown landing
+	 * inside `buildRunContext` is a cancellation, not a failure, and recording it as
+	 * one would put an unactionable row in the Errored view on every restart.
+	 */
+	const throwVerdict = (
+		error: unknown,
+	): { status: HeartbeatRunStatus; message: string; timedOut: boolean } => {
+		const isAbort = error instanceof Error && error.name === 'AbortError';
+		const reason = runAbortReason(runAbort.signal);
+		return {
+			status: reason
+				? abortedRunStatus(reason)
+				: isAbort
+					? HeartbeatRunStatus.Cancelled
+					: HeartbeatRunStatus.Failed,
+			message:
+				abortErrorMessage(reason) ?? (error instanceof Error ? error.message : String(error)),
+			timedOut: reason === 'run_timeout',
+		};
+	};
+
+	/**
+	 * Spend one strike of the lost-run budget, then retry or escalate.
+	 *
+	 * Counted the way the orphan detector counts it, so a transport loss, a failed
+	 * tunnel start and a vanished driver converge on one ceiling rather than each
+	 * retrying forever. Best-effort: failing to queue the retry must never replace
+	 * the real error already on the row.
+	 */
+	const spendLostRunStrike = async (): Promise<void> => {
+		try {
+			const bumped = await deps.db.query<{ process_loss_retry_count: number }>(
+				`UPDATE heartbeat_runs SET process_loss_retry_count = process_loss_retry_count + 1
+				 WHERE id = $1 RETURNING process_loss_retry_count`,
+				[heartbeatRunId],
+			);
+			await retryOrEscalateLostRun(deps.db, {
+				runId: heartbeatRunId,
+				memberId: agent.id,
+				teamId: runTeamId,
+				priorRetries: Math.max(0, (bumped.rows[0]?.process_loss_retry_count ?? 1) - 1),
+			});
+		} catch (e) {
+			log.error(`Run ${heartbeatRunId}: could not queue a transport retry:`, e);
+		}
+	};
+
 	let provider: AiProvider;
 	let runtimeType: AgentRuntime;
 	// Null on the agent-override path: the override names only a provider, and
@@ -2483,20 +2541,9 @@ export async function runAgent(
 			const durationMs = Date.now() - startTime;
 			const isAbort = (error as Error).name === 'AbortError';
 			const reason = runAbortReason(runAbort.signal);
-			const errorMessage = abortErrorMessage(reason) ?? (error as Error).message;
-			// The **signal** decides the status, not the shape of the thrown error.
-			// Only Docker's exec reliably rejects with an `AbortError` when its
-			// attach is torn down; a managed backend's exec may reject with
-			// anything or resolve outright, and keying on the error name there
-			// recorded a timed-out run as `failed` while still stamping it with the
-			// timeout's own message - measured against the live Daytona API. An
-			// error with no abort reason behind it is a genuine failure; a bare
-			// abort (user cancel, shutdown) is still `cancelled`.
-			const status = reason
-				? abortedRunStatus(reason)
-				: isAbort
-					? HeartbeatRunStatus.Cancelled
-					: HeartbeatRunStatus.Failed;
+			// Same verdict the setup window records, from one implementation - see
+			// `throwVerdict`, which carries the reasoning.
+			const { status, message: errorMessage } = throwVerdict(error);
 
 			// Aborting the exec only tears down its attach stream — Docker leaves the
 			// agent CLI running in the container, so a user-terminated or timed-out run
@@ -2540,28 +2587,12 @@ export async function runAgent(
 			// has a bounded retry that carries the previous attempt's log tail
 			// forward and escalates to an approval once it stops being worth
 			// retrying - so it takes that path instead of burning the agent's turn on
-			// a transport fault. Best-effort: a failure to queue the retry must not
-			// replace the real error.
-			if (error instanceof ExecStreamLostError) {
-				await (async () => {
-					// Counted the same way the orphan detector counts it, so repeated
-					// transport losses on one agent converge on the same ceiling rather
-					// than retrying forever.
-					const bumped = await deps.db.query<{ process_loss_retry_count: number }>(
-						`UPDATE heartbeat_runs SET process_loss_retry_count = process_loss_retry_count + 1
-						 WHERE id = $1 RETURNING process_loss_retry_count`,
-						[heartbeatRunId],
-					);
-					await retryOrEscalateLostRun(deps.db, {
-						runId: heartbeatRunId,
-						memberId: agent.id,
-						teamId: runTeamId,
-						priorRetries: Math.max(0, (bumped.rows[0]?.process_loss_retry_count ?? 1) - 1),
-					});
-				})().catch((e) =>
-					log.error(`Run ${heartbeatRunId}: could not queue a transport retry:`, e),
-				);
-			}
+			// a transport fault.
+			//
+			// Read from the shared classifier rather than a local `instanceof`, so the
+			// exec path and the setup window agree on what a retry is for and widening
+			// the set is one row rather than a second condition here.
+			if (classifyRunFailure(error) === RunFailureClass.Transient) await spendLostRunStrike();
 
 			await cleanupRunArtifacts();
 			return {
@@ -4186,7 +4217,14 @@ async function updateHeartbeatRun(
 	},
 	broadcast: HeartbeatRunBroadcast,
 ): Promise<void> {
-	await db.query(
+	// Guarded on a non-terminal status, so whoever declared the outcome first owns
+	// it. Several writers can reach one run - the runner's own catches, the
+	// container-death sweep, an operator terminate, the orphan pass - and the first
+	// to land is the one that actually observed the run; a later write would
+	// replace a specific cause with a vaguer one, and under MVCC an unconditional
+	// re-stamp also leaves a dead tuple behind. Same shape as
+	// `markHeartbeatRunRunning` and `failProjectRuns`.
+	const applied = await db.query<{ id: string }>(
 		`UPDATE heartbeat_runs
 		 SET status = $1::heartbeat_run_status,
 		     started_at = COALESCE(started_at, now()),
@@ -4197,7 +4235,9 @@ async function updateHeartbeatRun(
 		     output_tokens = COALESCE($5, output_tokens),
 		     cost_cents = COALESCE($6, cost_cents),
 		     usage_partial = COALESCE($7, usage_partial)
-		 WHERE id = $8`,
+		 WHERE id = $8
+		   AND status IN ($9::heartbeat_run_status, $10::heartbeat_run_status)
+		 RETURNING id`,
 		[
 			update.status,
 			update.exitCode,
@@ -4207,21 +4247,39 @@ async function updateHeartbeatRun(
 			update.usage?.costCents ?? null,
 			update.usagePartial ?? null,
 			runId,
+			HeartbeatRunStatus.Queued,
+			HeartbeatRunStatus.Running,
 		],
 	);
-	broadcastHeartbeatRunChange(broadcast, runId, update.status, 'UPDATE');
-	broadcast.events?.emit({
-		type: 'agent_run.completed',
-		teamId: broadcast.teamId,
-		projectId: broadcast.projectId ?? null,
-		runId,
-		taskId: broadcast.taskId,
-		agentMemberId: broadcast.memberId,
-		status: update.status as HeartbeatRunStatus,
-		exitCode: update.exitCode,
-		error: update.error ?? null,
-	});
+	if (applied.rows.length > 0) {
+		broadcastHeartbeatRunChange(broadcast, runId, update.status, 'UPDATE');
+		broadcast.events?.emit({
+			type: 'agent_run.completed',
+			teamId: broadcast.teamId,
+			projectId: broadcast.projectId ?? null,
+			runId,
+			taskId: broadcast.taskId,
+			agentMemberId: broadcast.memberId,
+			status: update.status as HeartbeatRunStatus,
+			exitCode: update.exitCode,
+			error: update.error ?? null,
+		});
+	} else {
+		// Logged only when the two verdicts disagree, so the ordinary idempotent
+		// case - the same path finalizing twice - stays quiet.
+		const current = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		const settled = current.rows[0]?.status;
+		if (settled && settled !== update.status) {
+			log.warn(
+				`Run ${runId}: kept terminal status '${settled}'; dropped a later '${update.status}'`,
+			);
+		}
+	}
 
+	// Outside the guard: tokens burned are burned whoever declared the outcome.
 	// Run completion is the canonical cost event: record the run's total spend as a
 	// single cost_entries row (guarded on positive usage so failure/abort paths and
 	// retries — which carry no usage — never double-insert), then reactively pause

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -115,10 +115,10 @@ import { ContainerGitExecutor, type GitExecutor } from './git-executor';
 import { buildGitIdentityEnv } from './git-identity';
 import type { LogStreamBroker } from './log-stream-broker';
 import {
+	buildMcpInjection,
 	HEZO_MCP_SERVER_NAME,
 	MCP_ADAPTERS,
 	type McpDescriptor,
-	validateInjection,
 } from './mcp-injectors';
 import { retryOrEscalateLostRun, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
@@ -142,7 +142,7 @@ import {
 } from './runtime-home';
 import { resolveRuntimeForTask } from './runtime-resolver';
 import { createBundleVault } from './sandbox/bundle-vault';
-import type { RunEndpoints } from './sandbox/endpoints';
+import { PREFLIGHT_TUNNEL_ENDPOINTS, type RunEndpoints } from './sandbox/endpoints';
 import type { SandboxFiles } from './sandbox/files';
 import { dockerSandboxHandle } from './sandbox/handle';
 import { setPoolMemberDiskUsage, setPoolMemberUnpushedFlag } from './sandbox/pool-db';
@@ -735,7 +735,7 @@ export async function buildRuntimeInvocation(
 		.then((r) => r.rows.map((row) => row.slug))
 		.catch(() => [] as string[]);
 
-	const mcpInjection = adapter.build(mcpDescriptors, {
+	const mcpInjection = buildMcpInjection(runtimeType, mcpDescriptors, {
 		hostHomeDir: homeMount?.hostDir ?? null,
 		containerHomeDir: homeMount?.containerDir ?? null,
 		provider,
@@ -744,7 +744,6 @@ export async function buildRuntimeInvocation(
 		stopJudge,
 		systemPrompt,
 	});
-	validateInjection(adapter, mcpInjection);
 
 	// Through SandboxFiles, rooted at the subscription base: the container reads
 	// these, so on a backend whose container is not on this machine the write has
@@ -1135,6 +1134,17 @@ function abortedRunStatus(reason: RunAbortReason | null): HeartbeatRunStatus {
 const CAPACITY_PARK_POLL_MS = 5_000;
 
 /**
+ * The stand-in bearer the pre-claim dry run gives the `hezo` MCP descriptor.
+ *
+ * Shaped like the signed token the real run mints - three dot-separated
+ * segments of token characters - so an adapter that inlines it into a file is
+ * caught by the same check that would catch the real one. It is never written
+ * anywhere and never reaches a container: the dry run's output is discarded and
+ * `buildRuntimeInvocation` builds again with the real token.
+ */
+const PREFLIGHT_BEARER_TOKEN = 'preflight.dry.run';
+
+/**
  * How long a run waits for capacity before giving up and returning to the queue.
  *
  * Deliberately not the agent's own `run_timeout_min`: letting the park run to
@@ -1519,6 +1529,68 @@ export async function runAgent(
 
 	if (signal?.aborted) return finalizeAbort();
 
+	// Prove the host-side half of the run before the pool is touched.
+	//
+	// Same reasoning as the credential resolution above: a misconfigured instance
+	// is an ordinary state, not an exceptional one, and it must not cost a
+	// container. `validateInjection` is a hard failure that ends the run, and it
+	// used to fire ~4s *after* a sandbox had been provisioned - which on a full
+	// budget means after another project's container was retired to make room. One
+	// bad connector header therefore cost two cold provisions per lap, forever.
+	//
+	// The dry run is the real descriptor list, the real adapter and the real home
+	// paths; only the tunnel's loopback port is stand-in, because it is chosen by
+	// an in-container probe and cannot exist yet. Nothing in an adapter or in
+	// `validateInjection` reads a port, which a drift test pins across every
+	// runtime rather than a comment asserting it here.
+	//
+	// The descriptors are loaded once and threaded into the run, so this costs no
+	// extra query.
+	let connectorDescriptors: McpDescriptor[];
+	try {
+		connectorDescriptors = await loadConnectorDescriptors(deps.db, project.id);
+		const homePaths = MCP_ADAPTERS[runtimeType].capabilities.requiresHomeDir
+			? {
+					hostHomeDir: getHostSubscriptionRootImpl(
+						provider,
+						runtimeType,
+						deps.dataDir,
+						runTeamId,
+						project.id,
+						heartbeatRunId,
+					),
+					containerHomeDir: getContainerSubscriptionRootImpl(provider, runtimeType, heartbeatRunId),
+				}
+			: { hostHomeDir: null, containerHomeDir: null };
+		buildMcpInjection(
+			runtimeType,
+			[
+				{
+					kind: 'http',
+					name: HEZO_MCP_SERVER_NAME,
+					url: `${PREFLIGHT_TUNNEL_ENDPOINTS.hezoBaseUrl}/mcp`,
+					// Shaped like the real signed token so the inlined-bearer check has
+					// something to catch. The real one is minted later, with the run.
+					bearerToken: PREFLIGHT_BEARER_TOKEN,
+				},
+				...connectorDescriptors,
+			],
+			{
+				hostHomeDir: homePaths.hostHomeDir,
+				containerHomeDir: homePaths.containerHomeDir,
+				provider,
+				runModel: modelOverride,
+				projectDocSlugs: [],
+				stopJudge: true,
+				systemPrompt: null,
+			},
+		);
+	} catch (e) {
+		return finalizeFailure(
+			`This run cannot be prepared: ${(e as Error).message} No container was started.`,
+		);
+	}
+
 	/**
 	 * Record that this run is parked waiting for container capacity.
 	 *
@@ -1784,14 +1856,13 @@ export async function runAgent(
 			};
 		}
 
-		// Loaded before the tunnel because its split-routing policy needs the
-		// connector hosts: the per-connector method allowlist is enforced *at the
-		// proxy*, so a connector routed direct would skip its policy check even when
-		// no secret is involved. They resolve from the db and the project alone -
-		// only the `hezo` descriptor needs the tunnel's endpoints, and that one is
-		// container loopback and never proxied - so nothing here waits on the
-		// tunnel. Threaded into `buildRunContext` after, so a run resolves them once.
-		const connectorDescriptors = await loadConnectorDescriptors(deps.db, project.id);
+		// The descriptors were loaded by the preflight above, before the container
+		// was claimed - they resolve from the db and the project alone, and only the
+		// `hezo` descriptor needs the tunnel's endpoints. They are needed here
+		// because the tunnel's split-routing policy is built from the connector
+		// hosts: the per-connector method allowlist is enforced *at the proxy*, so a
+		// connector routed direct would skip its policy check even when no secret is
+		// involved.
 
 		// The tunnel is how a container reaches Hezo - the only how, on every
 		// backend. Started here because it needs both allocations above: there is

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -460,8 +460,12 @@ export class ChatSessionManager {
 	 * Mark sessions left `starting`/`running` by a previous process as crashed —
 	 * their in-container process (if any) is orphaned and the in-memory state is
 	 * gone. Frees the singleton index so a fresh session can start.
+	 *
+	 * Three statements and nothing else, so like the job manager's own DB repair
+	 * it runs at boot regardless of lock state - an instance that comes up locked
+	 * would otherwise serve a session that reads as live and can never answer.
 	 */
-	async reconcileOnStartup(): Promise<void> {
+	async reconcileDatabaseOnStartup(): Promise<void> {
 		await this.deps.db.query(
 			`UPDATE chat_sessions SET status = $1, stopped_at = now()
 			 WHERE status IN ($2, $3)`,

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -593,7 +593,11 @@ export async function provisionContainer(
 		// and the instance budget counts swap at full weight, so a kernel that
 		// silently drops the limit leaves the pool's arithmetic describing a machine
 		// that does not exist. A managed backend returns none of these.
-		for (const warning of Warnings) emit('stderr', `⚠ ${warning}`);
+		// Defaulted, not trusted: the seam declares `Warnings` required, but a
+		// stub or a future adapter that omits it must not take a provision down
+		// with it - failing a container start over a missing advisory would be a
+		// worse bug than the one this line reports.
+		for (const warning of Warnings ?? []) emit('stderr', `⚠ ${warning}`);
 		// Joined the pool the moment the container exists, not once it is finished.
 		// Everything below - starting, the MTU pin, the CA, the repo sync, the MCP
 		// installs - is the expensive part, and until this write the container was

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -49,7 +49,7 @@ import {
 } from './run-concurrency';
 import { DOCKER_HOST_GATEWAY_ENTRY } from './sandbox/endpoints';
 import { INSTANCE_LABEL, PROJECT_LABEL, TEAM_LABEL } from './sandbox/labels';
-import { planCrossProjectReclaim } from './sandbox/pool';
+import { detectReclaimChurn, planCrossProjectReclaim, type ReclaimEvent } from './sandbox/pool';
 import {
 	type ContainerAllocation,
 	claimPoolMember,
@@ -564,7 +564,7 @@ export async function provisionContainer(
 		// to absorb (see ContainerConfig.HostConfig.DiskGb).
 		const diskGb = await getProjectContainerDiskGb(db, project.id);
 
-		const { Id } = await docker.createContainer(containerName, {
+		const { Id, Warnings } = await docker.createContainer(containerName, {
 			Image: baseImage,
 			Cmd: ['sleep', 'infinity'],
 			Env: env,
@@ -586,6 +586,14 @@ export async function provisionContainer(
 		});
 
 		openStream(Id);
+		// The engine's own account of what it could not honour, on the container's
+		// own stream beside the MTU-pin warning rather than in a server log nobody
+		// correlates. Docker's canonical one is the missing swap-limit capability,
+		// and it matters here more than anywhere: the config above sets `MemorySwap`
+		// and the instance budget counts swap at full weight, so a kernel that
+		// silently drops the limit leaves the pool's arithmetic describing a machine
+		// that does not exist. A managed backend returns none of these.
+		for (const warning of Warnings) emit('stderr', `⚠ ${warning}`);
 		// Joined the pool the moment the container exists, not once it is finished.
 		// Everything below - starting, the MTU pin, the CA, the repo sync, the MCP
 		// installs - is the expensive part, and until this write the container was
@@ -948,6 +956,33 @@ export async function assertProjectNotArchived(db: Db, projectId: string): Promi
  */
 const reclaimLock = new Map<string, Promise<unknown>>();
 
+/** How far back the churn check looks, and how loud it has to get to be worth saying. */
+const CHURN_WINDOW_MS = 10 * 60_000;
+const CHURN_MIN_RECLAIMS = 4;
+/** At most one churn warning per window, so a thrashing instance says so without flooding. */
+const CHURN_WARN_INTERVAL_MS = CHURN_WINDOW_MS;
+
+/**
+ * Recent cross-project reclaims, so the instance can say when it is thrashing
+ * rather than reclaiming.
+ *
+ * In-process and advisory - it only ever produces a log line, so losing it on
+ * restart costs nothing. Bounded two ways, which is the whole eviction rule:
+ * entries older than {@link CHURN_WINDOW_MS} are dropped on every write, and the
+ * ring is hard-capped so a pathological burst inside one window cannot grow it.
+ */
+const RECLAIM_HISTORY_CAP = 200;
+const reclaimHistory: ReclaimEvent[] = [];
+let lastChurnWarnAtMs = 0;
+
+function recordReclaims(events: readonly ReclaimEvent[], nowMs: number): void {
+	reclaimHistory.push(...events);
+	const cutoff = nowMs - CHURN_WINDOW_MS;
+	const kept = reclaimHistory.filter((e) => e.atMs >= cutoff).slice(-RECLAIM_HISTORY_CAP);
+	reclaimHistory.length = 0;
+	reclaimHistory.push(...kept);
+}
+
 interface ReclaimCandidateRow {
 	container_id: string;
 	project_id: string;
@@ -1062,6 +1097,34 @@ async function reclaimIdleCapacityForProject(
 			`project ${ref(requestingSlug, requestingProjectId)} needs ${needGb.toFixed(1)} GB; ` +
 				`reclaiming ${plan.freedGb.toFixed(1)} GB from ${byProject.size} other project(s)`,
 		);
+
+		// A single reclaim is the mechanism working. The same pair trading a
+		// container back and forth every few minutes is a budget too small for the
+		// workload, and nothing else on the instance says so - this was an info line
+		// among thousands while two projects churned for hours. Rate-limited to one
+		// per window, and it names the remedy rather than just the symptom.
+		const nowMs = Date.now();
+		recordReclaims(
+			[...byProject.keys()].map((victimProjectId) => ({
+				atMs: nowMs,
+				requestingProjectId,
+				victimProjectId,
+				freedGb: plan.freedGb / byProject.size,
+			})),
+			nowMs,
+		);
+		const churn = detectReclaimChurn(reclaimHistory, nowMs, CHURN_WINDOW_MS, CHURN_MIN_RECLAIMS);
+		if (churn.churning && nowMs - lastChurnWarnAtMs >= CHURN_WARN_INTERVAL_MS) {
+			lastChurnWarnAtMs = nowMs;
+			const pair = churn.reciprocal ? ` between two projects taking it back off each other,` : '';
+			log.warn(
+				`container memory is thrashing: ${churn.reclaims} reclaims in the last ` +
+					`${Math.round(CHURN_WINDOW_MS / 60_000)} minutes,${pair} ` +
+					`${churn.freedGb.toFixed(1)} GB churned. The instance memory budget is smaller ` +
+					`than the concurrent workload - raise it in Settings > Containers, or lower a ` +
+					`project's per-container cap.`,
+			);
+		}
 
 		let reclaimedAny = false;
 		for (const [victimId, group] of byProject) {

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
 	CHAT_IDLE_TIMEOUT_MIN,
+	CONTAINER_RECLAIM_MIN_AGE_SEC,
 	CONTAINER_RECLAIM_MIN_IDLE_SEC,
 	ContainerStatus,
 	HeartbeatRunStatus,
@@ -955,6 +956,8 @@ interface ReclaimCandidateRow {
 	memory_bytes: string | number | null;
 	has_unpushed_commits: boolean;
 	idle_for_ms: string | number;
+	age_ms: string | number | null;
+	project_resumable: string | number;
 }
 
 /**
@@ -995,7 +998,15 @@ async function reclaimIdleCapacityForProject(
 			// sitting outside the window.
 			`SELECT m.container_id, m.project_id, p.slug, p.team_id, m.memory_bytes,
 			        m.has_unpushed_commits,
-			        EXTRACT(EPOCH FROM (now() - m.last_released_at)) * 1000 AS idle_for_ms
+			        EXTRACT(EPOCH FROM (now() - m.last_released_at)) * 1000 AS idle_for_ms,
+			        EXTRACT(EPOCH FROM (now() - m.created_at)) * 1000 AS age_ms,
+			        -- What the victim would have left to serve its own next run.
+			        -- Correlated rather than joined so the outer row set stays the
+			        -- reclaim candidates; served by idx_container_pool_members_project.
+			        (SELECT count(*) FROM container_pool_members s
+			          WHERE s.project_id = m.project_id
+			            AND s.state IN ('idle', 'busy', 'suspended')
+			            AND NOT s.reserved_for_chat) AS project_resumable
 			   FROM container_pool_members m
 			   JOIN projects p ON p.id = m.project_id
 			  WHERE m.state = 'idle' AND NOT m.reserved_for_chat
@@ -1024,10 +1035,13 @@ async function reclaimIdleCapacityForProject(
 						? (capGb.get(row.project_id) ?? 0)
 						: Number(row.memory_bytes) / 1024 ** 3,
 				idleForMs: Number(row.idle_for_ms),
+				ageMs: row.age_ms === null ? null : Number(row.age_ms),
+				projectResumableMembers: Number(row.project_resumable),
 				hasUnpushedCommits: row.has_unpushed_commits,
 			})),
 			needGb,
 			CONTAINER_RECLAIM_MIN_IDLE_SEC * 1000,
+			CONTAINER_RECLAIM_MIN_AGE_SEC * 1000,
 		);
 		if (plan.freedGb === 0) return false;
 
@@ -1688,13 +1702,20 @@ export async function stopContainerGracefully(
 	let exitReason: ContainerExitReason = 'container_stopped';
 	try {
 		await docker.stopContainer(containerId);
+		// Conditional on the id, exactly as `clearProjectContainerIfNamed` is on the
+		// destroy path. A project can hold several pool members, so writing
+		// `container_status = Stopped` for whichever one this is said the project's
+		// *designated* container was down when it may still be running - and that
+		// row is read by a capacity gate (`getActiveContainers` stops counting it,
+		// under-counting the budget) and by the idle pass (`IDLE_CANDIDATE_SQL`
+		// requires `running`, so the project is skipped from then on).
 		await db.query(
 			`UPDATE projects
 			 SET container_status = $1::container_status,
 			     container_last_logs = COALESCE($2, container_last_logs),
 			     container_error = NULL
-			 WHERE id = $3`,
-			[ContainerStatus.Stopped, annotatedLogs, projectId],
+			 WHERE id = $3 AND container_id = $4`,
+			[ContainerStatus.Stopped, annotatedLogs, projectId, containerId],
 		);
 		await setPoolMemberOutcome(db, containerId, annotatedLogs, null);
 		// A stopped container is a *suspended* pool member: it still exists and its
@@ -1708,13 +1729,15 @@ export async function stopContainerGracefully(
 		);
 	} catch (err) {
 		const errorMessage = err instanceof Error ? err.message : String(err);
+		// Same guard as the success arm: only the project's designated container may
+		// move the project row.
 		await db.query(
 			`UPDATE projects
 			 SET container_status = $1::container_status,
 			     container_last_logs = COALESCE($2, container_last_logs),
 			     container_error = $3
-			 WHERE id = $4`,
-			[ContainerStatus.Error, annotatedLogs, errorMessage, projectId],
+			 WHERE id = $4 AND container_id = $5`,
+			[ContainerStatus.Error, annotatedLogs, errorMessage, projectId, containerId],
 		);
 		await setPoolMemberOutcome(db, containerId, annotatedLogs, errorMessage);
 		exitReason = 'container_error';
@@ -1840,7 +1863,7 @@ export async function isProjectIdleForContainerStop(
 }
 
 /**
- * Idle members of projects that are *working*, on each member's own clock.
+ * Idle pool members past their own idle window, whatever their project is doing.
  *
  * The query above asks a project-shaped question - "has everything here gone
  * quiet?" - and a project with two busy containers and two idle ones never
@@ -1849,10 +1872,14 @@ export async function isProjectIdleForContainerStop(
  * memory. This asks the member-shaped question instead, which is the one that
  * bounds the budget.
  *
- * The `EXISTS` restricts it to working projects on purpose: a fully idle project
- * belongs to {@link findIdleContainerCandidates}, which retires its pool as a
- * unit and keeps one member suspended for a warm restart. Overlapping the two
- * would take that warm member away.
+ * It used to carry an `EXISTS ... state = 'busy'` so that a fully idle project
+ * was left to {@link findIdleContainerCandidates} and its warm-start guarantee.
+ * The two preconditions did not partition the space: a project whose runs last
+ * seconds is never quiet (queued wakeups and recent finishes keep it out of the
+ * project-shaped pass) and rarely busy when the once-a-minute cron samples it,
+ * so its idle members matched neither and pinned the budget indefinitely. The
+ * warm-start floor now lives in `planSurplusIdleRetirement`, where it is a
+ * property of the plan rather than of which pass ran, so this can be total.
  *
  * The chat's pinned member is excluded - it is not counted against the budget, so
  * retiring it frees nothing. Served by `idx_container_pool_members_idle`.
@@ -1864,10 +1891,6 @@ const STALE_IDLE_MEMBER_SQL = (extraSql: string, limitSql: string) => `
 	 WHERE m.state = 'idle'
 	   AND NOT m.reserved_for_chat
 	   AND m.last_released_at < now() - ($1 * interval '1 minute')
-	   AND EXISTS (
-	     SELECT 1 FROM container_pool_members b
-	      WHERE b.project_id = m.project_id AND b.state = 'busy'
-	   )
 	   ${extraSql}
 	 ORDER BY m.last_released_at
 	 ${limitSql}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -114,6 +114,15 @@ const MAX_CONSECUTIVE_TIMEOUT_CONTINUATIONS = 5;
 // gets at most one progress run a day from this path and a dormant one gets none.
 const PROGRESS_REFRESH_INTERVAL_HOURS = 24;
 const FAILURE_PING_ERROR_MAX_LEN = 500;
+/**
+ * The outcomes that must never post a failure notice: a cancel is the user's own
+ * doing, and a success has nothing to report.
+ */
+const NON_PINGING_STATUSES: HeartbeatRunStatus[] = [
+	HeartbeatRunStatus.Succeeded,
+	HeartbeatRunStatus.Cancelled,
+];
+
 const FAILURE_TERMINAL_STATUSES: HeartbeatRunStatus[] = [
 	HeartbeatRunStatus.Failed,
 	HeartbeatRunStatus.TimedOut,
@@ -397,6 +406,8 @@ export class JobManager {
 	private cron: Cron;
 	private runningTasks = new Map<string, RunningTask>();
 	private liveRuns = new Map<string, LiveRun>();
+	/** Set by {@link stopAcceptingWork}; makes `launchTask` refuse new work. */
+	private draining = false;
 	private guards = new Map<string, boolean>();
 	/**
 	 * Containers the last orphan sweep found unreferenced. One sighting is not
@@ -742,6 +753,10 @@ export class JobManager {
 		timeoutMs: number,
 		runContext?: RunDispatchContext,
 	): boolean {
+		// A shutdown in progress must not take new work: the wakeup cron fires every
+		// five seconds, so without this a drain would keep being handed fresh runs
+		// by the very scheduler it is waiting out.
+		if (this.draining) return false;
 		if (this.runningTasks.has(key)) return false;
 		const ac = new AbortController();
 
@@ -812,6 +827,60 @@ export class JobManager {
 		return new Map(this.runningTasks);
 	}
 
+	/**
+	 * Stop scheduling and refuse new dispatches.
+	 *
+	 * Separate from {@link shutdown} so a drain can sit between them. Aborting and
+	 * clearing the registries in one step, as `shutdown` does, leaves the abort
+	 * nowhere to land: the DB closes while the runs it just cancelled are still
+	 * writing their terminal rows.
+	 */
+	/**
+	 * How many agent runs are in flight right now.
+	 *
+	 * The same figure `autoInstallStagedUpdate` gates on, exposed so the update
+	 * banner shows one definition of busy rather than inventing a second.
+	 */
+	inFlightRunCount(): number {
+		return this.runningTasks.size;
+	}
+
+	stopAcceptingWork(): void {
+		this.draining = true;
+		this.cron.shutdown();
+	}
+
+	/**
+	 * Abort every in-flight run and wait, bounded, for its completion path to
+	 * write a terminal row. Returns what was still in flight at the deadline, so
+	 * the caller can name it rather than exiting silently on unfinished work.
+	 *
+	 * Ordering is the caller's and it matters: `killLiveRunProcesses()` goes
+	 * first, so the in-container tree is already dead and the abort lands in
+	 * milliseconds rather than waiting on an exec that will never end.
+	 */
+	async drainRunningRuns(deadlineMs: number): Promise<LiveRun[]> {
+		const entries = [...this.runningTasks.values()];
+		if (entries.length === 0) return [];
+		log.info(`Shutdown: draining ${entries.length} in-flight run(s), up to ${deadlineMs}ms`);
+		for (const task of entries) {
+			clearTimeout(task.timeoutId);
+			task.abortController.abort('server_shutdown');
+		}
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		await Promise.race([
+			Promise.allSettled(entries.map((e) => e.promise)),
+			new Promise<void>((resolve) => {
+				timer = setTimeout(resolve, deadlineMs);
+			}),
+		]);
+		if (timer) clearTimeout(timer);
+		const stillRunning = new Set(
+			entries.filter((e) => this.runningTasks.get(e.key) === e).map((e) => e.key),
+		);
+		return [...this.liveRuns.values()].filter((r) => stillRunning.has(r.taskKey));
+	}
+
 	shutdown(): void {
 		for (const task of this.runningTasks.values()) {
 			clearTimeout(task.timeoutId);
@@ -859,16 +928,32 @@ export class JobManager {
 	}
 
 	/**
+	 * Both halves of startup reconciliation, in order. The shape existing callers
+	 * and tests already use.
+	 */
+	async reconcileOnStartup(): Promise<void> {
+		await this.reconcileDatabaseOnStartup();
+		await this.reconcileContainersOnStartup();
+	}
+
+	/**
 	 * Reconcile DB state with the (now-empty) in-process run registry. Runs in
 	 * `running` or `queued` state from the previous process were necessarily lost
 	 * with that process — fail them, reset their agents to idle, release locks,
 	 * broadcast, and enqueue recovery wakeups so work resumes.
 	 *
-	 * Also self-heals projects stuck in `error` state whose underlying container
-	 * is actually alive (e.g. from a prior false-positive transport-error trip).
+	 * **Deliberately callable before the vault is unlocked.** It is raw SQL and
+	 * broadcasts; nothing here decrypts anything or touches the container backend.
+	 * Coming up locked after a restart is the intended behaviour, not a gap - but
+	 * while this was behind the unlock hook, an instance that came up locked
+	 * served stranded `running` rows and stuck-busy agents until a human arrived,
+	 * with the orphan cron not started either.
+	 *
+	 * Idempotent by construction: every UPDATE is guarded by a status predicate,
+	 * so a second call finds no rows and queues no wakeups.
 	 */
-	async reconcileOnStartup(): Promise<void> {
-		const { db, docker, wsManager } = this.deps;
+	async reconcileDatabaseOnStartup(): Promise<void> {
+		const { db, wsManager } = this.deps;
 
 		const stranded = await db.query<{
 			id: string;
@@ -1001,7 +1086,19 @@ export class JobManager {
 				`Startup reconciliation: failed ${stranded.rows.length} stranded run(s), reset ${resetAgents.rows.length} agent(s) to idle, failed ${strandedRepos.rows.length} interrupted repo setup(s)`,
 			);
 		}
+	}
 
+	/**
+	 * The container-backend half of startup reconciliation.
+	 *
+	 * Split from the DB half because this one genuinely needs a connected engine,
+	 * so it stays behind the unlock hook while the repair above runs at boot.
+	 *
+	 * Also self-heals projects stuck in `error` state whose underlying container
+	 * is actually alive (e.g. from a prior false-positive transport-error trip).
+	 */
+	async reconcileContainersOnStartup(): Promise<void> {
+		const { docker } = this.deps;
 		// Ahead of every other container pass: the ones below adopt, restart and
 		// re-provision from the same rows, so a retired project must be emptied
 		// before they look at it.
@@ -2642,6 +2739,7 @@ export class JobManager {
 				taskIdentifier,
 				teamId,
 				result.heartbeatRunId,
+				result.stderr?.trim() || null,
 			);
 		}
 
@@ -3132,6 +3230,8 @@ export class JobManager {
 		taskIdentifier: string,
 		teamId: string,
 		runId: string,
+		/** What the caller knows went wrong, for a row that recorded nothing. */
+		fallbackError: string | null = null,
 	): Promise<void> {
 		const { db } = this.deps;
 
@@ -3140,7 +3240,17 @@ export class JobManager {
 			[runId],
 		);
 		const run = runRow.rows[0];
-		if (!run || !FAILURE_TERMINAL_STATUSES.includes(run.status)) return;
+		if (!run) return;
+		// An explicit no-ping list rather than a terminal-status gate. A cancel is
+		// the user's own doing and a success has nothing to report; those are the
+		// only two outcomes that must never ping. Everything else reaching here has
+		// already been judged a failure by the caller - and gating on *terminal*
+		// meant a run whose driver threw before finalizing it silenced the thread
+		// entirely, which is the case this whole area exists to report.
+		if (NON_PINGING_STATUSES.includes(run.status)) return;
+		const status = FAILURE_TERMINAL_STATUSES.includes(run.status)
+			? run.status
+			: HeartbeatRunStatus.Failed;
 
 		const recent = await db.query<{ status: HeartbeatRunStatus }>(
 			`SELECT status FROM heartbeat_runs
@@ -3164,10 +3274,11 @@ export class JobManager {
 			return;
 		}
 
-		const truncatedError = run.error
-			? run.error.length > FAILURE_PING_ERROR_MAX_LEN
-				? `${run.error.slice(0, FAILURE_PING_ERROR_MAX_LEN)}…`
-				: run.error
+		const rawError = run.error ?? fallbackError;
+		const truncatedError = rawError
+			? rawError.length > FAILURE_PING_ERROR_MAX_LEN
+				? `${rawError.slice(0, FAILURE_PING_ERROR_MAX_LEN)}…`
+				: rawError
 			: null;
 
 		const inserted = await db.query<Record<string, unknown>>(
@@ -3180,7 +3291,7 @@ export class JobManager {
 				JSON.stringify({
 					kind: 'run_failed',
 					run_id: runId,
-					status: run.status,
+					status,
 					error: truncatedError,
 					member_id: memberId,
 					agent_slug: agentSlug,

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -2512,6 +2512,10 @@ export class JobManager {
 						err,
 					);
 					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
+					// Settle the row *before* the bookkeeping below, which reads it.
+					// `postFailurePing` returns early on a non-terminal status, so a run
+					// that threw past its own finalizer used to notify nobody at all.
+					if (registeredRunId) await this.finalizeThrownRun(registeredRunId, err);
 					// The completion bookkeeping (lock release, idle flip, wakeup
 					// resolution) must still run or the agent stays stuck busy with
 					// no recovery path. Synthesize a failed result; the failure-ping
@@ -2918,6 +2922,8 @@ export class JobManager {
 						err,
 					);
 					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
+					// Before the completion bookkeeping, which reads the row.
+					if (registeredRunId) await this.finalizeThrownRun(registeredRunId, err);
 					await this.onProgressUpdateComplete(memberId, teamId, wakeupId, {
 						success: false,
 						exitCode: -1,
@@ -3191,6 +3197,47 @@ export class JobManager {
 			'INSERT',
 			commentRow,
 		);
+	}
+
+	/**
+	 * Last resort: leave no run row non-terminal after a throw.
+	 *
+	 * `runAgent` finalizes its own row on every path it knows about. This covers
+	 * the ones it does not - a throw in the plumbing between the row's insert and
+	 * its first `try`, a failure inside a catch's own bookkeeping - and it covers
+	 * whatever is added there next, which is what makes the property permanent
+	 * rather than a description of today's call graph.
+	 *
+	 * It matters because everything downstream reads the row rather than the
+	 * thrown error: `postFailurePing` returns early on a non-terminal status, so
+	 * the task thread stayed silent, and the orphan pass then declared the process
+	 * lost when the process was alive and had thrown.
+	 *
+	 * Status-guarded, so a row the runner did finalize keeps its own richer
+	 * verdict; this only ever writes when nothing else did. No usage is passed, so
+	 * it cannot touch cost accounting.
+	 */
+	private async finalizeThrownRun(runId: string, err: unknown): Promise<void> {
+		const message = err instanceof Error ? err.message : String(err);
+		await this.deps.db
+			.query(
+				`UPDATE heartbeat_runs
+				 SET status = $1::heartbeat_run_status,
+				     started_at = COALESCE(started_at, now()),
+				     finished_at = now(),
+				     exit_code = COALESCE(exit_code, -1),
+				     error = COALESCE(error, $2)
+				 WHERE id = $3
+				   AND status IN ($4::heartbeat_run_status, $5::heartbeat_run_status)`,
+				[
+					HeartbeatRunStatus.Failed,
+					message,
+					runId,
+					HeartbeatRunStatus.Queued,
+					HeartbeatRunStatus.Running,
+				],
+			)
+			.catch((e) => log.error(`Could not finalize thrown run ${runId}:`, e));
 	}
 
 	private async chainNextTaskWakeup(

--- a/packages/server/src/services/mcp-injectors/index.ts
+++ b/packages/server/src/services/mcp-injectors/index.ts
@@ -5,7 +5,8 @@ import { geminiAdapter } from './gemini';
 import { grokAdapter } from './grok';
 import { kimiAdapter } from './kimi';
 import { opencodeAdapter } from './opencode';
-import type { RuntimeMcpAdapter } from './types';
+import type { McpAdapterContext, McpDescriptor, McpInjection, RuntimeMcpAdapter } from './types';
+import { validateInjection } from './validate';
 
 /**
  * Per-runtime MCP adapter table. The `Record<AgentRuntime, ...>` typing means
@@ -20,6 +21,29 @@ export const MCP_ADAPTERS: Record<AgentRuntime, RuntimeMcpAdapter> = {
 	[AgentRuntime.Grok]: grokAdapter,
 	[AgentRuntime.Kimi]: kimiAdapter,
 };
+
+/**
+ * Render a runtime's MCP artifacts and prove they satisfy the adapter contract.
+ *
+ * The build and the check are one call because they are one question, and
+ * because the answer has to be reachable twice: once before a container is
+ * claimed, to refuse a run whose configuration cannot work, and once for real
+ * inside `buildRuntimeInvocation`. Two builders would be two things to keep in
+ * step; this is one, called from both.
+ *
+ * Everything it reads is host-side - the adapter table, the descriptor list, the
+ * per-run home paths, the project's doc slugs - so it needs no container.
+ */
+export function buildMcpInjection(
+	runtime: AgentRuntime,
+	descriptors: readonly McpDescriptor[],
+	ctx: McpAdapterContext,
+): McpInjection {
+	const adapter = MCP_ADAPTERS[runtime];
+	const injection = adapter.build(descriptors, ctx);
+	validateInjection(adapter, injection);
+	return injection;
+}
 
 export type {
 	McpAdapterCapabilities,

--- a/packages/server/src/services/mcp-injectors/validate.ts
+++ b/packages/server/src/services/mcp-injectors/validate.ts
@@ -1,5 +1,24 @@
 import { isAbsolute } from 'node:path';
+import { createPlaceholderRegex, PLACEHOLDER_PROBE } from '../../lib/credential-placeholder';
 import type { McpInjection, RuntimeMcpAdapter } from './types';
+
+/**
+ * A rendered file with every secret placeholder removed.
+ *
+ * A connector's `Authorization` header is `Bearer __HEZO_SECRET_<NAME>__` by
+ * design - the egress proxy substitutes the value at request time, and the real
+ * one never enters a run. The placeholder is made of characters the bearer
+ * pattern below accepts, so scanning the raw text reports the one value the
+ * whole scheme exists to put there. Blanking placeholders first leaves a real
+ * token as the only thing that can still match.
+ *
+ * The cheap literal probe skips the regex for the files that carry no
+ * placeholder at all, which is most of them.
+ */
+function withoutSecretPlaceholders(contents: string): string {
+	if (!contents.includes(PLACEHOLDER_PROBE)) return contents;
+	return contents.replace(createPlaceholderRegex(), '');
+}
 
 /**
  * Defensive sanity check on the spawn artifacts an adapter emits. Throws on
@@ -38,7 +57,7 @@ export function validateInjection(adapter: RuntimeMcpAdapter, injection: McpInje
 		// rendered. Passthrough files are exempt - see McpInjectionFile.passthrough.
 		for (const file of injection.files) {
 			if (file.passthrough) continue;
-			if (/Bearer [A-Za-z0-9._-]{8,}/.test(file.contents)) {
+			if (/Bearer [A-Za-z0-9._-]{8,}/.test(withoutSecretPlaceholders(file.contents))) {
 				throw new Error(
 					`adapter declared env-var bearer storage but inlined a bearer token in ${file.hostPath}`,
 				);

--- a/packages/server/src/services/oauth/token-resolver.ts
+++ b/packages/server/src/services/oauth/token-resolver.ts
@@ -25,9 +25,35 @@ const REFRESH_BACKOFF_MAX_MS = 15 * 60_000;
 interface RefreshFailure {
 	attempts: number;
 	nextAttemptAt: number;
+	/**
+	 * Set when the failure cannot be retried out of. Carries the connection's
+	 * `updatedAt` at the time it was parked, so reconnecting - which moves that
+	 * timestamp - un-parks it without needing an explicit hook.
+	 */
+	parkedAtRowVersion?: number;
 }
 
 const failures = new Map<string, RefreshFailure>();
+
+/**
+ * Whether a refresh failure can ever succeed on a retry.
+ *
+ * Two shapes reach this, and neither improves with time: the grant is gone, so
+ * only a human reconnecting restores it; or the connection record is missing the
+ * fields a refresh needs, so it was never able to refresh at all. Retrying
+ * either is what produced connections sitting at 51 attempts and climbing, four
+ * times an hour, forever - a fixed cost with no path to success and nothing said
+ * to the operator beyond a log line.
+ *
+ * Matched on the message because that is what both the provider's token endpoint
+ * and the generic refresh give us; `invalid_grant` is the OAuth 2.0 error code
+ * for exactly this, so it is a contract rather than a phrase we invented.
+ */
+export function isPermanentRefreshFailure(message: string): boolean {
+	return /invalid_grant|invalid_client|unauthorized_client|needs token_url \+ client_id/i.test(
+		message,
+	);
+}
 
 function backoffDelay(attempts: number): number {
 	return Math.min(REFRESH_BACKOFF_BASE_MS * 2 ** (attempts - 1), REFRESH_BACKOFF_MAX_MS);
@@ -133,8 +159,10 @@ export async function refreshExpiringTokens(
 		provider: string;
 		expires_at: Date | null;
 		has_refresh: boolean;
+		updated_at: Date;
 	}>(
-		`SELECT id, provider, expires_at, refresh_token_secret_id IS NOT NULL AS has_refresh
+		`SELECT id, provider, expires_at, updated_at,
+		        refresh_token_secret_id IS NOT NULL AS has_refresh
 		 FROM oauth_connections
 		 WHERE expires_at IS NOT NULL
 		   AND expires_at <= $1
@@ -154,7 +182,23 @@ export async function refreshExpiringTokens(
 		// A connection whose last refresh failed stays out of the sweep until its
 		// backoff elapses — silently, since logging every suppressed retry would
 		// reproduce the flood this exists to stop.
-		.filter((r) => (failures.get(r.id)?.nextAttemptAt ?? 0) <= now);
+		//
+		// A parked one has an infinite backoff and only ever comes back by being
+		// reconnected, which moves `updated_at`. Comparing that here is what makes
+		// the park self-clearing: no hook to remember on the reconnect path, and
+		// nothing to go stale if a new way to reconnect is added later.
+		.filter((r) => {
+			const failure = failures.get(r.id);
+			if (!failure) return true;
+			if (
+				failure.parkedAtRowVersion !== undefined &&
+				r.updated_at.getTime() !== failure.parkedAtRowVersion
+			) {
+				failures.delete(r.id);
+				return true;
+			}
+			return failure.nextAttemptAt <= now;
+		});
 
 	// Chunked rather than one unbounded Promise.all: each refresh is a provider
 	// round-trip plus a secret read and decrypt, and those decrypts queue behind
@@ -225,14 +269,28 @@ async function doRefresh(deps: ConnectionStoreDeps, connectionId: string): Promi
 		log.info('oauth token refreshed', { id: conn.id, provider: conn.provider });
 	} catch (e) {
 		const message = (e as Error).message;
+		const permanent = isPermanentRefreshFailure(message);
 		const state = recordFailure(conn.id, Date.now());
-		log.warn('oauth token refresh failed', {
-			id: conn.id,
-			provider: conn.provider,
-			error: message,
-			attempts: state.attempts,
-			retry_in_s: Math.round((state.nextAttemptAt - Date.now()) / 1000),
-		});
+		if (permanent) {
+			// Park it rather than backing off: no number of attempts turns a revoked
+			// grant or a connection missing its token endpoint into a working one.
+			// Stamped with the row version so reconnecting clears this on its own.
+			state.nextAttemptAt = Number.POSITIVE_INFINITY;
+			state.parkedAtRowVersion = conn.updatedAt.getTime();
+			log.warn('oauth token refresh cannot succeed; reconnect required', {
+				id: conn.id,
+				provider: conn.provider,
+				error: message,
+			});
+		} else {
+			log.warn('oauth token refresh failed', {
+				id: conn.id,
+				provider: conn.provider,
+				error: message,
+				attempts: state.attempts,
+				retry_in_s: Math.round((state.nextAttemptAt - Date.now()) / 1000),
+			});
+		}
 		// Record it on the connector too, so a stale token is visible on the
 		// Connectors page instead of only in the log. Best-effort: a failure here
 		// must not mask the refresh failure we are already reporting.

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -250,6 +250,7 @@ export async function detectOrphans(
 				runId: run.id,
 				memberId: run.member_id,
 				teamId: run.team_id,
+				taskId: run.task_id,
 				priorRetries: run.process_loss_retry_count,
 			},
 			tail.text,
@@ -277,7 +278,14 @@ export async function detectOrphans(
  */
 export async function retryOrEscalateLostRun(
 	db: Db,
-	run: { runId: string; memberId: string; teamId: string; priorRetries: number },
+	run: {
+		runId: string;
+		memberId: string;
+		teamId: string;
+		/** The task the lost run was working, so the retry returns to it. */
+		taskId?: string | null;
+		priorRetries: number;
+	},
 	/** Log excerpt the caller has already read, to save reading it twice. */
 	knownLogTail?: string,
 ): Promise<void> {
@@ -293,6 +301,14 @@ export async function retryOrEscalateLostRun(
 
 		await createWakeup(db, run.memberId, run.teamId, WakeupSource.Timer, {
 			reason: 'orphan_retry',
+			// Naming the task is what makes this a retry rather than a nudge. A
+			// task-less wakeup coalesces onto the agent's queued heartbeat and
+			// `activateAgent` then picks a task by its own ordering, so the retry
+			// could land on different work than was lost - and `retry_of_run_id`
+			// would record lineage across two unrelated tasks. It also brings the
+			// pre-dispatch busy and capacity guards into play, since every one of
+			// them is inside `if (wakeupTaskId)`.
+			...(run.taskId ? { task_id: run.taskId } : {}),
 			retry_count: run.priorRetries + 1,
 			max_retries: MAX_RETRIES,
 			previous_failure: {
@@ -302,15 +318,35 @@ export async function retryOrEscalateLostRun(
 			},
 		});
 	} else {
+		// One record per stuck agent, not one per ceiling. A partial unique index
+		// would be stronger, but this pass is serial in a single process and an
+		// index needs a migration for a guard that is not racing anything.
+		// The member id is bound twice on purpose: once as the uuid column and once
+		// as the text `payload->>` compares against. One parameter in both places
+		// leaves Postgres unable to deduce a single type for it.
 		await db.query(
-			`INSERT INTO approvals (team_id, type, payload)
-				 VALUES ($1, $2::approval_type, $3::jsonb)`,
+			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload)
+			 SELECT $1, $2::approval_type, $3::uuid, $5::jsonb
+			 WHERE NOT EXISTS (
+			   SELECT 1 FROM approvals
+			   WHERE team_id = $1 AND type = $2::approval_type AND status = 'pending'
+			     AND payload->>'type' = 'agent_error'
+			     AND payload->>'member_id' = $4::text
+			 )`,
 			[
 				run.teamId,
 				ApprovalType.Strategy,
+				run.memberId,
+				run.memberId,
 				JSON.stringify({
 					type: 'agent_error',
 					member_id: run.memberId,
+					// Named so the approval can be read back to the run that produced
+					// it; without these the record said an agent had failed and gave a
+					// human nowhere to look.
+					run_id: run.runId,
+					task_id: run.taskId ?? null,
+					last_error: knownLogTail?.trim().slice(-ORPHAN_LOG_TAIL_CHARS) || null,
 					message: `Agent has failed ${MAX_RETRIES} consecutive times. Manual intervention required.`,
 				}),
 			],

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -64,7 +64,14 @@ const ORPHAN_ERROR_TAIL_CHARS = 400;
 function orphanErrorMessage(neverStarted: boolean, logTail: string): string {
 	const verdict = neverStarted
 		? 'Never started: no host process was driving this run, so it was returned to the queue.'
-		: 'Orphaned: process no longer running';
+		: // Says what was observed rather than what was inferred. This pass performs
+			// no process check - it finds a `running` row that no live run in this
+			// process claims - and the old wording ("process no longer running")
+			// asserted one, which read as a fact while being a guess. It was also the
+			// text every setup failure ended up wearing, because those runs threw
+			// without recording anything and this was the only writer left.
+			'Orphaned: nothing was driving this run any more, so no result was ever recorded. ' +
+			'A restart, a crash or a wedged dispatch - not the agent failing.';
 	const excerpt = logTail.trim().slice(-ORPHAN_ERROR_TAIL_CHARS).trim();
 	return excerpt ? `${verdict}\n\nLast log output:\n${excerpt}` : verdict;
 }
@@ -155,8 +162,6 @@ export async function detectOrphans(
 		// here exactly like a healthy running one.
 		if (liveRunIds.has(run.id)) continue;
 
-		orphanCount++;
-
 		// The two arms are not the same event, and giving them one verdict was the
 		// bug. A `running` run had a process doing work that vanished mid-flight:
 		// output may be half-written, the container may hold a wedged tree, and the
@@ -174,7 +179,7 @@ export async function detectOrphans(
 		const tail = await readRunLogTail(db, run.id, ORPHAN_LOG_TAIL_CHARS);
 		const error = orphanErrorMessage(neverStarted, tail.text);
 
-		await db.query(
+		const reaped = await db.query<{ id: string }>(
 			`UPDATE heartbeat_runs
 			 SET status = $2::heartbeat_run_status,
 			     finished_at = now(),
@@ -182,14 +187,28 @@ export async function detectOrphans(
 			     -- Only a real process loss counts toward the escalation. A run that
 			     -- never started is being handed back, not retried after a failure.
 			     process_loss_retry_count = process_loss_retry_count + $4::int
-			 WHERE id = $1`,
+			 WHERE id = $1
+			   AND status IN ($5::heartbeat_run_status, $6::heartbeat_run_status)
+			 RETURNING id`,
 			[
 				run.id,
 				neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed,
 				error,
 				neverStarted ? 0 : 1,
+				HeartbeatRunStatus.Queued,
+				HeartbeatRunStatus.Running,
 			],
 		);
+		// The row went terminal between the scan and this write - its own driver got
+		// there first, a container-death sweep claimed it, or an operator terminated
+		// it. That writer observed the run; this pass only ever observed its absence
+		// from an in-process registry, so their verdict stands and none of the repair
+		// below is this pass's to do. Unguarded, the race replaced a specific cause
+		// with the generic one and spent a strike on a run that had already reported
+		// itself.
+		if (reaped.rows.length === 0) continue;
+
+		orphanCount++;
 
 		// Task-less runs can't resolve a container here; the startup sweep is
 		// their backstop.

--- a/packages/server/src/services/run-failure-classification.ts
+++ b/packages/server/src/services/run-failure-classification.ts
@@ -1,0 +1,60 @@
+/**
+ * Whether a run failure is worth another attempt.
+ *
+ * The question is not how bad the failure was but whether the next attempt will
+ * see the same thing. A dropped output stream or a vanished driver is a fact
+ * about this attempt; a rejected credential, a bad MCP injection or a
+ * misconfigured connector is a fact about the instance, and a retry reproduces
+ * it exactly - having claimed a container first.
+ */
+export const RunFailureClass = {
+	Transient: 'transient',
+	Permanent: 'permanent',
+} as const;
+export type RunFailureClass = (typeof RunFailureClass)[keyof typeof RunFailureClass];
+
+/**
+ * The failures known to be worth retrying, keyed by `Error.name`.
+ *
+ * Keyed by name rather than by constructor for two reasons. The throwers live
+ * under `sandbox/`, `egress/` and `mcp-injectors/`, and none of them may take a
+ * dependency on run-retry policy to be classified - the alternative inverts that
+ * dependency at every throw site. And it keeps this module importing nothing, so
+ * it can never close a cycle with `agent-runner` or `containers`.
+ *
+ * **No provider-specific type may be listed here.** This module sits above the
+ * `ContainerEngine` seam, and a row naming a backend is the conditional that
+ * seam exists to prevent. A provider's failure earns a retry by being translated
+ * into a backend-agnostic type inside that provider's own adapter, which is what
+ * `ExecStreamLostError` already documents itself as doing. The unit test asserts
+ * the shape rather than trusting this paragraph.
+ */
+const TRANSIENT_ERROR_NAMES: Record<string, true> = {
+	// The container's output stream closed while the command was still going:
+	// the transport lost the run, not the agent.
+	ExecStreamLostError: true,
+	// Tunnel ports are per-container, so a redispatch can land somewhere with
+	// room. Nothing about the run itself is wrong.
+	TunnelPortsExhaustedError: true,
+};
+
+/**
+ * Unrecognised means permanent, deliberately.
+ *
+ * A retry is a recovery mechanism for a named, known-transient condition, not a
+ * default posture; minting one for a failure nobody has classified is the
+ * "degrades to" behaviour the codebase rules out. The failure direction is also
+ * asymmetric - a permanent verdict is loud, ending in a terminal row carrying
+ * the real error and a notice on the task thread, while a transient one is
+ * silent and spends a container per attempt. Reclassifying a newly-understood
+ * transient failure is one row above.
+ */
+export function classifyRunFailure(error: unknown): RunFailureClass {
+	const name = error instanceof Error ? error.name : '';
+	return TRANSIENT_ERROR_NAMES[name] ? RunFailureClass.Transient : RunFailureClass.Permanent;
+}
+
+/** The transient names, for the guard test. Not for branching on. */
+export function transientRunFailureNames(): string[] {
+	return Object.keys(TRANSIENT_ERROR_NAMES);
+}

--- a/packages/server/src/services/sandbox/endpoints.ts
+++ b/packages/server/src/services/sandbox/endpoints.ts
@@ -111,3 +111,19 @@ export function tunnelRunEndpoints(ports: TunnelPorts): RunEndpoints {
 		sshPort: ports.ssh,
 	};
 }
+
+/**
+ * One representative triple, for host-side work that must be proven before a
+ * container exists.
+ *
+ * The real ports are chosen by an in-container probe, so they cannot be known
+ * until the container is up - but every real triple has this shape and differs
+ * only in the port digits, and nothing in an MCP adapter or in
+ * `validateInjection` reads a port. That is a claim rather than an assumption,
+ * so `mcp-injection-endpoint-independence.test.ts` pins it across every runtime.
+ */
+export const PREFLIGHT_TUNNEL_ENDPOINTS: RunEndpoints = tunnelRunEndpoints({
+	proxy: TUNNEL_PORT_BASE,
+	mcp: TUNNEL_PORT_BASE + 1,
+	ssh: TUNNEL_PORT_BASE + 2,
+});

--- a/packages/server/src/services/sandbox/pool.ts
+++ b/packages/server/src/services/sandbox/pool.ts
@@ -265,8 +265,8 @@ export function planIdleShutdown(members: readonly PoolMember[]): IdleRetirement
 }
 
 /**
- * Which of a **working** project's idle containers to retire, judged on each
- * member's own idle clock rather than on the project falling quiet.
+ * Which of a project's idle containers to retire, judged on each member's own
+ * idle clock rather than on the project falling quiet.
  *
  * {@link planIdleShutdown} answers "this whole project has gone idle, retire its
  * pool". That is the only question the sweeper used to ask, and it left a gap
@@ -276,11 +276,22 @@ export function planIdleShutdown(members: readonly PoolMember[]): IdleRetirement
  * kept working. Every other project saw a budget it could not reach and queued
  * indefinitely.
  *
- * So a project that is *working* has its idle members judged individually. There
- * is no keep-one-warm rule here, unlike the whole-project plan: the busy members
- * are about to become idle themselves, so warmth for the next run is already
- * accounted for, and holding a second container against that is what the caller
- * is trying to stop.
+ * This pass used to require the project to hold a `busy` member, so that its
+ * warm-start guarantee could be left to the whole-project pass. Between them the
+ * two preconditions did not partition the space: a project whose runs each last
+ * a few seconds is never quiet (queued wakeups and recent finishes keep it out
+ * of the whole-project pass) and rarely busy at the instant a once-a-minute cron
+ * samples it. Its idle members matched neither pass and pinned the budget
+ * indefinitely - which is exactly what `docs/containers/overview.md` promises
+ * cannot happen.
+ *
+ * So the precondition is gone and the warm-start floor lives here instead, as a
+ * property of the plan rather than of which pass happened to run: hold one
+ * member back only when the project has no other way to serve its next run
+ * without a cold provision, and **suspend** that one rather than leave it
+ * running, since a suspended member costs the instance budget nothing and
+ * resumes in about a second. That converges on {@link planIdleShutdown}'s own
+ * rule - two planners, one invariant.
  *
  * `staleMemberIds` are the members the caller has established sat idle past the
  * window - the clock lives in SQL, where it can be indexed, so this stays pure.
@@ -291,17 +302,32 @@ export function planSurplusIdleRetirement(
 	members: readonly PoolMember[],
 	staleMemberIds: ReadonlySet<string>,
 ): IdleRetirementPlan {
-	// Not a working project - either fully idle, in which case the whole-project
-	// pass owns it and its warm-start guarantees, or holding nothing at all.
-	if (!members.some((m) => m.state === 'busy')) return { suspend: [], destroy: [] };
-
 	const stale = members.filter(
 		(m) => m.state === 'idle' && !m.reservedForChat && staleMemberIds.has(m.id),
 	);
-	return {
-		suspend: stale.filter((m) => m.hasUnpushedCommits),
-		destroy: stale.filter((m) => !m.hasUnpushedCommits),
-	};
+	if (stale.length === 0) return { suspend: [], destroy: [] };
+
+	// Unchanged: work that reached no durable remote is suspended, never
+	// destroyed. See planIdleShutdown for the reasoning in full.
+	const pinned = stale.filter((m) => m.hasUnpushedCommits);
+	const disposable = stale.filter((m) => !m.hasUnpushedCommits);
+
+	// Three things already guarantee a warm start, and any one of them is enough:
+	// a busy member (about to become idle itself), a suspended member (a ~1s
+	// resume through the ladder's resume rung), or a pinned member this plan is
+	// about to suspend. The chat's own member does not count - `usable` excludes
+	// it from the ladder, so it is no route to serving a task run.
+	const resumableAlready =
+		pinned.length > 0 ||
+		members.some((m) => !m.reservedForChat && (m.state === 'busy' || m.state === 'suspended'));
+	if (resumableAlready) return { suspend: pinned, destroy: disposable };
+
+	// Nothing else can serve the next run, so the first stale member is held back
+	// and suspended. First rather than newest, matching planIdleShutdown's
+	// `[first, ...rest]`: consistency between the two planners is worth more than
+	// a marginal warmth heuristic, and `loadPoolMembers` orders by created_at.
+	const [keep, ...rest] = disposable;
+	return { suspend: keep ? [keep] : [], destroy: rest };
 }
 
 /** An idle container in some *other* project, offered up to cover a blocked run. */
@@ -312,6 +338,20 @@ export interface ReclaimCandidate {
 	memoryGb: number;
 	/** How long it has sat idle. The caller supplies the clock; this stays pure. */
 	idleForMs: number;
+	/**
+	 * How long the container has existed. A separate question from how long it
+	 * has been idle - see the age floor in {@link planCrossProjectReclaim}. Null
+	 * means the start was never stamped, which is treated as old so a member from
+	 * before that stamping existed is not newly protected.
+	 */
+	ageMs: number | null;
+	/**
+	 * How many members this candidate's project holds that could serve its next
+	 * run without a cold provision - busy, idle or suspended, this candidate
+	 * included. A property of the project rather than of the candidate, so the
+	 * caller counts it and this stays pure.
+	 */
+	projectResumableMembers: number;
 	hasUnpushedCommits: boolean;
 }
 
@@ -347,20 +387,35 @@ export interface ReclaimPlan {
  *   both runs pay a cold start to hand memory to a third project that would lose
  *   it the same way. This is what stops two starved projects reclaiming from each
  *   other in a loop.
+ * - **`minAgeMs` floors it again, on a different clock.** How long a container
+ *   has *existed* is a separate question from how long it has sat idle: one
+ *   created at T, claimed, and released at T+5s clears a 30s idle floor at T+35s
+ *   while still being a container the instance has only just paid a cold
+ *   provision for. Retiring it to hand its memory to a project that will pay the
+ *   same cold start for a replacement is a loss on both sides, which is what an
+ *   operator sees as their instance thrashing.
  *
- * Unpushed commits are suspended rather than destroyed, for the reason
- * {@link planIdleShutdown} sets out at length: suspend frees the memory and keeps
- * the only copy of the work.
+ * A candidate is **suspended rather than destroyed** whenever taking it would
+ * leave its project with no way to serve its own next run - and always when it
+ * holds unpushed commits, for the reason {@link planIdleShutdown} sets out at
+ * length. The two free identical budget memory, since a suspended member is not
+ * counted, so destroying buys the requester nothing and costs the victim a full
+ * cold provision. Bounded at one suspended member per project by construction:
+ * the arm fires only when the project has no other resumable member, and
+ * afterwards it has exactly one.
  */
 export function planCrossProjectReclaim(
 	candidates: readonly ReclaimCandidate[],
 	needGb: number,
 	minIdleMs: number,
+	minAgeMs = 0,
 ): ReclaimPlan {
 	const empty: ReclaimPlan = { suspend: [], destroy: [], freedGb: 0 };
 	if (needGb <= 0) return empty;
 
-	const eligible = candidates.filter((c) => c.idleForMs >= minIdleMs);
+	const eligible = candidates.filter(
+		(c) => c.idleForMs >= minIdleMs && (c.ageMs === null || c.ageMs >= minAgeMs),
+	);
 	if (eligible.reduce((sum, c) => sum + c.memoryGb, 0) < needGb) return empty;
 
 	const heldBy = new Map<string, number>();
@@ -374,9 +429,15 @@ export function planCrossProjectReclaim(
 	});
 
 	const plan: ReclaimPlan = { suspend: [], destroy: [], freedGb: 0 };
+	const takenFrom = new Map<string, number>();
 	for (const candidate of ordered) {
 		if (plan.freedGb >= needGb) break;
-		(candidate.hasUnpushedCommits ? plan.suspend : plan.destroy).push(candidate);
+		const taken = (takenFrom.get(candidate.projectId) ?? 0) + 1;
+		takenFrom.set(candidate.projectId, taken);
+		const wouldStrandVictim = taken >= candidate.projectResumableMembers;
+		(candidate.hasUnpushedCommits || wouldStrandVictim ? plan.suspend : plan.destroy).push(
+			candidate,
+		);
 		plan.freedGb += candidate.memoryGb;
 	}
 	return plan;

--- a/packages/server/src/services/sandbox/pool.ts
+++ b/packages/server/src/services/sandbox/pool.ts
@@ -442,3 +442,61 @@ export function planCrossProjectReclaim(
 	}
 	return plan;
 }
+
+/** One completed cross-project reclaim, for {@link detectReclaimChurn}. */
+export interface ReclaimEvent {
+	atMs: number;
+	requestingProjectId: string;
+	victimProjectId: string;
+	freedGb: number;
+}
+
+export interface ChurnVerdict {
+	churning: boolean;
+	/** Reclaims inside the window. */
+	reclaims: number;
+	/** The pair trading containers back and forth, when that is what happened. */
+	reciprocal: readonly [string, string] | null;
+	freedGb: number;
+}
+
+/**
+ * Whether the instance is thrashing rather than reclaiming.
+ *
+ * Two shapes, and the first is the one an operator cannot otherwise see: two
+ * projects taking memory back off each other, every few minutes, indefinitely.
+ * A single project losing a container to a genuinely starved neighbour is the
+ * mechanism working as designed; the same pair swapping one container in a loop
+ * is a budget too small for the workload, and no amount of correct reclaiming
+ * will fix it.
+ *
+ * Pure, and here rather than beside the log call, because it is a decision about
+ * the pool and every other decision about the pool lives in this file.
+ */
+export function detectReclaimChurn(
+	events: readonly ReclaimEvent[],
+	nowMs: number,
+	windowMs: number,
+	minReclaims: number,
+): ChurnVerdict {
+	const recent = events.filter((e) => nowMs - e.atMs <= windowMs);
+	const freedGb = recent.reduce((sum, e) => sum + e.freedGb, 0);
+	if (recent.length < minReclaims) {
+		return { churning: false, reclaims: recent.length, reciprocal: null, freedGb };
+	}
+
+	// A pair is reciprocal when each has taken from the other inside the window.
+	const took = new Set(recent.map((e) => `${e.requestingProjectId}>${e.victimProjectId}`));
+	for (const edge of took) {
+		const [from, to] = edge.split('>');
+		if (took.has(`${to}>${from}`)) {
+			return { churning: true, reclaims: recent.length, reciprocal: [from, to], freedGb };
+		}
+	}
+	return {
+		churning: recent.length >= minReclaims,
+		reclaims: recent.length,
+		reciprocal: null,
+		freedGb,
+	};
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -457,10 +457,28 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		log.error('Failed to seed default team:', err);
 	}
 
+	// Before the app serves a request, and regardless of lock state: the API must
+	// never show a run as `running` when the process driving it is gone. Both
+	// halves below are raw SQL - the container-backend passes stay behind the
+	// unlock hook, where a connected engine exists.
+	setStartupPhase('workspace', 'Recovering runs interrupted by the last shutdown');
+	try {
+		await jobManager.reconcileDatabaseOnStartup();
+		await chatSessionManager.reconcileDatabaseOnStartup();
+	} catch (err) {
+		log.error('Startup database reconciliation failed:', err);
+	}
+
 	function startUnlockedServices(): void {
+		// The crons deliberately stay here rather than joining the repair above. A
+		// locked instance dispatches nothing - dispatch needs the backend and the
+		// provider credentials - and `MasterKeyManager` has no re-lock path, so no
+		// run can go stale while locked. The boot repair closes the only gap;
+		// starting the wakeup dispatcher against a pending engine would open a new
+		// one.
 		jobManager
-			.reconcileOnStartup()
-			.catch((err) => log.error('Startup reconciliation failed:', err))
+			.reconcileContainersOnStartup()
+			.catch((err) => log.error('Startup container reconciliation failed:', err))
 			.finally(() => {
 				jobManager.start();
 				// Warm the HQ container as soon as the instance is unlocked so the CEO
@@ -473,10 +491,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 						.catch((err) => log.error('Failed to warm HQ container on startup:', err)),
 				);
 			});
-		chatSessionManager
-			.reconcileOnStartup()
-			.catch((err) => log.error('CEO session reconciliation failed:', err))
-			.finally(() => chatSessionManager.start());
+		chatSessionManager.start();
 		// Re-encode any legacy plaintext webhook secret (migration 050) before the
 		// adapters come up. Needs the master key, which migrations at boot do not
 		// have — this is the first moment it exists. Idempotent: a no-op once every

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../src/services/agent-runner';
 import { ensureProjectContainerRunning } from '../src/services/containers';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { detectOrphans } from '../src/services/orphan-detector';
 import { PricingService, upsertManualRate } from '../src/services/pricing';
 import { CONTAINER_SUBSCRIPTION_BASE } from '../src/services/runtime-home';
 import type { ContainerEngine } from '../src/services/sandbox/types';
@@ -1333,11 +1334,22 @@ describe('runAgent lifecycle — egress + ssh wiring', () => {
 			} as any,
 		});
 
-		// Setup failures propagate out of `runAgent` (the job manager catches them);
-		// the point here is that the resources are released on the way past.
-		await expect(runAgent(deps, makeAgent(), makeTask(), makeProject())).rejects.toThrow(
-			'refused the write',
+		// A setup failure is recorded, not propagated: `runAgent` resolves with a
+		// failed result and the row carries the real cause. It used to throw past
+		// every writer, leaving the row `running` with no error - which silenced the
+		// failure ping (it returns early on a non-terminal status) and left the
+		// orphan pass to invent "process no longer running" 30s later.
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		expect(result.success).toBe(false);
+		expect(result.stderr).toContain('refused the write');
+
+		const row = await db.query<{ status: string; error: string | null; finished_at: string }>(
+			'SELECT status, error, finished_at FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
 		);
+		expect(row.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(row.rows[0].error).toContain('refused the write');
+		expect(row.rows[0].finished_at).not.toBeNull();
 
 		// The tunnel really did start - otherwise the assertion below is vacuous.
 		expect(rootsSeen).toContain(CONTAINER_WORKSPACE_ROOT);
@@ -1348,6 +1360,161 @@ describe('runAgent lifecycle — egress + ssh wiring', () => {
 		expect(sshCalls.released.sort()).toEqual(sshCalls.allocated.sort());
 		expect(egressCalls.released.sort()).toEqual(egressCalls.allocated.sort());
 		expect(sshCalls.allocated.some((id) => !id.startsWith('provision-'))).toBe(true);
+	});
+
+	/** The same injection the release test uses: fails inside `buildRunContext`. */
+	const dockerRefusingTheRuntimeHome = (): ContainerEngine => {
+		const base = makeDocker({
+			openExecChannel: async () => ({
+				write: () => {},
+				onData: () => {},
+				onStderr: () => {},
+				onClose: () => {},
+				close: () => {},
+			}),
+		});
+		const stubFiles = base.files.bind(base);
+		return {
+			...base,
+			files: (containerId: string, containerRoot: string) => {
+				if (containerRoot.startsWith(CONTAINER_SUBSCRIPTION_BASE)) {
+					throw new Error('sandbox file API refused the write');
+				}
+				return stubFiles(containerId, containerRoot);
+			},
+		} as unknown as ContainerEngine;
+	};
+
+	const orphanRetriesFor = async (memberId: string): Promise<number> => {
+		const res = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND payload->>'reason' = 'orphan_retry'`,
+			[memberId],
+		);
+		return res.rows[0].c;
+	};
+
+	it('does not mint a recovery retry for a setup failure that will reproduce', async () => {
+		// A configuration fault fails identically on every attempt, so a retry costs
+		// a container and buys nothing. This is the loop that turned one bad MCP
+		// injection into hundreds of failed runs on a single task.
+		const before = await orphanRetriesFor(agentId);
+
+		const result = await runAgent(
+			baseDeps(dockerRefusingTheRuntimeHome()),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(await orphanRetriesFor(agentId)).toBe(before);
+		const row = await db.query<{ process_loss_retry_count: number }>(
+			'SELECT process_loss_retry_count FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(row.rows[0].process_loss_retry_count).toBe(0);
+	});
+
+	it('mints one bounded retry when the setup failure is a lost transport', async () => {
+		const before = await orphanRetriesFor(agentId);
+
+		const base = makeDocker({
+			openExecChannel: async () => ({
+				write: () => {},
+				onData: () => {},
+				onStderr: () => {},
+				onClose: () => {},
+				close: () => {},
+			}),
+		});
+		const stubFiles = base.files.bind(base);
+		const docker = {
+			...base,
+			files: (containerId: string, containerRoot: string) => {
+				if (containerRoot.startsWith(CONTAINER_SUBSCRIPTION_BASE)) {
+					// Classified by name, so constructing it here needs no import from
+					// the sandbox package - which is the property being relied on.
+					throw Object.assign(new Error('output stream closed'), {
+						name: 'ExecStreamLostError',
+					});
+				}
+				return stubFiles(containerId, containerRoot);
+			},
+		} as unknown as ContainerEngine;
+
+		const result = await runAgent(baseDeps(docker), makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(false);
+		expect(await orphanRetriesFor(agentId)).toBe(before + 1);
+		const row = await db.query<{ process_loss_retry_count: number }>(
+			'SELECT process_loss_retry_count FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(row.rows[0].process_loss_retry_count).toBe(1);
+	});
+
+	it('records a cancelled run, not a failed one, when the abort lands mid-setup', async () => {
+		// A shutdown reaching `buildRunContext` is a cancellation, and recording it
+		// as a failure would put an unactionable row in the Errored view on every
+		// restart. The shape is the real one: aborting the signal makes the awaited
+		// operation reject with an AbortError.
+		const controller = new AbortController();
+		const base = makeDocker({
+			openExecChannel: async () => ({
+				write: () => {},
+				onData: () => {},
+				onStderr: () => {},
+				onClose: () => {},
+				close: () => {},
+			}),
+		});
+		const stubFiles = base.files.bind(base);
+		const docker = {
+			...base,
+			files: (containerId: string, containerRoot: string) => {
+				if (containerRoot.startsWith(CONTAINER_SUBSCRIPTION_BASE)) {
+					controller.abort();
+					throw new DOMException('Aborted', 'AbortError');
+				}
+				return stubFiles(containerId, containerRoot);
+			},
+		} as unknown as ContainerEngine;
+
+		const result = await runAgent(
+			baseDeps(docker),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			controller.signal,
+		);
+
+		const row = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(row.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
+	});
+
+	it('leaves nothing for the orphan pass to reap after a setup failure', async () => {
+		// The end-to-end property. The row is terminal the moment the run fails, so
+		// the 30s pass never selects it and never overwrites the real cause with
+		// "Orphaned: process no longer running".
+		const result = await runAgent(
+			baseDeps(dockerRefusingTheRuntimeHome()),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+		);
+
+		expect(await detectOrphans(db, new Set())).toBe(0);
+		const row = await db.query<{ error: string | null }>(
+			'SELECT error FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(row.rows[0].error).toContain('refused the write');
+		expect(row.rows[0].error).not.toContain('Orphaned');
 	});
 });
 

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -1497,6 +1497,83 @@ describe('runAgent lifecycle — egress + ssh wiring', () => {
 		expect(row.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
 	});
 
+	it('refuses a run whose MCP config cannot build, without starting a container', async () => {
+		// The production failure, and the assertion that matters is the call count.
+		// `validateInjection` needs no container, so firing it after one had been
+		// provisioned made every lap pay a cold provision - and, on a full budget,
+		// retire another project's container to make room for it first.
+		//
+		// The poison is a realistic misconfiguration: a SaaS connector whose header
+		// carries a raw token instead of a `__HEZO_SECRET_*__` placeholder. Codex
+		// stores bearers in env, so inlining one into its config.toml is exactly the
+		// contract violation the adapter check exists for.
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, activated_at)
+			 VALUES ($1, 'saas', $2::jsonb, 'installed', now())`,
+			[
+				'preflight-poison',
+				JSON.stringify({
+					url: 'https://example.test/mcp',
+					headers: { Authorization: 'Bearer sk-live-not-a-placeholder' },
+				}),
+			],
+		);
+		await db.query(`DELETE FROM ai_provider_configs WHERE provider = 'openai'`);
+		await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: JSON.stringify({
+					tokens: {
+						id_token: 'header.payload.sig',
+						access_token: 'header.payload.sig',
+						refresh_token: 'rt-preflight',
+						account_id: 'acct-preflight',
+					},
+				}),
+				auth_method: AiAuthMethod.Subscription,
+				label: 'openai-preflight',
+			}),
+		});
+		try {
+			let created = 0;
+			const base = makeDocker();
+			const docker = {
+				...base,
+				createContainer: async (...args: unknown[]) => {
+					created++;
+					return (base.createContainer as (...a: unknown[]) => unknown)(...args) as never;
+				},
+			} as unknown as ContainerEngine;
+
+			// Pinned to Codex because it stores bearers in env; on an `inline` runtime
+			// the adapter contract permits a header in a file and there is nothing to
+			// refuse.
+			const result = await runAgent(
+				baseDeps(docker),
+				makeAgent(),
+				{ ...makeTask(), runtime_type: 'codex' as const },
+				makeProject(),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.stderr).toContain('cannot be prepared');
+			expect(result.stderr).toContain('No container was started');
+			expect(created).toBe(0);
+
+			const row = await db.query<{ status: string; error: string }>(
+				'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+				[result.heartbeatRunId],
+			);
+			expect(row.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+			expect(row.rows[0].error).toContain('inlined a bearer token');
+		} finally {
+			await db.query('DELETE FROM mcp_connections WHERE name = $1', ['preflight-poison']);
+			await db.query(`DELETE FROM ai_provider_configs WHERE provider = 'openai'`);
+		}
+	});
+
 	it('leaves nothing for the orphan pass to reap after a setup failure', async () => {
 		// The end-to-end property. The row is terminal the moment the run fails, so
 		// the 30s pass never selects it and never overwrites the real cause with

--- a/packages/server/test/chat-session-compaction-lifecycle.test.ts
+++ b/packages/server/test/chat-session-compaction-lifecycle.test.ts
@@ -920,7 +920,7 @@ describe('ChatSessionManager — warm resources (ssh bridge + egress) and lifecy
 			[conversationId],
 		);
 
-		await manager.reconcileOnStartup();
+		await manager.reconcileDatabaseOnStartup();
 
 		const session = await ctx.db.query<{ status: string }>(
 			'SELECT status FROM chat_sessions LIMIT 1',

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -691,7 +691,7 @@ describe('ChatSessionManager', () => {
 			[ceo.rows[0].id, DEFAULT_TEAM_ID, projectId],
 		);
 		const { manager } = makeManager(ctx, makeChatDocker(ctx.dataDir, projectId).docker);
-		await manager.reconcileOnStartup();
+		await manager.reconcileDatabaseOnStartup();
 		const r = await ctx.db.query<{ status: string }>('SELECT status FROM chat_sessions LIMIT 1');
 		expect(r.rows[0].status).toBe(ChatSessionStatus.Crashed);
 	});
@@ -714,7 +714,7 @@ describe('ChatSessionManager', () => {
 		const done = await insert('complete', 'all good');
 		const userMsg = await insert('complete', 'hello', 'user');
 
-		await manager.reconcileOnStartup();
+		await manager.reconcileDatabaseOnStartup();
 
 		const rows = await ctx.db.query<{ id: string; status: string }>(
 			'SELECT id, status FROM chat_messages',

--- a/packages/server/test/containers-pool-acquire.test.ts
+++ b/packages/server/test/containers-pool-acquire.test.ts
@@ -326,13 +326,27 @@ describe('acquireRunContainer reclaiming from another project', () => {
 	async function seedIdle(
 		project: string,
 		containerId: string,
-		over: { idleMin?: number; unpushed?: boolean } = {},
+		over: { idleMin?: number; unpushed?: boolean; ageMin?: number } = {},
 	): Promise<void> {
+		// `ageMin` defaults well past the reclaim age floor, and above `idleMin`:
+		// a container cannot have been idle for longer than it has existed, and a
+		// row left at `created_at = now()` reads as one the instance has only just
+		// paid to build, which reclaim declines.
+		const idleMin = over.idleMin ?? 10;
 		await db.query(
 			`INSERT INTO container_pool_members
-			   (project_id, container_id, state, memory_bytes, has_unpushed_commits, last_released_at)
-			 VALUES ($1, $2, 'idle', $3, $4, now() - ($5 || ' minutes')::interval)`,
-			[project, containerId, CAP_BYTES, over.unpushed ?? false, over.idleMin ?? 10],
+			   (project_id, container_id, state, memory_bytes, has_unpushed_commits,
+			    last_released_at, created_at)
+			 VALUES ($1, $2, 'idle', $3, $4, now() - ($5 || ' minutes')::interval,
+			         now() - ($6 || ' minutes')::interval)`,
+			[
+				project,
+				containerId,
+				CAP_BYTES,
+				over.unpushed ?? false,
+				idleMin,
+				over.ageMin ?? Math.max(60, idleMin),
+			],
 		);
 	}
 
@@ -345,14 +359,62 @@ describe('acquireRunContainer reclaiming from another project', () => {
 		await setMaxContainerMemoryGb(db, 2);
 		try {
 			const acquired = await acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED);
-			expect(removed).toContain('donor-idle');
 			expect(acquired.containerId).not.toBe('donor-idle');
-			// The donor's row goes with the container - it is destroyed, never handed over.
-			const left = await db.query<{ container_id: string }>(
-				'SELECT container_id FROM container_pool_members WHERE project_id = $1',
+			// It was the donor's only container, so it is suspended rather than
+			// destroyed: both free the same budget memory, and suspend leaves the
+			// donor a ~1s resume instead of a full cold provision.
+			expect(stopped).toContain('donor-idle');
+			expect(removed).not.toContain('donor-idle');
+			const left = await db.query<{ container_id: string; state: string }>(
+				'SELECT container_id, state FROM container_pool_members WHERE project_id = $1',
 				[donor],
 			);
-			expect(left.rows).toEqual([]);
+			expect(left.rows).toEqual([{ container_id: 'donor-idle', state: 'suspended' }]);
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
+		}
+	});
+
+	it('destroys a donor’s surplus and keeps one resumable', async () => {
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Surplus Donor');
+		const starved = await freshProject('Reclaim Surplus Starved');
+		await seedIdle(donor, 'donor-a');
+		await seedIdle(donor, 'donor-b');
+		// Room for two containers, both held by the donor.
+		await setMaxContainerMemoryGb(db, 4);
+		try {
+			await acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED);
+			// One container's worth covers the shortfall, and the donor still has
+			// another, so that one is destroyed outright.
+			expect(removed.length).toBe(1);
+			expect(stopped).toEqual([]);
+			const left = await db.query<{ c: number }>(
+				`SELECT COUNT(*)::int AS c FROM container_pool_members
+				  WHERE project_id = $1 AND state IN ('idle', 'suspended')`,
+				[donor],
+			);
+			expect(left.rows[0].c).toBe(1);
+		} finally {
+			await setMaxContainerMemoryGb(db, 40);
+		}
+	});
+
+	it('never reclaims a container the instance only just built', async () => {
+		// The age floor, distinct from the idle one: this container has been idle
+		// far longer than the idle window but was provisioned moments ago, so
+		// retiring it would throw away a cold provision the instance just paid for.
+		await emptyFleet();
+		const donor = await freshProject('Reclaim Fresh Donor');
+		const starved = await freshProject('Reclaim Fresh Starved');
+		await seedIdle(donor, 'donor-brandnew', { idleMin: 10, ageMin: 1 });
+		await setMaxContainerMemoryGb(db, 2);
+		try {
+			await expect(
+				acquireRunContainer(deps(reclaimingDocker()), starved, TASK_STARVED),
+			).rejects.toThrow(PoolCapacityError);
+			expect(removed).not.toContain('donor-brandnew');
+			expect(stopped).not.toContain('donor-brandnew');
 		} finally {
 			await setMaxContainerMemoryGb(db, 40);
 		}

--- a/packages/server/test/docs-terminology.test.ts
+++ b/packages/server/test/docs-terminology.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -13,7 +13,11 @@ import { loadFilesystemDocs } from '../src/services/docs-bundle';
  *  - the whole `docs/` tree, including the generated `docs/reference/mcp-api.md`
  *    (it is not exempt — its dashes are fixed in the MCP tool descriptions and
  *    `TOOL_DOC_META` that generate it, then `bun run build:docs` re-emits it);
- *  - the READMEs, which the docs loader does not reach.
+ *  - the READMEs, which the docs loader does not reach;
+ *  - the web app's own source, whose UI strings the rule covers too and which
+ *    nothing checked until 207 of them had accumulated. Code comments are
+ *    exempt by AGENTS.md, so comment-only lines are skipped - the same rule the
+ *    sweep that cleared them used, so guard and fix cannot disagree.
  *
  * Read the docs straight off the filesystem rather than via `loadDocs()`: that
  * helper prefers `docs-bundle.json` once a build has populated it, which would
@@ -25,6 +29,28 @@ const REPO_ROOT = join(here, '..', '..', '..');
 const DOCS_DIR = join(REPO_ROOT, 'docs');
 
 const README_PATHS = ['README.md', 'packages/server/README.md', 'packages/shared/README.md'];
+
+const WEB_SRC_DIR = join(REPO_ROOT, 'packages', 'web', 'src');
+/**
+ * The message catalogs have their own dash guard in `i18n-catalog.test.ts`,
+ * which checks all twelve languages rather than just the source strings.
+ */
+const WEB_SKIP = join('lib', 'i18n', 'catalog');
+
+/** A line that is wholly a comment. Exempt, per AGENTS.md § terminology. */
+const COMMENT_LINE = /^\s*(\/\/|\*|\/\*)/;
+
+async function walkWebSource(dir: string, rel = ''): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const out: string[] = [];
+	for (const entry of entries) {
+		const childRel = join(rel, entry.name);
+		if (childRel.startsWith(WEB_SKIP)) continue;
+		if (entry.isDirectory()) out.push(...(await walkWebSource(join(dir, entry.name), childRel)));
+		else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) out.push(childRel);
+	}
+	return out;
+}
 
 /** Dashes banned from user-facing prose, with the name to print on a failure. */
 const BANNED_DASHES = [
@@ -70,6 +96,30 @@ describe('user-facing prose uses hyphens, never em or en dashes', () => {
 		expect(
 			violations.slice(0, 25),
 			`${violations.length} banned dash(es) in docs/. ${FIX} docs/reference/mcp-api.md is generated: fix the tool description or TOOL_DOC_META in packages/server/src/mcp/ and re-run 'bun run build:docs'.`,
+		).toEqual([]);
+	});
+
+	it('no web UI string contains an em or en dash', async () => {
+		const files = await walkWebSource(WEB_SRC_DIR);
+		// Guard the guard: a broken path would make the assertion below vacuous.
+		expect(files.length).toBeGreaterThan(100);
+
+		const violations = (
+			await Promise.all(
+				files.map(async (rel) => {
+					const raw = await readFile(join(WEB_SRC_DIR, rel), 'utf-8');
+					const withoutComments = raw
+						.split('\n')
+						.map((line) => (COMMENT_LINE.test(line) ? '' : line))
+						.join('\n');
+					return findDashes(join('packages/web/src', rel), withoutComments);
+				}),
+			)
+		).flat();
+
+		expect(
+			violations.slice(0, 25),
+			`${violations.length} banned dash(es) in web UI strings. ${FIX}`,
 		).toEqual([]);
 	});
 

--- a/packages/server/test/job-manager-idle-stop.test.ts
+++ b/packages/server/test/job-manager-idle-stop.test.ts
@@ -538,9 +538,45 @@ describe('surplus idle containers in a working project', () => {
 		expect(await remaining()).toEqual(['busy-1', 'chat']);
 	});
 
-	it('leaves a fully idle project to the whole-project pass, which keeps one warm', async () => {
-		// No busy member, so this is not a working project: the pass above owns it
-		// and suspends one member for a warm restart rather than picking them off.
+	it('keeps exactly one member warm for a fully idle project', async () => {
+		// Both passes answer this the same way now that the warm-start floor lives
+		// in the planner rather than in which pass happened to run.
+		await seedMember('a', 'idle');
+		await seedMember('b', 'idle');
+
+		const { stops, removes } = await sweep();
+		expect(stops).toEqual(['a']);
+		expect(removes).toEqual(['b']);
+	});
+
+	it('frees the surplus of a project that is working but holds no busy member', async () => {
+		// The production dead zone, end to end. A run that finished seconds ago
+		// keeps the project inside BUSY_PROJECTS_SQL, so the whole-project pass
+		// declines; no member is `busy` at this instant, so the surplus pass used to
+		// decline as well. Three idle members then pinned 12 of a 16 GB budget
+		// indefinitely and every acquire in another project reclaimed instead.
+		await db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+			 VALUES ($1, $2, $3, 'failed'::heartbeat_run_status, now() - interval '1 minute', now())`,
+			[agentId, teamId, taskId],
+		);
+		await seedMember('a', 'idle');
+		await seedMember('b', 'idle');
+		await seedMember('c', 'idle');
+
+		const { stops, removes } = await sweep();
+		expect(stops).toEqual(['a']);
+		expect(removes.sort()).toEqual(['b', 'c']);
+		expect(await remaining()).toEqual(['a']);
+	});
+
+	it('frees the surplus when a queued wakeup is what keeps the project busy', async () => {
+		// The other arm of BUSY_PROJECTS_SQL, and the one a retry storm produces.
+		await db.query(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, payload, status)
+			 VALUES ($1, $2, 'timer'::wakeup_source, $3::jsonb, 'queued'::wakeup_status)`,
+			[agentId, teamId, JSON.stringify({ task_id: taskId })],
+		);
 		await seedMember('a', 'idle');
 		await seedMember('b', 'idle');
 

--- a/packages/server/test/job-manager-shutdown-drain.test.ts
+++ b/packages/server/test/job-manager-shutdown-drain.test.ts
@@ -1,0 +1,106 @@
+// The drain is plain JS timing over the dispatch registries, not `node:`
+// behaviour, so it belongs in the vitest tier rather than the Bun-native one.
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { safeClose } from './helpers';
+import { createStubDocker, createTestApp } from './helpers/app';
+
+let db: Db;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+
+function makeManager(): JobManager {
+	return new JobManager({
+		db,
+		docker: createStubDocker({ ping: async () => true }),
+		masterKeyManager,
+		serverPort: 3100,
+		dataDir,
+		wsManager: { broadcast: () => {} } as unknown as JobManagerDeps['wsManager'],
+		logs: new LogStreamBroker(),
+		containerLogStreamer: new ContainerLogStreamer(),
+	});
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('shutdown drain', () => {
+	it('refuses new work once it has stopped accepting', () => {
+		// Without this the 5s wakeup cron keeps handing fresh runs to a process on
+		// its way out, and the drain below never converges.
+		const jm = makeManager();
+		expect(jm.launchTask('drain-accepting', async () => {}, 1_000)).toBe(true);
+		jm.stopAcceptingWork();
+		expect(jm.launchTask('drain-refused', async () => {}, 1_000)).toBe(false);
+		jm.shutdown();
+	});
+
+	it('returns immediately when nothing is in flight', async () => {
+		const jm = makeManager();
+		expect(await jm.drainRunningRuns(5_000)).toEqual([]);
+		jm.shutdown();
+	});
+
+	it('waits for a settling run and aborts it with the shutdown reason', async () => {
+		// Before the drain existed, `shutdown()` aborted and cleared the registries
+		// in one step, so the DB closed while the runs it had just cancelled were
+		// still writing their terminal rows.
+		const jm = makeManager();
+		let seenReason: unknown;
+		const launched = jm.launchTask(
+			'drain-settling',
+			(signal) =>
+				new Promise<void>((resolve) => {
+					signal.addEventListener('abort', () => {
+						seenReason = signal.reason;
+						resolve();
+					});
+				}),
+			60_000,
+		);
+		expect(launched).toBe(true);
+
+		const stranded = await jm.drainRunningRuns(5_000);
+
+		expect(seenReason).toBe('server_shutdown');
+		expect(stranded).toEqual([]);
+		jm.shutdown();
+	});
+
+	it('gives up at the deadline rather than holding shutdown open', async () => {
+		// A run that never settles must not outlast the budget the service manager
+		// allows, or the supervisor SIGKILLs mid-write.
+		const jm = makeManager();
+		// Released after the assertion so the test leaves nothing pending behind it -
+		// an unsettled promise here would hang the suite's own teardown, not just
+		// this case.
+		let release: (() => void) | undefined;
+		jm.launchTask(
+			'drain-wedged',
+			() =>
+				new Promise<void>((resolve) => {
+					release = resolve;
+				}),
+			60_000,
+		);
+		const started = Date.now();
+		await jm.drainRunningRuns(200);
+		expect(Date.now() - started).toBeLessThan(5_000);
+		jm.shutdown();
+		release?.();
+	});
+});

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -913,6 +913,67 @@ describe('JobManager workflow methods', () => {
 				return r.rows;
 			}
 
+			it('settles a run its driver abandoned, so the thread still hears about it', async () => {
+				// The production regression. `runAgent` threw past its own finalizer,
+				// so the row stayed `running` - and `postFailurePing` returns early on
+				// a non-terminal status, so nothing at all reached the task thread.
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.Running);
+
+				const manager = createJobManager();
+				await (manager as any).finalizeThrownRun(runId, new Error('sandbox refused the write'));
+
+				const row = await db.query<{ status: string; error: string; exit_code: number }>(
+					'SELECT status, error, exit_code FROM heartbeat_runs WHERE id = $1',
+					[runId],
+				);
+				expect(row.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+				expect(row.rows[0].error).toBe('sandbox refused the write');
+				expect(row.rows[0].exit_code).toBe(-1);
+
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					taskId,
+					taskIdentifier,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stderr: 'sandbox refused the write',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const pings = (await readSystemComments()).filter((c) => c.content.kind === 'run_failed');
+				expect(pings.length).toBe(1);
+				expect(pings[0].content.error).toBe('sandbox refused the write');
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('leaves a run somebody else already settled alone', async () => {
+				// The guard. A row the runner finalized keeps its own richer verdict.
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.Succeeded);
+
+				const manager = createJobManager();
+				await (manager as any).finalizeThrownRun(runId, new Error('a later, vaguer error'));
+
+				const row = await db.query<{ status: string; error: string | null }>(
+					'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+					[runId],
+				);
+				expect(row.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
+				expect(row.rows[0].error).toBeNull();
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
 			it('posts a system comment on failed status without queuing a retry wakeup', async () => {
 				await clearRunsAndComments();
 				const runId = await seedRun(HeartbeatRunStatus.Failed, 'The operation timed out.');

--- a/packages/server/test/mcp-injection-endpoint-independence.test.ts
+++ b/packages/server/test/mcp-injection-endpoint-independence.test.ts
@@ -1,0 +1,77 @@
+// The pre-claim preflight builds a runtime's MCP injection before the tunnel
+// exists, so it uses a stand-in loopback port. That is only sound if no adapter
+// and no part of `validateInjection` reads the port - a claim, and this is what
+// pins it rather than a comment asserting it.
+
+import { AgentRuntime, AiProvider } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import {
+	buildMcpInjection,
+	HEZO_MCP_SERVER_NAME,
+	MCP_ADAPTERS,
+} from '../src/services/mcp-injectors';
+import {
+	TUNNEL_PORT_BASE,
+	TUNNEL_PORT_RANGE,
+	tunnelRunEndpoints,
+} from '../src/services/sandbox/endpoints';
+
+const HOME = '/workspace/.hezo/subscription/codex/run-1';
+
+function injectionAt(runtime: AgentRuntime, mcpPort: number) {
+	const endpoints = tunnelRunEndpoints({
+		proxy: mcpPort - 1,
+		mcp: mcpPort,
+		ssh: mcpPort + 1,
+	});
+	const requiresHome = MCP_ADAPTERS[runtime].capabilities.requiresHomeDir;
+	return buildMcpInjection(
+		runtime,
+		[
+			{
+				kind: 'http',
+				name: HEZO_MCP_SERVER_NAME,
+				url: `${endpoints.hezoBaseUrl}/mcp`,
+				bearerToken: 'jwt.body.signature',
+			},
+		],
+		{
+			hostHomeDir: requiresHome ? HOME : null,
+			containerHomeDir: requiresHome ? HOME : null,
+			provider: AiProvider.Anthropic,
+			runModel: null,
+			projectDocSlugs: [],
+			stopJudge: true,
+			systemPrompt: null,
+		},
+	);
+}
+
+describe('MCP injection is independent of the tunnel port', () => {
+	const low = TUNNEL_PORT_BASE + 1;
+	const high = TUNNEL_PORT_BASE + TUNNEL_PORT_RANGE - 1;
+
+	for (const runtime of Object.values(AgentRuntime)) {
+		it(`${runtime} differs only in the port digits`, () => {
+			const a = JSON.stringify(injectionAt(runtime, low));
+			const b = JSON.stringify(injectionAt(runtime, high));
+			// Substituting one port for the other must make the two identical. If an
+			// adapter ever branched on a port, or embedded one somewhere the
+			// substitution does not reach, this is where it shows up.
+			const normalise = (s: string, port: number) =>
+				s
+					.split(String(port))
+					.join('<MCP>')
+					.split(String(port - 1))
+					.join('<PROXY>')
+					.split(String(port + 1))
+					.join('<SSH>');
+			expect(normalise(a, low)).toBe(normalise(b, high));
+		});
+
+		it(`${runtime} accepts the preflight's stand-in ports`, () => {
+			// The preflight would otherwise refuse every run on this runtime.
+			expect(() => injectionAt(runtime, low)).not.toThrow();
+		});
+	}
+});

--- a/packages/server/test/mcp-injectors.test.ts
+++ b/packages/server/test/mcp-injectors.test.ts
@@ -442,6 +442,54 @@ describe('validateInjection', () => {
 		).toThrow(/inlined a bearer token/);
 	});
 
+	// Every adapter that stores bearers in env, so a new one inherits the cases
+	// below rather than needing them written again.
+	const envVarAdapters = Object.entries(MCP_ADAPTERS).filter(
+		([, a]) => a.capabilities.bearerTokenStorage === 'env-var',
+	);
+
+	it('covers more than one env-var adapter', () => {
+		expect(envVarAdapters.length).toBeGreaterThan(1);
+	});
+
+	for (const [runtime, adapter] of envVarAdapters) {
+		// A connector's Authorization header is a placeholder by design; the egress
+		// proxy substitutes the value at request time. Reading it as an inlined
+		// token failed every run on these runtimes for any project with a
+		// bearer-auth MCP connector.
+		it(`accepts a secret placeholder in a rendered header (${runtime})`, () => {
+			expect(() =>
+				validateInjection(adapter, {
+					cliArgs: [],
+					envEntries: [],
+					files: [
+						{
+							hostPath: '/tmp/config.toml',
+							mode: 0o600,
+							contents: 'Authorization = "Bearer __HEZO_SECRET_NOTION_TOKEN__"',
+						},
+					],
+				}),
+			).not.toThrow();
+		});
+
+		it(`still rejects a real token alongside a placeholder (${runtime})`, () => {
+			expect(() =>
+				validateInjection(adapter, {
+					cliArgs: [],
+					envEntries: [],
+					files: [
+						{
+							hostPath: '/tmp/config.toml',
+							mode: 0o600,
+							contents: 'a = "Bearer __HEZO_SECRET_NOTION_TOKEN__"\nb = "Bearer sk-live-abcdefgh"',
+						},
+					],
+				}),
+			).toThrow(/inlined a bearer token/);
+		});
+	}
+
 	it('rejects a file mode that is zero or out of range', () => {
 		for (const mode of [0, 0o1000]) {
 			expect(() =>

--- a/packages/server/test/migrate-062-drop-vestigial-process-pid.test.ts
+++ b/packages/server/test/migrate-062-drop-vestigial-process-pid.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '062_drop_vestigial_process_pid.sql';
+
+describe('062_drop_vestigial_process_pid migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let memberId: string;
+	let failedRunId: string;
+	let succeededRunId: string;
+
+	const FAILED_ERROR = 'Orphaned: nothing was driving this run any more';
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		memberId = member.rows[0].id;
+
+		const failed = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, status, error, exit_code, cost_cents,
+			    input_tokens, output_tokens, process_loss_retry_count, finished_at)
+			 VALUES ($1, $2, 'failed'::heartbeat_run_status, $3, -1, 42, 100, 200, 2, now())
+			 RETURNING id`,
+			[teamId, memberId, FAILED_ERROR],
+		);
+		failedRunId = failed.rows[0].id;
+
+		const succeeded = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, exit_code, cost_cents, finished_at)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, 0, 7, now())
+			 RETURNING id`,
+			[teamId, memberId],
+		);
+		succeededRunId = succeeded.rows[0].id;
+
+		// The retry lineage must survive: it is what bounds the lost-run chain, and
+		// it is the column deliberately kept while `process_pid` goes.
+		await h.db.query('UPDATE heartbeat_runs SET retry_of_run_id = $1 WHERE id = $2', [
+			succeededRunId,
+			failedRunId,
+		]);
+
+		await h.applyTarget(TARGET);
+	});
+
+	afterAll(async () => {
+		await h.close();
+	});
+
+	it('keeps every pre-existing run row and everything recorded on it', async () => {
+		const rows = await h.db.query<{
+			id: string;
+			status: string;
+			error: string | null;
+			exit_code: number | null;
+			cost_cents: number | null;
+			input_tokens: number | null;
+			output_tokens: number | null;
+			process_loss_retry_count: number;
+			retry_of_run_id: string | null;
+		}>(
+			`SELECT id, status::text AS status, error, exit_code, cost_cents,
+			        input_tokens, output_tokens, process_loss_retry_count, retry_of_run_id
+			 FROM heartbeat_runs ORDER BY created_at`,
+		);
+		expect(rows.rows.length).toBe(2);
+
+		const failed = rows.rows.find((r) => r.id === failedRunId);
+		expect(failed?.status).toBe('failed');
+		expect(failed?.error).toBe(FAILED_ERROR);
+		expect(failed?.exit_code).toBe(-1);
+		expect(Number(failed?.cost_cents)).toBe(42);
+		expect(Number(failed?.input_tokens)).toBe(100);
+		expect(Number(failed?.output_tokens)).toBe(200);
+		expect(failed?.process_loss_retry_count).toBe(2);
+		expect(failed?.retry_of_run_id).toBe(succeededRunId);
+
+		const succeeded = rows.rows.find((r) => r.id === succeededRunId);
+		expect(succeeded?.status).toBe('succeeded');
+		expect(Number(succeeded?.cost_cents)).toBe(7);
+	});
+
+	it('removes the column', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'heartbeat_runs' AND column_name = 'process_pid'`,
+		);
+		expect(cols.rows).toEqual([]);
+	});
+
+	it('keeps retry_of_run_id, which the lost-run ceiling reads', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'heartbeat_runs'
+			   AND column_name IN ('retry_of_run_id', 'process_loss_retry_count')
+			 ORDER BY column_name`,
+		);
+		expect(cols.rows.map((r) => r.column_name)).toEqual([
+			'process_loss_retry_count',
+			'retry_of_run_id',
+		]);
+	});
+});

--- a/packages/server/test/oauth-token-resolver.test.ts
+++ b/packages/server/test/oauth-token-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { decrypt } from '../src/crypto/encryption';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
@@ -142,6 +142,97 @@ describe('refreshExpiringTokens', () => {
 			[after?.accessTokenSecretId],
 		);
 		expect(decrypt(accessRow.rows[0].encrypted_value, key)).toBe('access-stale');
+	});
+
+	it('stops retrying a grant that can never be refreshed again', async () => {
+		// Two connections on a live instance sat at 51 attempts and climbing, four
+		// times an hour, forever: `invalid_grant` needs a human to reconnect and a
+		// connection missing its token endpoint was never able to refresh at all.
+		// Neither improves with another attempt.
+		await makeConnection({
+			provider: 'p-dead',
+			providerAccountId: 'a-dead',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let calls = 0;
+		registerRefreshFn('p-dead', async () => {
+			calls++;
+			throw new Error('token endpoint error: invalid_grant - re-authentication required');
+		});
+
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+
+		// Jump well past the 15-minute backoff ceiling. Without the park this is
+		// exactly when the next of the 51 attempts would fire; with it there is no
+		// next attempt at all.
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date(Date.now() + 60 * 60_000));
+			await refreshExpiringTokens({ db, masterKeyManager });
+			await refreshExpiringTokens({ db, masterKeyManager });
+		} finally {
+			vi.useRealTimers();
+		}
+		expect(calls).toBe(1);
+	});
+
+	it('retries a transient refresh failure once its backoff elapses', async () => {
+		// The park must not swallow the ordinary case, which is what the backoff is
+		// for.
+		await makeConnection({
+			provider: 'p-flaky',
+			providerAccountId: 'a-flaky',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let calls = 0;
+		registerRefreshFn('p-flaky', async () => {
+			calls++;
+			throw new Error('socket hang up');
+		});
+
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+		// Backed off, not parked: the same jump that proves the park above must let
+		// this one through, or the park has swallowed the ordinary case.
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(new Date(Date.now() + 60 * 60_000));
+			await refreshExpiringTokens({ db, masterKeyManager });
+		} finally {
+			vi.useRealTimers();
+		}
+		expect(calls).toBe(2);
+	});
+
+	it('un-parks a connection once it is reconnected', async () => {
+		const conn = await makeConnection({
+			provider: 'p-reconnect',
+			providerAccountId: 'a-reconnect',
+			expiresAt: new Date(Date.now() - 1_000),
+			withRefresh: true,
+		});
+		let calls = 0;
+		registerRefreshFn('p-reconnect', async () => {
+			calls++;
+			throw new Error('token endpoint error: invalid_grant');
+		});
+
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(1);
+
+		// Reconnecting moves `updated_at`, which is what clears the park - no hook
+		// on the reconnect path to remember or to go stale.
+		await db.query(
+			`UPDATE oauth_connections SET updated_at = now() + interval '1 second' WHERE id = $1`,
+			[conn.id],
+		);
+		await refreshExpiringTokens({ db, masterKeyManager });
+		expect(calls).toBe(2);
 	});
 
 	it('coalesces concurrent refreshes for the same connection', async () => {

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -10,7 +10,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
 import { appendRunLogChunks } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
-import { CAPACITY_PARK_MAX_MS } from '../src/services/agent-runner';
+import {
+	CAPACITY_PARK_MAX_MS,
+	createHeartbeatRun,
+	extractReplacedRun,
+} from '../src/services/agent-runner';
 import {
 	detectOrphans,
 	healStaleRunState,
@@ -198,6 +202,130 @@ describe('detectOrphans', () => {
 		expect(wakeups.rows.length).toBeGreaterThanOrEqual(1);
 		const payload = wakeups.rows[0].payload as Record<string, unknown>;
 		expect(payload.reason).toBe('orphan_retry');
+	});
+
+	it('the retry chain terminates, because a retried run inherits the count', async () => {
+		// The bug this exists for: `createHeartbeatRun` wrote neither
+		// `retry_of_run_id` nor `process_loss_retry_count`, so every retried run
+		// started at 0, `0 + 1 < MAX_RETRIES` was always true, and the escalation
+		// below was unreachable. The old coverage set the counter by hand on one
+		// row and so never drove reap -> wakeup -> new run -> reap at all.
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+
+		const latestRetryPayload = async (): Promise<Record<string, unknown> | null> => {
+			const res = await db.query<{ payload: Record<string, unknown> }>(
+				`SELECT payload FROM agent_wakeup_requests
+				 WHERE member_id = $1 AND payload->>'reason' = 'orphan_retry'
+				 ORDER BY created_at DESC LIMIT 1`,
+				[agentId],
+			);
+			return res.rows[0]?.payload ?? null;
+		};
+
+		// The replacement run the dispatcher would create for that retry wakeup.
+		const runReplacing = async (payload: Record<string, unknown>): Promise<string> => {
+			// Settle the queued retry first, exactly as dispatching it would. Left
+			// queued, the *next* reap's wakeup coalesces onto it (both are task-less)
+			// and its payload never advances.
+			await db.query(
+				`UPDATE agent_wakeup_requests SET status = $1::wakeup_status
+				 WHERE member_id = $2 AND status = $3::wakeup_status
+				   AND payload->>'reason' = 'orphan_retry'`,
+				[WakeupStatus.Completed, agentId, WakeupStatus.Queued],
+			);
+			const wakeup = await db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, payload, status)
+				 VALUES ($1, $2, $3::wakeup_source, $4::jsonb, $5::wakeup_status) RETURNING id`,
+				[agentId, teamId, WakeupSource.Timer, JSON.stringify(payload), WakeupStatus.Claimed],
+			);
+			return createHeartbeatRun(
+				db,
+				{ id: agentId, title: 'A', slug: 'a', team_id: teamId } as never,
+				teamId,
+				null,
+				{ teamId, taskId: null, memberId: agentId },
+				wakeup.rows[0].id,
+				null,
+				undefined,
+				extractReplacedRun(payload),
+			);
+		};
+
+		const countOf = async (id: string): Promise<number> => {
+			const r = await db.query<{ n: number; retry_of: string | null }>(
+				'SELECT process_loss_retry_count AS n, retry_of_run_id AS retry_of FROM heartbeat_runs WHERE id = $1',
+				[id],
+			);
+			return r.rows[0].n;
+		};
+		const lineageOf = async (id: string): Promise<string | null> => {
+			const r = await db.query<{ retry_of: string | null }>(
+				'SELECT retry_of_run_id AS retry_of FROM heartbeat_runs WHERE id = $1',
+				[id],
+			);
+			return r.rows[0].retry_of;
+		};
+
+		const runA = await insertOrphanRun(agentId, teamId, {});
+		await detectOrphans(db, new Set());
+		const payloadA = await latestRetryPayload();
+		expect(payloadA?.retry_count).toBe(1);
+
+		const runB = await runReplacing(payloadA as Record<string, unknown>);
+		expect(await countOf(runB)).toBe(1);
+		expect(await lineageOf(runB)).toBe(runA);
+
+		await db.query(
+			`UPDATE heartbeat_runs SET status = $1::heartbeat_run_status,
+			   started_at = now() - interval '10 minutes' WHERE id = $2`,
+			[HeartbeatRunStatus.Running, runB],
+		);
+		await detectOrphans(db, new Set());
+		const payloadB = await latestRetryPayload();
+		expect(payloadB?.retry_count).toBe(2);
+
+		const runC = await runReplacing(payloadB as Record<string, unknown>);
+		expect(await countOf(runC)).toBe(2);
+		expect(await lineageOf(runC)).toBe(runB);
+
+		// The ceiling. Reaping C must escalate rather than mint a fourth attempt.
+		const retriesBefore = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND payload->>'reason' = 'orphan_retry'`,
+			[agentId],
+		);
+		await db.query(
+			`UPDATE heartbeat_runs SET status = $1::heartbeat_run_status,
+			   started_at = now() - interval '10 minutes' WHERE id = $2`,
+			[HeartbeatRunStatus.Running, runC],
+		);
+		await detectOrphans(db, new Set());
+
+		const retriesAfter = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND payload->>'reason' = 'orphan_retry'`,
+			[agentId],
+		);
+		expect(retriesAfter.rows[0].c).toBe(retriesBefore.rows[0].c);
+
+		const approvals = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM approvals
+			 WHERE team_id = $1 AND payload->>'type' = 'agent_error'`,
+			[teamId],
+		);
+		expect(approvals.rows[0].c).toBe(1);
+
+		// A second ceiling files nothing new: one record per stuck agent.
+		const runD = await insertOrphanRun(agentId, teamId, { retryCount: 2 });
+		await detectOrphans(db, new Set());
+		expect(await countOf(runD)).toBe(3);
+		const approvalsAgain = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM approvals
+			 WHERE team_id = $1 AND payload->>'type' = 'agent_error'`,
+			[teamId],
+		);
+		expect(approvalsAgain.rows[0].c).toBe(1);
 	});
 
 	it('creates an approval request when retry count >= 3 (MAX_RETRIES)', async () => {

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -455,7 +455,48 @@ describe('detectOrphans for runs stranded before they started', () => {
 		expect(byId.get(queuedId)?.error).toContain('Never started');
 		// A process that vanished mid-run is.
 		expect(byId.get(runningId)?.status).toBe(HeartbeatRunStatus.Failed);
-		expect(byId.get(runningId)?.error).toContain('Orphaned: process no longer running');
+		expect(byId.get(runningId)?.error).toContain('Orphaned: nothing was driving this run');
+	});
+
+	it('leaves a run alone that went terminal between the scan and the write', async () => {
+		// The lost-update race. The scan sees a `running` row; by the time this pass
+		// writes, the run's own driver has recorded the real cause. Unguarded, the
+		// generic verdict replaced it and a strike was spent on a run that had
+		// already reported itself.
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const runId = await insertOrphanRun(agentId, teamId, {});
+
+		// Settle the row from underneath the pass, after its SELECT and before its
+		// UPDATE, by hooking the query the scan itself makes.
+		const racingDb = {
+			...db,
+			query: async (sql: string, params?: unknown[]) => {
+				const res = await db.query(sql, params as never);
+				if (sql.includes('FROM heartbeat_runs hr')) {
+					await db.query(
+						`UPDATE heartbeat_runs SET status = $1::heartbeat_run_status,
+						   finished_at = now(), error = $2 WHERE id = $3`,
+						[HeartbeatRunStatus.Failed, 'the real cause', runId],
+					);
+				}
+				return res;
+			},
+		} as unknown as typeof db;
+
+		expect(await detectOrphans(racingDb, new Set())).toBe(0);
+
+		const row = await db.query<{ error: string; process_loss_retry_count: number }>(
+			'SELECT error, process_loss_retry_count FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(row.rows[0].error).toBe('the real cause');
+		expect(row.rows[0].process_loss_retry_count).toBe(0);
+		const wakeups = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND payload->>'reason' = 'orphan_retry'`,
+			[agentId],
+		);
+		expect(wakeups.rows[0].c).toBe(0);
 	});
 });
 

--- a/packages/server/test/run-failure-classification.test.ts
+++ b/packages/server/test/run-failure-classification.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+	classifyRunFailure,
+	RunFailureClass,
+	transientRunFailureNames,
+} from '../src/services/run-failure-classification';
+import { ExecStreamLostError } from '../src/services/sandbox/errors';
+import { TunnelPortsExhaustedError } from '../src/services/sandbox/tunnel/ports';
+
+describe('classifyRunFailure', () => {
+	it('treats a lost output stream as transient', () => {
+		expect(classifyRunFailure(new ExecStreamLostError('docker'))).toBe(RunFailureClass.Transient);
+	});
+
+	it('treats exhausted tunnel ports as transient', () => {
+		expect(classifyRunFailure(new TunnelPortsExhaustedError('c1'))).toBe(RunFailureClass.Transient);
+	});
+
+	it('treats an MCP injection fault as permanent', () => {
+		// The production failure: a config error reproduces identically on every
+		// attempt, so retrying it burns a container per lap and never converges.
+		expect(
+			classifyRunFailure(
+				new Error('adapter declared env-var bearer storage but inlined a bearer token in /x'),
+			),
+		).toBe(RunFailureClass.Permanent);
+	});
+
+	it('treats a provider quota or cap failure as permanent, by default rather than by name', () => {
+		// Constructed by name so this test does not import a provider module above
+		// the seam - which is also the point being made.
+		for (const name of [
+			'DaytonaQuotaExceededError',
+			'DaytonaMemoryCapExceededError',
+			'SandboxImageNotPullableError',
+		]) {
+			expect(classifyRunFailure(Object.assign(new Error('x'), { name }))).toBe(
+				RunFailureClass.Permanent,
+			);
+		}
+	});
+
+	it('treats anything that is not an Error as permanent', () => {
+		for (const thrown of [undefined, null, 'a string', 42, { name: 'ExecStreamLostError' }]) {
+			expect(classifyRunFailure(thrown)).toBe(RunFailureClass.Permanent);
+		}
+	});
+
+	it('names no backend, so nothing above the container seam branches on a provider', () => {
+		for (const name of transientRunFailureNames()) {
+			expect(name).not.toMatch(/Daytona|Docker|Sandbox[A-Z]/);
+		}
+	});
+});

--- a/packages/server/test/runtime-control.test.ts
+++ b/packages/server/test/runtime-control.test.ts
@@ -3,7 +3,12 @@ import { getActiveRuntime, setActiveRuntime, shutdownRuntime } from '../src/runt
 import type { StartupResult } from '../src/startup';
 
 function fakeRuntime() {
-	const jobManager = { shutdown: vi.fn(), killLiveRunProcesses: vi.fn(async () => {}) };
+	const jobManager = {
+		shutdown: vi.fn(),
+		killLiveRunProcesses: vi.fn(async () => {}),
+		stopAcceptingWork: vi.fn(),
+		drainRunningRuns: vi.fn(async () => []),
+	};
 	const chatSessionManager = { stop: vi.fn(async () => {}) };
 	const egressProxy = { releaseAll: vi.fn(async () => {}) };
 	const sshAgentServer = { releaseAll: vi.fn(async () => {}) };
@@ -40,6 +45,20 @@ describe('shutdownRuntime', () => {
 		expect(jobManager.killLiveRunProcesses.mock.invocationCallOrder[0]).toBeLessThan(
 			jobManager.shutdown.mock.invocationCallOrder[0],
 		);
+		// The whole order is load-bearing: stop scheduling first or the 5s wakeup
+		// cron keeps feeding the drain; reap the in-container trees next so the
+		// aborts land in milliseconds; drain before `shutdown()` clears the
+		// registries, or the aborts have nowhere to land and the db closes while
+		// cancelled runs are still writing their terminal rows.
+		expect(jobManager.stopAcceptingWork).toHaveBeenCalledTimes(1);
+		expect(jobManager.drainRunningRuns).toHaveBeenCalledTimes(1);
+		const order = [
+			jobManager.stopAcceptingWork.mock.invocationCallOrder[0],
+			jobManager.killLiveRunProcesses.mock.invocationCallOrder[0],
+			jobManager.drainRunningRuns.mock.invocationCallOrder[0],
+			jobManager.shutdown.mock.invocationCallOrder[0],
+		];
+		expect(order).toEqual([...order].sort((a, b) => a - b));
 		expect(jobManager.shutdown).toHaveBeenCalledTimes(1);
 		expect(chatSessionManager.stop).toHaveBeenCalledTimes(1);
 		expect(egressProxy.releaseAll).toHaveBeenCalledTimes(1);

--- a/packages/server/test/sandbox-pool.test.ts
+++ b/packages/server/test/sandbox-pool.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import {
+	detectReclaimChurn,
 	type PoolCapacity,
 	type PoolMember,
 	planCrossProjectReclaim,
@@ -643,5 +644,63 @@ describe('reclaim floors', () => {
 		// blocked behind it is still parked rather than requeued.
 		expect(CONTAINER_RECLAIM_MIN_AGE_SEC).toBeGreaterThan(CONTAINER_IDLE_TIMEOUT_MIN * 60);
 		expect(CONTAINER_RECLAIM_MIN_AGE_SEC).toBeGreaterThan(CONTAINER_RECLAIM_MIN_IDLE_SEC);
+	});
+});
+
+describe('detectReclaimChurn', () => {
+	const ev = (atMs: number, from: string, to: string) => ({
+		atMs,
+		requestingProjectId: from,
+		victimProjectId: to,
+		freedGb: 4,
+	});
+	const WINDOW = 10 * 60_000;
+	const NOW = 1_000_000;
+
+	it('calls a reciprocal pair churn', () => {
+		// The shape an operator cannot otherwise see: two projects taking the same
+		// memory back off each other, indefinitely.
+		const verdict = detectReclaimChurn(
+			[
+				ev(NOW - 60_000, 'a', 'b'),
+				ev(NOW - 120_000, 'b', 'a'),
+				ev(NOW - 180_000, 'a', 'b'),
+				ev(NOW - 240_000, 'b', 'a'),
+			],
+			NOW,
+			WINDOW,
+			4,
+		);
+		expect(verdict.churning).toBe(true);
+		expect(verdict.reciprocal).toEqual(['a', 'b']);
+		expect(verdict.freedGb).toBe(16);
+	});
+
+	it('does not call one starved project reclaiming repeatedly churn on its own', () => {
+		// One project losing containers to a genuinely starved neighbour is the
+		// mechanism working, so it must not be reported as a reciprocal pair.
+		const verdict = detectReclaimChurn(
+			[ev(NOW - 60_000, 'a', 'b'), ev(NOW - 120_000, 'a', 'c')],
+			NOW,
+			WINDOW,
+			4,
+		);
+		expect(verdict.churning).toBe(false);
+		expect(verdict.reciprocal).toBeNull();
+	});
+
+	it('ignores events outside the window', () => {
+		const verdict = detectReclaimChurn(
+			[ev(NOW - WINDOW - 1, 'a', 'b'), ev(NOW - WINDOW - 2, 'b', 'a')],
+			NOW,
+			WINDOW,
+			1,
+		);
+		expect(verdict.reclaims).toBe(0);
+		expect(verdict.churning).toBe(false);
+	});
+
+	it('says nothing about an empty history', () => {
+		expect(detectReclaimChurn([], NOW, WINDOW, 1).churning).toBe(false);
 	});
 });

--- a/packages/server/test/sandbox-pool.test.ts
+++ b/packages/server/test/sandbox-pool.test.ts
@@ -1,3 +1,8 @@
+import {
+	CONTAINER_IDLE_TIMEOUT_MIN,
+	CONTAINER_RECLAIM_MIN_AGE_SEC,
+	CONTAINER_RECLAIM_MIN_IDLE_SEC,
+} from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import {
 	type PoolCapacity,
@@ -361,11 +366,57 @@ describe('planSurplusIdleRetirement', () => {
 		expect(plan.suspend).toEqual([]);
 	});
 
-	it('leaves a fully idle project to the whole-project pass', () => {
-		// That pass keeps one member suspended for a warm restart; picking its
-		// members off individually here would take that away.
+	it('converges on the whole-project plan when the project holds nothing else', () => {
+		// This used to return an empty plan and defer to the whole-project pass,
+		// which keeps one member suspended for a warm restart. The two passes'
+		// preconditions did not partition the space, so the warm-start rule moved
+		// here and both planners now answer the same way: keep one, suspended.
 		const plan = planSurplusIdleRetirement([member('a'), member('b')], stale('a', 'b'));
-		expect(plan).toEqual({ suspend: [], destroy: [] });
+		expect(plan.suspend.map((m) => m.id)).toEqual(['a']);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['b']);
+	});
+
+	it('retires every stale member of a project that is working but holds no busy one', () => {
+		// The production dead zone. Runs lasting a few seconds leave the project
+		// out of the whole-project pass (recent finishes and queued wakeups keep it
+		// "busy") while it rarely holds a `busy` member when the once-a-minute cron
+		// samples. Its idle members matched neither pass and pinned the budget: on
+		// the instance this came from, three of them held 12 of 16 GB indefinitely.
+		const plan = planSurplusIdleRetirement(
+			[member('a'), member('b'), member('c')],
+			stale('a', 'b', 'c'),
+		);
+		expect(plan.suspend.map((m) => m.id)).toEqual(['a']);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['b', 'c']);
+	});
+
+	it('holds nothing back when a suspended member already covers the warm start', () => {
+		const plan = planSurplusIdleRetirement(
+			[member('suspended', { state: 'suspended' }), member('a'), member('b')],
+			stale('a', 'b'),
+		);
+		expect(plan.suspend).toEqual([]);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['a', 'b']);
+	});
+
+	it('holds nothing back when a pinned member is already being suspended', () => {
+		const plan = planSurplusIdleRetirement(
+			[member('pinned', { hasUnpushedCommits: true }), member('a')],
+			stale('pinned', 'a'),
+		);
+		expect(plan.suspend.map((m) => m.id)).toEqual(['pinned']);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['a']);
+	});
+
+	it('does not count the chat member as a warm start for task runs', () => {
+		// `usable` excludes a chat-reserved member from the ladder, so it is no
+		// route to serving a task run and cannot discharge the floor.
+		const plan = planSurplusIdleRetirement(
+			[member('chat', { state: 'suspended', reservedForChat: true }), member('a'), member('b')],
+			stale('a', 'b'),
+		);
+		expect(plan.suspend.map((m) => m.id)).toEqual(['a']);
+		expect(plan.destroy.map((m) => m.id)).toEqual(['b']);
 	});
 
 	it('leaves an idle container that has not yet gone stale', () => {
@@ -411,6 +462,10 @@ describe('planCrossProjectReclaim', () => {
 		projectId,
 		memoryGb: 2,
 		idleForMs: 5 * 60_000,
+		ageMs: 60 * 60_000,
+		// Default high, so the existing cases exercise destroy as they always did;
+		// the suspend-the-last-one arm is asserted by its own cases below.
+		projectResumableMembers: 9,
 		hasUnpushedCommits: false,
 		...over,
 	});
@@ -499,5 +554,94 @@ describe('planCrossProjectReclaim', () => {
 
 	it('asks for nothing when the shortfall is zero or negative', () => {
 		expect(planCrossProjectReclaim([candidate('a', 'p1')], 0, MIN_IDLE).freedGb).toBe(0);
+	});
+
+	const MIN_AGE = 5 * 60_000;
+
+	it('ignores a container the instance only just built, however idle it looks', () => {
+		// A separate clock from the idle floor. One created at T, claimed and
+		// released at T+5s clears a 30s idle floor at T+35s while still being a
+		// container the instance has only just paid a cold provision for.
+		const plan = planCrossProjectReclaim(
+			[candidate('brandnew', 'p1', { idleForMs: 60 * 60_000, ageMs: 20_000 })],
+			2,
+			MIN_IDLE,
+			MIN_AGE,
+		);
+		expect(plan).toEqual({ suspend: [], destroy: [], freedGb: 0 });
+	});
+
+	it('applies the two floors independently', () => {
+		const oldButJustReleased = candidate('a', 'p1', { idleForMs: 1_000, ageMs: 60 * 60_000 });
+		const youngButLongIdle = candidate('b', 'p2', { idleForMs: 60 * 60_000, ageMs: 20_000 });
+		expect(planCrossProjectReclaim([oldButJustReleased], 2, MIN_IDLE, MIN_AGE).freedGb).toBe(0);
+		expect(planCrossProjectReclaim([youngButLongIdle], 2, MIN_IDLE, MIN_AGE).freedGb).toBe(0);
+	});
+
+	it('treats a container with no recorded start as old enough', () => {
+		// Members predating the start stamp must not become newly protected.
+		const plan = planCrossProjectReclaim(
+			[candidate('unstamped', 'p1', { ageMs: null })],
+			2,
+			MIN_IDLE,
+			MIN_AGE,
+		);
+		expect(plan.freedGb).toBe(2);
+	});
+
+	it('suspends the victim’s last container rather than destroying it', () => {
+		// Both free the same budget memory - a suspended member is not counted - so
+		// destroying buys the requester nothing and costs the victim a full cold
+		// provision on its next run.
+		const plan = planCrossProjectReclaim(
+			[candidate('only', 'p1', { projectResumableMembers: 1 })],
+			2,
+			MIN_IDLE,
+			MIN_AGE,
+		);
+		expect(plan.suspend.map((c) => c.containerId)).toEqual(['only']);
+		expect(plan.destroy).toEqual([]);
+	});
+
+	it('destroys a victim’s surplus and suspends only the last one taken', () => {
+		const plan = planCrossProjectReclaim(
+			[
+				candidate('a', 'p1', { projectResumableMembers: 2 }),
+				candidate('b', 'p1', { projectResumableMembers: 2 }),
+			],
+			4,
+			MIN_IDLE,
+			MIN_AGE,
+		);
+		expect(plan.destroy.length).toBe(1);
+		expect(plan.suspend.length).toBe(1);
+		// Bounded at one suspended member per project by construction.
+		expect(plan.freedGb).toBe(4);
+	});
+
+	it('keeps the hoarder losing first once suspend is in play', () => {
+		const plan = planCrossProjectReclaim(
+			[
+				candidate('h1', 'hoarder', { projectResumableMembers: 3 }),
+				candidate('h2', 'hoarder', { projectResumableMembers: 3 }),
+				candidate('q1', 'quiet', { projectResumableMembers: 1 }),
+			],
+			2,
+			MIN_IDLE,
+			MIN_AGE,
+		);
+		expect(plan.destroy.map((c) => c.containerId)).toEqual(['h1']);
+		expect(plan.suspend).toEqual([]);
+	});
+});
+
+describe('reclaim floors', () => {
+	it('lets a project’s own surplus pass get first refusal, and stays inside the park window', () => {
+		// The derivation, not the number. The age floor must sit above the idle
+		// window - so memory reachable both ways is freed the cheaper way, by the
+		// pass that keeps the project warm - and below the capacity park, so a run
+		// blocked behind it is still parked rather than requeued.
+		expect(CONTAINER_RECLAIM_MIN_AGE_SEC).toBeGreaterThan(CONTAINER_IDLE_TIMEOUT_MIN * 60);
+		expect(CONTAINER_RECLAIM_MIN_AGE_SEC).toBeGreaterThan(CONTAINER_RECLAIM_MIN_IDLE_SEC);
 	});
 });

--- a/packages/server/test/startup-boot-paths.test.ts
+++ b/packages/server/test/startup-boot-paths.test.ts
@@ -156,4 +156,47 @@ describe('startup boot paths (master key, routes, socket cleanup)', () => {
 		expect(result.masterKeyState).toBe('locked');
 		expect(result.masterKeyManager.getState()).toBe('locked');
 	}, 60_000);
+
+	it('repairs a stranded run on a locked boot, with the job manager still stopped', async () => {
+		// The gap this closes. Reconciliation used to run only from the unlock hook,
+		// so an instance that came up locked - the intended behaviour after a plain
+		// restart or a crash - served a `running` row and a stuck-busy agent until a
+		// human arrived, with the orphan cron not started either.
+		{
+			const seedRuntime = await startup(baseConfig(dataDir));
+			const team = await seedRuntime.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ('Stranded', 'stranded-boot') RETURNING id`,
+			);
+			await seedRuntime.db.query(
+				`INSERT INTO members (team_id, member_type, display_name)
+				 VALUES ($1, 'agent', 'Worker')`,
+				[team.rows[0].id],
+			);
+			const member = await seedRuntime.db.query<{ id: string }>(
+				`SELECT id FROM members WHERE team_id = $1 LIMIT 1`,
+				[team.rows[0].id],
+			);
+			await seedRuntime.db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, status, started_at)
+				 VALUES ($1, $2, 'running'::heartbeat_run_status, now())`,
+				[team.rows[0].id, member.rows[0].id],
+			);
+			seedRuntime.jobManager.shutdown();
+			await seedRuntime.chatSessionManager.stop();
+			await waitForBackground();
+			await seedRuntime.db.close().catch(() => undefined);
+		}
+
+		result = await startup(baseConfig(dataDir));
+		expect(result.masterKeyState).toBe('locked');
+		// Still locked, so the crons stay stopped - the repair is not a licence to
+		// start dispatching against a backend that is not connected.
+		expect((result.jobManager as unknown as { started: boolean }).started).toBe(false);
+
+		const rows = await result.db.query<{ status: string; error: string | null }>(
+			`SELECT status::text AS status, error FROM heartbeat_runs
+			 WHERE status IN ('running', 'queued')`,
+		);
+		expect(rows.rows).toEqual([]);
+	}, 60_000);
 });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -389,6 +389,28 @@ export const CHAT_IDLE_TIMEOUT_MIN = 15;
 export const CONTAINER_RECLAIM_MIN_IDLE_SEC = 30;
 
 /**
+ * How long a container must have **existed** before another project may reclaim
+ * it, independent of how long it has sat idle.
+ *
+ * {@link CONTAINER_RECLAIM_MIN_IDLE_SEC} floors the idle clock; this floors the
+ * container's whole life, and they are different questions. One created at T,
+ * claimed, and released at T+5s clears the idle floor at T+35s while still being
+ * a container the instance has only just paid a cold provision for - an image
+ * resolve, a clone and a round of package installs. Retiring it to hand its
+ * memory to a project that will pay the same cold start for a replacement is a
+ * loss on both sides.
+ *
+ * Derived rather than picked. It must exceed {@link CONTAINER_IDLE_TIMEOUT_MIN}
+ * so a project's own surplus-idle pass always gets first refusal: that pass
+ * keeps the project warm and cross-project reclaim cannot, so memory reachable
+ * both ways should be freed the cheaper way. And it must stay inside the
+ * capacity-park window, so a run blocked behind this floor is still parked
+ * rather than requeued when the surplus pass frees the same memory properly.
+ * Five minutes sits between the two with room either side.
+ */
+export const CONTAINER_RECLAIM_MIN_AGE_SEC = 300;
+
+/**
  * The "latest few" messages kept in the active window after a compaction flush.
  * Internal constant (not an operator setting): everything older than this tail
  * is summarized into long-term memory and dropped from the chatbox.

--- a/packages/web/src/components/agent-cli-picker.tsx
+++ b/packages/web/src/components/agent-cli-picker.tsx
@@ -55,7 +55,7 @@ export function AgentCliPicker({ provider, value, onChange, disabled }: AgentCli
 						variant={runtime === selected ? 'primary' : 'secondary'}
 						onClick={() => onChange(runtime)}
 					>
-						{/* Product name — never translated, same rule as Captain/CEO/Hezo. */}
+						{/* Product name - never translated, same rule as Captain/CEO/Hezo. */}
 						{AGENT_RUNTIME_LABELS[runtime]}
 						{runtime === defaultRuntime && (
 							<span className="text-[10px] uppercase tracking-wide opacity-70">

--- a/packages/web/src/components/api-key-instructions.tsx
+++ b/packages/web/src/components/api-key-instructions.tsx
@@ -27,7 +27,7 @@ const KIMI_KEY_INSTRUCTIONS: ProviderInstructionContent = {
 			Copy the key (starts with <code>sk-</code>) and paste it below.
 		</>,
 	],
-	footer: <>The Kimi API is prepaid — top up a small balance on the platform before agents run.</>,
+	footer: <>The Kimi API is prepaid - top up a small balance on the platform before agents run.</>,
 };
 
 /**
@@ -52,12 +52,12 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				and click <strong>Create key</strong>.
 			</>,
 			<>
-				Copy the key (starts with <code>sk-ant-</code>) and paste it below — it's only shown once.
+				Copy the key (starts with <code>sk-ant-</code>) and paste it below - it's only shown once.
 			</>,
 		],
 		footer: (
 			<>
-				API usage is billed per token from prepaid credits — add credits under the Console's Billing
+				API usage is billed per token from prepaid credits - add credits under the Console's Billing
 				settings. Have a Claude Pro or Max plan? Use the <strong>Claude Code subscription</strong>{' '}
 				option above instead.
 			</>
@@ -77,12 +77,12 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				page and click <strong>Create new secret key</strong>.
 			</>,
 			<>
-				Copy the key (starts with <code>sk-</code>) and paste it below — it's only shown once.
+				Copy the key (starts with <code>sk-</code>) and paste it below - it's only shown once.
 			</>,
 		],
 		footer: (
 			<>
-				API usage is billed separately from ChatGPT — add a payment method under the platform's
+				API usage is billed separately from ChatGPT - add a payment method under the platform's
 				Billing settings. Have a ChatGPT Plus or Pro plan? Use the{' '}
 				<strong>Codex subscription</strong> option above instead.
 			</>
@@ -108,7 +108,7 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 		],
 		footer: (
 			<>
-				AI Studio keys start on a free tier with strict rate limits — enable billing on the key's
+				AI Studio keys start on a free tier with strict rate limits - enable billing on the key's
 				Google Cloud project for sustained agent use. Have a Google AI Pro/Ultra plan? Use the{' '}
 				<strong>Gemini subscription</strong> option above instead.
 			</>
@@ -127,10 +127,10 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				<InstructionsLink href="https://platform.deepseek.com/api_keys">API keys</InstructionsLink>{' '}
 				and click <strong>Create new API key</strong>.
 			</>,
-			<>Copy the key and paste it below — it's only shown once.</>,
+			<>Copy the key and paste it below - it's only shown once.</>,
 		],
 		footer: (
-			<>The DeepSeek API is prepaid — top up your balance on the platform before agents run.</>
+			<>The DeepSeek API is prepaid - top up your balance on the platform before agents run.</>
 		),
 	},
 	[AiProvider.ZAi]: {
@@ -149,7 +149,7 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 		],
 		footer: (
 			<>
-				Usage is billed from your prepaid balance — top up on the{' '}
+				Usage is billed from your prepaid balance - top up on the{' '}
 				<InstructionsLink href="https://z.ai/manage-apikey/billing">Billing</InstructionsLink> page
 				if needed.
 			</>
@@ -170,12 +170,12 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				and click <strong>Create key</strong>.
 			</>,
 			<>
-				Copy the key (starts with <code>sk-or-</code>) and paste it below — it's only shown once.
+				Copy the key (starts with <code>sk-or-</code>) and paste it below - it's only shown once.
 			</>,
 		],
 		footer: (
 			<>
-				One OpenRouter key routes to models from many labs. Usage is prepaid — buy credits in your
+				One OpenRouter key routes to models from many labs. Usage is prepaid - buy credits in your
 				OpenRouter account before agents run.
 			</>
 		),
@@ -196,13 +196,13 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				and click <strong>Create API key</strong>.
 			</>,
 			<>
-				Copy the key (starts with <code>xai-</code>) and paste it below — it's only shown once.
+				Copy the key (starts with <code>xai-</code>) and paste it below - it's only shown once.
 			</>,
 		],
 		footer: (
 			<>
 				Runs use xAI's <strong>Grok Build</strong> CLI on the <code>grok-4.5</code> model. API usage
-				is billed per token — add credits under the console's Billing settings before agents run.
+				is billed per token - add credits under the console's Billing settings before agents run.
 			</>
 		),
 	},
@@ -221,7 +221,7 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				<code>http://localhost:11434</code> by default.
 			</>,
 			<>
-				Set <strong>Server URL</strong> to an address the agent container can reach —{' '}
+				Set <strong>Server URL</strong> to an address the agent container can reach -{' '}
 				<code>http://host.docker.internal:11434</code> for a server on this machine.
 			</>,
 		],
@@ -245,7 +245,7 @@ export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent
 				<code>http://localhost:1234</code> by default.
 			</>,
 			<>
-				Set <strong>Server URL</strong> to an address the agent container can reach —{' '}
+				Set <strong>Server URL</strong> to an address the agent container can reach -{' '}
 				<code>http://host.docker.internal:1234</code> for a server on this machine. If you enabled{' '}
 				<strong>Require Authentication</strong>, put the key under <strong>Advanced</strong>.
 			</>,

--- a/packages/web/src/components/app-header.tsx
+++ b/packages/web/src/components/app-header.tsx
@@ -42,7 +42,7 @@ export function AppHeader({
 			data-testid="app-header"
 		>
 			<div className="flex items-center gap-0.5">
-				{/* Below lg the menu is a side drawer — the logo opens it. */}
+				{/* Below lg the menu is a side drawer - the logo opens it. */}
 				<button
 					type="button"
 					onClick={onOpenDrawer}
@@ -53,7 +53,7 @@ export function AppHeader({
 				>
 					<Logo size="sm" />
 				</button>
-				{/* At lg+ the rail/sidebar are persistent — the logo links home. */}
+				{/* At lg+ the rail/sidebar are persistent - the logo links home. */}
 				<Link
 					to="/home"
 					aria-label={t('nav.home')}
@@ -66,8 +66,8 @@ export function AppHeader({
 			</div>
 
 			<div className="flex items-center gap-0.5">
-				{/* Leftmost of the action group. Styled as a quiet outlined button —
-				    transparent fill, primary-red border and "+" — so it sits with the
+				{/* Leftmost of the action group. Styled as a quiet outlined button -
+				    transparent fill, primary-red border and "+" - so it sits with the
 				    other nav icons while the accent still marks it as the create action.
 				    The 32px tap target matches its neighbours; the bordered box inside is
 				    a compact 22px with an edge-to-edge plus. */}

--- a/packages/web/src/components/approval-card.tsx
+++ b/packages/web/src/components/approval-card.tsx
@@ -112,6 +112,23 @@ function ApprovalMessage({ approval }: { approval: Approval }) {
 			);
 		}
 		case ApprovalType.Strategy: {
+			// The orphan pass files a Strategy approval when an agent has burned its
+			// retry budget. It carries no `plan`, so it rendered as a bare
+			// "Proposing strategy" with nothing under it - a record that said an
+			// agent had failed while giving the reader nowhere to look.
+			if (p.type === 'agent_error') {
+				const lastError = p.last_error as string | undefined;
+				return (
+					<>
+						<span>{(p.message as string) ?? 'Agent needs attention'}</span>
+						{lastError && (
+							<span className="block text-xs text-text-2 mt-1 whitespace-pre-wrap">
+								{lastError}
+							</span>
+						)}
+					</>
+				);
+			}
 			const plan = p.plan as string | undefined;
 			return (
 				<>

--- a/packages/web/src/components/approval-card.tsx
+++ b/packages/web/src/components/approval-card.tsx
@@ -153,7 +153,7 @@ function ApprovalMessage({ approval }: { approval: Approval }) {
 			return (
 				<>
 					<span>
-						Suggesting goal <span className="font-medium">{title}</span> — approving creates it
+						Suggesting goal <span className="font-medium">{title}</span> - approving creates it
 					</span>
 					{p.measurement && (
 						<span className="block text-xs text-text-2 mt-1">
@@ -320,7 +320,7 @@ export function ApprovalCard({ approval, showTeam = false }: ApprovalCardProps) 
 						</Button>
 					</Link>
 				)}
-				{/* Hires are decided only on the edit/review page, never inline — the
+				{/* Hires are decided only on the edit/review page, never inline - the
 				    proposal must be opened and reviewed before approve/deny. */}
 				{approval.type !== ApprovalType.Hire && (
 					<>

--- a/packages/web/src/components/asset-review/asset-review-panel.tsx
+++ b/packages/web/src/components/asset-review/asset-review-panel.tsx
@@ -119,7 +119,7 @@ export function AssetReviewPanel({
 					)}
 				</h2>
 				<div className="flex items-center gap-0.5">
-					<Tooltip content="Action this review — copy a handoff for an agent">
+					<Tooltip content="Action this review - copy a handoff for an agent">
 						<button
 							type="button"
 							aria-label="Action this review"

--- a/packages/web/src/components/budget-banner.tsx
+++ b/packages/web/src/components/budget-banner.tsx
@@ -21,8 +21,8 @@ export function BudgetBanner({ projectId }: { projectId: string }) {
 	if (!projectOver && overAgents.length === 0) return null;
 
 	const message = projectOver
-		? 'Project is over budget — agent runs are paused'
-		: `${overAgents.length} agent${overAgents.length === 1 ? '' : 's'} over budget — run${
+		? 'Project is over budget - agent runs are paused'
+		: `${overAgents.length} agent${overAgents.length === 1 ? '' : 's'} over budget - run${
 				overAgents.length === 1 ? '' : 's'
 			} paused`;
 

--- a/packages/web/src/components/budget/project-budget-panel.tsx
+++ b/packages/web/src/components/budget/project-budget-panel.tsx
@@ -153,7 +153,7 @@ function BindingBanner({ project, projectId }: { project: EntityBudgetStatus; pr
 					<strong className="font-semibold">
 						{WINDOW_LABELS[binding.key]} is the binding window
 					</strong>{' '}
-					— at {p}% of the {dollars(binding.s.limitCents)} {binding.key} cap. Runs pause at the cap;
+					- at {p}% of the {dollars(binding.s.limitCents)} {binding.key} cap. Runs pause at the cap;
 					about {dollars(remaining)} left {scope}.
 				</p>
 			</div>

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -431,7 +431,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 			    the page content below the nav bar (the header stays clear and usable,
 			    matching the panel's own top-12 boundary), so the panel reads clearly
 			    against the page. It always shows on mobile (where the panel floats over
-			    the page with margins around it) and, on desktop, only in expanded mode —
+			    the page with margins around it) and, on desktop, only in expanded mode -
 			    the anchored corner panel doesn't need one. Clicking it dismisses the chat. */}
 			<button
 				type="button"
@@ -455,7 +455,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 						</span>
 						{/* Mirror the in-thread typing dots up here so the "CEO is working"
 						    signal stays visible even when the latest reply is scrolled out of
-						    view. Decorative only — the in-thread indicator carries the aria
+						    view. Decorative only - the in-thread indicator carries the aria
 						    live-region announcement, so this stays aria-hidden to avoid a
 						    duplicate read. */}
 						{streaming && (
@@ -476,7 +476,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 					</div>
 					<div className="flex items-center gap-1">
 						{/* Convert this conversation into a task (assistant web threads only).
-						    Disabled while a reply streams — converting aborts the in-flight
+						    Disabled while a reply streams - converting aborts the in-flight
 						    turn, so the honest affordance is to wait it out. */}
 						{canConvert && (
 							<Tooltip content={t('chat.convert.action')} side="bottom">
@@ -649,7 +649,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 					    messages + composer. */}
 					<div className="flex min-h-0 min-w-0 flex-1 flex-col">
 						{/* Thread switcher: every thread from every surface, grouped like the
-						    rail — your own chats first, then team channels (read-only). */}
+						    rail - your own chats first, then team channels (read-only). */}
 						<div
 							className={`flex items-center gap-1 border-b border-border px-3 py-1.5 ${
 								expanded ? 'md:hidden' : ''
@@ -780,7 +780,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 											<span>
 												This conversation lives in <b>{threadLabel(activeThread)}</b> on{' '}
 												{channelDisplayName(activeThread.channel)}. Hezo replies there when
-												mentioned — continue it by mentioning Hezo in the channel.
+												mentioned - continue it by mentioning Hezo in the channel.
 											</span>
 										</div>
 									)}
@@ -851,7 +851,7 @@ export function ChatWidget({ open, onOpenChange, launch = null }: ChatWidgetProp
 															identifier: convertedTask?.identifier ?? '',
 														})
 													: activeReadOnly
-														? `Read-only — reply from ${channelDisplayName(activeThread?.channel ?? '')}`
+														? `Read-only - reply from ${channelDisplayName(activeThread?.channel ?? '')}`
 														: busy
 															? 'Queue your next message…'
 															: 'Ask the CEO anything, across every project…'

--- a/packages/web/src/components/chatbox-section.tsx
+++ b/packages/web/src/components/chatbox-section.tsx
@@ -70,10 +70,10 @@ export function ChatboxSection() {
 				<h2 className="text-[13px] font-medium mb-1">Long-term memory</h2>
 				<p className="text-[13px] text-text-2 max-w-[680px]">
 					When the window fills, the assistant summarizes the older messages into a durable
-					long-term memory and drops them from the chatbox — so standing facts survive even as
+					long-term memory and drops them from the chatbox - so standing facts survive even as
 					messages scroll out. That memory is fed back into every chat turn, and it captures durable
 					operator preferences, decisions, and the gist of off-project threads (never live project
-					or task data, which is always read fresh). It's maintained automatically — you never have
+					or task data, which is always read fresh). It's maintained automatically - you never have
 					to tell the assistant to remember anything. You can review and edit it on the assistant's{' '}
 					<Link
 						to="/projects/$projectId/agents/$agentId/chat-history"

--- a/packages/web/src/components/comment-ref-link.tsx
+++ b/packages/web/src/components/comment-ref-link.tsx
@@ -39,7 +39,7 @@ export function CommentRefLink({
 }) {
 	return (
 		<Tooltip
-			content={`Comment in ${taskIdentifier.toUpperCase()}${taskTitle ? ` — ${taskTitle}` : ''}`}
+			content={`Comment in ${taskIdentifier.toUpperCase()}${taskTitle ? ` - ${taskTitle}` : ''}`}
 		>
 			<Link
 				to="/projects/$projectId/tasks/$taskId"

--- a/packages/web/src/components/comment-renderers/action-comment.tsx
+++ b/packages/web/src/components/comment-renderers/action-comment.tsx
@@ -35,7 +35,7 @@ export function ActionComment({ comment, projectId }: Props) {
 				data-testid="action-unknown"
 				title={kind ? `Unrecognized action: ${kind}` : undefined}
 			>
-				This item needs a newer version to display — refresh the page.
+				This item needs a newer version to display - refresh the page.
 			</p>
 		);
 	}

--- a/packages/web/src/components/comment-renderers/asset-deletion-request-comment.tsx
+++ b/packages/web/src/components/comment-renderers/asset-deletion-request-comment.tsx
@@ -54,8 +54,8 @@ export function AssetDeletionRequestComment({ comment, projectId, taskId }: Prop
 				<div className="flex-1">
 					<p className="text-sm font-medium text-text-1">
 						{approved
-							? `Deletion approved — ${deletedCount} asset${deletedCount === 1 ? '' : 's'} deleted`
-							: 'Deletion denied — assets kept'}
+							? `Deletion approved - ${deletedCount} asset${deletedCount === 1 ? '' : 's'} deleted`
+							: 'Deletion denied - assets kept'}
 					</p>
 					<p className="text-xs text-text-2 mt-0.5">
 						{assets.map((a) => `assets/${a.path}`).join(', ')}

--- a/packages/web/src/components/comment-renderers/comment-reactions.tsx
+++ b/packages/web/src/components/comment-renderers/comment-reactions.tsx
@@ -80,7 +80,7 @@ export function CommentReactions({ comment, projectId, taskId }: Props) {
 						</button>
 					</Popover.Trigger>
 					{/* Portal + z-50 so the picker escapes the comment card's
-					    `overflow-hidden` and the Virtuoso row's stacking context —
+					    `overflow-hidden` and the Virtuoso row's stacking context -
 					    an in-flow `absolute` popup was clipped and painted under the
 					    next comment. Radix flips it above the trigger near the
 					    viewport's bottom edge. */}

--- a/packages/web/src/components/comment-renderers/connect-required-comment.tsx
+++ b/packages/web/src/components/comment-renderers/connect-required-comment.tsx
@@ -46,15 +46,15 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 
 	const statusLabel =
 		status === 'failed'
-			? 'Last connect attempt failed — try again'
+			? 'Last connect attempt failed - try again'
 			: status === 'degraded'
 				? // It connected once and the stored credential has since stopped being
 					// accepted, so this card is a reconnect prompt rather than a first-time
 					// setup step. Without this branch it fell into the green "connected"
 					// case above and told the operator everything was fine.
-					`${display_name} stopped working — reconnect to restore this agent's access`
+					`${display_name} stopped working - reconnect to restore this agent's access`
 				: status === 'revoked'
-					? 'Connector revoked — reconnect'
+					? 'Connector revoked - reconnect'
 					: `Connect ${display_name} to authorize this agent's access`;
 
 	return (

--- a/packages/web/src/components/comment-renderers/credential-request-comment.tsx
+++ b/packages/web/src/components/comment-renderers/credential-request-comment.tsx
@@ -122,7 +122,7 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 								className="text-xs text-warning-soft-fg mt-1"
 								data-testid="credential-no-hosts-warning"
 							>
-								⚠ Not scoped to any host — this credential won't be substituted into any request
+								⚠ Not scoped to any host - this credential won't be substituted into any request
 								until an allowlist is set.
 							</p>
 						)
@@ -179,7 +179,7 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 					)}
 					<div className="flex flex-col gap-1">
 						<label htmlFor={`hosts-${comment.id}`} className="text-xs text-text-2">
-							Allowed hosts — the API host(s) this value may be sent to (comma-separated). The
+							Allowed hosts - the API host(s) this value may be sent to (comma-separated). The
 							egress proxy substitutes it only for these hosts.
 						</label>
 						<input
@@ -197,7 +197,7 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 						/>
 						{showSuggestionHint && (
 							<p className="text-xs text-text-3" data-testid="credential-hosts-suggested">
-								Suggested from the request — review and edit if these aren't right.
+								Suggested from the request - review and edit if these aren't right.
 							</p>
 						)}
 					</div>

--- a/packages/web/src/components/comment-renderers/helpers.ts
+++ b/packages/web/src/components/comment-renderers/helpers.ts
@@ -49,6 +49,25 @@ export function runStatusLabel(status: string): string {
 	return status;
 }
 
+/**
+ * The one-line form of a run's `error`, for a place with a line to spare.
+ *
+ * The stored value is multi-line by design - a runner failure carries a stack,
+ * the orphan pass appends a log tail - and the first line is the verdict in
+ * every writer's shape, which is what a summary wants. The whole text stays one
+ * click away in the expanded block and on the run page.
+ */
+export const RUN_ERROR_SUMMARY_MAX_CHARS = 180;
+
+export function runErrorSummary(error: string | null | undefined): string | null {
+	if (!error) return null;
+	const first = error.split('\n', 1)[0].trim();
+	if (!first) return null;
+	return first.length > RUN_ERROR_SUMMARY_MAX_CHARS
+		? `${first.slice(0, RUN_ERROR_SUMMARY_MAX_CHARS).trimEnd()}...`
+		: first;
+}
+
 export function runStatusDotClass(status: string): string {
 	if (status === HeartbeatRunStatus.Running || status === HeartbeatRunStatus.Queued)
 		return 'bg-warning animate-pulse';

--- a/packages/web/src/components/comment-renderers/hire-proposal-comment.tsx
+++ b/packages/web/src/components/comment-renderers/hire-proposal-comment.tsx
@@ -79,7 +79,7 @@ export function HireProposalComment({ comment, projectId }: Props) {
 					</p>
 					{roleDescription && <p className="text-xs text-text-2 mt-0.5">{roleDescription}</p>}
 					<p className="text-xs text-text-2 mt-1">
-						Pending admin review — edit and review the full spec to approve or deny.
+						Pending admin review - edit and review the full spec to approve or deny.
 					</p>
 				</div>
 			</div>

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,6 +1,6 @@
 import { HeartbeatRunStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
-import { DoorOpen, Loader2, RotateCw } from 'lucide-react';
+import { AlertTriangle, DoorOpen, Loader2, RotateCw } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { useAgentLookup } from '../../hooks/use-agent-lookup';
 import { type ContainerHealth, useContainerHealth } from '../../hooks/use-container-health';
@@ -24,7 +24,7 @@ import { RelativeTime } from '../ui/relative-time';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
 import { CommentTimestampLink } from './comment-timestamp-link';
-import { runStatusDotClass, runStatusLabel } from './helpers';
+import { runErrorSummary, runStatusDotClass, runStatusLabel } from './helpers';
 
 interface Props {
 	comment: CommentDataOf<'run'>;
@@ -87,13 +87,13 @@ function skillSourceLabel(url: string): string {
 function containerNotReadyReason(health: ContainerHealth | null): string {
 	switch (health?.kind) {
 		case 'rebuilding':
-			return 'Container is rebuilding — retry will be available once it finishes';
+			return 'Container is rebuilding - retry will be available once it finishes';
 		case 'provisioning':
-			return 'Container is starting up — retry will be available once it is running';
+			return 'Container is starting up - retry will be available once it is running';
 		default:
 			// error, or the project index has not loaded yet (stopped never blocks —
 			// the retry lazy-starts the container).
-			return 'Container hit an error — fix it from the Container page to retry';
+			return 'Container hit an error - fix it from the Container page to retry';
 	}
 }
 
@@ -198,6 +198,12 @@ export function RunCommentBody({
 			: null;
 	const [expanded, setExpanded] = useState(false);
 	const logRegionId = `run-comment-log-${runId}`;
+	// Gated on the error rather than on the status: a cancelled run carries a
+	// reason too ("the container it was on stopped", "server shut down while this
+	// run was in flight"), and that is exactly the sentence a reader is looking
+	// for. The colour follows the status; the presence does not.
+	const errorSummary = runErrorSummary(run?.error);
+	const errored = status === HeartbeatRunStatus.Failed || status === HeartbeatRunStatus.TimedOut;
 	const { t } = useI18n();
 	// Ticks live while the run is in flight; empty until it actually starts, so a
 	// queued run does not show a stopwatch for work that has not begun.
@@ -390,8 +396,41 @@ export function RunCommentBody({
 					// Completed or still loading: collapsed by default, expandable on click.
 					expandToggle
 				))}
+			{inline && !isActive && errorSummary && (
+				// Its own row rather than a segment of `summaryRow`, which is a wrapping
+				// flex line tuned for narrow viewports that a reason of any length would
+				// fight. Until this existed the reason was rendered in exactly one place
+				// in the whole app - the run detail page - so a failed run in a thread
+				// said only that it had failed.
+				<button
+					type="button"
+					onClick={() => setExpanded((v) => !v)}
+					aria-expanded={expanded}
+					aria-controls={logRegionId}
+					aria-label={t('comment.runErrorExpand')}
+					data-testid="run-comment-error"
+					className={`flex w-full min-w-0 items-start gap-1.5 rounded-md px-2 py-1 text-left text-[11.5px] ${
+						errored ? 'bg-danger-soft text-danger-soft-fg' : 'bg-surface-3 text-text-2'
+					}`}
+				>
+					<AlertTriangle className="mt-[3px] h-3 w-3 shrink-0" aria-hidden="true" />
+					<span className="min-w-0 truncate">{errorSummary}</span>
+				</button>
+			)}
 			{((isActive && !working) || expanded) && (
 				<div id={logRegionId}>
+					{run?.error && (
+						// Mirrors the run detail page's block, so the two surfaces read the
+						// same rather than the reason living in one of them.
+						<div className="mb-2" data-testid="run-comment-error-full">
+							<div className="mb-1 text-[11px] uppercase tracking-wider text-text-3">
+								{t('comment.runError')}
+							</div>
+							<pre className="max-h-[140px] overflow-auto whitespace-pre-wrap rounded-lg bg-danger-soft p-3 font-mono text-xs text-danger-soft-fg">
+								{run.error}
+							</pre>
+						</div>
+					)}
 					<LogViewer
 						lines={lines}
 						compact

--- a/packages/web/src/components/connector-api-key-form.tsx
+++ b/packages/web/src/components/connector-api-key-form.tsx
@@ -38,7 +38,7 @@ export function apiKeyGuideFor(
 				'Pick or create a project in the Google Cloud Console.',
 				'Enable the YouTube Data API v3 (APIs & Services → Library).',
 				'Open Credentials → Create credentials → API key, then paste it below.',
-				'No OAuth consent screen is needed — an API key covers public, read-only data.',
+				'No OAuth consent screen is needed - an API key covers public, read-only data.',
 			],
 		};
 	}

--- a/packages/web/src/components/connector-completion.tsx
+++ b/packages/web/src/components/connector-completion.tsx
@@ -90,7 +90,7 @@ export function ConnectorCompletion({
 		authStart.mutate(connector.id, {
 			onSuccess: ({ auth_url }) => {
 				if (!auth_url) {
-					setInfo("This MCP server doesn't advertise OAuth — use the API key option below.");
+					setInfo("This MCP server doesn't advertise OAuth - use the API key option below.");
 					return;
 				}
 				const popup = window.open(auth_url, 'hezo-connect', 'width=600,height=720');

--- a/packages/web/src/components/connector-methods-dialog.tsx
+++ b/packages/web/src/components/connector-methods-dialog.tsx
@@ -283,7 +283,7 @@ function MethodCategory({
 											// operator take it for a declaration.
 											<span
 												className="text-[10px] uppercase tracking-wide text-text-3"
-												title="Category inferred from the method name — this server declares no read-only hint"
+												title="Category inferred from the method name - this server declares no read-only hint"
 											>
 												inferred
 											</span>

--- a/packages/web/src/components/connector-oauth-broker-form.tsx
+++ b/packages/web/src/components/connector-oauth-broker-form.tsx
@@ -64,7 +64,7 @@ const PROVIDER_GUIDES: Record<string, ProviderGuide> = {
 		steps: [
 			'Register a New OAuth App under GitHub Developer settings.',
 			'Enable “Device Flow” in the app’s settings and save.',
-			'Copy the app’s Client ID below — the device flow needs no client secret.',
+			'Copy the app’s Client ID below - the device flow needs no client secret.',
 		],
 	},
 };
@@ -227,7 +227,7 @@ export function ConnectorOAuthBrokerForm({
 				: 'Client secret (optional)';
 	const secretHint =
 		guide?.secret === 'none'
-			? 'This provider’s device flow doesn’t use a client secret — leave this blank.'
+			? 'This provider’s device flow doesn’t use a client secret - leave this blank.'
 			: guide?.secret === 'required'
 				? 'Paste the client secret shown next to the client ID in the console.'
 				: 'Only needed if your provider issues a secret for its device-flow client.';
@@ -280,7 +280,7 @@ export function ConnectorOAuthBrokerForm({
 					{statusMessage}
 				</p>
 				<p className="text-xs text-text-3">
-					Keep this open — it finishes as soon as you approve. The code expires in a few minutes; if
+					Keep this open - it finishes as soon as you approve. The code expires in a few minutes; if
 					it lapses, cancel and start again.
 				</p>
 				{onCancel && (
@@ -302,7 +302,7 @@ export function ConnectorOAuthBrokerForm({
 				</div>
 			)}
 
-			{/* How the device flow works — three plain steps. */}
+			{/* How the device flow works - three plain steps. */}
 			<div className="rounded-md border border-info-soft/60 bg-info-soft/40 px-3 py-2.5">
 				<div className="flex items-center gap-1.5 text-xs font-medium text-info-soft-fg mb-1.5">
 					<Info className="size-3.5" />
@@ -310,7 +310,7 @@ export function ConnectorOAuthBrokerForm({
 				</div>
 				<ol className="list-decimal ml-4 space-y-1 text-xs text-text-2 marker:text-text-3">
 					<li>Paste an OAuth client ID for {connectorLabel}.</li>
-					<li>Hezo shows a short code and a link — open it on any device and approve.</li>
+					<li>Hezo shows a short code and a link - open it on any device and approve.</li>
 					<li>
 						Hezo keeps the tokens fresh and hands your agents a placeholder, never the real token.
 					</li>
@@ -489,8 +489,8 @@ export function ConnectorOAuthBrokerForm({
 				<ShieldCheck className="size-4 shrink-0 text-info mt-0.5" />
 				<span>
 					The client secret and refresh token are stored encrypted in the Hezo vault and never enter
-					an agent run. Only the short-lived access token is exposed to agents — as a placeholder
-					the egress proxy fills in — and Hezo refreshes it automatically.
+					an agent run. Only the short-lived access token is exposed to agents - as a placeholder
+					the egress proxy fills in - and Hezo refreshes it automatically.
 				</span>
 			</div>
 

--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -136,7 +136,7 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 						<FieldLabel
 							htmlFor="goal-name"
 							tooltipLabel="About goal name"
-							tooltip="A short, outcome-focused name for the goal — what success looks like, not the work to get there."
+							tooltip="A short, outcome-focused name for the goal - what success looks like, not the work to get there."
 						>
 							Goal name
 						</FieldLabel>
@@ -152,14 +152,14 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 					<label className="flex flex-col gap-1.5">
 						<FieldLabel
 							tooltipLabel="About measurement"
-							tooltip="How will you know this goal is achieved? Be precise — this is the bar the Captain measures progress against."
+							tooltip="How will you know this goal is achieved? Be precise - this is the bar the Captain measures progress against."
 						>
 							Measurement
 						</FieldLabel>
 						<textarea
 							value={measurement}
 							onChange={(e) => setMeasurement(e.target.value)}
-							placeholder="How will you know this goal is achieved? Be precise — this is the bar the Captain measures against."
+							placeholder="How will you know this goal is achieved? Be precise - this is the bar the Captain measures against."
 							rows={3}
 							className={textareaClass}
 						/>
@@ -168,14 +168,14 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 					<label className="flex flex-col gap-1.5">
 						<FieldLabel
 							tooltipLabel="About suggested actions"
-							tooltip="Optional — specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
+							tooltip="Optional - specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
 						>
 							Suggested actions <span className="text-text-3">(optional)</span>
 						</FieldLabel>
 						<textarea
 							value={actions}
 							onChange={(e) => setActions(e.target.value)}
-							placeholder="Optional — specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
+							placeholder="Optional - specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
 							rows={3}
 							className={textareaClass}
 						/>
@@ -205,7 +205,7 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 						<label className="flex flex-col gap-1.5">
 							<FieldLabel
 								tooltipLabel="About deadline"
-								tooltip="Optional — a target date for reaching this goal. Leave blank for an open-ended goal."
+								tooltip="Optional - a target date for reaching this goal. Leave blank for an open-ended goal."
 							>
 								Deadline <span className="text-text-3">(optional)</span>
 							</FieldLabel>

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -233,7 +233,7 @@ function TeamDetail({
 					</>
 				)}
 			</div>
-			{/* Confirming is the only action here — the create actions live on the entry
+			{/* Confirming is the only action here - the create actions live on the entry
 			    step. Full-width on mobile, right-aligned from sm: up, matching that
 			    step's footer. */}
 			<div className="shrink-0 flex flex-col sm:flex-row sm:justify-end">
@@ -562,7 +562,7 @@ export function CreateProjectWithTeamDialog({
 										{(error as { message?: string }).message || 'Failed to create project'}
 									</p>
 								)}
-								{/* The submit actions belong to the entry step alone — the browse and
+								{/* The submit actions belong to the entry step alone - the browse and
 								    detail screens are for picking, and confirm via "Select team". Gating
 								    the row here also unmounts the mod+Enter binding on those screens. */}
 								{selection && (

--- a/packages/web/src/components/dashboard/progress-update-runs.tsx
+++ b/packages/web/src/components/dashboard/progress-update-runs.tsx
@@ -114,7 +114,7 @@ export function ProgressUpdateRuns({ projectId }: { projectId: string }) {
 								data-testid="progress-update-run"
 								className="flex flex-col gap-1.5 px-3 py-2.5"
 							>
-								{/* Collapsible run card — the same summary/expand/log UI as an agent run on a task. */}
+								{/* Collapsible run card - the same summary/expand/log UI as an agent run on a task. */}
 								<LazyMount minHeight={32} testId="progress-update-run-lazy">
 									<RunCommentBody
 										projectId={projectId}

--- a/packages/web/src/components/database-section.tsx
+++ b/packages/web/src/components/database-section.tsx
@@ -103,7 +103,7 @@ export function DatabaseSection() {
 								</strong>{' '}
 								using{' '}
 								<strong className="font-medium text-text-1">{formatBytes(superseded.bytes)}</strong>{' '}
-								of disk. This can’t be undone — your current database is untouched, but you won’t be
+								of disk. This can’t be undone - your current database is untouched, but you won’t be
 								able to roll back to an earlier version.
 							</>
 						}
@@ -318,15 +318,15 @@ function CompactionControl({
 					<>
 						This trims the full logs of agent runs older than{' '}
 						<strong className="font-medium text-text-1">{retentionDays} days</strong> down to their
-						final portion — the agent’s end-of-run summary and outcome. The full command that
+						final portion - the agent’s end-of-run summary and outcome. The full command that
 						launched each run is kept, every trimmed log is clearly marked as compacted, and status,
 						timing, tokens and cost are unchanged. Runs newer than the window are untouched. The
 						detailed step-by-step output is permanently discarded and can’t be recovered.
 						{usage.backend === 'embedded' && (
 							<>
 								{' '}
-								It then rewrites the run-logs table to return the freed space — and accumulated
-								storage bloat — to disk, which briefly locks that table.
+								It then rewrites the run-logs table to return the freed space - and accumulated
+								storage bloat - to disk, which briefly locks that table.
 							</>
 						)}
 					</>

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -409,7 +409,7 @@ export function DocsLibrary({
 						    editor z-30) so an open comment editor is never hidden. */}
 						{/* `flex-wrap` + the title's `basis-full sm:basis-auto` keep the
 						    title on its own full-width first line on mobile, with the
-						    action cluster wrapping beneath it — the whole set of icon
+						    action cluster wrapping beneath it - the whole set of icon
 						    buttons can't share a 375px line with a readable title, and a
 						    `min-w-0` title squeezed by `shrink-0` actions would otherwise
 						    collapse to zero width (an invisible heading). Tablet/desktop
@@ -501,7 +501,7 @@ export function DocsLibrary({
 											</Button>
 										)}
 										{/* Active docs offer Archive (reversible, no confirm); the hard
-										    delete only appears on archived docs — a two-step flow that
+										    delete only appears on archived docs - a two-step flow that
 										    keeps the destructive action off the everyday toolbar. */}
 										{!readOnly &&
 											!archivedInfo &&
@@ -559,7 +559,7 @@ export function DocsLibrary({
 									<span className="text-text-2">
 										Hidden from the Active list and from agents
 										{archivedInfo.archivedByName
-											? ` — archived by ${archivedInfo.archivedByName}`
+											? ` - archived by ${archivedInfo.archivedByName}`
 											: ''}{' '}
 										<RelativeTime iso={archivedInfo.archivedAt} />.
 									</span>
@@ -584,7 +584,7 @@ export function DocsLibrary({
 						)}
 
 						{/* The doc's "what this is" line, above the metadata banner. Only
-						    shown when set — an empty description reads as no subtitle. */}
+						    shown when set - an empty description reads as no subtitle. */}
 						{mode === 'view' && supportsDescription && docDescription && (
 							<p
 								className="text-[13px] leading-relaxed text-text-2 mb-4"

--- a/packages/web/src/components/document-download-menu.tsx
+++ b/packages/web/src/components/document-download-menu.tsx
@@ -99,7 +99,7 @@ export function DocumentDownloadMenu({
 			{variant === 'icon' ? <Tooltip content="Download document">{trigger}</Tooltip> : trigger}
 			<Popover.Portal>
 				{/* z-[70] clears the task-detail preview panel, which is a full-screen
-				    z-[60] overlay below lg — at z-50 the portalled menu painted behind
+				    z-[60] overlay below lg - at z-50 the portalled menu painted behind
 				    it and was invisible on mobile. Dialogs (z-[80]/[90]) still win. */}
 				<Popover.Content
 					align="end"

--- a/packages/web/src/components/document-review/action-review-dialog.tsx
+++ b/packages/web/src/components/document-review/action-review-dialog.tsx
@@ -120,7 +120,7 @@ export function ActionReviewDialog({
 					Action this review
 				</Dialog.Title>
 				<Dialog.Description className="mb-3 text-[12.5px] leading-relaxed text-text-2">
-					Add this handoff as a comment on a task — pick one from Add to task, or copy it — and
+					Add this handoff as a comment on a task - pick one from Add to task, or copy it - and
 					assign it to the agent who should action the feedback. The agent reads the review comments
 					directly from the {sourceNoun}.
 				</Dialog.Description>

--- a/packages/web/src/components/document-review/review-handoff.ts
+++ b/packages/web/src/components/document-review/review-handoff.ts
@@ -8,8 +8,8 @@
 export function buildReviewHandoff(filename: string): string {
 	return [
 		`Review comments have been left on the document ${filename}.`,
-		`Read it with read_project_doc — the pending review comments come back alongside the content, each anchoring a comment to an exact quote from the document.`,
-		`IMPORTANT: capture ALL review comments before your first write. Any update to the document automatically deletes every review comment on it, so keep them in context and make one consolidated update rather than multiple passes (documents are revisioned — one clean revision also beats a trail of partial ones).`,
+		`Read it with read_project_doc - the pending review comments come back alongside the content, each anchoring a comment to an exact quote from the document.`,
+		`IMPORTANT: capture ALL review comments before your first write. Any update to the document automatically deletes every review comment on it, so keep them in context and make one consolidated update rather than multiple passes (documents are revisioned - one clean revision also beats a trail of partial ones).`,
 		`Action each comment and update the document accordingly. If any feedback is unclear or you are unsure how to proceed, ask the admin in the task thread before making changes.`,
 	].join('\n\n');
 }
@@ -18,7 +18,7 @@ export function buildReviewHandoff(filename: string): string {
 export function buildAssetReviewHandoff(path: string): string {
 	return [
 		`Review comments have been left on the asset assets/${path}.`,
-		`Read it with read_project_asset — the pending review comments come back alongside the content. On a text asset each comment anchors to an exact quote; a comment without a quote applies to the whole file.`,
+		`Read it with read_project_asset - the pending review comments come back alongside the content. On a text asset each comment anchors to an exact quote; a comment without a quote applies to the whole file.`,
 		`IMPORTANT: capture ALL review comments before your first write. Any write_project_asset to this path automatically deletes every review comment on it, so keep them in context and make one consolidated update rather than multiple passes.`,
 		`Action each comment and update the asset accordingly. If any feedback is unclear or you are unsure how to proceed, ask the admin in the task thread before making changes.`,
 	].join('\n\n');

--- a/packages/web/src/components/document-review/review-help.tsx
+++ b/packages/web/src/components/document-review/review-help.tsx
@@ -29,13 +29,13 @@ export function ReviewHelp({
 					<li>
 						On a <strong>text asset</strong> (markdown, plain text),{' '}
 						<strong>select any text</strong> or <strong>hover a line</strong> to leave an anchored
-						comment — exactly like a document. Other asset types (images, HTML, PDFs, …) take{' '}
+						comment - exactly like a document. Other asset types (images, HTML, PDFs, …) take{' '}
 						<strong>whole-asset comments</strong> from the review panel.
 					</li>
 				) : (
 					<>
 						<li>
-							<strong>Select any text</strong> in the document to leave a comment on it — the text
+							<strong>Select any text</strong> in the document to leave a comment on it - the text
 							stays highlighted.
 						</li>
 						<li>
@@ -48,8 +48,8 @@ export function ReviewHelp({
 					<strong>Click a highlight</strong> (or its margin icon) to edit or delete that comment.
 				</li>
 				<li>
-					The <strong>clipboard button</strong> opens a handoff you can copy — or post straight onto
-					a task you pick from the <strong>Add to task</strong> list — agents read the comments
+					The <strong>clipboard button</strong> opens a handoff you can copy - or post straight onto
+					a task you pick from the <strong>Add to task</strong> list - agents read the comments
 					directly from the {isAsset ? 'asset' : 'document'}.
 				</li>
 				<li>
@@ -60,8 +60,8 @@ export function ReviewHelp({
 				<TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
 				<span>
 					{isAsset
-						? 'Any write to the asset — by you or an agent — automatically deletes all existing review comments. A review applies to the current version of the asset only.'
-						: 'Any update to the document — by you or an agent — automatically deletes all existing review comments. A review applies to the current version of the document only.'}
+						? 'Any write to the asset - by you or an agent - automatically deletes all existing review comments. A review applies to the current version of the asset only.'
+						: 'Any update to the document - by you or an agent - automatically deletes all existing review comments. A review applies to the current version of the document only.'}
 				</span>
 			</div>
 		</HelpDialog>

--- a/packages/web/src/components/document-review/review-surface.tsx
+++ b/packages/web/src/components/document-review/review-surface.tsx
@@ -305,7 +305,7 @@ export function ReviewSurface({
 			)}
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: mouseover raises the pointer-only hover-a-line ghost; keyboard users comment via selection or the focusable highlights */}
-			{/* biome-ignore lint/a11y/useKeyWithMouseEvents: same — the hover affordance has no keyboard analogue by design */}
+			{/* biome-ignore lint/a11y/useKeyWithMouseEvents: same - the hover affordance has no keyboard analogue by design */}
 			<div ref={contentRef} className="relative" onMouseOver={handleContentMouseOver}>
 				{prose}
 			</div>

--- a/packages/web/src/components/document-review/review-toolbar-actions.tsx
+++ b/packages/web/src/components/document-review/review-toolbar-actions.tsx
@@ -75,7 +75,7 @@ export function ReviewToolbarActions({
 					</button>
 				</Tooltip>
 			)}
-			<Tooltip content="Action this review — copy a handoff for an agent">
+			<Tooltip content="Action this review - copy a handoff for an agent">
 				<button
 					type="button"
 					aria-label="Action this review"

--- a/packages/web/src/components/document-review/revision-history-dialog.tsx
+++ b/packages/web/src/components/document-review/revision-history-dialog.tsx
@@ -90,7 +90,7 @@ export function RevisionHistoryDialog({
 									</div>
 									<div className="px-3 py-2.5">
 										{e.isInitial || !e.changelog.trim() ? (
-											<p className="text-xs italic text-text-3">Initial version — no changelog.</p>
+											<p className="text-xs italic text-text-3">Initial version - no changelog.</p>
 										) : (
 											<MarkdownProse projectId={projectId} projectSlug={projectSlug}>
 												{e.changelog}

--- a/packages/web/src/components/goal-detail/goal-detail-page.tsx
+++ b/packages/web/src/components/goal-detail/goal-detail-page.tsx
@@ -221,7 +221,7 @@ export function GoalDetailPage({ projectId, goalId }: GoalDetailPageProps) {
 
 	return (
 		<div className="max-w-3xl">
-			{/* `Progress › Goals › <goal>` — the shared primitive, so this reads the same as the
+			{/* `Progress › Goals › <goal>` - the shared primitive, so this reads the same as the
 			    task and asset breadcrumbs rather than being a third hand-rolled one. */}
 			<div className="mb-2">
 				<Breadcrumb

--- a/packages/web/src/components/goal-smart-guidance.tsx
+++ b/packages/web/src/components/goal-smart-guidance.tsx
@@ -18,7 +18,7 @@ export function GoalSmartGuidance({ className = '' }: { className?: string }) {
 				{GOAL_SMART_GUIDANCE.map((item) => (
 					<li key={item.letter} className="text-xs text-text-3 leading-relaxed">
 						<span className="font-semibold text-text-2">
-							{item.letter} — {item.label}:
+							{item.letter} - {item.label}:
 						</span>{' '}
 						{item.hint}
 					</li>

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -264,7 +264,7 @@ export function GoalsList({ projectId }: GoalsListProps) {
 						<div className="flex flex-col gap-3">
 							<p className="text-sm text-text-2 leading-relaxed">
 								Goals are the outcomes the Captain steers the team toward. Write each one so
-								progress is unambiguous — strong goals follow the{' '}
+								progress is unambiguous - strong goals follow the{' '}
 								<span className="font-semibold">SMART</span> framework:
 							</p>
 							<GoalSmartGuidance className="border-0 bg-transparent p-0" />
@@ -294,7 +294,7 @@ export function GoalsList({ projectId }: GoalsListProps) {
 					{view === 'archived'
 						? 'No archived goals.'
 						: suggestions.length > 0
-							? 'No active goals yet — approve a suggestion above to create one.'
+							? 'No active goals yet - approve a suggestion above to create one.'
 							: 'No active goals.'}
 				</div>
 			) : (

--- a/packages/web/src/components/hq-container-notice.tsx
+++ b/packages/web/src/components/hq-container-notice.tsx
@@ -60,7 +60,7 @@ function noticeTitle(health: Exclude<ContainerHealth, { kind: 'healthy' }>): str
 				? 'Stopping the HQ container…'
 				: 'Starting the HQ container…';
 		case 'stopped':
-			return 'The HQ container is asleep — it starts automatically when needed';
+			return 'The HQ container is asleep - it starts automatically when needed';
 		case 'error':
 			return 'The HQ container has an error';
 	}

--- a/packages/web/src/components/markdown-editor.tsx
+++ b/packages/web/src/components/markdown-editor.tsx
@@ -32,7 +32,7 @@ function VarChip({ chip, onInsert }: { chip: EditorChip; onInsert: (token: strin
 				e.preventDefault();
 				setOpen((o) => !o);
 			}}
-			aria-label={chip.description ? `${chip.token} — ${chip.description}` : chip.token}
+			aria-label={chip.description ? `${chip.token} - ${chip.description}` : chip.token}
 			className="text-[11px] px-2 py-0.5 rounded-md bg-info-soft text-info-soft-fg cursor-pointer hover:opacity-80"
 		>
 			{chip.token}

--- a/packages/web/src/components/markdown-thumbnail.tsx
+++ b/packages/web/src/components/markdown-thumbnail.tsx
@@ -32,7 +32,7 @@ export function MarkdownThumbnail({ url, contentType }: { url: string; contentTy
 			aria-hidden
 			className="pointer-events-none h-full w-full overflow-hidden [mask-image:linear-gradient(to_bottom,black_65%,transparent)]"
 		>
-			{/* prose-sm rendered at ~60% via transform — proportional headings and
+			{/* prose-sm rendered at ~60% via transform - proportional headings and
 			    spacing read as a real document; w-[166%] refills the width post-scale. */}
 			<div className="w-[166%] origin-top-left scale-[0.6] px-3 py-2 prose prose-sm max-w-none [&_*]:text-text-1!">
 				<Markdown remarkPlugins={[remarkGfm]} components={THUMBNAIL_COMPONENTS}>

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -265,7 +265,7 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 							<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
 							<span>
 								<span className="font-semibold text-text-1">
-									No one can recover it — not even Hezo.
+									No one can recover it - not even Hezo.
 								</span>{' '}
 								Lose these words and your data is locked away for good.
 							</span>
@@ -274,7 +274,7 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 							<Lock className="w-4 h-4 shrink-0 mt-0.5" />
 							<span>
 								<span className="font-semibold text-text-1">Save it now</span> in a password manager
-								or another safe place — you'll confirm it on the next step.
+								or another safe place - you'll confirm it on the next step.
 							</span>
 						</div>
 					</div>

--- a/packages/web/src/components/model-pricing-section.tsx
+++ b/packages/web/src/components/model-pricing-section.tsx
@@ -23,7 +23,7 @@ const PER_MILLION = 1_000_000;
 
 /** Per-token rate → "$X.XX" per million tokens, the friendlier unit to read/enter. */
 function fmtPerMillion(perToken: number | null): string {
-	if (perToken == null) return '—';
+	if (perToken == null) return '-';
 	return `$${(perToken * PER_MILLION).toFixed(2)}`;
 }
 
@@ -193,7 +193,7 @@ export function ModelPricingSection() {
 								</span>{' '}
 								Hezo multiplies the token counts each runtime reports by these per-model rates.
 								Dollar figures a runtime emits itself (e.g.{' '}
-								<span className="font-mono">total_cost_usd</span>) are ignored — they are
+								<span className="font-mono">total_cost_usd</span>) are ignored - they are
 								client-side estimates from the CLI's own rate card, which is wrong for third-party
 								endpoints.
 							</p>
@@ -207,11 +207,11 @@ export function ModelPricingSection() {
 								</span>{' '}
 								The catalog carries no cache pricing, so cached reads and writes are billed at the
 								full input rate. Providers charge cache reads at a steep discount, so real bills are
-								usually lower than the recorded figures — never higher.
+								usually lower than the recorded figures - never higher.
 							</p>
 							<p>
 								A manual override wins over the catalog for its model and <em>can</em> set cache
-								rates — add one for exact billing, to correct a rate, or to price a model the
+								rates - add one for exact billing, to correct a rate, or to price a model the
 								catalog lacks.
 							</p>
 						</div>

--- a/packages/web/src/components/next-heartbeat-indicator.tsx
+++ b/packages/web/src/components/next-heartbeat-indicator.tsx
@@ -27,7 +27,7 @@ export function NextHeartbeatIndicator({
 	if (!nextHeartbeatAt) return null;
 	if (hasActionableWork && !countdown) return null;
 
-	const label = hasActionableWork ? countdown!.label : '—';
+	const label = hasActionableWork ? countdown!.label : '-';
 	const isDue = hasActionableWork && countdown!.isDue;
 
 	return (

--- a/packages/web/src/components/org-chart-tree.tsx
+++ b/packages/web/src/components/org-chart-tree.tsx
@@ -227,7 +227,7 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 		<div data-testid={testId}>
 			{/* The viewport's height is left to the content so a space-taking
 			    horizontal scrollbar gets a gutter below the chart instead of eating
-			    ~15px out of the box and shearing the bottom row's border — the same
+			    ~15px out of the box and shearing the bottom row's border - the same
 			    border PR #620 was about. Its vertical overflow must be stated
 			    explicitly: a non-`visible` value on one axis computes the other to
 			    `auto`, which would let a vertical scrollbar appear alongside.
@@ -243,13 +243,13 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 				}`}
 			>
 				{/* The scaled chart keeps its untransformed layout box, so this sizer
-				    carries the painted size instead — it is what gives the viewport a
+				    carries the painted size instead - it is what gives the viewport a
 				    correct scroll extent, and clipping to it keeps the untransformed
 				    tree's layout overflow from leaking into that extent.
 
 				    `mx-auto` is the whole centring story: CSS 2.1 §10.3.3 zeroes
 				    over-constrained auto margins, so the sizer centres while the chart
-				    fits and goes flush left the moment it outgrows the viewport —
+				    fits and goes flush left the moment it outgrows the viewport -
 				    which is what puts the chart's left edge at scrollLeft 0 instead of
 				    stranding it out of reach. `justify-center` on a scroll container
 				    would strand it, the same way the old measurement did. */}

--- a/packages/web/src/components/project-plan-upload.tsx
+++ b/packages/web/src/components/project-plan-upload.tsx
@@ -9,7 +9,7 @@ interface ProjectPlanUploadProps {
 }
 
 const HELP_CONTENT =
-	'Attach a fuller document describing what this project is for when the description above isn’t enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it’s used directly as the plan. Supported files: .md, .txt, .markdown.';
+	'Attach a fuller document describing what this project is for when the description above isn’t enough - goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it’s used directly as the plan. Supported files: .md, .txt, .markdown.';
 
 /**
  * Compact "attach project plan" control: a single minimal-height row with a

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -102,7 +102,7 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 						  handlers, and pointerdown bubbles up here anyway. The wrapper is
 						  also what the hook measures and transforms, so the lifted avatar
 						  and its displaced neighbours all move *inside* the scroll
-						  container — `overflow-y-auto` never has an escaping element to
+						  container - `overflow-y-auto` never has an escaping element to
 						  clip. `items-center` keeps it shrink-to-fit, so it adds no layout.
 						*/
 						return (
@@ -141,7 +141,7 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 						  bottom while the avatars scroll beneath. The full-width opaque
 						  wrapper masks avatars sliding under. The shadow is always on
 						  (upward, so the overflow box can't clip it away in the stuck
-						  position) — there is no separator border in either state.
+						  position) - there is no separator border in either state.
 						*/
 						<div className="sticky bottom-0 z-10 shrink-0 w-full flex justify-center py-1 bg-surface-2">
 							<Tooltip content="New project" side="right">

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -76,7 +76,7 @@ export function ProjectSidebar({
 			<span className="inline-flex items-center gap-1.5">
 				<span>Containers</span>
 				{containerFailed && (
-					<Tooltip content="Container failed — click for details" side="right">
+					<Tooltip content="Container failed - click for details" side="right">
 						<span
 							role="img"
 							data-testid="project-sidebar-container-error"
@@ -148,7 +148,7 @@ export function ProjectSidebar({
 			<span className="inline-flex items-center gap-1.5">
 				<span>{t('nav.goals')}</span>
 				{hasNoGoals && (
-					<Tooltip content="No goals yet — create one to focus the team" side="right">
+					<Tooltip content="No goals yet - create one to focus the team" side="right">
 						<span
 							role="img"
 							aria-label="No goals yet"
@@ -189,7 +189,7 @@ export function ProjectSidebar({
 			label: t('nav.assets'),
 		},
 		...(isInternal
-			? // HQ has no Budget or Settings — Container stays at the top level, after
+			? // HQ has no Budget or Settings - Container stays at the top level, after
 				// Connectors and Skills, with Activity last as everywhere else.
 				[connectorsPage, skillsPage, containerPage, activityPage]
 			: [
@@ -260,7 +260,7 @@ export function ProjectSidebar({
 						<span className="flex flex-1 items-center gap-1.5 min-w-0">
 							<Globe
 								className="w-3 h-3 shrink-0 text-text-3"
-								aria-label="Global agent — works across all projects"
+								aria-label="Global agent - works across all projects"
 							/>
 							<AgentStatusLabel
 								variant="sidebar"

--- a/packages/web/src/components/related-items-list.tsx
+++ b/packages/web/src/components/related-items-list.tsx
@@ -32,7 +32,7 @@ export function RelatedItemsList({
 		<div className="mt-1 pl-4 border-l border-border flex flex-col gap-0.5" data-testid={testId}>
 			{label && <span className="text-[11px] uppercase tracking-wide text-text-3">{label}</span>}
 			{items.length === 0 ? (
-				<span className="text-xs text-text-3">{emptyLabel ?? '—'}</span>
+				<span className="text-xs text-text-3">{emptyLabel ?? '-'}</span>
 			) : (
 				items.map((it) =>
 					it.href ? (

--- a/packages/web/src/components/reload-prompt-banner.tsx
+++ b/packages/web/src/components/reload-prompt-banner.tsx
@@ -19,7 +19,7 @@ export function ReloadPromptBanner() {
 			className="shrink-0 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2.5 text-[13px] bg-info-soft text-info-soft-fg border-b border-border"
 		>
 			<span className="flex-1">
-				Hezo was updated in the background. Refresh to load the latest version — some items may not
+				Hezo was updated in the background. Refresh to load the latest version - some items may not
 				display correctly until you do.
 			</span>
 			<Button

--- a/packages/web/src/components/repo-git-state-panel.tsx
+++ b/packages/web/src/components/repo-git-state-panel.tsx
@@ -104,7 +104,7 @@ export function RepoGitStatePanel({ projectId, repoId, repoName }: RepoGitStateP
 					className="rounded-md border border-border bg-surface-2 p-3 text-xs text-text-2"
 					data-testid={`repo-git-container-stopped-${repoName}`}
 				>
-					Container is stopped —{' '}
+					Container is stopped -{' '}
 					<Link
 						to="/projects/$projectId/container"
 						params={{ projectId }}

--- a/packages/web/src/components/settings/apply-type-section.tsx
+++ b/packages/web/src/components/settings/apply-type-section.tsx
@@ -26,7 +26,7 @@ export function ApplyTypeSection({ projectId }: { projectId: string }) {
 		setResult(
 			added.length > 0
 				? `Added ${added.length} role${added.length === 1 ? '' : 's'}: ${added.join(', ')}.`
-				: 'Already up to date — nothing to add.',
+				: 'Already up to date - nothing to add.',
 		);
 	}
 
@@ -34,7 +34,7 @@ export function ApplyTypeSection({ projectId }: { projectId: string }) {
 		<section data-testid="apply-type-section">
 			<h2 className="text-[15px] font-medium mb-1">Refresh from a type</h2>
 			<p className="text-[13px] text-text-2 mb-3">
-				Merge a team type into this team — adds any missing roles and refreshes built-in prompts.
+				Merge a team type into this team - adds any missing roles and refreshes built-in prompts.
 				Never removes agents or customizations you've added. To copy another team's setup, save it
 				as a type first, then apply it here.
 			</p>

--- a/packages/web/src/components/settings/automations-section.tsx
+++ b/packages/web/src/components/settings/automations-section.tsx
@@ -51,7 +51,7 @@ export function AutomationsSection({
 					<span className="text-text-2 block mt-0.5">
 						When an agent replies to a comment that @-mentioned it, automatically wake the original
 						commenter so they see the response right away. Disable to have the original commenter
-						pick up accumulated replies on their next heartbeat instead — useful when a single
+						pick up accumulated replies on their next heartbeat instead - useful when a single
 						comment @-mentions several agents and you'd rather batch their responses.
 					</span>
 				</span>

--- a/packages/web/src/components/settings/general-section.tsx
+++ b/packages/web/src/components/settings/general-section.tsx
@@ -10,7 +10,7 @@ export function GeneralSection({ team }: { team: Team | undefined }) {
 					<span className="text-xs font-medium uppercase tracking-wider text-text-2 block mb-1.5">
 						Team name
 					</span>
-					<div className="text-[13px]">{team?.name ?? '—'}</div>
+					<div className="text-[13px]">{team?.name ?? '-'}</div>
 				</div>
 				{team?.description && (
 					<div>

--- a/packages/web/src/components/subscription-paste-form.tsx
+++ b/packages/web/src/components/subscription-paste-form.tsx
@@ -15,7 +15,7 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 			</>,
 			<>
 				Run <code>claude setup-token</code> (requires a Claude Pro or Max subscription). A browser
-				window opens — sign in with the Claude account whose subscription you want to use.
+				window opens - sign in with the Claude account whose subscription you want to use.
 			</>,
 			<>
 				Copy the token it prints (it starts with <code>sk-ant-oat01-</code>) and paste it into the
@@ -38,7 +38,7 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 				Install the Codex CLI on your local machine: <code>npm install -g @openai/codex</code>.
 			</>,
 			<>
-				Run <code>codex login</code>. A browser window will open at <code>auth.openai.com</code> —
+				Run <code>codex login</code>. A browser window will open at <code>auth.openai.com</code> -
 				sign in with the ChatGPT account whose subscription you want to use.
 			</>,
 			<>
@@ -50,7 +50,7 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 		footer: (
 			<>
 				Heads up: this credential auto-rotates each time Hezo runs Codex. Don't keep using the same
-				login on your laptop afterwards — pick one or the other, otherwise the refresh token will
+				login on your laptop afterwards - pick one or the other, otherwise the refresh token will
 				desync. To stop, remove the credential here and re-run <code>codex login</code> locally.
 			</>
 		),
@@ -65,12 +65,12 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 			</>,
 			<>
 				Run <code>gemini</code> and choose <strong>Sign in with Google</strong>. A browser window
-				will open — sign in with the Google account whose Gemini access you want to use.
+				will open - sign in with the Google account whose Gemini access you want to use.
 			</>,
 			<>
 				Open <code>~/.gemini/oauth_creds.json</code> (macOS/Linux) or{' '}
 				<code>%USERPROFILE%\.gemini\oauth_creds.json</code> (Windows). On newer Gemini CLI versions
-				the credential may be stored in your OS keychain instead — sign out and back in with{' '}
+				the credential may be stored in your OS keychain instead - sign out and back in with{' '}
 				<code>GEMINI_FORCE_FILE_STORAGE=true</code> set to force a plaintext file.
 			</>,
 			<>Copy the entire contents of that file and paste them into the box below.</>,

--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,16 +1,27 @@
+import { HeartbeatRunStatus } from '@hezo/shared';
 import { AlertTriangle, ChevronRight } from 'lucide-react';
 import type { Task } from '../../hooks/use-tasks';
+import { useI18n } from '../../lib/i18n';
 import { jumpToComment } from '../comment-renderers';
+import { runErrorSummary } from '../comment-renderers/helpers';
 
 interface Props {
 	task: Task;
 }
 
 export function LastRunFailedBanner({ task }: Props) {
-	const failed = task.last_run_status === 'failed' || task.last_run_status === 'timed_out';
+	const { t } = useI18n();
+	const timedOut = task.last_run_status === HeartbeatRunStatus.TimedOut;
+	const failed = timedOut || task.last_run_status === HeartbeatRunStatus.Failed;
 	if (task.has_active_run || !failed || !task.last_run_comment_public_id) return null;
 
 	const commentId = task.last_run_comment_public_id;
+	const reason = runErrorSummary(task.last_run_error);
+	// Four keys rather than two plus a {status} variable: the status word inflects
+	// with the sentence in several of these languages.
+	const label = reason
+		? t(timedOut ? 'tasks.lastRun.timedOutReason' : 'tasks.lastRun.failedReason', { reason })
+		: t(timedOut ? 'tasks.lastRun.timedOut' : 'tasks.lastRun.failed');
 	return (
 		<a
 			href={`#comment-${commentId}`}
@@ -19,11 +30,9 @@ export function LastRunFailedBanner({ task }: Props) {
 			className="mb-4 flex items-center gap-2 rounded-md bg-danger/10 px-4 py-2 text-[13px] font-medium text-danger hover:bg-danger/15 transition-colors"
 		>
 			<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-			<span className="min-w-0 truncate">
-				{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view it
-			</span>
+			<span className="min-w-0 truncate">{label}</span>
 			<span className="ml-auto flex items-center gap-1 shrink-0">
-				<span className="hidden sm:inline">Jump to run</span>
+				<span className="hidden sm:inline">{t('tasks.lastRun.jump')}</span>
 				<ChevronRight className="w-3.5 h-3.5" />
 			</span>
 		</a>

--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -88,7 +88,7 @@ export function TaskHeader({
 			</nav>
 			<TaskTitle task={task} updateTask={updateTask} />
 
-			{/* Wire spec — status / priority / assignee render as quiet-tint badges
+			{/* Wire spec - status / priority / assignee render as quiet-tint badges
 			    (treatment A, the default), color-coding state at a glance the same way
 			    the task list does, with a mono runs / duration / cost summary pushed
 			    right. Assignee carries no semantic state, so it stays neutral. */}
@@ -109,7 +109,7 @@ export function TaskHeader({
 						<span className="inline-block w-1.5 h-1.5 rounded-full bg-info-soft-fg" />
 						{task.queued_wakeup.reason === 'instance_at_capacity' ||
 						task.queued_wakeup.reason === 'project_at_capacity'
-							? 'Queued — at the container limit'
+							? 'Queued - at the container limit'
 							: 'Run queued'}
 					</Badge>
 				)}
@@ -125,7 +125,7 @@ export function TaskHeader({
 				)}
 			</div>
 
-			{/* Always rendered, even with no description — the empty card is the only
+			{/* Always rendered, even with no description - the empty card is the only
 			    affordance for adding one. */}
 			<div
 				className="mb-5 rounded-md border border-border bg-surface overflow-hidden"

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -251,7 +251,7 @@ export function TaskSidebar({
 								</AgentRef>
 							) : (
 								<AgentStatusLabel
-									name="—"
+									name="-"
 									runtimeStatus={AgentRuntimeStatus.Idle}
 									badge={assigneeRunBadge}
 									className="flex-1 min-w-0"
@@ -279,7 +279,7 @@ export function TaskSidebar({
 								) : (
 									<span className="flex flex-1 min-w-0 items-center">
 										<AgentStatusLabel
-											name="—"
+											name="-"
 											runtimeStatus={AgentRuntimeStatus.Idle}
 											className="min-w-0"
 										/>
@@ -376,7 +376,7 @@ export function TaskSidebar({
 							{task.project_name}
 						</Link>
 					) : (
-						<span className="text-[13px] text-text-1">—</span>
+						<span className="text-[13px] text-text-1">-</span>
 					)}
 				</div>
 

--- a/packages/web/src/components/task-detail/task-summary.tsx
+++ b/packages/web/src/components/task-detail/task-summary.tsx
@@ -129,7 +129,7 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				label="Progress Summary"
 				infoLabel="About Progress Summary"
 				infoTestId="progress-summary-info"
-				infoContent="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt — alongside the description and rules — so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
+				infoContent="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt - alongside the description and rules - so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
 				editorAriaLabel="Progress Summary"
 				value={task.progress_summary}
 				emptyText="No progress summary yet."
@@ -145,7 +145,7 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				label="Rules"
 				infoLabel="About Rules"
 				infoTestId="rules-info"
-				infoContent="Approach constraints and required workflows for this task — e.g. 'run the full suite before pushing' or 'consult the architect before touching auth'. Automatically prepended to every agent run's task prompt. Agents can update via the update_task tool as they discover new rules."
+				infoContent="Approach constraints and required workflows for this task - e.g. 'run the full suite before pushing' or 'consult the architect before touching auth'. Automatically prepended to every agent run's task prompt. Agents can update via the update_task tool as they discover new rules."
 				editorAriaLabel="Rules"
 				editorPlaceholder="e.g., Consult the architect before making changes..."
 				value={task.rules}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -429,7 +429,7 @@ export function TaskList({ projectId }: TaskListProps) {
 							</Tooltip>
 						)}
 						{row.has_unread_admin_mention && (
-							<Tooltip content="Unread mention — needs your review">
+							<Tooltip content="Unread mention - needs your review">
 								<AtSign
 									role="img"
 									aria-label="Unread mention"
@@ -467,7 +467,7 @@ export function TaskList({ projectId }: TaskListProps) {
 							row.project_name ? (
 								<Badge color="info">{row.project_name}</Badge>
 							) : (
-								<span className="text-text-3">—</span>
+								<span className="text-text-3">-</span>
 							),
 					},
 				]),
@@ -498,7 +498,7 @@ export function TaskList({ projectId }: TaskListProps) {
 					/>
 				) : (
 					<span className="block max-w-[140px] truncate text-text-2">
-						{row.assignee_name || '—'}
+						{row.assignee_name || '-'}
 					</span>
 				),
 		},

--- a/packages/web/src/components/task-run-dot.tsx
+++ b/packages/web/src/components/task-run-dot.tsx
@@ -32,8 +32,8 @@ export function TaskRunDot({ hasActiveRun, queuedWakeup }: TaskRunDotProps) {
 		const label =
 			queuedWakeup.reason === 'instance_at_capacity' ||
 			queuedWakeup.reason === 'project_at_capacity'
-				? 'Run queued — at the container limit'
-				: 'Run queued — waiting';
+				? 'Run queued - at the container limit'
+				: 'Run queued - waiting';
 		return (
 			<Tooltip content={label}>
 				<span

--- a/packages/web/src/components/team-roster-table.tsx
+++ b/packages/web/src/components/team-roster-table.tsx
@@ -55,7 +55,7 @@ function withCaptain(roles: TeamRosterRow[]): TeamRosterRow[] {
 }
 
 /** The dash shown when a role reports to nobody in the roster. */
-const NO_REPORTS_TO = '—';
+const NO_REPORTS_TO = '-';
 
 /**
  * Turn a `reports_to_slug` into something a human reads: the title of the role it

--- a/packages/web/src/components/ui/actor-badge.tsx
+++ b/packages/web/src/components/ui/actor-badge.tsx
@@ -21,7 +21,7 @@ export function ActorBadge({
 }) {
 	if (actorType === 'api_key') {
 		return (
-			<Tooltip content={name ? `${name} — API key (external MCP client)` : 'API key'}>
+			<Tooltip content={name ? `${name} - API key (external MCP client)` : 'API key'}>
 				<span
 					role="img"
 					className={`inline-flex items-center align-middle text-text-3 ${className ?? ''}`}
@@ -35,7 +35,7 @@ export function ActorBadge({
 	}
 	if (actorType === 'admin' || actorType === 'user') {
 		return (
-			<Tooltip content={name ? `${name} — human admin (via web)` : 'Human admin (via web)'}>
+			<Tooltip content={name ? `${name} - human admin (via web)` : 'Human admin (via web)'}>
 				<span
 					role="img"
 					className={`inline-flex items-center align-middle text-text-3 ${className ?? ''}`}

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -21,7 +21,7 @@ export function Toaster() {
 		<RadixToast.Provider swipeDirection="right" duration={ERROR_DURATION_MS}>
 			{/* Persistent connection indicator, pinned above transient toasts. It never
 			    auto-dismisses (duration Infinity), so it stays until the socket heals
-			    or the user clears it — via the close button or a right swipe, both of
+			    or the user clears it - via the close button or a right swipe, both of
 			    which route through onOpenChange into a 20s snooze. Reconnect attempts
 			    continue underneath; if the socket is still down when the snooze
 			    expires the indicator comes back. */}

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useMe } from '../hooks/use-me';
 import { useApplyUpdate, useDownloadUpdate, useUpdateStatus } from '../hooks/use-update-check';
+import { Trans, useI18n } from '../lib/i18n';
 import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { UpdateRestartOverlay } from './update-restart-overlay';
@@ -55,6 +56,7 @@ export function UpdateBanner() {
 	// mid-download and surfaces "Install & restart" the moment the binary is staged —
 	// without a manual reload.
 	const { data } = useUpdateStatus({ poll: true });
+	const { t, plural } = useI18n();
 	const { data: me } = useMe();
 	const apply = useApplyUpdate();
 	const download = useDownloadUpdate();
@@ -102,16 +104,22 @@ export function UpdateBanner() {
 	const showInstall = canApply && staged;
 	const showRetry = canApply && !staged && errored;
 
+	// The old copy promised that in-flight runs "are paused and resume
+	// automatically". Neither half was true: a run is failed with exit code -1 and
+	// a *new* run is queued in its place. Say what happens.
+	const runsInFlight = data.runsInFlight ?? 0;
 	const confirmDescription = (
 		<>
-			Hezo will shut down and restart on <span className="font-medium">{latest}</span>. In-flight
-			agent runs are paused and resume automatically.
+			<Trans
+				k="updates.confirm.restart"
+				vars={{ version: <span className="font-medium">{latest}</span> }}
+			/>{' '}
+			{runsInFlight > 0 && <>{plural('updates.confirm.runsInFlight', runsInFlight)} </>}
+			{t('updates.confirm.drain')}
 			{!data.autoUnlock && (
 				<>
 					{' '}
-					<span className="font-medium text-text-1">
-						You'll need your 12-word master key to unlock Hezo again once it restarts.
-					</span>
+					<span className="font-medium text-text-1">{t('updates.confirm.reunlock')}</span>
 				</>
 			)}
 		</>
@@ -137,7 +145,7 @@ export function UpdateBanner() {
 				) : (
 					<span className="font-semibold">{latest}</span>
 				)}{' '}
-				is available — you're on {data.current}.
+				is available - you're on {data.current}.
 			</span>
 			<div className="flex items-center gap-2 sm:gap-3">
 				{showInstall ? (

--- a/packages/web/src/components/update-restart-overlay.tsx
+++ b/packages/web/src/components/update-restart-overlay.tsx
@@ -122,7 +122,7 @@ export function UpdateRestartOverlay({
 					{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
 					In-flight agent runs are paused and resume automatically.{' '}
 					{autoUnlock
-						? 'Hezo will come back unlocked — no master key needed.'
+						? 'Hezo will come back unlocked - no master key needed.'
 						: "When Hezo comes back you'll need your 12-word master key to unlock it again."}
 				</p>
 			</div>

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -21,7 +21,7 @@ export type { GoalRunActivity, GoalWithProject, ProgressUpdateRunSummary };
  * lockstep.
  */
 export const GOAL_EXPLAINER_TOOLTIP =
-	"A goal is a high-level objective your team works toward. Approve it to create the goal — it then appears on this project's Goals page, where the Captain tracks progress and re-checks it on the schedule shown.";
+	"A goal is a high-level objective your team works toward. Approve it to create the goal - it then appears on this project's Goals page, where the Captain tracks progress and re-checks it on the schedule shown.";
 
 /** A pending goal suggestion (a Captain/CEO proposal awaiting admin approval). */
 export interface GoalSuggestion {
@@ -236,7 +236,7 @@ export function useRunProgressUpdateNow(projectId: string) {
 			// The Captain was busy, so the run was queued instead of erroring — it fires
 			// automatically once the Captain frees up. Surface the queued row live.
 			if (data.queued) {
-				toast.info('Progress update queued — it will run when the Captain is free.');
+				toast.info('Progress update queued - it will run when the Captain is free.');
 				queryClient.invalidateQueries({ queryKey: queryKeys.projects.goalQueuedRun(projectId) });
 				return;
 			}

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -72,7 +72,7 @@ export function isActiveRunStatus(status: RunStatus): boolean {
 }
 
 export function getRunWaitingMessage(status: RunStatus, queuedReason?: string | null): string {
-	if (status === 'queued') return `Queued — ${queuedReason ?? 'waiting to start'}…`;
+	if (status === 'queued') return `Queued - ${queuedReason ?? 'waiting to start'}…`;
 	if (status === 'running') return 'Waiting for log output…';
 	return 'No output.';
 }

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -66,6 +66,8 @@ export interface Task {
 	 */
 	admin_action_pending: boolean;
 	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
+	/** Capped server-side; the run detail read serves the whole value. */
+	last_run_error: string | null;
 	/** Id of the last completed run — the target of a manual retry. */
 	last_run_id: string | null;
 	last_run_comment_id: string | null;

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -23,6 +23,11 @@ export interface UpdateStatusInfo extends UpdateInfo {
 	autoUnlock: boolean;
 	/** The server can actually apply-and-restart (supervised compiled binary). */
 	canApply: boolean;
+	/**
+	 * Agent runs in flight right now; the restart drains them. Optional because a
+	 * server older than this field simply omits it, and the banner defaults to 0.
+	 */
+	runsInFlight?: number;
 }
 
 /**

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Ausblenden",
 	"toast.error": "Etwas ist schiefgelaufen",
 	"toast.info": "Hinweis",
-	"toast.success": "Fertig"
+	"toast.success": "Fertig",
+	"comment.runError": "Fehler",
+	"comment.runErrorExpand": "Vollständigen Fehler anzeigen",
+	"tasks.lastRun.failed": "Letzter Lauf fehlgeschlagen",
+	"tasks.lastRun.timedOut": "Letzter Lauf hat das Zeitlimit erreicht",
+	"tasks.lastRun.failedReason": "Letzter Lauf fehlgeschlagen: {reason}",
+	"tasks.lastRun.timedOutReason": "Letzter Lauf hat das Zeitlimit erreicht: {reason}",
+	"tasks.lastRun.jump": "Zum Lauf springen",
+	"updates.confirm.restart": "Hezo wird beendet und startet mit {version} neu.",
+	"updates.confirm.drain": "Hezo wartet einige Sekunden, bis laufende Agentenläufe abgeschlossen sind, und stoppt dann. Was noch läuft, wird neu eingereiht und beginnt von vorne.",
+	"updates.confirm.runsInFlight.one": "{count} Agentenlauf ist gerade aktiv.",
+	"updates.confirm.runsInFlight.other": "{count} Agentenläufe sind gerade aktiv.",
+	"updates.confirm.reunlock": "Sie benötigen Ihren 12-Wörter-Hauptschlüssel, um Hezo nach dem Neustart wieder zu entsperren."
 }

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Dismiss",
 	"toast.error": "Something went wrong",
 	"toast.info": "Heads up",
-	"toast.success": "Done"
+	"toast.success": "Done",
+	"comment.runError": "Error",
+	"comment.runErrorExpand": "Show the full error",
+	"tasks.lastRun.failed": "Last run failed",
+	"tasks.lastRun.timedOut": "Last run timed out",
+	"tasks.lastRun.failedReason": "Last run failed: {reason}",
+	"tasks.lastRun.timedOutReason": "Last run timed out: {reason}",
+	"tasks.lastRun.jump": "Jump to run",
+	"updates.confirm.restart": "Hezo will shut down and restart on {version}.",
+	"updates.confirm.drain": "Hezo waits a few seconds for agent runs in flight to finish, then stops. Anything still running is re-queued and starts over.",
+	"updates.confirm.runsInFlight.one": "{count} agent run is in flight right now.",
+	"updates.confirm.runsInFlight.other": "{count} agent runs are in flight right now.",
+	"updates.confirm.reunlock": "You'll need your 12-word master key to unlock Hezo again once it restarts."
 }

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Descartar",
 	"toast.error": "Algo salió mal",
 	"toast.info": "Aviso",
-	"toast.success": "Listo"
+	"toast.success": "Listo",
+	"comment.runError": "Error",
+	"comment.runErrorExpand": "Ver el error completo",
+	"tasks.lastRun.failed": "El último intento falló",
+	"tasks.lastRun.timedOut": "El último intento agotó el tiempo",
+	"tasks.lastRun.failedReason": "El último intento falló: {reason}",
+	"tasks.lastRun.timedOutReason": "El último intento agotó el tiempo: {reason}",
+	"tasks.lastRun.jump": "Ir al intento",
+	"updates.confirm.restart": "Hezo se apagará y reiniciará con {version}.",
+	"updates.confirm.drain": "Hezo espera unos segundos a que terminen los intentos de agente en curso y luego se detiene. Lo que siga en marcha vuelve a la cola y empieza de nuevo.",
+	"updates.confirm.runsInFlight.one": "{count} intento de agente está en curso ahora mismo.",
+	"updates.confirm.runsInFlight.other": "{count} intentos de agente están en curso ahora mismo.",
+	"updates.confirm.reunlock": "Necesitarás tu clave maestra de 12 palabras para desbloquear Hezo cuando se reinicie."
 }

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Ignorer",
 	"toast.error": "Une erreur est survenue",
 	"toast.info": "À noter",
-	"toast.success": "Terminé"
+	"toast.success": "Terminé",
+	"comment.runError": "Erreur",
+	"comment.runErrorExpand": "Afficher l'erreur complète",
+	"tasks.lastRun.failed": "La dernière exécution a échoué",
+	"tasks.lastRun.timedOut": "La dernière exécution a expiré",
+	"tasks.lastRun.failedReason": "La dernière exécution a échoué : {reason}",
+	"tasks.lastRun.timedOutReason": "La dernière exécution a expiré : {reason}",
+	"tasks.lastRun.jump": "Aller à l'exécution",
+	"updates.confirm.restart": "Hezo va s’arrêter puis redémarrer sur {version}.",
+	"updates.confirm.drain": "Hezo attend quelques secondes que les exécutions d'agent en cours se terminent, puis s'arrête. Ce qui tourne encore est remis en file et repart de zéro.",
+	"updates.confirm.runsInFlight.one": "{count} exécution d'agent est en cours.",
+	"updates.confirm.runsInFlight.other": "{count} exécutions d'agent sont en cours.",
+	"updates.confirm.reunlock": "Vous aurez besoin de votre clé maîtresse de 12 mots pour déverrouiller Hezo après le redémarrage."
 }

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Ignora",
 	"toast.error": "Qualcosa è andato storto",
 	"toast.info": "Nota",
-	"toast.success": "Fatto"
+	"toast.success": "Fatto",
+	"comment.runError": "Errore",
+	"comment.runErrorExpand": "Mostra l'errore completo",
+	"tasks.lastRun.failed": "L'ultima esecuzione non è riuscita",
+	"tasks.lastRun.timedOut": "L'ultima esecuzione è scaduta",
+	"tasks.lastRun.failedReason": "L'ultima esecuzione non è riuscita: {reason}",
+	"tasks.lastRun.timedOutReason": "L'ultima esecuzione è scaduta: {reason}",
+	"tasks.lastRun.jump": "Vai all'esecuzione",
+	"updates.confirm.restart": "Hezo si arresterà e ripartirà con {version}.",
+	"updates.confirm.drain": "Hezo attende qualche secondo che le esecuzioni degli agenti in corso finiscano, poi si ferma. Ciò che è ancora in esecuzione torna in coda e riparte da capo.",
+	"updates.confirm.runsInFlight.one": "{count} esecuzione di agente è in corso adesso.",
+	"updates.confirm.runsInFlight.other": "{count} esecuzioni di agente sono in corso adesso.",
+	"updates.confirm.reunlock": "Ti servirà la chiave principale di 12 parole per sbloccare Hezo dopo il riavvio."
 }

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "非表示",
 	"toast.error": "問題が発生しました",
 	"toast.info": "お知らせ",
-	"toast.success": "完了"
+	"toast.success": "完了",
+	"comment.runError": "エラー",
+	"comment.runErrorExpand": "エラーの全文を表示します",
+	"tasks.lastRun.failed": "前回の実行が失敗しました",
+	"tasks.lastRun.timedOut": "前回の実行がタイムアウトしました",
+	"tasks.lastRun.failedReason": "前回の実行が失敗しました: {reason}",
+	"tasks.lastRun.timedOutReason": "前回の実行がタイムアウトしました: {reason}",
+	"tasks.lastRun.jump": "実行に移動します",
+	"updates.confirm.restart": "Hezo を停止し、{version} で再起動します。",
+	"updates.confirm.drain": "Hezo は実行中のエージェント実行が終わるまで数秒待ってから停止します。まだ実行中のものは再度キューに入り、最初からやり直します。",
+	"updates.confirm.runsInFlight.one": "現在 {count} 件のエージェント実行が進行中です。",
+	"updates.confirm.runsInFlight.other": "現在 {count} 件のエージェント実行が進行中です。",
+	"updates.confirm.reunlock": "再起動後に Hezo のロックを解除するには、12 語のマスターキーが必要です。"
 }

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "숨기기",
 	"toast.error": "문제가 발생했습니다",
 	"toast.info": "알림",
-	"toast.success": "완료"
+	"toast.success": "완료",
+	"comment.runError": "오류",
+	"comment.runErrorExpand": "전체 오류 보기",
+	"tasks.lastRun.failed": "마지막 실행이 실패했어요",
+	"tasks.lastRun.timedOut": "마지막 실행이 시간을 초과했어요",
+	"tasks.lastRun.failedReason": "마지막 실행이 실패했어요: {reason}",
+	"tasks.lastRun.timedOutReason": "마지막 실행이 시간을 초과했어요: {reason}",
+	"tasks.lastRun.jump": "실행으로 이동",
+	"updates.confirm.restart": "Hezo를 종료하고 {version}으로 다시 시작해요.",
+	"updates.confirm.drain": "Hezo는 진행 중인 에이전트 실행이 끝날 때까지 몇 초 기다린 뒤 멈춰요. 그래도 남아 있는 실행은 큐로 돌아가 처음부터 다시 시작해요.",
+	"updates.confirm.runsInFlight.one": "지금 에이전트 실행 {count}건이 진행 중이에요.",
+	"updates.confirm.runsInFlight.other": "지금 에이전트 실행 {count}건이 진행 중이에요.",
+	"updates.confirm.reunlock": "다시 시작한 뒤 Hezo 잠금을 해제하려면 12단어 마스터 키가 필요해요."
 }

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Verbergen",
 	"toast.error": "Er ging iets mis",
 	"toast.info": "Let op",
-	"toast.success": "Klaar"
+	"toast.success": "Klaar",
+	"comment.runError": "Fout",
+	"comment.runErrorExpand": "Volledige fout tonen",
+	"tasks.lastRun.failed": "Laatste run is mislukt",
+	"tasks.lastRun.timedOut": "Laatste run heeft de tijdslimiet bereikt",
+	"tasks.lastRun.failedReason": "Laatste run is mislukt: {reason}",
+	"tasks.lastRun.timedOutReason": "Laatste run heeft de tijdslimiet bereikt: {reason}",
+	"tasks.lastRun.jump": "Ga naar de run",
+	"updates.confirm.restart": "Hezo wordt afgesloten en start opnieuw op met {version}.",
+	"updates.confirm.drain": "Hezo wacht een paar seconden tot lopende agent-runs klaar zijn en stopt dan. Wat nog draait, gaat terug in de wachtrij en begint opnieuw.",
+	"updates.confirm.runsInFlight.one": "Er is nu {count} agent-run bezig.",
+	"updates.confirm.runsInFlight.other": "Er zijn nu {count} agent-runs bezig.",
+	"updates.confirm.reunlock": "Je hebt je hoofdsleutel van 12 woorden nodig om Hezo na de herstart weer te ontgrendelen."
 }

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Ukryj",
 	"toast.error": "Coś poszło nie tak",
 	"toast.info": "Uwaga",
-	"toast.success": "Gotowe"
+	"toast.success": "Gotowe",
+	"comment.runError": "Błąd",
+	"comment.runErrorExpand": "Pokaż pełny błąd",
+	"tasks.lastRun.failed": "Ostatnie uruchomienie nie powiodlo sie",
+	"tasks.lastRun.timedOut": "Ostatnie uruchomienie przekroczylo limit czasu",
+	"tasks.lastRun.failedReason": "Ostatnie uruchomienie nie powiodlo sie: {reason}",
+	"tasks.lastRun.timedOutReason": "Ostatnie uruchomienie przekroczylo limit czasu: {reason}",
+	"tasks.lastRun.jump": "Przejdz do uruchomienia",
+	"updates.confirm.restart": "Hezo zostanie zamkniete i uruchomi sie ponownie w wersji {version}.",
+	"updates.confirm.drain": "Hezo czeka kilka sekund na zakonczenie trwajacych uruchomien agentow, a potem sie zatrzymuje. To, co nadal dziala, wraca do kolejki i zaczyna od poczatku.",
+	"updates.confirm.runsInFlight.one": "Trwa teraz {count} uruchomienie agenta.",
+	"updates.confirm.runsInFlight.other": "Trwa teraz {count} uruchomien agentow.",
+	"updates.confirm.reunlock": "Do odblokowania Hezo po restarcie potrzebny bedzie 12-wyrazowy klucz glowny."
 }

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Dispensar",
 	"toast.error": "Algo deu errado",
 	"toast.info": "Atenção",
-	"toast.success": "Pronto"
+	"toast.success": "Pronto",
+	"comment.runError": "Erro",
+	"comment.runErrorExpand": "Ver o erro completo",
+	"tasks.lastRun.failed": "A última execução falhou",
+	"tasks.lastRun.timedOut": "A última execução expirou",
+	"tasks.lastRun.failedReason": "A última execução falhou: {reason}",
+	"tasks.lastRun.timedOutReason": "A última execução expirou: {reason}",
+	"tasks.lastRun.jump": "Ir para a execução",
+	"updates.confirm.restart": "O Hezo vai desligar e reiniciar na {version}.",
+	"updates.confirm.drain": "O Hezo espera alguns segundos para que as execuções de agente em andamento terminem e então para. O que ainda estiver rodando volta para a fila e começa de novo.",
+	"updates.confirm.runsInFlight.one": "{count} execução de agente está em andamento agora.",
+	"updates.confirm.runsInFlight.other": "{count} execuções de agente estão em andamento agora.",
+	"updates.confirm.reunlock": "Você vai precisar da sua chave mestra de 12 palavras para desbloquear o Hezo depois que ele reiniciar."
 }

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "Dölj",
 	"toast.error": "Något gick fel",
 	"toast.info": "Observera",
-	"toast.success": "Klart"
+	"toast.success": "Klart",
+	"comment.runError": "Fel",
+	"comment.runErrorExpand": "Visa hela felet",
+	"tasks.lastRun.failed": "Den senaste körningen misslyckades",
+	"tasks.lastRun.timedOut": "Den senaste körningen nådde tidsgränsen",
+	"tasks.lastRun.failedReason": "Den senaste körningen misslyckades: {reason}",
+	"tasks.lastRun.timedOutReason": "Den senaste körningen nådde tidsgränsen: {reason}",
+	"tasks.lastRun.jump": "Gå till körningen",
+	"updates.confirm.restart": "Hezo stängs av och startar om på {version}.",
+	"updates.confirm.drain": "Hezo väntar några sekunder på att pågående agentkörningar ska bli klara och stannar sedan. Det som fortfarande kör läggs tillbaka i kön och börjar om.",
+	"updates.confirm.runsInFlight.one": "{count} agentkörning pågår just nu.",
+	"updates.confirm.runsInFlight.other": "{count} agentkörningar pågår just nu.",
+	"updates.confirm.reunlock": "Du behöver din huvudnyckel på 12 ord för att låsa upp Hezo igen efter omstarten."
 }

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -437,5 +437,17 @@
 	"toast.dismiss": "忽略",
 	"toast.error": "出错了",
 	"toast.info": "提示",
-	"toast.success": "完成"
+	"toast.success": "完成",
+	"comment.runError": "错误",
+	"comment.runErrorExpand": "查看完整错误",
+	"tasks.lastRun.failed": "上次运行失败",
+	"tasks.lastRun.timedOut": "上次运行超时",
+	"tasks.lastRun.failedReason": "上次运行失败：{reason}",
+	"tasks.lastRun.timedOutReason": "上次运行超时：{reason}",
+	"tasks.lastRun.jump": "跳转到运行",
+	"updates.confirm.restart": "Hezo 将关闭并以 {version} 重新启动。",
+	"updates.confirm.drain": "Hezo 会等待几秒钟，让进行中的代理运行完成，然后停止。仍在运行的会重新排队并从头开始。",
+	"updates.confirm.runsInFlight.one": "当前有 {count} 个代理运行正在进行。",
+	"updates.confirm.runsInFlight.other": "当前有 {count} 个代理运行正在进行。",
+	"updates.confirm.reunlock": "重启后需要用你的 12 个单词主密钥再次解锁 Hezo。"
 }

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -448,11 +448,11 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 						</div>
 					)}
 					{/* Collapsed: a slim expand tab docked to the project rail's right
-					    edge, flush under the app header. Desktop-only — below lg the
+					    edge, flush under the app header. Desktop-only - below lg the
 					    project menu is a drawer, so there is nothing to collapse.
 					    z-50 is load-bearing, not decorative: collapsed, <main> starts at
 					    the rail's right edge, so this tab shares its top-left corner with
-					    whatever <main> stickies there — today ContainerStatusBanner (z-40)
+					    whatever <main> stickies there - today ContainerStatusBanner (z-40)
 					    and BudgetBanner (z-30), which sit in this same stacking context.
 					    Anything at or below their z-index gets painted over and the tab
 					    silently vanishes, stranding the user with no way to re-expand.
@@ -474,7 +474,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 					{/* The relative wrapper hosts the scroll-to-bottom pill as a sibling
 					    of the scroller, so the pill stays pinned over the content area
 					    (never scrolling with it) on ANY page whose long-form content
-					    overflows <main> — task threads, documents, settings, etc. It is
+					    overflows <main> - task threads, documents, settings, etc. It is
 					    also the pills' positioning anchor: `--pill-center-x` (set above
 					    from a route's registered content column) is measured relative to
 					    it. */}

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -269,7 +269,7 @@ function WelcomeCard({ onCreate }: { onCreate: () => void }) {
 					<div>
 						<h1 className="text-base font-semibold text-text-1">Get started with Hezo</h1>
 						<p className="text-[13px] text-text-2 mt-1 max-w-md">
-							Create your first project. Each one gets its own team — spin it up from a template, or
+							Create your first project. Each one gets its own team - spin it up from a template, or
 							let the CEO scope it with you first.
 						</p>
 					</div>

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -52,7 +52,7 @@ function DocPreviewPage() {
 					</span>
 					<div className="flex shrink-0 items-center gap-1">
 						<ReviewToolbarActions projectId={projectId} filename={filename} variant="inline" />
-						{/* Archived docs are read-only — mirror the Documents toolbar and drop
+						{/* Archived docs are read-only - mirror the Documents toolbar and drop
 						    Edit while keeping History. */}
 						{!doc.archived_at && (
 							<Tooltip content="Edit document">
@@ -80,7 +80,7 @@ function DocPreviewPage() {
 								<History className="h-4 w-4" />
 							</Link>
 						</Tooltip>
-						{/* Same client-side download the Documents toolbar offers — this
+						{/* Same client-side download the Documents toolbar offers - this
 						    standalone tab is where a doc gets read in full, so it's where
 						    saving a copy is most likely to be wanted. */}
 						<DocumentDownloadMenu filename={filename} content={doc.content} variant="icon" />

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/chat-history.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/chat-history.tsx
@@ -19,12 +19,12 @@ function ChatHistoryHelp() {
 					The chatbox keeps the most recent messages verbatim, up to a size cap. When the
 					conversation grows past that cap, the assistant summarizes the whole window into this{' '}
 					<strong className="text-text-1">long-term memory</strong> and the older messages drop out
-					of the live chat — so scrolling up tops out at what's still in the window.
+					of the live chat - so scrolling up tops out at what's still in the window.
 				</p>
 				<p>
 					This long-term memory is fed back into the assistant on every turn, so the gist of past
 					exchanges survives even after the raw messages scroll away. It captures durable, standing
-					knowledge only — operator preferences, decisions, and the gist of off-project threads —
+					knowledge only - operator preferences, decisions, and the gist of off-project threads -
 					not live project or task state, which the assistant always reads fresh.
 				</p>
 				<p>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -73,7 +73,7 @@ function ExecutionDetailPage() {
 	);
 
 	const elapsed = useElapsedDuration(run?.started_at ?? '', run?.finished_at ?? null);
-	const elapsedDisplay = run?.started_at ? elapsed : '—';
+	const elapsedDisplay = run?.started_at ? elapsed : '-';
 
 	if (isLoading) return <div className="text-text-2 text-sm">Loading...</div>;
 	if (!run) return <div className="text-text-2 text-sm">Run not found.</div>;

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -327,8 +327,8 @@ function AgentSettingsPage() {
 							? 'Disabling unassigns this agent from open tasks and stops it from being scheduled.'
 							: 'This agent is disabled and cannot be assigned new work. Enable to resume scheduling.'}
 				</div>
-				{/* The HQ instance singletons (CEO/Coach) can never be disabled — the disable
-				    button is hidden for them — but if one is somehow disabled, the admin can
+				{/* The HQ instance singletons (CEO/Coach) can never be disabled - the disable
+				    button is hidden for them - but if one is somehow disabled, the admin can
 				    still re-enable it to recover. */}
 				{!isInstanceAgent && agent.admin_status === AgentAdminStatus.Enabled && (
 					<Button

--- a/packages/web/src/routes/projects/$projectId/agents/hire.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/hire.tsx
@@ -349,7 +349,7 @@ function HireAgentPage() {
 	if (!approval) {
 		return (
 			<p className="text-sm text-text-2">
-				This hire proposal is no longer pending — it may have already been resolved.
+				This hire proposal is no longer pending - it may have already been resolved.
 			</p>
 		);
 	}

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -308,7 +308,7 @@ function ProjectAssetsPage() {
 				// A directory dragged from the OS arrives as an extensionless "file";
 				// folders can't be uploaded — files land in the folder that's open.
 				if (!file.type && !file.name.includes('.')) {
-					pushError(file.name, 'Folders can’t be uploaded — upload files individually');
+					pushError(file.name, 'Folders can’t be uploaded - upload files individually');
 					continue;
 				}
 				try {
@@ -510,14 +510,14 @@ function ProjectAssetsPage() {
 						description={
 							filter === ArchiveFilter.Archived
 								? 'Assets that you or agents archive appear here.'
-								: 'Everything is archived — switch the filter to Archived to browse or restore items.'
+								: 'Everything is archived - switch the filter to Archived to browse or restore items.'
 						}
 					/>
 				) : folderIsEmpty ? (
 					<EmptyState
 						icon={<Folder className="w-10 h-10" />}
 						title="This folder is empty"
-						description="Drop files here or use Upload — the folder persists once a file lands in it."
+						description="Drop files here or use Upload - the folder persists once a file lands in it."
 					/>
 				) : (
 					<ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -1131,7 +1131,7 @@ function AssetCard({
 					</Tooltip>
 					{isArchived ? (
 						<>
-							{/* Restore first; the hard delete only lives on archived cards —
+							{/* Restore first; the hard delete only lives on archived cards -
 							    active cards offer the reversible Archive instead. */}
 							<Tooltip content="Restore asset">
 								<button

--- a/packages/web/src/routes/projects/$projectId/assets_.view.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets_.view.tsx
@@ -245,7 +245,7 @@ function AssetViewerPage() {
 				}
 				aside={
 					<>
-						{/* Mobile pull-in for the review panel — same affordance as the task
+						{/* Mobile pull-in for the review panel - same affordance as the task
 						    page's side rail: edge chevron + scrim, hidden at lg+. */}
 						<button
 							type="button"

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -103,7 +103,7 @@ function ConnectorsPage() {
 						Connectors
 					</h1>
 					<p className="text-sm text-text-3 mt-1">
-						Third-party services agents use — GitHub for git operations, MCP servers + skill files
+						Third-party services agents use - GitHub for git operations, MCP servers + skill files
 						for everything else. Tokens are stored in the Hezo vault and substituted at egress;
 						agents never see them.
 					</p>
@@ -359,7 +359,7 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 						data-testid="connector-add-docs-url"
 					/>
 					<p className="text-xs text-text-3">
-						A direct REST API the agent calls itself — no MCP server. After creating, attach the API
+						A direct REST API the agent calls itself - no MCP server. After creating, attach the API
 						key from its row; agents get the placeholder + base URL via <code>list_connectors</code>{' '}
 						and the egress proxy substitutes the key, scoped to the allowed hosts.
 					</p>
@@ -584,7 +584,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				// A null auth_url means the server advertises no OAuth (public /
 				// header-authenticated) — not an error: point the user at the API key.
 				if (!auth_url) {
-					setInfo("This MCP server doesn't advertise OAuth — connect it with the API key option.");
+					setInfo("This MCP server doesn't advertise OAuth - connect it with the API key option.");
 					return;
 				}
 				const popup = window.open(auth_url, 'hezo-connect', 'width=600,height=720');
@@ -709,7 +709,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 						<>
 							{/* A degraded connector's credential is dead and only a human can
 							    replace it, so the reconnect affordance has to live here in the
-							    connected branch — it used to exist only in the not-connected
+							    connected branch - it used to exist only in the not-connected
 							    branch below, which a stale-token row never reached, leaving
 							    Disconnect as the only button on a connector the operator
 							    wanted to fix. `auth-start` re-runs cleanly on an active row
@@ -790,7 +790,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				</div>
 			</div>
 
-			{/* Inline OAuth device-flow completion for an OAuth-backed `api` connector —
+			{/* Inline OAuth device-flow completion for an OAuth-backed `api` connector -
 			    the same broker form the task comment shows, with the agent-preset
 			    provider locked (or a manual picker when none). A static-key api
 			    connector (query-placement) never shows this; it leads with the API key. */}

--- a/packages/web/src/routes/projects/$projectId/custom-prompt.tsx
+++ b/packages/web/src/routes/projects/$projectId/custom-prompt.tsx
@@ -43,7 +43,7 @@ function CustomPromptPage() {
 					Custom Prompt
 				</h1>
 				<p className="text-sm text-text-3 mt-1">
-					Shared instructions added to every agent's system prompt in this project — house
+					Shared instructions added to every agent's system prompt in this project - house
 					conventions, standards, and standing do's and don'ts. Injected in full on every run, so
 					keep it concise. Every edit is versioned and restorable below.
 				</p>

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -204,14 +204,14 @@ function ProjectDocumentsPage() {
 
 	return (
 		<>
-			{/* Section header — frames Documents as the team's long-term memory,
+			{/* Section header - frames Documents as the team's long-term memory,
 			    mirroring the Assets page header. On mobile it hides once a doc is
 			    open or the new-doc form is up (single-pane), staying visible on md+
 			    where the two-pane layout always shows the list. */}
 			<div className={`mb-4 ${!file && !isCreating ? '' : 'hidden md:block'}`}>
 				<h1 className="text-base font-semibold text-text-1">Documents</h1>
 				<p className="text-[13px] text-text-2">
-					Your team's long-term memory — the guidelines, research, and reference material the team
+					Your team's long-term memory - the guidelines, research, and reference material the team
 					builds up and returns to across the project.
 				</p>
 			</div>

--- a/packages/web/src/routes/projects/$projectId/skills.tsx
+++ b/packages/web/src/routes/projects/$projectId/skills.tsx
@@ -101,7 +101,7 @@ function ProjectSkillsPage() {
 					Skills
 				</h1>
 				<p className="text-sm text-text-3 mt-1">
-					Reusable skill docs for this project's agents. These are scoped to this project — edit or
+					Reusable skill docs for this project's agents. These are scoped to this project - edit or
 					remove them here. Global skills are shown below for reference and are managed on the{' '}
 					<Link to="/settings/skills" className="underline hover:text-text-1">
 						global Skills page
@@ -139,7 +139,7 @@ function ProjectSkillsPage() {
 						/>
 					</div>
 					<Input
-						placeholder="Description (optional — auto-derived from content if empty)"
+						placeholder="Description (optional - auto-derived from content if empty)"
 						value={description}
 						onChange={(e) => setDescription(e.target.value)}
 					/>

--- a/packages/web/src/routes/settings/api-keys.tsx
+++ b/packages/web/src/routes/settings/api-keys.tsx
@@ -59,7 +59,7 @@ function ApiKeysPage() {
 			return label ? (
 				<span className="text-xs font-mono text-text-2">{label}</span>
 			) : (
-				<span className="text-text-3">—</span>
+				<span className="text-text-3">-</span>
 			);
 		},
 	};
@@ -181,7 +181,7 @@ function ApiKeysPage() {
 					</div>
 					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
 						An API key connects an external tool or agent to this Hezo instance over MCP. A key acts
-						with <span className="font-medium">full access</span> — every project and team — so only
+						with <span className="font-medium">full access</span> - every project and team - so only
 						create or approve keys you trust. Revoke one at any time to disable it immediately.
 					</p>
 				</div>
@@ -189,7 +189,7 @@ function ApiKeysPage() {
 				{newKey && (
 					<div className="border border-success rounded-md bg-success-soft p-3 mb-5">
 						<p className="text-xs text-success-soft-fg font-medium mb-1">
-							New API key created — copy it now, it won't be shown again:
+							New API key created - copy it now, it won't be shown again:
 						</p>
 						<div className="flex items-center gap-2">
 							<code className="text-xs font-mono break-all flex-1">{newKey}</code>

--- a/packages/web/src/routes/settings/chat-channels.tsx
+++ b/packages/web/src/routes/settings/chat-channels.tsx
@@ -51,7 +51,7 @@ function ChatSettingsPage() {
 				<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
 					Chat apps connect in two modes. <span className="font-medium">Assistant (DM)</span>: DM
 					the bot and each conversation becomes its own CEO chat thread, listed in the chatbox here
-					— only linked identities may chat, and replies go back where you asked.{' '}
+					- only linked identities may chat, and replies go back where you asked.{' '}
 					<span className="font-medium">Coworker (channels)</span>: invite the bot to a channel and
 					anyone there can @-mention it; it reads the recent channel messages for context and
 					replies in-thread. Channel threads show up read-only in the web chatbox.
@@ -76,13 +76,13 @@ function TelegramSection() {
 		>
 			<h2 className="text-[15px] font-medium mb-1">
 				Telegram{' '}
-				<span className="text-text-2 font-normal text-[13px]">— assistant + coworker modes</span>
+				<span className="text-text-2 font-normal text-[13px]">- assistant + coworker modes</span>
 			</h2>
 			<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
 				Create a bot with @BotFather, then paste its token. Saving registers the inbound webhook
 				automatically. A private DM is one thread; the Topics supergroup you designate below gives
 				you parallel personal threads (one per topic). For coworker mode, add the bot to any other
-				group and disable BotFather privacy mode (/setprivacy → Disable) so it can see mentions —
+				group and disable BotFather privacy mode (/setprivacy → Disable) so it can see mentions -
 				anyone there can then @-mention it, and it answers with the group’s recent messages as
 				context.
 			</p>
@@ -123,13 +123,13 @@ function SlackSection() {
 		>
 			<h2 className="text-[15px] font-medium mb-1">
 				Slack{' '}
-				<span className="text-text-2 font-normal text-[13px]">— assistant + coworker modes</span>
+				<span className="text-text-2 font-normal text-[13px]">- assistant + coworker modes</span>
 			</h2>
 			<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
 				The CEO joins your Slack workspace as a coworker: invite it to a channel, @-mention it, and
 				it reads the conversation for context and replies in the thread. It also answers DMs as a
 				personal assistant (linked identities only). Create the Slack app from the manifest in the
-				docs, install it, then paste both tokens — no public URL needed (Socket Mode).
+				docs, install it, then paste both tokens - no public URL needed (Socket Mode).
 			</p>
 			<div className="flex flex-col gap-3">
 				<label className="flex items-center gap-2 text-[13px]">
@@ -144,7 +144,7 @@ function SlackSection() {
 				<div>
 					<label className="block text-[13px] font-medium mb-1" htmlFor="slack-token">
 						Bot token <span className="text-text-2">(xoxb-…)</span>{' '}
-						{slack?.has_token && <span className="text-text-2">(set — paste to replace)</span>}
+						{slack?.has_token && <span className="text-text-2">(set - paste to replace)</span>}
 					</label>
 					<Input
 						id="slack-token"
@@ -160,7 +160,7 @@ function SlackSection() {
 				<div>
 					<label className="block text-[13px] font-medium mb-1" htmlFor="slack-app-token">
 						App-level token <span className="text-text-2">(xapp-…, Socket Mode)</span>{' '}
-						{slack?.has_app_token && <span className="text-text-2">(set — paste to replace)</span>}
+						{slack?.has_app_token && <span className="text-text-2">(set - paste to replace)</span>}
 					</label>
 					<Input
 						id="slack-app-token"
@@ -181,7 +181,7 @@ function SlackSection() {
 							checked={groupMode}
 							onChange={(e) => setGroupMode(e.target.checked)}
 						/>
-						Coworker mode — respond to @-mentions in channels the bot is invited to
+						Coworker mode - respond to @-mentions in channels the bot is invited to
 					</label>
 					<label className="flex items-center gap-2 text-[13px]">
 						<input
@@ -190,7 +190,7 @@ function SlackSection() {
 							checked={dmMode}
 							onChange={(e) => setDmMode(e.target.checked)}
 						/>
-						Assistant mode — answer DMs from linked identities (each DM is a thread here)
+						Assistant mode - answer DMs from linked identities (each DM is a thread here)
 					</label>
 				</div>
 				{validationErrors.length > 0 && (
@@ -239,14 +239,14 @@ function DiscordSection() {
 		>
 			<h2 className="text-[15px] font-medium mb-1">
 				Discord{' '}
-				<span className="text-text-2 font-normal text-[13px]">— assistant + coworker modes</span>
+				<span className="text-text-2 font-normal text-[13px]">- assistant + coworker modes</span>
 			</h2>
 			<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
 				The CEO joins your Discord server as a coworker: @-mention it in a channel and it reads the
 				recent messages for context and replies there. It also answers DMs as a personal assistant
 				(linked identities only). Create a bot in the Discord Developer Portal, enable the{' '}
 				<span className="font-medium">Message Content</span> intent, invite it to your server, then
-				paste its bot token — no public URL needed (gateway connection).
+				paste its bot token - no public URL needed (gateway connection).
 			</p>
 			<div className="flex flex-col gap-3">
 				<label className="flex items-center gap-2 text-[13px]">
@@ -261,7 +261,7 @@ function DiscordSection() {
 				<div>
 					<label className="block text-[13px] font-medium mb-1" htmlFor="discord-token">
 						Bot token{' '}
-						{discord?.has_token && <span className="text-text-2">(set — paste to replace)</span>}
+						{discord?.has_token && <span className="text-text-2">(set - paste to replace)</span>}
 					</label>
 					<Input
 						id="discord-token"
@@ -282,7 +282,7 @@ function DiscordSection() {
 							checked={groupMode}
 							onChange={(e) => setGroupMode(e.target.checked)}
 						/>
-						Coworker mode — respond to @-mentions in channels on servers the bot joined
+						Coworker mode - respond to @-mentions in channels on servers the bot joined
 					</label>
 					<label className="flex items-center gap-2 text-[13px]">
 						<input
@@ -291,7 +291,7 @@ function DiscordSection() {
 							checked={dmMode}
 							onChange={(e) => setDmMode(e.target.checked)}
 						/>
-						Assistant mode — answer DMs from linked identities (each DM is a thread here)
+						Assistant mode - answer DMs from linked identities (each DM is a thread here)
 					</label>
 				</div>
 				{validationErrors.length > 0 && (
@@ -354,7 +354,7 @@ function ChannelForm({
 			<div>
 				<label className="block text-[13px] font-medium mb-1" htmlFor={`${channel}-token`}>
 					Bot token{' '}
-					{config?.has_token && <span className="text-text-2">(set — paste to replace)</span>}
+					{config?.has_token && <span className="text-text-2">(set - paste to replace)</span>}
 				</label>
 				<Input
 					id={`${channel}-token`}
@@ -370,7 +370,7 @@ function ChannelForm({
 			<div>
 				<label className="block text-[13px] font-medium mb-1" htmlFor={`${channel}-group`}>
 					Your Topics supergroup id{' '}
-					<span className="text-text-2">(optional — your personal parallel threads)</span>
+					<span className="text-text-2">(optional - your personal parallel threads)</span>
 				</label>
 				<Input
 					id={`${channel}-group`}
@@ -388,7 +388,7 @@ function ChannelForm({
 					checked={groupMode}
 					onChange={(e) => setGroupMode(e.target.checked)}
 				/>
-				Coworker mode — respond to mentions in other groups the bot is added to
+				Coworker mode - respond to mentions in other groups the bot is added to
 			</label>
 			<div>
 				<Button size="sm" data-testid={`${channel}-save`} onClick={handleSave} disabled={saving}>
@@ -425,7 +425,7 @@ function IdentitiesSection() {
 				Only these external accounts may DM the CEO (assistant mode). Telegram: your numeric user id
 				(message @userinfobot to find it). Slack: your member ID (profile → ⋯ → Copy member ID,
 				starts with U). Discord: your user ID (enable Developer Mode, then right-click your name →
-				Copy User ID). Coworker mode doesn't use this list — inviting the bot to a channel is the
+				Copy User ID). Coworker mode doesn't use this list - inviting the bot to a channel is the
 				authorization there.
 			</p>
 

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -167,7 +167,7 @@ function InstanceConnectorsPage() {
 						title={
 							createScope === ALL_PROJECTS
 								? 'Add connector (All projects)'
-								: `Add connector — ${createScopeName}`
+								: `Add connector - ${createScopeName}`
 						}
 						onClose={closeForm}
 						onSubmit={handleCreate}
@@ -311,7 +311,7 @@ function InstanceConnectorRow({
 			onSuccess: ({ auth_url }) => {
 				if (!auth_url) {
 					setRowInfo(
-						"This MCP server doesn't advertise OAuth — authenticate with a header placeholder if needed.",
+						"This MCP server doesn't advertise OAuth - authenticate with a header placeholder if needed.",
 					);
 					return;
 				}

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -89,7 +89,7 @@ function InstanceCredentialsPage() {
 			.filter(Boolean);
 		if (!allowAllHosts && hosts.length === 0) {
 			setError(
-				'Add at least one allowed host (e.g. api.stripe.com) or check Allow all hosts — a secret with no hosts cannot be substituted by the egress proxy.',
+				'Add at least one allowed host (e.g. api.stripe.com) or check Allow all hosts - a secret with no hosts cannot be substituted by the egress proxy.',
 			);
 			return;
 		}
@@ -178,7 +178,7 @@ function InstanceCredentialsPage() {
 						<Tooltip
 							content={`In use by ${r.connectors.length} connector${
 								r.connectors.length === 1 ? '' : 's'
-							} — remove ${r.connectors.length === 1 ? 'it' : 'them'} first`}
+							} - remove ${r.connectors.length === 1 ? 'it' : 'them'} first`}
 						>
 							{/* Wrapping span keeps the tooltip working over a disabled button. */}
 							<span className="inline-flex">
@@ -280,7 +280,7 @@ function InstanceCredentialsPage() {
 								checked={allowAllHosts}
 								onChange={(e) => setAllowAllHosts(e.target.checked)}
 							/>
-							Allow this credential to reach any host (escape hatch — use sparingly)
+							Allow this credential to reach any host (escape hatch - use sparingly)
 						</label>
 						<label className="flex items-start gap-2 text-[13px] text-text-2">
 							<input
@@ -292,7 +292,7 @@ function InstanceCredentialsPage() {
 							/>
 							<span>
 								Allow substitution into small JSON request bodies (e.g. an API login that takes the
-								credential in the body). Off by default — enable only for APIs that require it.
+								credential in the body). Off by default - enable only for APIs that require it.
 							</span>
 						</label>
 						{error && <p className="text-[13px] text-danger">{error}</p>}

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -180,7 +180,7 @@ function InstanceSkillsPage() {
 						</div>
 						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
 							Every skill across every project. Each project's runs see its own skills plus any
-							scoped to "All projects" — author them here, search skills.sh, or let an agent create
+							scoped to "All projects" - author them here, search skills.sh, or let an agent create
 							one while it works.
 						</p>
 					</div>
@@ -221,7 +221,7 @@ function InstanceSkillsPage() {
 								? 'Edit skill'
 								: createScope === ALL_PROJECTS
 									? 'Add skill (All projects)'
-									: `Add skill — ${createScopeName}`
+									: `Add skill - ${createScopeName}`
 						}
 						onClose={resetForm}
 						onSubmit={handleSubmit}
@@ -252,7 +252,7 @@ function InstanceSkillsPage() {
 							/>
 						</div>
 						<Input
-							placeholder="Description (optional — auto-derived from content if empty)"
+							placeholder="Description (optional - auto-derived from content if empty)"
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 						/>
@@ -303,7 +303,7 @@ function InstanceSkillsPage() {
 
 				{!skills.length ? (
 					<p className="text-[13px] text-text-2">
-						No skills yet. Add one above — global, or scoped to a project.
+						No skills yet. Add one above - global, or scoped to a project.
 					</p>
 				) : (
 					<div className="flex flex-col gap-1">
@@ -347,7 +347,7 @@ function InstanceSkillsPage() {
 				description={
 					<>
 						These recommended global skills will be added to this instance. They'll appear like any
-						skill you authored — edit, delete, or re-scope them freely.
+						skill you authored - edit, delete, or re-scope them freely.
 						<span className="mt-2 block font-medium text-text-1" data-testid="default-skill-names">
 							{missingDefaults.map((m) => m.name).join(', ')}
 						</span>

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -315,7 +315,9 @@ test('agent header shows a dash when the agent has no work to do', async () => {
 
 	const indicator = await findByTestId('next-heartbeat');
 	expect(indicator.textContent).toContain('Next heartbeat');
-	expect(indicator.textContent).toContain('—');
+	// A plain hyphen is the "no value" glyph, per AGENTS.md's dash rule; this
+	// asserted the em dash the sweep replaced.
+	expect(indicator.textContent).toContain('-');
 	expect(indicator.textContent).not.toMatch(/due now|in \d/);
 });
 

--- a/packages/web/test/i18n-catalog.test.ts
+++ b/packages/web/test/i18n-catalog.test.ts
@@ -143,6 +143,9 @@ describe('message catalogs', () => {
 		'containers.column.project': ['nl'],
 		// Same word in Dutch, as `containers.column.project` above already records.
 		'marketplace.projectLabel': ['nl'],
+		// "Error" is the Spanish word, spelled identically. Every other language
+		// differs (Fehler, Erreur, Errore, Fout, Blad, Erro, Fel, ...).
+		'comment.runError': ['es'],
 		// Spanish pluralises "rol" to "roles", spelt exactly like the English.
 		// The singular differs ("1 rol"), and every other language does too
 		// (Rollen, rôles, ruoli, papéis, ...).

--- a/packages/web/test/task-detail-failed-banner.test.tsx
+++ b/packages/web/test/task-detail-failed-banner.test.tsx
@@ -13,14 +13,15 @@ async function insertFailedRunWithComment(
 	workspace: SeededWorkspace,
 	task: SeededTask,
 	status: 'failed' | 'timed_out' = 'failed',
+	error: string | null = null,
 ): Promise<{ runId: string; commentId: string; commentPublicId: string }> {
 	const { db } = getTestContext();
 	const agentId = workspace.agents[0].id;
 	const runRes = await db.query<{ id: string }>(
-		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
-		 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '1 minute', now())
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, error)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '1 minute', now(), $5)
 		 RETURNING id`,
-		[agentId, workspace.team.id, task.id, status],
+		[agentId, workspace.team.id, task.id, status, error],
 	);
 	const runId = runRes.rows[0].id;
 	const commentRes = await db.query<{ id: string; public_id: string }>(
@@ -142,4 +143,60 @@ test('banner is suppressed while a retry is currently running', async () => {
 	await waitFor(() => {
 		expect(queryByTestId('last-run-failed-banner')).toBeNull();
 	});
+});
+
+test('the banner carries the reason, and never an em dash', async () => {
+	// The reason lived in exactly one place in the whole app - the run detail page
+	// - so a failed task said only that it had failed.
+	const seeded = { projectSlug: '', taskIdentifier: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Reason Task' });
+			await insertFailedRunWithComment(
+				ws,
+				task,
+				'failed',
+				'This run cannot be prepared: adapter declared env-var bearer storage\nsecond line',
+			);
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	const banner = await findByTestId('last-run-failed-banner', undefined, { timeout: 10_000 });
+	expect(banner.textContent).toContain('This run cannot be prepared');
+	// Only the first line: the stored value is multi-line by design.
+	expect(banner.textContent).not.toContain('second line');
+	expect(banner.textContent).not.toMatch(/[\u2013\u2014]/);
+});
+
+test('the banner falls back to the bare label when the run recorded no reason', async () => {
+	const seeded = { projectSlug: '', taskIdentifier: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Bare Task' });
+			await insertFailedRunWithComment(ws, task, 'timed_out', null);
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	const banner = await findByTestId('last-run-failed-banner', undefined, { timeout: 10_000 });
+	expect(banner.textContent).toContain('Last run timed out');
 });

--- a/test/browser/passive-mention-style.spec.ts
+++ b/test/browser/passive-mention-style.spec.ts
@@ -62,6 +62,18 @@ test.describe('Passive mention styling', () => {
 		// than the handle the author typed - its name when it has one, else its role.
 		await expect(passive).toHaveText(agents[0].human_name?.trim() || agents[0].title);
 
+		// The other two links have to be waited for in their own right. The task
+		// reference resolves through a separate async lookup (`useTaskMentions` ->
+		// POST /tasks/resolve) that can land well after the agent chip, so waiting
+		// on the passive mention alone is not waiting for this one - and reading
+		// computed styles before it mounts raced that query instead of testing the
+		// cascade, which is what this spec exists for. It shows up only when the
+		// server is loaded enough for the resolve to lose the race, which is CI.
+		const taskRef = page.getByTestId('task-mention-link');
+		await expect(taskRef).toBeVisible({ timeout: 20_000 });
+		const plainLink = page.locator('a[href="https://example.com/notes"]');
+		await expect(plainLink).toBeVisible({ timeout: 20_000 });
+
 		const styles = await page.evaluate(() => {
 			const pick = (sel: string) => {
 				const el = document.querySelector(sel);

--- a/test/browser/task-mention-status.spec.ts
+++ b/test/browser/task-mention-status.spec.ts
@@ -48,11 +48,28 @@ test.describe('Task mention — status pill tooltip & terminal strikethrough', (
 			title: 'Cancelled target task',
 		});
 		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-		const patchRes = await page.request.patch(
-			`/api/projects/${proj.slug}/tasks/${target.identifier.toLowerCase()}`,
-			{ headers, data: { status: 'cancelled' } },
-		);
-		expect(patchRes.ok()).toBeTruthy();
+		// Cancelling is unguarded, but it is not the last word: creating a task with
+		// an assignee fires a wakeup, and `createHeartbeatRun` flips the task to
+		// `in_progress` when the run row lands. Under load that flip arrives *after*
+		// this PATCH and quietly undoes it - the mention then resolves as
+		// non-terminal, so the link loses its strikethrough and the tooltip renders
+		// with no status pill. Re-assert until the cancel is the state that stuck.
+		const targetPath = `/api/projects/${proj.slug}/tasks/${target.identifier.toLowerCase()}`;
+		await expect(async () => {
+			const patchRes = await page.request.patch(targetPath, {
+				headers,
+				data: { status: 'cancelled' },
+			});
+			expect(patchRes.ok()).toBeTruthy();
+			const read = await page.request.get(targetPath, { headers });
+			const task = ((await read.json()) as { data: { status: string; has_active_run: boolean } })
+				.data;
+			// Both, and the second is the one that makes it stick: a run still in
+			// flight flips the status again the moment its row lands, so a cancel
+			// that has merely been *written* is not yet the state the page will see.
+			expect(task.has_active_run).toBe(false);
+			expect(task.status).toBe('cancelled');
+		}).toPass({ timeout: 30_000 });
 
 		const source = await createTaskViaApi(page, proj.slug, token, {
 			project_id: proj.id,


### PR DESCRIPTION
One trigger riding five structural defects, found from a live instance that was
burning containers and producing nothing: 741 events on one task, 735 of them
failed runs, and the only failure text anywhere was `Orphaned: process no longer
running` - reachable solely from the run detail page, and false.

## The trigger

Connectors emit `Authorization: Bearer __HEZO_SECRET_<NAME>__` by design, so no
real secret enters a run. Codex renders connector headers into `config.toml` and
Kimi Code into its own config, and both declare `bearerTokenStorage: 'env-var'`,
so `validateInjection` scanned those files with `/Bearer [A-Za-z0-9._-]{8,}/`.
Underscores are inside that character class, so the placeholder matched and the
guard reported the one value the whole scheme exists to put there.

It is dormant on the four `inline` runtimes - Claude Code, Gemini, Grok and
OpenCode skip the check entirely - so **moving an instance's default provider to
Codex is what turned it on for every run**, not any release.

## Why one config error became 735 failed runs

| Defect | Effect |
|---|---|
| `runAgent`'s outer `try` had only a `finally` | Everything from the container claim to the exec threw past every writer, leaving the row `running` with no error |
| `postFailurePing` gated on a terminal status | Returned early on that row, so the task thread said nothing at all |
| The orphan pass then wrote the only visible message | `Orphaned: process no longer running` - a process check it never performs |
| `createHeartbeatRun` wrote neither counter column | `priorRetries` was always 0, so `0 + 1 < MAX_RETRIES` always held and the escalation branch was unreachable |
| Two retirement passes did not partition the space | Idle pool members of a working-but-not-busy project were reachable by neither, pinning the memory budget |

Each lap also claimed a container - and on a full budget, retired another
project's to make room for a run that died four seconds later.

## What changed

**Run failure accounting.** The setup window gets a catch that finalizes with the
real error and returns a failed result rather than rethrowing, which routes into
the normal completion path so the wakeup settles and the failure ping fires
against a terminal row. `classifyRunFailure` decides whether a failure is worth
retrying - unrecognised means permanent, deliberately. `updateHeartbeatRun` and
the orphan reap are status-guarded so the first writer to observe a run owns its
verdict. Retry lineage is carried on `retry_of_run_id` and
`process_loss_retry_count`, read from the prior **row** rather than the wakeup
payload, so the ceiling is unforgeable and the chain ends.

**Containers.** The surplus-idle pass drops its `busy`-member precondition and
the warm-start floor moves into the planner, restoring what
`docs/containers/overview.md` already promised. Reclaim suspends rather than
destroys where that would strand a victim - both free identical budget memory,
so destroying bought the requester nothing. A second floor,
`CONTAINER_RECLAIM_MIN_AGE_SEC`, stops a container the instance just paid to
build being retired to fund another cold start. Host-side validation now runs
**before** the pool is touched.

**Surfacing.** A failed run's reason renders in the task thread and on the
task-detail banner, not only on the run detail page two expansions away.

**Restarts.** DB reconciliation runs at boot regardless of lock state - it is raw
SQL, and while it sat behind the unlock hook an instance that came up locked
served stranded `running` rows until a human arrived. Shutdown gains a bounded
drain so the DB no longer closes while cancelled runs are still writing.

## Two things found on the way

- **A credential leak.** The per-run home holds the CLI's model-provider key in
  plaintext - the sole permitted exception to the red line - and was removed only
  by `cleanupRunArtifacts`, unreachable when `buildRunContext` throws. A setup
  failure left that key on a container the pool hands to the next run. Now
  scrubbed in the `finally`.
- **`stopContainerGracefully`** wrote `projects.container_status` for the whole
  project whatever member it suspended, under-counting a capacity gate and making
  the idle pass skip the project from then on.

## Also

`process_pid` dropped (migration 062, with a data-preservation test) - never
written, because a run's work happens in a container. The OAuth resolver stops
retrying grants that cannot come back; two connections on the live instance sat
at 51 attempts and climbing, four times an hour. And the em-dash rule, which
covered UI strings but was checked nowhere: 207 strings swept across 83 files,
with `docs-terminology.test.ts` extended to `packages/web/src` so it stays clear.

## Verification

1689 web component tests, 372 shared, 574 across the server verification set, 25
docs/drift guards. Each fix was confirmed to fail without its change - including
the reap-to-reap retry chain, the dead-zone reproduction, and a preflight failure
asserting **zero** `createContainer` calls.
