### PR TITLE
feat(deploy): install behind an existing reverse proxy and firewall (xCloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,16 @@ firewall, and drops you at the in-browser setup.
   <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/hezo-ai/hezo&cloudshell_workspace=deploy/gcp&cloudshell_tutorial=tutorial.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="34" /></a>
   <a href="https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://hezo-deploy.s3.us-east-1.amazonaws.com/hezo.cfn.yaml&stackName=hezo"><img src="https://img.shields.io/badge/Deploy_on-AWS-FF9900?style=for-the-badge&logo=amazonwebservices&logoColor=white" alt="Deploy on AWS" height="34" /></a>
   <a href="./docs/deployment/one-click.md"><img src="https://img.shields.io/badge/Deploy_on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white" alt="Deploy on DigitalOcean" height="34" /></a>
+  <a href="./docs/deployment/one-click.md#deploying-on-xcloud"><img src="https://img.shields.io/badge/Deploy_on-xCloud-1B1F3B?style=for-the-badge" alt="Deploy on xCloud" height="34" /></a>
 </p>
 
 **Google Cloud** and **AWS** are one-click today - Google Cloud opens Cloud Shell
 and runs the deploy, and AWS opens a CloudFormation **Launch Stack** (pick a size,
 then **Create stack**). **DigitalOcean** opens a short guide until its
-[Marketplace image](./deploy/marketplace/digitalocean/README.md) is listed. Any
-provider that takes cloud-init works too - see
-[One-click deploy](./docs/deployment/one-click.md).
+[Marketplace image](./deploy/marketplace/digitalocean/README.md) is listed, and
+**xCloud** opens one too - it manages a server you already own, so Hezo installs
+behind the panel's own Nginx rather than bringing its own. Any provider that takes
+cloud-init works too - see [One-click deploy](./docs/deployment/one-click.md).
 
 > These buttons target VM providers because the default setup runs each project's agents
 > on the host's own container-runtime socket, which needs a **real VM** - not a

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,16 +10,22 @@ host** — not to a managed-container PaaS. These artifacts automate that host s
 
 | Path | Purpose |
 |---|---|
-| `provision.sh` | The canonical, self-contained installer. Creates a swap file (default 6 GB, `HEZO_SWAP_SIZE`) so low-RAM hosts don't get OOM-killed, installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, exempts Hezo from needrestart's automatic restarts, and locks the firewall down. Single source of truth — everything else runs it. |
+| `provision.sh` | The canonical, self-contained installer. Creates a swap file (default 6 GB, `HEZO_SWAP_SIZE`) so low-RAM hosts don't get OOM-killed, installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, exempts Hezo from needrestart's automatic restarts, and locks the firewall down. The last two of those are modes: `HEZO_PROXY=none` installs no Caddy and `HEZO_FIREWALL=none` touches no rules, for hosts where something else already owns them. Single source of truth — everything else runs it. |
 | `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
 | `aws/` | CloudFormation **Launch Stack** template (`hezo.cfn.yaml`) — an EC2 VM whose UserData runs `provision.sh`. See [`aws/README.md`](aws/README.md). |
 | `gcp/` | **Open in Cloud Shell** deploy — `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) with a guided `tutorial.md`. See [`gcp/README.md`](gcp/README.md). |
 | `marketplace/digitalocean/` | Packer template that bakes `provision.sh` into a DigitalOcean Marketplace 1-Click image. See [`marketplace/digitalocean/README.md`](marketplace/digitalocean/README.md). |
+| `xcloud/` | Running Hezo behind a control panel's own Nginx (`HEZO_PROXY=none HEZO_FIREWALL=none`), plus the catalogue-outreach runbook. See [`xcloud/README.md`](xcloud/README.md). |
 
 Every per-provider button hands `provision.sh` (or the cloud-init) to a fresh VM —
 there is one installer, wrapped per provider. Hezo needs the **host Docker socket**
 (it launches a container per project), so all of these target a **real VM**; a
 managed-container PaaS (Render, Railway, Cloud Run) can't run it.
+
+A VM already managed by a control panel is still a fresh VM to Hezo, but the panel owns
+80/443 and the firewall. `provision.sh` has two explicit modes for that — `HEZO_PROXY`
+and `HEZO_FIREWALL`, both documented in its header — so there is still one installer
+rather than a second script per panel.
 
 ### How one-click per provider stands today
 
@@ -28,6 +34,7 @@ managed-container PaaS (Render, Railway, Cloud Run) can't run it.
 | **Google Cloud** | `gcp/` Cloud Shell button | Nothing — Cloud Shell reads this repo directly; works on `main`. |
 | **AWS** | `aws/hezo.cfn.yaml` | A one-time upload of the template to a public S3 URL (CloudFormation quick-create requires S3). Manual `aws cloudformation deploy` works today. |
 | **DigitalOcean** | `marketplace/digitalocean/` Packer image | An external DO vendor account + DO's image review to publish the listing. The cloud-init path works today. |
+| **xCloud** | `xcloud/` runbook + the `provision.sh` modes | A curated catalogue with no public submission process, spec or intake form — outreach to `support@xcloud.host` only. The manual path works today. |
 
 ## How it works
 
@@ -53,7 +60,10 @@ deliberately. See `docs/deployment/self-hosting.md` § Keeping the host patched.
 Firewall posture: only **80/443** are public; **3100** (the Hezo server) and
 **20000–29999** (the per-run egress proxy) stay host-local, while the Docker
 bridge (`docker0`) can still reach the host so agent containers get their tools.
-See `docs/deployment/self-hosting.md` § Networking & firewall.
+See `docs/deployment/self-hosting.md` § Networking & firewall. Under
+`HEZO_FIREWALL=none` none of that is written and the host's existing rules decide the
+posture — Hezo binds `0.0.0.0:3100`, so closing that port becomes the other firewall's
+job.
 
 ## Using it
 
@@ -80,6 +90,14 @@ throwaway VM/droplet:
 2. **Throwaway droplet:** create a small droplet with the cloud-init, then from your
    laptop hit `https://<ip>.sslip.io/health` (a valid cert proves the Let's Encrypt
    path) and load the root URL to confirm you reach the master-key gate. Destroy it.
+3. **The modes, if you touched them:** on a VM with `nginx` and a few `ufw` rules
+   already in place, run with `HEZO_PROXY=none HEZO_FIREWALL=none
+   HEZO_DOMAIN_OVERRIDE=hezo.local` and check that `caddy` is absent, `/etc/caddy` was
+   never created, `ufw status numbered` is byte-identical to before, and
+   `/etc/hezo/hezo.env` carries `HEZO_WEB_URL=https://hezo.local`. Then re-run with **no**
+   variables at all — the modes persist in `/etc/hezo/deploy.env`, so the second run must
+   still install no Caddy and touch no rules. Bad values (`HEZO_PROXY=nginx`) and
+   `HEZO_PROXY=none` without a domain must both refuse before mutating anything.
 
 ## DigitalOcean Marketplace image (Phase 2)
 

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -6,13 +6,13 @@
 # "Startup script" field when creating an Ubuntu server (2 GB RAM+ recommended).
 # Works as-is on DigitalOcean, Hetzner, Vultr, Linode, and AWS Lightsail.
 #
-# On first boot it creates a 4 GB swap file (so low-RAM boxes don't get OOM-killed),
+# On first boot it creates a 6 GB swap file (so low-RAM boxes don't get OOM-killed),
 # installs Docker, downloads Hezo, sets up automatic HTTPS via Caddy, and starts Hezo
 # under systemd. After ~2 minutes, open the URL it derives (https://<public-ip>.sslip.io)
 # and finish the short in-browser setup: create your master key, set an admin
 # password, and connect a model.
 #
-# OPTIONAL - change the swap size (default 4G, auto-shrunk to fit the disk): set
+# OPTIONAL - change the swap size (default 6G, auto-shrunk to fit the disk): set
 # HEZO_SWAP_SIZE below (e.g. 2G, or 0 to disable). Existing swap is left untouched.
 #
 # OPTIONAL — use your own domain instead of sslip.io: point an A record at the
@@ -28,7 +28,7 @@ packages:
   - curl
 
 runcmd:
-  # To change the swap size (default 4G; set 0 to disable), set this before the curl line:
+  # To change the swap size (default 6G; set 0 to disable), set this before the curl line:
   # - [ sh, -c, "echo 'HEZO_SWAP_SIZE=2G' >> /etc/environment" ]
   # To use your own domain, set this before the curl line (A record must point here first):
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -17,14 +17,36 @@
 #   6. exempts Hezo from needrestart's automatic restarts (it comes back locked)
 #   7. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
 #
+# Steps 4 and 7 assume this script owns the host. On a server managed by a control
+# panel (xCloud, RunCloud, Ploi, cPanel) the panel already owns 80/443 and the
+# firewall, so declare that with HEZO_PROXY=none and HEZO_FIREWALL=none below and
+# point the panel's site at 127.0.0.1:3100. See deploy/xcloud/README.md.
+#
 # It never sets the master key: that is generated in the browser on first run and
 # shown once, so it cannot be pre-seeded. After boot, open the printed URL and
 # finish the short setup (create master key, set admin password, connect a model).
 #
 # Optional environment variables (set in the shell, or seeded into /etc/hezo/deploy.env
 # by cloud-init before this script runs — see deploy/cloud-init/hezo.cloud-config.yaml):
+#   HEZO_PROXY             which reverse proxy fronts Hezo: caddy (default) or none.
+#                          `none` means one is already installed and owns 80/443 - this
+#                          script then installs no Caddy, derives no sslip.io address,
+#                          and requires HEZO_DOMAIN_OVERRIDE (the name that proxy serves)
+#                          so HEZO_WEB_URL is correct. Point the existing proxy at
+#                          127.0.0.1:3100, passing Host, X-Forwarded-Proto and the
+#                          WebSocket upgrade headers. Use it on a control-panel host.
+#   HEZO_FIREWALL          which firewall this script configures: ufw (default) or none.
+#                          `none` leaves the host's rules completely untouched - use it
+#                          when a control panel or cloud firewall owns them, so this
+#                          script never resets rules it did not create. Note what that
+#                          hands you: Hezo binds 0.0.0.0:3100 and has no bind-host
+#                          setting, so keeping 3100 off the public internet becomes
+#                          entirely your firewall's job. Verify it from another machine.
+#                          Both modes are persisted into /etc/hezo/deploy.env, so a later
+#                          bare re-run on the same host stays in them.
 #   HEZO_DOMAIN_OVERRIDE   use this domain instead of <public-ip>.sslip.io
-#                          (point an A record at the host first; Caddy gets a cert for it)
+#                          (point an A record at the host first; Caddy gets a cert for it).
+#                          Required when HEZO_PROXY=none.
 #   HEZO_DATABASE_URL      managed/external Postgres 14+ connection string
 #                          (postgres://user:pass@host:5432/hezo?sslmode=require).
 #                          sslmode follows libpq rules: require encrypts without
@@ -73,6 +95,41 @@ if [[ -f "${DEPLOY_ENV}" ]]; then
 fi
 
 log() { echo "[hezo-provision] $*"; }
+
+# ---------------------------------------------------------------------------
+# Modes. Both default to this script owning the host, so every existing wrapper
+# (cloud-init, AWS, GCP, the DigitalOcean image) behaves exactly as before. They
+# are declared by the operator, never sniffed: nothing here detects an installed
+# nginx and quietly changes course.
+# ---------------------------------------------------------------------------
+PROXY="${HEZO_PROXY:-caddy}"
+FIREWALL="${HEZO_FIREWALL:-ufw}"
+
+case "${PROXY}" in
+	caddy | none) ;;
+	*)
+		echo "HEZO_PROXY must be 'caddy' or 'none' (got '${PROXY}')." >&2
+		exit 1
+		;;
+esac
+
+case "${FIREWALL}" in
+	ufw | none) ;;
+	*)
+		echo "HEZO_FIREWALL must be 'ufw' or 'none' (got '${FIREWALL}')." >&2
+		exit 1
+		;;
+esac
+
+# With no Caddy there is no sslip.io derivation, so the domain the existing proxy
+# serves has to be supplied - Hezo builds absolute URLs (the OAuth callback an MCP
+# connection registers with its provider among them) from HEZO_WEB_URL, and a blank
+# one fails later at connect time rather than here.
+if [[ "${PROXY}" == "none" && -z "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
+	echo "HEZO_PROXY=none needs HEZO_DOMAIN_OVERRIDE set to the domain your reverse proxy serves" >&2
+	echo "(it becomes HEZO_WEB_URL=https://<domain>). See deploy/xcloud/README.md." >&2
+	exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # 1. Swap file — give low-RAM hosts a memory cushion so the install itself and
@@ -232,11 +289,17 @@ if [[ ! -f "${ENV_FILE}" ]]; then
 	install -m 600 /dev/null "${ENV_FILE}"
 	cat >"${ENV_FILE}" <<EOF
 HEZO_DATA_DIR=${DATA_DIR}
-# HEZO_WEB_URL is written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
+# HEZO_WEB_URL is written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh),
+# or right below when an existing reverse proxy owns the address (HEZO_PROXY=none).
 # Do NOT put your master key in this file. Hezo keeps it in memory only and comes up locked
 # after each restart by design; unlock it from the browser gate. A copy of the key on disk
 # next to the encrypted data would let anyone who reads this box decrypt your vault.
 EOF
+	# With an existing proxy there is nothing to derive: the domain it serves was
+	# supplied up front, so write the URL now rather than deferring to first boot.
+	if [[ "${PROXY}" == "none" ]]; then
+		echo "HEZO_WEB_URL=https://${HEZO_DOMAIN_OVERRIDE}" >>"${ENV_FILE}"
+	fi
 	# Managed data hosting (optional): persist the database / asset-storage settings
 	# provided at provision time so the systemd unit picks them up. To wire them into
 	# an already-provisioned host, edit this file directly and restart hezo — see
@@ -248,30 +311,44 @@ EOF
 	done
 fi
 
-# Persist optional settings the first-boot unit reads (domain override, swap size).
-if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" || -n "${HEZO_SWAP_SIZE:-}" ]]; then
+# Persist the settings that must survive this run: the modes (read back by the block
+# at the top of this script, and by the first-boot unit) plus the domain override and
+# swap size. The modes are written only when they are not the default, so a Caddy
+# install writes exactly the file it always did.
+#
+# Persisting them is what makes a later bare re-run safe. Someone who pipes this
+# script into `sudo bash` again on a panel-managed host, without re-typing the two
+# variables, must not get Caddy installed and their firewall reset - so the host
+# remembers. An explicit variable still wins, so switching modes stays possible.
+if [[ "${PROXY}" != "caddy" || "${FIREWALL}" != "ufw" || -n "${HEZO_DOMAIN_OVERRIDE:-}" || -n "${HEZO_SWAP_SIZE:-}" ]]; then
 	install -m 600 /dev/null "${DEPLOY_ENV}"
+	[[ "${PROXY}" != "caddy" ]] && echo "HEZO_PROXY=${PROXY}" >>"${DEPLOY_ENV}"
+	[[ "${FIREWALL}" != "ufw" ]] && echo "HEZO_FIREWALL=${FIREWALL}" >>"${DEPLOY_ENV}"
 	[[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]] && echo "HEZO_DOMAIN_OVERRIDE=${HEZO_DOMAIN_OVERRIDE}" >>"${DEPLOY_ENV}"
 	[[ -n "${HEZO_SWAP_SIZE:-}" ]] && echo "HEZO_SWAP_SIZE=${HEZO_SWAP_SIZE}" >>"${DEPLOY_ENV}"
 fi
 
 # ---------------------------------------------------------------------------
 # 5. Caddy (reverse proxy, automatic HTTPS, WebSocket passthrough)
+#    Skipped wholesale under HEZO_PROXY=none: the proxy already on this host owns
+#    80/443, and installing Caddy beside it would leave two services fighting for
+#    the same ports. Nothing is written under /etc/caddy in that mode.
 # ---------------------------------------------------------------------------
-if ! command -v caddy >/dev/null 2>&1; then
-	log "Installing Caddy…"
-	apt-get update -y
-	apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
-	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' |
-		gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' |
-		tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
-	apt-get update -y
-	apt-get install -y caddy
-fi
+if [[ "${PROXY}" == "caddy" ]]; then
+	if ! command -v caddy >/dev/null 2>&1; then
+		log "Installing Caddy…"
+		apt-get update -y
+		apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
+		curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' |
+			gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+		curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' |
+			tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+		apt-get update -y
+		apt-get install -y caddy
+	fi
 
-# The site address is provided at runtime by hezo-firstboot via /etc/caddy/hezo.env.
-cat >/etc/caddy/Caddyfile <<'EOF'
+	# The site address is provided at runtime by hezo-firstboot via /etc/caddy/hezo.env.
+	cat >/etc/caddy/Caddyfile <<'EOF'
 # Managed by Hezo provision.sh — the site address comes from HEZO_SITE_ADDRESS
 # (written to /etc/caddy/hezo.env by hezo-firstboot). Caddy provisions a
 # Let's Encrypt certificate for it automatically and passes WebSocket upgrades
@@ -281,9 +358,9 @@ cat >/etc/caddy/Caddyfile <<'EOF'
 }
 EOF
 
-# Feed HEZO_SITE_ADDRESS into Caddy's process and order it after first-boot.
-install -d /etc/systemd/system/caddy.service.d
-cat >/etc/systemd/system/caddy.service.d/hezo.conf <<'EOF'
+	# Feed HEZO_SITE_ADDRESS into Caddy's process and order it after first-boot.
+	install -d /etc/systemd/system/caddy.service.d
+	cat >/etc/systemd/system/caddy.service.d/hezo.conf <<'EOF'
 [Unit]
 After=hezo-firstboot.service
 Wants=hezo-firstboot.service
@@ -291,11 +368,18 @@ Wants=hezo-firstboot.service
 [Service]
 EnvironmentFile=/etc/caddy/hezo.env
 EOF
-# Placeholder so caddy's EnvironmentFile exists before first-boot writes the real value.
-[[ -f /etc/caddy/hezo.env ]] || echo 'HEZO_SITE_ADDRESS=:80' >/etc/caddy/hezo.env
+	# Placeholder so caddy's EnvironmentFile exists before first-boot writes the real value.
+	[[ -f /etc/caddy/hezo.env ]] || echo 'HEZO_SITE_ADDRESS=:80' >/etc/caddy/hezo.env
+else
+	log "HEZO_PROXY=none: leaving the existing reverse proxy alone (point it at 127.0.0.1:3100)."
+fi
 
 # ---------------------------------------------------------------------------
 # 6. First-boot unit: derive the public URL, wire it into Caddy + Hezo
+#    Installed in every mode - it also creates swap on the machine-image path -
+#    but under HEZO_PROXY=none there is no address to derive, so it stops after
+#    the swap step. provision.sh already wrote HEZO_WEB_URL from the domain the
+#    existing proxy serves.
 # ---------------------------------------------------------------------------
 cat >/usr/local/sbin/hezo-firstboot.sh <<'EOF'
 #!/usr/bin/env bash
@@ -314,6 +398,15 @@ SENTINEL="/var/lib/hezo/.firstboot-done"
 # skipped it at build time.
 if [[ -x /usr/local/sbin/hezo-ensure-swap.sh ]]; then
 	HEZO_SWAP_SIZE="${HEZO_SWAP_SIZE:-}" /usr/local/sbin/hezo-ensure-swap.sh || true
+fi
+
+# An existing reverse proxy owns the address and its certificate; there is no Caddy
+# to point anywhere and HEZO_WEB_URL was written at provision time.
+if [[ "${HEZO_PROXY:-caddy}" == "none" ]]; then
+	install -d /var/lib/hezo
+	touch "${SENTINEL}"
+	echo "hezo-firstboot: existing reverse proxy owns the address; nothing to derive"
+	exit 0
 fi
 
 if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
@@ -402,8 +495,15 @@ EOF
 # 9. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
 #    but let the Docker bridge reach the host (agents call back over docker0).
 #    See docs/deployment/self-hosting.md § Networking & firewall.
+#
+#    Skipped wholesale under HEZO_FIREWALL=none, `ufw --force reset` included:
+#    on a host whose rules belong to a control panel or a cloud firewall, that
+#    reset would delete rules this script never created. Hezo binds 0.0.0.0:3100,
+#    so in that mode closing 3100 to the internet is the other firewall's job.
 # ---------------------------------------------------------------------------
-if command -v ufw >/dev/null 2>&1; then
+if [[ "${FIREWALL}" == "none" ]]; then
+	log "HEZO_FIREWALL=none: leaving the host firewall untouched."
+elif command -v ufw >/dev/null 2>&1; then
 	ufw --force reset >/dev/null 2>&1 || true
 	ufw default deny incoming
 	ufw default allow outgoing
@@ -425,14 +525,28 @@ if [[ "${HEZO_IMAGE_BUILD:-}" == "1" ]]; then
 	# absent, so it fires) which sets the real <ip>.sslip.io address, then Caddy and
 	# Hezo start. Guard against a baked sentinel/URL just in case.
 	rm -f /var/lib/hezo/.firstboot-done
-	systemctl enable hezo-firstboot.service caddy hezo
+	systemctl enable hezo-firstboot.service hezo
+	if [[ "${PROXY}" == "caddy" ]]; then
+		systemctl enable caddy
+	fi
 	log "Image build: services enabled for first boot (not started). URL is derived on the user's first boot."
 else
 	systemctl enable --now hezo-firstboot.service
-	systemctl enable --now caddy
-	# Re-run Caddy now that the real site address exists.
-	systemctl restart caddy
+	if [[ "${PROXY}" == "caddy" ]]; then
+		systemctl enable --now caddy
+		# Re-run Caddy now that the real site address exists.
+		systemctl restart caddy
+	fi
 	systemctl enable --now hezo
-	log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
-	log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"
+	if [[ "${PROXY}" == "caddy" ]]; then
+		log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
+		log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"
+	else
+		log "Done. Hezo is listening on port 3100."
+		log "Point your ${HEZO_DOMAIN_OVERRIDE} site at 127.0.0.1:3100, then open"
+		log "  https://${HEZO_DOMAIN_OVERRIDE}"
+		if [[ "${FIREWALL}" == "none" ]]; then
+			log "Confirm port 3100 is NOT reachable from outside this host - Hezo binds 0.0.0.0."
+		fi
+	fi
 fi

--- a/deploy/xcloud/README.md
+++ b/deploy/xcloud/README.md
@@ -1,0 +1,248 @@
+# Hezo on xCloud
+
+[xCloud](https://xcloud.host/) is a server-management control panel, not a
+managed-container service: you own the Ubuntu VPS and xCloud provisions and manages it.
+That is exactly the shape Hezo needs - a real VM with a host Docker socket - but it
+means xCloud, not Hezo, owns the web server, the certificate and the firewall.
+
+So Hezo installs as a **host systemd service behind xCloud's Nginx**, using the same
+[`deploy/provision.sh`](../provision.sh) as every other target, run with
+`HEZO_PROXY=none HEZO_FIREWALL=none`. One source of truth for host setup; the two modes
+say which parts of the host this script is not to touch.
+
+## What's code (here) vs. external ops
+
+| Step | Where |
+|---|---|
+| The installer and its `HEZO_PROXY` / `HEZO_FIREWALL` modes (`deploy/provision.sh`) | **This repo** |
+| The Nginx directives Hezo needs behind a proxy | **This repo** (below, and [`docs/deployment/cloud.md`](../../docs/deployment/cloud.md) § Serve it over HTTPS) |
+| An xCloud account, a server, a domain | **External** - the user's; there is a free trial |
+| Connecting the server, creating the site, issuing the certificate, pasting the Nginx block | **External** - xCloud dashboard |
+| Getting Hezo into xCloud's one-click catalogue | **External** - no self-serve process exists, see [Getting listed](#getting-listed) |
+
+## Do it in this order
+
+**Connect the server to xCloud first, then install Hezo.** xCloud only accepts a
+**fresh, empty** Ubuntu 24.04 LTS x64 server with root access
+([their requirements](https://xcloud.host/docs/how-to-set-up-server-with-other-providers/)),
+so a box that already has Hezo on it is a box xCloud will refuse.
+
+1. Create an Ubuntu 24.04 LTS x64 server, 2 GB RAM or more, and connect it to xCloud.
+2. Create a site for your domain and let xCloud issue its Let's Encrypt certificate.
+   Confirm the placeholder site loads over HTTPS **before** installing Hezo - that keeps
+   certificate problems and Hezo problems separate.
+3. SSH in and run the installer (below).
+4. Add the Nginx directives to the site.
+5. Open `https://your-domain` and finish the short first-run setup.
+
+## Why the two modes
+
+Run bare, `provision.sh` assumes it owns the host, and each of those assumptions is
+wrong here:
+
+| What it would do | Why that breaks an xCloud server |
+|---|---|
+| Install Caddy on 80/443 | xCloud's Nginx is already there; two services would fight for the ports |
+| `ufw --force reset` | Deletes the firewall rules xCloud manages from its dashboard |
+| Derive `<public-ip>.sslip.io` | xCloud owns the domain and holds the certificate for it |
+
+`HEZO_PROXY=none` turns off the first and third; `HEZO_FIREWALL=none` turns off the
+second. Everything else - swap, Docker, the binary, the systemd unit, the needrestart
+exemption - runs exactly as it does everywhere else.
+
+## Run it
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh \
+  | sudo HEZO_PROXY=none HEZO_FIREWALL=none HEZO_DOMAIN_OVERRIDE=hezo.example.com bash
+```
+
+**The variables go after `sudo`, not before `curl`.** `sudo` scrubs the environment, so
+`export HEZO_PROXY=none; curl ... | sudo bash` silently loses them - and that run is the
+one that installs Caddy and resets xCloud's firewall.
+
+`HEZO_DOMAIN_OVERRIDE` is required in this mode: with no Caddy there is nothing to derive
+an address from, and it is the only source of `HEZO_WEB_URL`. Hezo builds absolute URLs
+from that value (the OAuth callback an MCP connection registers with its provider among
+them), so a wrong one fails later at connect time rather than during the install.
+
+Both modes are recorded in `/etc/hezo/deploy.env`, so a later bare re-run of the
+installer on this host stays in them - it will not suddenly install Caddy and reset your
+firewall because someone forgot the variables. Passing a variable explicitly still wins,
+so switching back is possible.
+
+To put the database in a managed Postgres or assets in an S3-compatible bucket, add
+`HEZO_DATABASE_URL` and `HEZO_ASSET_STORAGE_URL` the same way - see
+[`docs/deployment/one-click.md`](../../docs/deployment/one-click.md) § Using managed data
+hosting.
+
+## The Nginx directives
+
+**Read the generated vhost first:** `cat /etc/nginx/sites-available/<site-name>`. Nginx
+refuses a duplicated single-value directive, and repeated `proxy_set_header` lines
+accumulate rather than replace, so add only what is missing rather than pasting blind.
+
+Target state for the location that proxies to Hezo:
+
+```nginx
+# Hezo - reverse proxy to the systemd service on this host.
+proxy_pass http://127.0.0.1:3100;
+proxy_http_version 1.1;
+
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+proxy_set_header Upgrade    $http_upgrade;
+proxy_set_header Connection "upgrade";
+
+proxy_read_timeout   3600s;
+proxy_send_timeout   3600s;
+client_max_body_size 12m;
+```
+
+What each group is for, and why none of it is optional, is in
+[`docs/deployment/cloud.md`](../../docs/deployment/cloud.md) § Serve it over HTTPS. The
+short version: `proxy_http_version 1.1` is what makes the WebSocket upgrade possible at
+all, `X-Forwarded-Proto` is what keeps OAuth callbacks on `https://`, the timeouts stop
+an idle activity stream being cut every 60 seconds, and the body size lets 10 MB
+attachments through.
+
+Add it through **NGINX -> Add a New Config** in the site's dashboard
+([how](https://xcloud.host/docs/configure-custom-nginx-xcloud/)). xCloud offers five
+placements:
+
+- **Inside Proxy Location Block** - use this on a site type where xCloud already emits
+  its own `proxy_pass` to an application port (set that port to `3100`), and drop the
+  `proxy_pass` line from the block above.
+- **Inside Server Block** - use this if the site has no `location /` of its own; paste a
+  complete `location / { ... }` including `proxy_pass`.
+- **After Server Block** is wrong for this: that include lands outside `server { }`,
+  where a `location` is a syntax error.
+
+Use **Run & Debug** rather than **Save Config** - it surfaces `nginx -t` errors in the
+dashboard instead of leaving a broken vhost.
+
+## What differs from the cloud-init path
+
+- Your own domain, not `<ip>.sslip.io`.
+- xCloud's certificate, renewed by xCloud. No Caddy is installed and nothing is written
+  under `/etc/caddy`.
+- xCloud's firewall. The installer leaves it completely alone - which also means
+  **closing port 3100 to the internet is now xCloud's job, not ours**: Hezo binds
+  `0.0.0.0` and has no bind-host setting. xCloud opens only 22, 80 and 443 by default,
+  so the default posture is right - verify it anyway (below).
+- Everything else is identical, the master key included: Hezo comes up **locked** after
+  any restart, by design, and unlocks from the browser gate.
+
+## Verify it
+
+On the server:
+
+```sh
+systemctl is-active hezo                  # active
+curl -s 127.0.0.1:3100/health             # {"ok":true}
+command -v caddy                          # nothing - no proxy was installed
+ufw status numbered                       # unchanged from before the install
+docker info >/dev/null && echo docker-ok  # the default sandbox backend needs it
+```
+
+From another machine, in this order:
+
+1. `curl --max-time 5 http://<server-ip>:3100/health` **must fail** (timeout or refused).
+   If it answers, the instance is exposed on a bare HTTP port - fix the firewall in the
+   xCloud dashboard before going any further.
+2. `curl -sI https://<domain>/health` returns 200 over a valid chain, with no `-k`.
+3. The WebSocket upgrade, which is the directive most likely to be missing:
+
+   ```sh
+   curl -si --max-time 5 https://<domain>/ws \
+     -H "Connection: Upgrade" -H "Upgrade: websocket" \
+     -H "Sec-WebSocket-Version: 13" \
+     -H "Sec-WebSocket-Key: $(openssl rand -base64 16)"
+   ```
+
+   `101 Switching Protocols` is a pass. A 200, 400 or 426 almost always means
+   `proxy_http_version 1.1` is missing.
+
+In the browser:
+
+4. Finish [first-run setup](../../docs/getting-started/first-run.md) - master key, admin
+   password, connect a model.
+5. Open the CEO chat and leave it idle for more than a minute. A live log stream that
+   survives proves both the upgrade and `proxy_read_timeout`.
+6. Connect an OAuth-backed MCP server or a GitHub account. The callback must land on
+   `https://`. If `X-Forwarded-Proto` is missing, Hezo builds an `http://` callback and
+   the provider rejects it, while every page still looks fine over TLS.
+7. Attach a roughly 9 MB file to a task. A 413 means `client_max_body_size` did not take.
+8. Create a project and confirm its container starts (Settings -> Containers).
+9. Reboot the server from the panel. Nginx and Hezo both come back, and Hezo is
+   **locked** at the gate - expected, not a failed deploy. Check
+   `/etc/needrestart/conf.d/hezo.conf` survived the panel's package management.
+
+If some API calls return 403 while the site otherwise works, suspect xCloud's WAF
+(`/etc/nginx/conf.d/7g-firewall.conf` and the per-site security toggles) and read
+`/var/log/nginx/<site-name>-error.log`.
+
+## Getting listed
+
+xCloud has a curated [one-click app catalogue](https://xcloud.host/one-click-apps/)
+carrying adjacent self-hosted AI tools - n8n, LibreChat, OpenWebUI/Ollama. Hezo belongs
+on that shelf, but:
+
+**There is no submission process.** No template spec, no partner program, no manifest
+format, no URL-based "Deploy to xCloud" button. `oneclick` is a read-only site-type
+filter in [their API](https://app.xcloud.host/api/v1/docs); neither the
+[CLI](https://github.com/xCloudDev/xCloud-cli) nor their agent skills have an
+app-authoring surface, and "Blueprints" are WordPress plugin and theme packs, not app
+templates. The catalogue is curated internally. The only route is contact:
+`support@xcloud.host`.
+
+That is the same split this repo already lives with for the
+[DigitalOcean Marketplace](../marketplace/digitalocean/README.md): everything needed to
+make it work today is in here, and the listing is theirs to grant.
+
+**Do the outreach only after the whole of [Verify it](#verify-it) has passed on a real
+server**, and keep that instance running. A live Hezo on their own platform is the
+strongest thing the pitch has.
+
+### What to send
+
+What Hezo is, what it needs from a host - Ubuntu 24.04 x64 or arm64, 2 GB RAM plus the
+6 GB swap the installer creates, Docker on the host for the default sandbox backend, one
+local port - the install command and the Nginx block above, and the URL of the live
+instance.
+
+Lead with the two questions that decide whether this is possible at all:
+
+1. **Does a catalogue entry have to be Docker Compose shaped?** Every current entry
+   appears to be, and the Docker + NGINX stack is mandatory for custom Docker apps. Hezo
+   runs agents in containers on the **host's** Docker socket, so containerizing the Hezo
+   server is not a packaging detail - it is a different product shape. Can an entry
+   instead be a host-level install script plus a site Nginx template?
+2. **Is there a spec, template repo, or intake form** we can PR or fill in?
+
+Record the date sent and the answer here - this file is the memory.
+
+If the answer is "Compose only", the decision to bring back is whether to publish a Hezo
+**server** image at all. None exists today (`ghcr.io/hezo-ai/agent-base` is the agent
+sandbox image, not the server), running the server in a container disables in-app update,
+and it would need a reviewed `/var/run/docker.sock` mount. That is a project, not a
+follow-up commit.
+
+## Teardown
+
+```sh
+sudo systemctl disable --now hezo hezo-firstboot
+sudo rm -f /usr/local/bin/hezo /usr/local/sbin/hezo-*.sh \
+  /etc/systemd/system/hezo.service /etc/systemd/system/hezo-firstboot.service \
+  /etc/needrestart/conf.d/hezo.conf
+sudo rm -rf /etc/hezo
+sudo systemctl daemon-reload
+```
+
+`/var/lib/hezo` is your data - back it up before deleting it, then remove it with
+`sudo HEZO_DATA_DIR=/var/lib/hezo hezo uninstall --yes` **before** deleting the binary
+above, since that also reaps the containers Hezo created. Finally delete the site from
+the xCloud dashboard, which removes its vhost and certificate.

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -125,7 +125,7 @@ network:
 - **Everything sensitive rides on every request** - your admin password, agent output,
   task content. TLS is the baseline.
 
-Configure the proxy to do all three of:
+Configure the proxy to do all four of:
 
 - **Pass through WebSocket upgrades** - the web app streams agent activity in real
   time.
@@ -134,8 +134,10 @@ Configure the proxy to do all three of:
   an MCP connection registers with its provider) from the forwarded scheme and host;
   without this header it falls back to `http://` and OAuth connects fail even though
   you're browsing over HTTPS.
+- **Accept a large enough request body** - task attachments go up to 10 MB, so a proxy
+  with a smaller cap rejects them before Hezo ever sees the upload.
 
-With Caddy all three are the default - a complete Caddyfile is:
+With Caddy all four are the default - a complete Caddyfile is:
 
 ```
 hezo.example.com {
@@ -143,14 +145,35 @@ hezo.example.com {
 }
 ```
 
-For nginx, set the headers explicitly on the proxied location:
+nginx needs each one spelled out on the proxied location, and its defaults work against
+you on three of them:
 
 ```nginx
-proxy_set_header Host $host;
+proxy_pass http://127.0.0.1:3100;
+proxy_http_version 1.1;
+
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header Upgrade $http_upgrade;
+
+proxy_set_header Upgrade    $http_upgrade;
 proxy_set_header Connection "upgrade";
+
+proxy_read_timeout   3600s;
+proxy_send_timeout   3600s;
+client_max_body_size 12m;
 ```
+
+The three easy ones to miss:
+
+- **`proxy_http_version 1.1`** - nginx talks HTTP/1.0 upstream by default, and a
+  WebSocket upgrade cannot be negotiated over 1.0. The `Upgrade` and `Connection`
+  headers alone will not get you a live stream.
+- **`proxy_read_timeout`** - the default is 60 seconds, so an idle activity stream is
+  cut about once a minute.
+- **`client_max_body_size`** - the default is 1 MB, well under Hezo's 10 MB attachment
+  limit; `12m` leaves headroom for the multipart envelope.
 
 On a private network (a VPN or mesh) where a public certificate authority can't see
 your hostname, use a private CA or a DNS-01 certificate - see

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -37,6 +37,8 @@ screen.
 - **DigitalOcean** - a Marketplace 1-Click Droplet is in the works; until it's
   listed, use the [cloud-init snippet](#deploy-it) below (paste it into the
   Droplet's user-data field).
+- **xCloud** manages a server you already own rather than creating one, so it takes a
+  slightly different path - see [Deploying on xCloud](#deploying-on-xcloud) below.
 
 Every other provider - Hetzner, Vultr, Linode, AWS Lightsail, or any Ubuntu VM -
 uses the portable [cloud-init snippet](#deploy-it) below.
@@ -61,6 +63,10 @@ On first boot the snippet:
 It deliberately does **not** set your master key - that's generated in your browser
 on first run and shown once, so it can't be pre-filled. The deploy gets you to the
 setup screen; you take it from there.
+
+On a server managed by a control panel, the proxy, the certificate and the firewall are
+the panel's job instead - the installer has explicit modes for that, and
+[Deploying on xCloud](#deploying-on-xcloud) is the worked example.
 
 ## Deploy it
 
@@ -112,6 +118,53 @@ read them before you paste if you'd like to see exactly what runs.
 | Vultr | **Additional Features → Enable Cloud-Init User-Data** |
 | Linode | **Add User Data** |
 | AWS Lightsail | **Add launch script** - and also open ports **80** and **443** in the Lightsail firewall (its console firewall is separate from the server's) |
+
+## Deploying on xCloud
+
+[xCloud](https://xcloud.host/) is a control panel that manages a server you own rather
+than creating one for you, and it brings its own Nginx, its own firewall and its own
+certificates. So there is no snippet to paste at create time: you connect the server,
+create a site, and Hezo installs behind that site as a normal host service.
+
+**Connect the server to xCloud first.** It only accepts a fresh, empty Ubuntu 24.04 LTS
+x64 server, so a box that already has Hezo on it is one it will refuse.
+
+1. **Create an Ubuntu 24.04 LTS x64 server**, 2 GB RAM or more, and connect it to
+   xCloud.
+2. **Create a site** for your domain and let xCloud issue its certificate. Load it over
+   HTTPS before going further - that keeps certificate problems separate from Hezo
+   problems.
+3. **SSH in and install Hezo:**
+
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh \
+     | sudo HEZO_PROXY=none HEZO_FIREWALL=none HEZO_DOMAIN_OVERRIDE=hezo.example.com bash
+   ```
+
+   The two modes tell the installer that this host already has a reverse proxy and a
+   managed firewall, so it installs no Caddy and leaves your rules alone. **Put the
+   variables after `sudo`, not before `curl`** - `sudo` scrubs the environment, and a
+   run that loses them is the run that installs Caddy against xCloud's Nginx and resets
+   xCloud's firewall.
+
+4. **Point the site at Hezo.** In the site's **NGINX** tab, add the reverse-proxy
+   directives from [Serve it over
+   HTTPS](/docs/deployment/cloud#serve-it-over-https) to the location that proxies to
+   `127.0.0.1:3100`. Read the generated vhost first and add only what is missing;
+   `proxy_http_version 1.1` is the one most often absent, and without it the live
+   activity stream never connects.
+5. **Open `https://your-domain`** and complete
+   [first-run setup](/docs/getting-started/first-run).
+
+What differs from the snippet path: your own domain instead of `<ip>.sslip.io`, xCloud's
+certificate instead of Caddy's, and xCloud's firewall instead of the one the installer
+would have written. That last one is worth a check - Hezo listens on port 3100 on every
+interface, so confirm from another machine that `http://<server-ip>:3100` is **not**
+reachable. xCloud opens only 22, 80 and 443 by default, so it should not be.
+
+The full operator runbook, including how to verify the WebSocket upgrade and what to
+send xCloud about a catalogue listing, is in
+[`deploy/xcloud/README.md`](https://github.com/hezo-ai/hezo/blob/main/deploy/xcloud/README.md).
 
 ## Using managed data hosting
 
@@ -252,6 +305,10 @@ to configure, and no browser warnings.
 **Prefer your own domain?** Point an A record at the server's IP, then set
 `HEZO_DOMAIN_OVERRIDE` (uncomment the line in the snippet above). Caddy provisions a
 certificate for that name instead.
+
+All of this is the Caddy path. On a panel-managed server the panel holds the certificate
+and `HEZO_DOMAIN_OVERRIDE` names the domain it already serves - see
+[Deploying on xCloud](#deploying-on-xcloud).
 
 ## After it's up
 

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -9,7 +9,7 @@ import {
 	generatePasswordSalt,
 	signAuthMessage,
 } from '@hezo/shared';
-import { expect, type Locator, type Page, type Response } from '@playwright/test';
+import { expect, type Locator, type Page, type Response, type Route } from '@playwright/test';
 import { TEST_MNEMONIC, TEST_PASSWORD } from './constants';
 
 // The phrase never goes over the wire: the Node test process derives the same
@@ -724,6 +724,29 @@ export async function clickAndWaitForResponse(
 	return response;
 }
 
+/** Playwright's wording when the page, context or browser closed mid-callback. */
+const ROUTE_TEARDOWN_RE = /Target (?:page, context or browser has been closed|closed)/i;
+
+/**
+ * Run a route callback that rewrites a real upstream response, absorbing the
+ * teardown race but nothing else.
+ *
+ * A request still in flight when the page tears down rejects inside the callback
+ * with `route.fetch: Target page, context or browser has been closed`, failing an
+ * otherwise-passing test. Letting that one through keeps the race out of the
+ * failure report. Every other error - a helper's own "not in the live index"
+ * assertion among them - still propagates, so a genuinely mis-set-up mock is not
+ * silently downgraded into an unmocked request.
+ */
+async function rewriteRoute(route: Route, rewrite: () => Promise<void>): Promise<void> {
+	try {
+		await rewrite();
+	} catch (err) {
+		if (!ROUTE_TEARDOWN_RE.test(err instanceof Error ? err.message : String(err))) throw err;
+		await route.continue().catch(() => {});
+	}
+}
+
 /**
  * Serve a deterministic `/api/projects` index for project-rail layout specs.
  *
@@ -739,25 +762,27 @@ export async function mockRailProjects(
 	page: Page,
 	options: { keepSlug: string; clones: number },
 ): Promise<void> {
-	await page.route('**/api/projects', async (route) => {
-		const res = await route.fetch();
-		const json = (await res.json()) as { data: Array<Record<string, unknown>> };
-		const kept = json.data.filter((p) => p.is_internal === true || p.slug === options.keepSlug);
-		const base = kept.find((p) => p.slug === options.keepSlug);
-		if (!base) {
-			throw new Error(`mockRailProjects: project "${options.keepSlug}" not in the live index`);
-		}
-		const clones = Array.from({ length: options.clones }, (_, i) => ({
-			...base,
-			id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
-			slug: `rail-fill-${i + 1}`,
-			name: `Rail Fill ${i + 1}`,
-		}));
-		await route.fulfill({
-			response: res,
-			body: JSON.stringify({ ...json, data: [...kept, ...clones] }),
-		});
-	});
+	await page.route('**/api/projects', (route) =>
+		rewriteRoute(route, async () => {
+			const res = await route.fetch();
+			const json = (await res.json()) as { data: Array<Record<string, unknown>> };
+			const kept = json.data.filter((p) => p.is_internal === true || p.slug === options.keepSlug);
+			const base = kept.find((p) => p.slug === options.keepSlug);
+			if (!base) {
+				throw new Error(`mockRailProjects: project "${options.keepSlug}" not in the live index`);
+			}
+			const clones = Array.from({ length: options.clones }, (_, i) => ({
+				...base,
+				id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
+				slug: `rail-fill-${i + 1}`,
+				name: `Rail Fill ${i + 1}`,
+			}));
+			await route.fulfill({
+				response: res,
+				body: JSON.stringify({ ...json, data: [...kept, ...clones] }),
+			});
+		}),
+	);
 	await page.route('**/api/projects/rail-fill-*/inbox/count', (route) =>
 		route.fulfill({
 			status: 200,
@@ -782,18 +807,14 @@ export async function mockRailProjects(
  */
 export async function scopeRailToProjects(page: Page, slugs: string[]): Promise<void> {
 	const keep = new Set(slugs);
-	await page.route('**/api/projects', async (route) => {
-		// A request still in flight when the page tears down rejects here; letting
-		// it through keeps that teardown race out of the test's failure report.
-		try {
+	await page.route('**/api/projects', (route) =>
+		rewriteRoute(route, async () => {
 			const res = await route.fetch();
 			const json = (await res.json()) as { data: Array<Record<string, unknown>> };
 			const data = json.data.filter((p) => p.is_internal === true || keep.has(p.slug as string));
 			await route.fulfill({ response: res, body: JSON.stringify({ ...json, data }) });
-		} catch {
-			await route.continue().catch(() => {});
-		}
-	});
+		}),
+	);
 }
 
 /**
@@ -803,28 +824,32 @@ export async function scopeRailToProjects(page: Page, slugs: string[]): Promise<
  * present and the per-team detail fetch still resolves for the original slugs.
  */
 export async function mockMarketplaceCatalog(page: Page, count: number): Promise<void> {
-	await page.route('**/api/marketplace/teams', async (route) => {
-		const res = await route.fetch();
-		const json = (await res.json()) as { data: Array<Record<string, unknown>> };
-		const base = json.data[0];
-		if (!base) throw new Error('mockMarketplaceCatalog: the live catalog is empty');
-		const filler = Array.from({ length: Math.max(0, count - json.data.length) }, (_, i) => ({
-			...base,
-			slug: `catalog-fill-${i + 1}`,
-			name: `Catalog Fill ${i + 1}`,
-		}));
-		await route.fulfill({
-			response: res,
-			body: JSON.stringify({ ...json, data: [...json.data, ...filler] }),
-		});
-	});
+	await page.route('**/api/marketplace/teams', (route) =>
+		rewriteRoute(route, async () => {
+			const res = await route.fetch();
+			const json = (await res.json()) as { data: Array<Record<string, unknown>> };
+			const base = json.data[0];
+			if (!base) throw new Error('mockMarketplaceCatalog: the live catalog is empty');
+			const filler = Array.from({ length: Math.max(0, count - json.data.length) }, (_, i) => ({
+				...base,
+				slug: `catalog-fill-${i + 1}`,
+				name: `Catalog Fill ${i + 1}`,
+			}));
+			await route.fulfill({
+				response: res,
+				body: JSON.stringify({ ...json, data: [...json.data, ...filler] }),
+			});
+		}),
+	);
 	// The clones have no def behind them; serve the real one so opening their detail
 	// renders a roster instead of the fetch-failed state.
-	await page.route('**/api/marketplace/teams/catalog-fill-*', async (route) => {
-		const url = new URL(route.request().url());
-		const real = `${url.origin}/api/marketplace/teams/software-development`;
-		await route.fulfill({ response: await route.fetch({ url: real }) });
-	});
+	await page.route('**/api/marketplace/teams/catalog-fill-*', (route) =>
+		rewriteRoute(route, async () => {
+			const url = new URL(route.request().url());
+			const real = `${url.origin}/api/marketplace/teams/software-development`;
+			await route.fulfill({ response: await route.fetch({ url: real }) });
+		}),
+	);
 }
 
 /**


### PR DESCRIPTION
Adds [xCloud.host](https://xcloud.host/) as a supported hosting target.

## Why it did not work before

xCloud is a server-management control panel, not a managed-container PaaS - you own the Ubuntu VPS and xCloud provisions and manages it. That is the right shape for Hezo (a real VM with a host Docker socket), but xCloud brings its own Nginx, its own UFW rules and its own certificates, and `provision.sh` assumed it owned the host:

| What it would do | Why that breaks an xCloud server |
|---|---|
| Install Caddy on 80/443 | xCloud's Nginx is already there; two services fighting for the ports |
| `ufw --force reset` | Deletes the firewall rules xCloud manages from its dashboard |
| Derive `<public-ip>.sslip.io` | xCloud owns the domain and holds the certificate for it |

## The two modes

`deploy/provision.sh` gains two variables. Both default to today's behaviour, so cloud-init, AWS, GCP and the DigitalOcean image are unchanged.

| Variable | Values | Default | `none` means |
|---|---|---|---|
| `HEZO_PROXY` | `caddy` \| `none` | `caddy` | Install no Caddy, derive no sslip.io address, and require `HEZO_DOMAIN_OVERRIDE` as the sole source of `HEZO_WEB_URL` |
| `HEZO_FIREWALL` | `ufw` \| `none` | `ufw` | Leave the host's rules completely untouched |

They are **declared by the operator, never sniffed** - nothing detects an installed nginx and quietly changes course, per `AGENTS.md` § One mechanism, no silent fallbacks. Bad values, and `HEZO_PROXY=none` with no domain, refuse before the script mutates anything.

Both are persisted into `/etc/hezo/deploy.env`, so a later bare re-run on a panel-managed host cannot regress into installing Caddy and resetting the firewall. An explicit variable still wins, so switching modes stays possible.

Sections skipped under the new modes: 5 (Caddy), the URL-derivation half of 6 (first boot), 9 (firewall), and the Caddy half of 10 (enable/start). Swap, Docker, the binary, the env file, `hezo.service` and the needrestart exemption run identically in every mode.

## `docs/deployment/cloud.md` was incomplete

The nginx snippet there was missing three directives whose nginx defaults work against Hezo, and the xCloud path depends on it being right:

- **`proxy_http_version 1.1`** - nginx proxies with HTTP/1.0 by default, so a WebSocket upgrade cannot be negotiated at all. The `Upgrade`/`Connection` headers alone do not give you a live activity stream.
- **`proxy_read_timeout`** - the 60s default cuts an idle stream about once a minute.
- **`client_max_body_size`** - the 1 MB default rejects Hezo's 10 MB task attachments (`ATTACHMENT_MAX_BYTES`) at the proxy, before Hezo sees the upload.

## The listing

`deploy/xcloud/README.md` carries the operator runbook and the catalogue-outreach runbook. Being straight about what is and is not possible: xCloud's one-click catalogue is **curated internally**, with no submission process, template spec, intake form, or URL-based deploy button. `oneclick` is a read-only site-type filter in their API; neither their CLI nor their agent skills have an app-authoring surface. So the listing is outreach to `support@xcloud.host` only - the same split this repo already lives with for the DigitalOcean Marketplace, where the artifact is in-repo and the publication is external.

The README records the two questions that decide feasibility (must a catalogue entry be Docker Compose shaped? is there a spec to PR?) and says plainly that "Compose only" would mean publishing a Hezo **server** image, which does not exist today and is a project rather than a follow-up commit.

## Verification

**Done here:** `bash -n`; the mode-resolution and persistence logic exercised directly, covering defaults, xCloud mode, a bare re-run staying in `none`/`none`, and all three refusal paths (bad `HEZO_PROXY`, bad `HEZO_FIREWALL`, `none` without a domain). `docs-terminology`, `docs-links` and `docs-bundle` pass; the full pre-commit chain (biome, typecheck, build, all four ack hooks, link check, prompt style) passes.

**Not done here, and the plan is in `deploy/xcloud/README.md` § Verify it:** `provision.sh` has no test tier, so the mode matrix wants a throwaway VM (nginx and some ufw rules pre-installed, then assert Caddy absent, `/etc/caddy` never created, `ufw status numbered` byte-identical), plus an end-to-end pass on a real xCloud trial account. The single highest-risk unknown is whether xCloud's generated proxy block passes the WebSocket upgrade and `X-Forwarded-Proto`; the README carries a `curl` probe for the first (`101 Switching Protocols` or it is missing `proxy_http_version 1.1`) and an OAuth-connect check for the second, which is invisible until a connect fails on a page that looks perfectly fine over TLS.

One security note worth a reviewer's eye: under `HEZO_FIREWALL=none`, Hezo binds `0.0.0.0:3100` and has no bind-host setting, so keeping that port off the internet becomes the panel's job. That is stated in the script header, `deploy/README.md`, the docs section and the xCloud README, and the verification checklist opens with a from-another-machine probe of port 3100.

## Deliberately out of scope

- A Hezo **server** Docker image for xCloud's Custom Docker path (new distribution artifact, disables in-app update inside a container, no managed-volume story on xCloud).
- Removing the now-vestigial `ufw allow in on docker0` rule from the default path. `docs/deployment/self-hosting.md` § Agent containers do not connect back to the host says it is no longer needed, and `deploy/README.md` and `.dev/hosted-architecture.md` still repeat the old claim - worth a separate commit, since it changes behaviour for the four existing wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01117qSii3h6zAiCBGqmDGpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01117qSii3h6zAiCBGqmDGpo)_