### PR TITLE
feat(tasks): make the progress summary agent-owned and read-only for humans

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -176,7 +176,12 @@ place a genuine per-repo write restriction is represented.
 
 **Tasks & threads.** `tasks` are Linear-style tickets with a frozen `identifier`
 (`<task_prefix>-<n>`, e.g. `IN-42`), a required `assignee_id → members.id`, `rules`, and
-an agent-maintained `progress_summary`. Numbering is atomic via `project_task_counters`.
+an agent-maintained `progress_summary`. `progress_summary` is agent-only on the write side:
+`PATCH /api/projects/:projectId/tasks/:taskId` 403s a non-agent caller carrying the field,
+and the web task view renders that card read-only. It is the agent's own account of its
+work, handed back to the next run in full, so a human rewrite would silently change what
+that run believes it did; humans redirect through a comment or `rules` instead.
+Numbering is atomic via `project_task_counters`.
 `task_dependencies` is the many-to-many blocking graph (`UNIQUE`, no self-blocks).
 `task_comments` is **polymorphic** over a `content_type` enum + `content` JSONB — `text`,
 `system` (timeline entries like `status_change`/`title_change`/`description_change`/`task_link`),

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -46,7 +46,7 @@ cached to go stale. Context reaches the agent in one of two ways:
 | Memory | Scope | How it reaches the agent | Kept current by |
 |---|---|---|---|
 | Rules | One task | In full, every run | You and agents |
-| Progress summary | One task | In full, every run | You and agents |
+| Progress summary | One task | In full, every run | Agents |
 | Comment thread | One task | Read by the agent at the start of a run | You and agents |
 | Project documents | One project | Manifest, full text on demand | You and agents |
 | Skills | Global or one project | Manifest, full text on demand | You and agents |

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -21,17 +21,19 @@ cleanly between runs and between agents.
   when you want agents to follow specific guidelines on a task - they're the right place
   for non-negotiables.
 - **Progress summary** - *where things stand*: a living checkpoint of what's been done
-  and what's left. Agents keep it up to date as they work, and you can edit it too. It
-  lets an agent returning to a task continue without re-reading the whole thread.
+  and what's left. It lets an agent returning to a task continue without re-reading the
+  whole thread. Agents own it: they write it as they work, and it is read-only for you -
+  it should say what the agent believes about its own work, not what you wish were true.
+  To change course, say so in a comment or in the rules.
 
 All three travel with the task as its **long-term memory**: at the start of every run the
 agent is handed the description, the rules, and the latest progress summary **in full**, so
 work carries cleanly from one run to the next even when a different agent picks the task
-up. You can edit the title, the description, the rules, and the summary yourself from the
-task view at any time, and so can the agents. Click the pencil next to the title to rename
-a task in place, or Edit on the Description card to write or rewrite its body; every one of
-those edits is recorded on the task's comment thread, so it is always clear what changed
-and who changed it. See [Documents & long-term memory](/docs/concepts/documents-and-memory)
+up. You can edit the title, the description, and the rules yourself from the task view at
+any time, and so can the agents; the progress summary is the one an agent writes and you
+read. Click the pencil next to the title to rename a task in place, or Edit on the
+Description card to write or rewrite its body; every one of those edits is recorded on the
+task's comment thread, so it is always clear what changed and who changed it. See [Documents & long-term memory](/docs/concepts/documents-and-memory)
 for how this fits the wider memory model.
 
 ## Comments and mentions

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -514,6 +514,19 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 	const scopeDenied = assertRunTaskScope(auth, taskId, body.status);
 	if (scopeDenied) return err(c, 'FORBIDDEN', scopeDenied, 403);
 
+	// The progress summary is the agent's own running checkpoint, written from
+	// inside a run via `update_task` and handed back to the next run in full. A
+	// human rewriting it silently changes what that run believes about its own
+	// work, so it is agent-only here; humans say what they want in a comment.
+	if (body.progress_summary !== undefined && auth.type !== AuthType.Agent) {
+		return err(
+			c,
+			'FORBIDDEN',
+			'The progress summary is maintained by agents and cannot be edited by hand',
+			403,
+		);
+	}
+
 	// `done` and `cancelled` are now the only terminal states; once a task is
 	// terminal only the admin can move it back to an active status (re-open).
 	if (
@@ -650,9 +663,9 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 		params.push(body.progress_summary);
 		idx++;
 		sets.push('progress_summary_updated_at = now()');
-		const updatedBy = auth.type === AuthType.Agent ? auth.memberId : null;
+		// Only an agent reaches here — the guard above rejects every other caller.
 		sets.push(`progress_summary_updated_by = $${idx}`);
-		params.push(updatedBy);
+		params.push(auth.type === AuthType.Agent ? auth.memberId : null);
 		idx++;
 	}
 	if (body.rules !== undefined) {

--- a/packages/server/test/agent-autonomy.test.ts
+++ b/packages/server/test/agent-autonomy.test.ts
@@ -1,6 +1,12 @@
 import { ApprovalType, TaskStatus } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { authHeader, createTestProject, createTestTeam, instanceCoachId } from './helpers/app';
+import {
+	authHeader,
+	createTestProject,
+	createTestTeam,
+	instanceCoachId,
+	mintAgentToken,
+} from './helpers/app';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
 
 let ctx: ServerTestContext;
@@ -169,7 +175,7 @@ describe('task automation: Coach wakeup on Done', () => {
 });
 
 describe('task: progress_summary and rules', () => {
-	it('can update progress_summary with tracking fields', async () => {
+	it('an agent can update progress_summary, and the write is attributed to it', async () => {
 		const createRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks`, {
 			method: 'POST',
 			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
@@ -181,15 +187,71 @@ describe('task: progress_summary and rules', () => {
 		});
 		const taskId = ((await createRes.json()) as any).data.id;
 
+		const { token: agentToken } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			engineerAgentId,
+			teamId,
+			taskId,
+		);
 		const patchRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
 			method: 'PATCH',
-			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ progress_summary: 'Completed API endpoints, working on tests' }),
 		});
 		expect(patchRes.status).toBe(200);
 		const updated = ((await patchRes.json()) as any).data;
 		expect(updated.progress_summary).toBe('Completed API endpoints, working on tests');
 		expect(updated.progress_summary_updated_at).toBeTruthy();
+		expect(updated.progress_summary_updated_by).toBe(engineerAgentId);
+	});
+
+	it('rejects a human writing progress_summary, leaving what the agent wrote intact', async () => {
+		const createRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Progress guard test',
+				assignee_id: engineerAgentId,
+			}),
+		});
+		const taskId = ((await createRes.json()) as any).data.id;
+
+		const { token: agentToken } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			engineerAgentId,
+			teamId,
+			taskId,
+		);
+		await ctx.app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ progress_summary: 'Agent checkpoint' }),
+		});
+
+		const patchRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ progress_summary: 'Human rewrite' }),
+		});
+		expect(patchRes.status).toBe(403);
+
+		// Rejected whole: a title alongside it does not slip through either.
+		const mixedRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Renamed', progress_summary: 'Human rewrite' }),
+		});
+		expect(mixedRes.status).toBe(403);
+
+		const row = await ctx.db.query<{ progress_summary: string; title: string }>(
+			'SELECT progress_summary, title FROM tasks WHERE id = $1',
+			[taskId],
+		);
+		expect(row.rows[0].progress_summary).toBe('Agent checkpoint');
+		expect(row.rows[0].title).toBe('Progress guard test');
 	});
 
 	it('can update rules', async () => {

--- a/packages/server/test/tasks-routes-uncovered.test.ts
+++ b/packages/server/test/tasks-routes-uncovered.test.ts
@@ -397,6 +397,8 @@ describe('GET /tasks/:taskId + resolve + latest-run', () => {
 });
 
 describe('PATCH /tasks/:taskId — field matrix', () => {
+	// `progress_summary` is absent here deliberately: it is agent-only, covered by
+	// the two tests below.
 	it('updates every writable field in one request', async () => {
 		const task = await createTask('Full patch target');
 		const res = await patchTask(task.id, {
@@ -405,7 +407,6 @@ describe('PATCH /tasks/:taskId — field matrix', () => {
 			status: 'in_progress',
 			priority: 'urgent',
 			labels: ['a', 'b'],
-			progress_summary: 'halfway there',
 			rules: 'be nice',
 			branch_name: 'feat/full-patch',
 			runtime_type: 'codex',
@@ -417,13 +418,22 @@ describe('PATCH /tasks/:taskId — field matrix', () => {
 		expect(data.status).toBe('in_progress');
 		expect(data.priority).toBe('urgent');
 		expect(data.labels).toEqual(['a', 'b']);
-		expect(data.progress_summary).toBe('halfway there');
 		expect(data.rules).toBe('be nice');
 		expect(data.branch_name).toBe('feat/full-patch');
 		expect(data.runtime_type).toBe('codex');
-		// Admin-set progress summary attributes to no member.
-		expect(data.progress_summary_updated_by).toBeNull();
-		expect(data.progress_summary_updated_at).not.toBeNull();
+	});
+
+	it('403s an admin-set progress_summary and writes nothing', async () => {
+		const task = await createTask('Human summary target');
+		const res = await patchTask(task.id, { progress_summary: 'admin wrote this' });
+		expect(res.status).toBe(403);
+		expect((await res.json()).error.message).toMatch(/maintained by agents/);
+		const row = await db.query<{ progress_summary: string | null; updated: string | null }>(
+			'SELECT progress_summary, progress_summary_updated_at AS updated FROM tasks WHERE id = $1',
+			[task.id],
+		);
+		expect(row.rows[0].progress_summary).toBeNull();
+		expect(row.rows[0].updated).toBeNull();
 	});
 
 	it('attributes an agent-set progress_summary to the agent', async () => {

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -362,9 +362,17 @@ describe('tasks CRUD', () => {
 
 		const summary =
 			'## Requirements\n- Build auth module\n\n## Done\n- Set up project\n\n## Next\n- Implement login';
+		// Agent-only field, so the write goes through a run-scoped token.
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			task.id,
+		);
 		const patchRes = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
 			method: 'PATCH',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ progress_summary: summary }),
 		});
 		expect(patchRes.status).toBe(200);
@@ -388,17 +396,25 @@ describe('tasks CRUD', () => {
 		});
 		const task = (await listRes.json()).data[0];
 
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			task.id,
+		);
+
 		// Set it first
 		await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
 			method: 'PATCH',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ progress_summary: 'Some summary' }),
 		});
 
 		// Clear it
 		const clearRes = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
 			method: 'PATCH',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ progress_summary: null }),
 		});
 		expect(clearRes.status).toBe(200);

--- a/packages/web/src/components/task-detail/task-summary.tsx
+++ b/packages/web/src/components/task-detail/task-summary.tsx
@@ -21,21 +21,25 @@ interface CollapsibleSummaryCardProps {
 	infoLabel: string;
 	infoTestId: string;
 	infoContent: string;
-	editorAriaLabel: string;
-	editorPlaceholder?: string;
 	value: string | null | undefined;
 	emptyText: string;
 	className: string;
 	projectId: string;
 	taskProjectSlug: string;
-	onSave: (value: string | null) => void;
+	/** Omit to render the card read-only: no Edit affordance and no editor. */
+	edit?: {
+		ariaLabel: string;
+		placeholder?: string;
+		onSave: (value: string | null) => void;
+	};
 }
 
 /**
  * One collapsible progress-summary/rules card. Collapsed by default — the
- * header (chevron toggle, label, info icon, Edit) stays visible while the body
- * hides. Clicking Edit auto-expands and enters edit mode, and the card stays
- * expanded after saving so the freshly-saved content is visible.
+ * header (chevron toggle, label, info icon, and Edit where the card is
+ * editable) stays visible while the body hides. Clicking Edit auto-expands and
+ * enters edit mode, and the card stays expanded after saving so the
+ * freshly-saved content is visible.
  */
 function CollapsibleSummaryCard({
 	testId,
@@ -44,14 +48,12 @@ function CollapsibleSummaryCard({
 	infoLabel,
 	infoTestId,
 	infoContent,
-	editorAriaLabel,
-	editorPlaceholder,
 	value,
 	emptyText,
 	className,
 	projectId,
 	taskProjectSlug,
-	onSave,
+	edit,
 }: CollapsibleSummaryCardProps) {
 	const [open, setOpen] = useState(false);
 	const [editing, setEditing] = useState(false);
@@ -76,7 +78,7 @@ function CollapsibleSummaryCard({
 					</button>
 					<InfoTooltip label={infoLabel} data-testid={infoTestId} content={infoContent} />
 				</div>
-				{!editing && (
+				{edit && !editing && (
 					<button
 						type="button"
 						onClick={() => {
@@ -91,14 +93,14 @@ function CollapsibleSummaryCard({
 			</div>
 			{open && (
 				<div className="mt-2">
-					{editing ? (
+					{edit && editing ? (
 						<MarkdownFieldEditor
-							ariaLabel={editorAriaLabel}
+							ariaLabel={edit.ariaLabel}
 							projectId={projectId}
 							projectSlug={taskProjectSlug}
 							value={value}
-							placeholder={editorPlaceholder}
-							onSave={onSave}
+							placeholder={edit.placeholder}
+							onSave={edit.onSave}
 							onClose={() => setEditing(false)}
 						/>
 					) : value ? (
@@ -116,9 +118,9 @@ function CollapsibleSummaryCard({
 
 /**
  * Renders the progress-summary and rules cards just below the task header.
- * Both are collapsible (collapsed by default) and edit inline against
- * `useUpdateTask`. Status changes do not run through here — `progress_summary`
- * and `rules` are plain text fields.
+ * Both are collapsible (collapsed by default). Rules edits inline against
+ * `useUpdateTask`; the progress summary is read-only here — agents own it and
+ * write it from inside a run, and the REST route rejects a human write.
  */
 export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: TaskSummaryProps) {
 	return (
@@ -129,14 +131,12 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				label="Progress Summary"
 				infoLabel="About Progress Summary"
 				infoTestId="progress-summary-info"
-				infoContent="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt - alongside the description and rules - so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
-				editorAriaLabel="Progress Summary"
+				infoContent="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt - alongside the description and rules - so work stays continuous across runs. Agents own it and update it at natural milestones via the update_task tool, so it is not editable by hand."
 				value={task.progress_summary}
 				emptyText="No progress summary yet."
 				className="bg-surface-2 rounded-md p-3 mb-3 text-[13px] text-text-2 leading-relaxed"
 				projectId={projectId}
 				taskProjectSlug={taskProjectSlug}
-				onSave={(v) => updateTask.mutate({ progress_summary: v })}
 			/>
 
 			<CollapsibleSummaryCard
@@ -146,14 +146,16 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				infoLabel="About Rules"
 				infoTestId="rules-info"
 				infoContent="Approach constraints and required workflows for this task - e.g. 'run the full suite before pushing' or 'consult the architect before touching auth'. Automatically prepended to every agent run's task prompt. Agents can update via the update_task tool as they discover new rules."
-				editorAriaLabel="Rules"
-				editorPlaceholder="e.g., Consult the architect before making changes..."
 				value={task.rules}
 				emptyText="No rules set."
 				className="bg-surface-2 rounded-md p-3 mb-5 text-[13px] text-text-2 leading-relaxed border-l-2 border-info"
 				projectId={projectId}
 				taskProjectSlug={taskProjectSlug}
-				onSave={(v) => updateTask.mutate({ rules: v })}
+				edit={{
+					ariaLabel: 'Rules',
+					placeholder: 'e.g., Consult the architect before making changes...',
+					onSave: (v) => updateTask.mutate({ rules: v }),
+				}}
 			/>
 		</>
 	);

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -200,7 +200,7 @@ interface UpdateTaskVars {
 	priority?: string;
 	assignee_id?: string | null;
 	labels?: string[];
-	progress_summary?: string | null;
+	// No `progress_summary`: agents own it, and the REST route rejects a human write.
 	rules?: string | null;
 	/** A task identifier or UUID to nest under; null promotes to top level. */
 	parent_task_id?: string | null;

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -115,6 +115,22 @@ export async function seedTask(
 	return task;
 }
 
+/**
+ * Set a task's agent-maintained progress summary directly. Agents write it from
+ * inside a run via `update_task`; the REST route rejects a human write, so there
+ * is no API path a test can use.
+ */
+export async function seedTaskProgress(task: SeededTask, summary: string): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`UPDATE tasks
+		 SET progress_summary = $1,
+		     progress_summary_updated_at = now()
+		 WHERE id = $2`,
+		[summary, task.id],
+	);
+}
+
 export interface SeededGoal {
 	id: string;
 	title: string;

--- a/packages/web/test/task-crud.test.tsx
+++ b/packages/web/test/task-crud.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
-import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+import { seedProject, seedTask, seedTaskProgress, seedWorkspace } from './helpers/seed';
 import { expandEventGroups } from './helpers/thread';
 
 async function lockTask(
@@ -136,7 +136,7 @@ test('task detail lists every agent running concurrently on a task', async () =>
 	expect(section.textContent).toContain(seeded.secondTitle);
 });
 
-test('can edit task rules and progress summary', async () => {
+test('can edit task rules', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 	const { findByTestId, findByText, router, user } = await renderApp({
 		initialPath: '/',
@@ -167,30 +167,52 @@ test('can edit task rules and progress summary', async () => {
 	)!;
 	await user.click(rulesSaveBtn);
 	await findByText('Consult architect before changes');
+});
+
+test('the progress summary card is read-only - it reads, with no way to edit it', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Summary Project' });
+			const task = await seedTask(ws, project, { title: 'Summary Test Task' });
+			await seedTaskProgress(task, 'Implementation started');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
 
 	const summarySection = await findByTestId('pinned-progress-summary');
-	const summaryEditBtn = Array.from(summarySection.querySelectorAll('button')).find(
-		(b) => b.textContent === 'Edit',
-	)!;
-	await user.click(summaryEditBtn);
+	expect(
+		Array.from(summarySection.querySelectorAll('button')).some((b) => b.textContent === 'Edit'),
+	).toBe(false);
 
-	const summaryTextarea = summarySection.querySelector('textarea') as HTMLTextAreaElement;
-	await user.type(summaryTextarea, 'Implementation started');
-	const summarySaveBtn = Array.from(summarySection.querySelectorAll('button')).find(
-		(b) => b.textContent === 'Save',
-	)!;
-	await user.click(summarySaveBtn);
-	await findByText('Implementation started');
+	// Expanding shows what the agent wrote, and still offers no editor.
+	await user.click(await findByTestId('progress-summary-toggle'));
+	const expanded = await findByTestId('pinned-progress-summary');
+	expect(expanded.textContent).toContain('Implementation started');
+	expect(expanded.querySelector('textarea')).toBe(null);
+	expect(
+		Array.from(expanded.querySelectorAll('button')).some((b) => b.textContent === 'Edit'),
+	).toBe(false);
 });
 
 test('task rules and progress summary render markdown formatting', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
+	const summaryBody = '1. Scaffolded routes\n2. Wired up DB\n3. Added tests';
 	const { findByTestId, router, user } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
 			const project = await seedProject(ws, { name: 'Markdown Project' });
 			const task = await seedTask(ws, project, { title: 'Markdown Task' });
+			await seedTaskProgress(task, summaryBody);
 			seeded.projectSlug = project.slug;
 			seeded.taskId = task.identifier.toLowerCase();
 		},
@@ -203,7 +225,6 @@ test('task rules and progress summary render markdown formatting', async () => {
 
 	const rulesBody =
 		'Use **bold** guidance.\n\n- first bullet\n- second bullet\n\nRun `bun test` before merge.';
-	const summaryBody = '1. Scaffolded routes\n2. Wired up DB\n3. Added tests';
 
 	const pinnedRules = await findByTestId('pinned-rules');
 	const rulesEditBtn = Array.from(pinnedRules.querySelectorAll('button')).find(
@@ -228,18 +249,8 @@ test('task rules and progress summary render markdown formatting', async () => {
 	expect(Array.from(liEls).some((li) => li.textContent === 'first bullet')).toBe(true);
 	expect(Array.from(liEls).some((li) => li.textContent === 'second bullet')).toBe(true);
 
-	const pinnedSummary = await findByTestId('pinned-progress-summary');
-	const summaryEditBtn = Array.from(pinnedSummary.querySelectorAll('button')).find(
-		(b) => b.textContent === 'Edit',
-	)!;
-	await user.click(summaryEditBtn);
-	const summaryTa = pinnedSummary.querySelector('textarea') as HTMLTextAreaElement;
-	await user.type(summaryTa, summaryBody);
-	const summarySaveBtn = Array.from(pinnedSummary.querySelectorAll('button')).find(
-		(b) => b.textContent === 'Save',
-	)!;
-	await user.click(summarySaveBtn);
-
+	// The summary is agent-written, so it is seeded rather than typed in.
+	await user.click(await findByTestId('progress-summary-toggle'));
 	await new Promise((r) => setTimeout(r, 100));
 	const refreshedSummary = await findByTestId('pinned-progress-summary');
 	const olLis = refreshedSummary.querySelectorAll('ol li');

--- a/packages/web/test/task-detail.test.tsx
+++ b/packages/web/test/task-detail.test.tsx
@@ -287,10 +287,11 @@ test('Progress Summary and Rules cards expose info icons with help text', async 
 
 	const progressCard = await findByTestId('pinned-progress-summary');
 	expect(progressCard.textContent).toContain('Progress Summary');
+	// Agent-owned: the card reads, so it carries no Edit affordance.
 	const progressEdit = Array.from(progressCard.querySelectorAll('button')).find(
 		(b) => b.textContent === 'Edit',
 	);
-	expect(progressEdit).toBeTruthy();
+	expect(progressEdit).toBeUndefined();
 
 	const rulesCard = await findByTestId('pinned-rules');
 	expect(rulesCard.textContent).toContain('Rules');


### PR DESCRIPTION
The task **Progress Summary** card offered an `Edit` button, so a human could rewrite it. It is the agent's own running account of its work, handed back to the next run in full alongside the description and rules - a human rewrite silently changes what that run believes it did. This makes the field agent-only on the write side.

## Changes

**Server** (`packages/server/src/routes/tasks.ts`)
- `PATCH /api/projects/:projectId/tasks/:taskId` returns 403 when a non-agent caller carries `progress_summary`. The whole request is rejected rather than the field being silently dropped, so a mixed patch (`title` + `progress_summary`) writes nothing.
- Only an agent now reaches the write, so `progress_summary_updated_by` is always the agent's member id.

**Web** (`packages/web/src/`)
- `CollapsibleSummaryCard` takes its edit affordance as an optional `edit` prop. The Progress Summary card omits it - it keeps the collapse toggle and the info tooltip, and renders no `Edit` button and no editor, expanded or not. Rules is unchanged and still edits inline.
- The info tooltip now says agents own the field and it is not editable by hand.
- `progress_summary` is off `UpdateTaskVars`, so sending it from the UI is a compile error.

## Tests

- `tasks-routes-uncovered.test.ts`: a new case asserts the admin patch 403s and leaves both `progress_summary` and `progress_summary_updated_at` null; `progress_summary` is out of the "every writable field" matrix (the agent-attribution case beside it covers the write).
- `agent-autonomy.test.ts`: the agent write now runs through a run-scoped token and asserts attribution; a new case covers the human rejection, the mixed-field rejection, and that the agent's text survives.
- `tasks.test.ts`: the two progress-summary writes switch to an agent token.
- `task-crud.test.tsx`: a new component test asserts the card has no `Edit` button and no textarea, collapsed or expanded, while still rendering what the agent wrote; the rules test and the markdown test are split accordingly, with a new `seedTaskProgress` helper (there is no API path a human test can use any more).
- `task-detail.test.tsx`: the info-icon test now expects no Edit button on the progress card.

Full `bun run typecheck`, biome, all 16 server `task*` test files, the two web component files and the docs guards pass locally.

## Docs

- `docs/concepts/tasks.md` - the progress summary is agent-owned and read-only for you; it is dropped from the list of fields you can edit, with a pointer to comments/rules for redirecting an agent.
- `docs/concepts/documents-and-memory.md` - the memory table's "Kept current by" cell reads **Agents**.
- `.dev/architecture.md` § Tasks & threads - records the agent-only write rule and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxH8xjJNJKSQ6EMgxsZXPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxH8xjJNJKSQ6EMgxsZXPF)_