### PR TITLE
fix(web): scope task-detail panel state to the task being viewed

### DIFF
--- a/packages/web/src/hooks/use-close-on-route-change.ts
+++ b/packages/web/src/hooks/use-close-on-route-change.ts
@@ -6,9 +6,12 @@ import { useEffect, useRef } from 'react';
  * menu — when the app navigates to a different page.
  *
  * Not every overlay unmounts on navigation. The ones rendered under `<Outlet />`
- * do, by accident of where they live; the ones rendered by the shell chrome in
- * `routes/__root.tsx` sit ABOVE the `<Outlet />` and never unmount, so their
- * `open` state survives a client-side navigation. The failure mode is a link
+ * do, by accident of where they live — but only when the ROUTE changes, since
+ * one component instance serves every set of params for a route (a task-detail
+ * overlay outlives a task→task navigation; that route remounts itself on task
+ * identity instead of reaching for this hook). The ones rendered by the shell
+ * chrome in `routes/__root.tsx` sit ABOVE the `<Outlet />` and never unmount, so
+ * their `open` state survives a client-side navigation. The failure mode is a link
  * inside the overlay: the page underneath swaps, the overlay does not, and a
  * full-screen Radix modal (overlay `z-[80]`, content `z-[90]`) is left covering
  * the page the reader just asked for, with no way through but its close button.

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -31,8 +31,26 @@ import { useTask, useUpdateTask } from '../../../../hooks/use-tasks';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * Everything below this boundary is per-task-VISIT state: the open document
+ * preview, the reply target, the view override, the mobile meta drawer. The
+ * router reuses ONE component instance for every task on this route, so a plain
+ * `useState` survives a task→task navigation and leaks into the next task —
+ * the previous task's document stayed pinned in the preview panel, and a stale
+ * `replyTarget` would parent the next comment to a comment on another task.
+ *
+ * Remounting on task identity is what makes "per visit" true, and keeps it true
+ * for state added later without every new `useState` having to remember to
+ * reset itself. Nothing worth carrying across tasks lives here — the preview
+ * panel's width is in localStorage and the task data is in the query cache, so
+ * a remount costs a re-render, not a refetch.
+ */
 function TaskDetailPage() {
 	const { projectId, taskId } = Route.useParams();
+	return <TaskDetailView key={`${projectId}/${taskId}`} projectId={projectId} taskId={taskId} />;
+}
+
+function TaskDetailView({ projectId, taskId }: { projectId: string; taskId: string }) {
 	const navigate = useNavigate();
 	const { data: task, isLoading } = useTask(projectId, taskId);
 
@@ -72,8 +90,8 @@ function TaskDetailPage() {
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
 	// Which view this page visit shows. The instance default is the value; the
 	// rail control overrides it for this visit only and writes nothing, so a
-	// reload - or opening another task - is back on the default. That is the whole
-	// of the per-visit rule: plain state on the route, nothing to go stale.
+	// reload - or opening another task - is back on the default. Plain state plus
+	// the remount above is the whole of the per-visit rule; nothing to go stale.
 	const { data: instanceSettings } = useInstanceSettings();
 	const defaultView = instanceSettings?.default_task_view ?? DEFAULT_TASK_VIEW;
 	const [viewOverride, setViewOverride] = useState<TaskView | null>(null);
@@ -83,7 +101,8 @@ function TaskDetailPage() {
 	// base width) and is user-resizable by dragging the divider between it and the
 	// task content (persisted in localStorage); and its own full-screen overlay
 	// (above the main content and the meta drawer) below lg. It is independent of
-	// the meta side rail.
+	// the meta side rail, and scoped to this task by the remount above — a doc
+	// opened from one task's comments must not follow the reader into the next.
 	const [preview, setPreview] = useState<PreviewItem | null>(null);
 	// The meta side rail is a collapsed-by-default drawer on mobile, toggled by
 	// the chevron. It is independent of the preview panel — opening/closing a

--- a/packages/web/test/task-detail-state-per-task.test.tsx
+++ b/packages/web/test/task-detail-state-per-task.test.tsx
@@ -1,0 +1,94 @@
+import { expect, test } from 'vitest';
+import { clickUntil, renderApp } from './helpers/render';
+import { seedComment, seedDocument, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// The task-detail route serves every task on `/projects/$projectId/tasks/$taskId`
+// from ONE component instance, so its per-visit `useState` used to survive a
+// task→task navigation and leak into the next task. These cover the two leaks
+// that reach the user: a document left pinned in the preview panel, and a reply
+// target that would parent the next comment to a comment on another task.
+
+test('the doc preview panel does not follow the reader into another task', async () => {
+	const ref = { projectSlug: '', firstTask: '', secondTask: '' };
+	const { findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Preview Project' });
+			await seedDocument(ws, project, {
+				filename: 'prd.md',
+				content: ['# Product Requirements', '', 'An unmistakable document body.'].join('\n'),
+			});
+			const first = await seedTask(ws, project, { title: 'Review the spec' });
+			await seedComment(ws, first, 'Please review prd.md before we ship.');
+			// The task the reader creates next. Deliberately has no doc mention of
+			// its own, so anything in the panel came from the task before it.
+			const second = await seedTask(ws, project, { title: 'Remove non-portfolio stocks' });
+			ref.projectSlug = project.slug;
+			ref.firstTask = first.identifier.toLowerCase();
+			ref.secondTask = second.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.firstTask },
+	});
+
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="doc-mention-link"]'),
+		() => !!document.querySelector('[data-testid="preview-panel"]'),
+		{ label: 'the doc mention' },
+	);
+	expect((await findByTestId('preview-panel-filename')).textContent).toBe('prd.md');
+
+	// Same route, different params — the navigation a freshly created task makes.
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.secondTask },
+	});
+
+	await findByText('Remove non-portfolio stocks');
+	expect(document.querySelector('[data-testid="preview-panel"]')).toBeNull();
+});
+
+test('a reply target does not follow the reader into another task', async () => {
+	const ref = { projectSlug: '', firstTask: '', secondTask: '' };
+	const { findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Reply Project' });
+			const first = await seedTask(ws, project, { title: 'Review the spec' });
+			await seedComment(ws, first, 'A comment worth replying to.');
+			const second = await seedTask(ws, project, { title: 'Remove non-portfolio stocks' });
+			ref.projectSlug = project.slug;
+			ref.firstTask = first.identifier.toLowerCase();
+			ref.secondTask = second.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.firstTask },
+	});
+
+	await clickUntil(
+		user,
+		() => document.querySelector('[data-testid="comment-reply"]'),
+		() => !!document.querySelector('[data-testid="reply-indicator"]'),
+		{ label: 'the comment reply button' },
+	);
+	await findByTestId('reply-indicator');
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.secondTask },
+	});
+
+	// A surviving target would post the next comment with a `parent_comment_id`
+	// pointing at a comment on the task the reader just left.
+	await findByText('Remove non-portfolio stocks');
+	expect(document.querySelector('[data-testid="reply-indicator"]')).toBeNull();
+});


### PR DESCRIPTION
## The bug

Opening a document in the task-detail side panel, then navigating to another task, left that document pinned in the panel on the new task - most visibly when creating a task, which lands on a brand new task showing a document it never mentioned.

## Root cause

The router serves every task on `/projects/$projectId/tasks/$taskId` from **one** component instance. A task-to-task navigation changes the params, not the instance, so the route's per-visit `useState` was never reset.

The open preview was the reported symptom. Two more pieces of state leaked the same way:

- **`replyTarget`** - a stale `Comment` from the task the reader left. The composer posts `parent_comment_id: replyTarget.id`, so the next comment would have been parented to a comment on a different task.
- **`viewOverride`** - whose own comment already claimed "opening another task - is back on the default". It wasn't.

## The fix

Split the route into an outer component that reads the params and an inner `TaskDetailView` keyed on task identity. One line resets every piece of per-visit state on arrival, and keeps resetting state added later without each new `useState` having to remember to reset itself.

Nothing worth carrying across tasks lives in that state - the panel width is in `localStorage` and task data is in the query cache - so a remount costs a re-render, not a refetch.

Also corrects the `useCloseOnRouteChange` docstring, whose "overlays under `<Outlet />` unmount on navigation" claim is exactly the reasoning that produced this bug: they unmount when the *route* changes, not when only its params do.

## Tests

New component tests in `packages/web/test/task-detail-state-per-task.test.tsx`, one per leak that reaches the user. Both fail without the fix (`expected <aside …> to be null`, `expected <div …> to be null`) and pass with it.

Verified green: `bun run typecheck`, `--package web --pattern task-` (24 files, 135 tests), plus the other five preview-touching component specs (29 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_016qk2SsVaWLXnaKUcjVeYgf)_