### PR TITLE
fix(runs): resolve Codex tool calls in the run log instead of leaving them pending

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2431,6 +2431,29 @@ because that branch coalesces consecutive lines into one markdown document, wher
 newline is a softbreak - so every runner line used to render as a clause appended to whatever
 the agent had last said.
 
+**A tool call and its result are paired by ORDER, not by id.** The persisted log is
+line-based text, so the structure the Formatted view renders is re-derived client-side:
+`parse-agent-log.ts` opens a `[tool]` line as a `pending` block and only flips it to
+success/error when a `[tool-result]`/`[tool-error]` line arrives, shifting a FIFO queue of
+pending calls. Claude Code's `tool_use_id` is on the wire but is deliberately not carried
+into the log - Claude emits N parallel calls then their N results in the same order, so
+order is sufficient. **The obligation that buys is on the parser: every `[tool]` line a
+runtime emits must be followed by its result line, and a runtime that learns a call's
+outcome in the same event emits both from that event.** A call left without one does not
+merely render pending forever - it stays queued and swallows the *next* call's result, so
+every tool after it reports somebody else's outcome. This is what the Codex `mcp_tool_call`
+branch got wrong: it rendered the call and dropped the `status`/`result`/`error` the item
+carried alongside it. A `command_execution` with no command string is dropped whole for the
+same reason - its result would have no call to belong to.
+
+**Only Claude Code reports a tool count.** Its `system`/`init` event lists the tools, so its
+session line carries `tools=N`. Codex's `thread.started` carries only a thread id and
+Gemini's `init` names no count, so their session lines omit the token entirely and the
+viewer hides the count rather than printing a zero nobody measured. Codex names no model
+anywhere in its stream either, so - exactly as for OpenCode - `createAgentStreamParser`
+seeds its parser with the run's own model as a pricing floor, without which every Codex run
+priced at $0. A model named on the stream still wins.
+
 The exec transport itself
 **retains nothing**: `execStart` with an `onChunk` callback forwards each frame and returns
 an empty `ExecResult`, because a run's raw stream-json output (every tool result in full)

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -113,8 +113,10 @@ export function createAgentStreamParser(
 	switch (runtime) {
 		case AgentRuntime.ClaudeCode:
 			return createClaudeCodeParser(price);
+		// Codex names no model in its stream (see `createCodexParser`), so like
+		// OpenCode it depends on the run's own model to price at all.
 		case AgentRuntime.Codex:
-			return createCodexParser(price);
+			return createCodexParser(price, runModel?.trim() || undefined);
 		case AgentRuntime.Gemini:
 			return createGeminiParser(price);
 		// OpenCode (`run --format json`) emits JSONL but with shapes that vary
@@ -275,7 +277,7 @@ export function createAgentChatParser(
 		case AgentRuntime.ClaudeCode:
 			return createClaudeChatParser(price);
 		case AgentRuntime.Codex:
-			return createCodexChatParser(price);
+			return createCodexChatParser(price, runModel?.trim() || undefined);
 		case AgentRuntime.Gemini:
 			return createGeminiChatParser(price);
 		case AgentRuntime.OpenCode:
@@ -335,14 +337,14 @@ function createClaudeChatParser(price: PriceModelFn): AgentChatParser {
 	return { onStdout: reader.onStdout, flush: reader.flush, getUsage: () => usage };
 }
 
-function createCodexChatParser(price: PriceModelFn): AgentChatParser {
+function createCodexChatParser(price: PriceModelFn, runModel?: string): AgentChatParser {
 	let usage: AgentRunUsage | null = null;
-	let modelId: string | undefined;
+	let modelId: string | undefined = runModel;
 	const render = (raw: unknown): AgentChatTurnEvent[] => {
 		const event = raw as CodexEvent;
 		const type = event.type ?? '';
 		if (type === 'thread.started') {
-			modelId = event.model ?? undefined;
+			if (event.model) modelId = event.model;
 			return [];
 		}
 		if (type === 'turn.completed' || type === 'turn.failed') {
@@ -370,7 +372,7 @@ function createCodexChatParser(price: PriceModelFn): AgentChatParser {
 			}
 			if (kind === 'command_execution') return [{ toolActivity: 'shell' }];
 			if (kind === 'mcp_tool_call' || kind === 'tool_call') {
-				return [{ toolActivity: item.name ?? 'tool' }];
+				return [{ toolActivity: item.tool ?? item.name ?? 'tool' }];
 			}
 		}
 		return [];
@@ -727,6 +729,16 @@ interface CodexUsage {
 	reasoning_output_tokens?: number;
 }
 
+/**
+ * One `item.completed` payload. Codex flattens the item's variant into the object,
+ * so `type` is the discriminant and the rest are that variant's own fields.
+ *
+ * An MCP tool call names its tool with `server` + `tool`, NOT `name` - there is no
+ * `name` field on that variant at all, so the `name` fallback below is only ever
+ * reached by the older `tool_call` spelling. It carries its own outcome too
+ * (`status`, `result`, `error`), which is what lets the call and its result be
+ * rendered from the same event.
+ */
 interface CodexItem {
 	type?: string;
 	item_type?: string;
@@ -737,8 +749,14 @@ interface CodexItem {
 	output?: string;
 	exit_code?: number;
 	name?: string;
+	server?: string;
+	tool?: string;
+	/** `in_progress` | `completed` | `failed`. */
+	status?: string;
 	arguments?: unknown;
 	args?: unknown;
+	result?: { content?: unknown; structured_content?: unknown } | null;
+	error?: { message?: string } | string | null;
 }
 
 interface CodexEvent {
@@ -750,19 +768,28 @@ interface CodexEvent {
 	error?: { message?: string } | string;
 }
 
-function createCodexParser(price: PriceModelFn): AgentStreamParser {
+/**
+ * @param runModel the model the run was launched with. Codex's `thread.started`
+ *   carries only a thread id - it names no model anywhere in the stream - so
+ *   without this every Codex run priced at $0. A model named in the stream still
+ *   wins; this is the floor, not an override.
+ */
+function createCodexParser(price: PriceModelFn, runModel?: string): AgentStreamParser {
 	let usage: AgentRunUsage | null = null;
 	let turns = 0;
-	let modelId: string | undefined;
+	let modelId: string | undefined = runModel;
 	let finalMessage: string | null = null;
 
 	const renderEvent = (raw: unknown): string[] => {
 		const event = raw as CodexEvent;
 		const type = event.type ?? '';
 
+		// No `tools=` here: Codex never reports how many tools it was given, and a
+		// hardcoded zero renders as a confident "0 tools" in the log header. Omitting
+		// the token makes the client drop the count rather than print a wrong one.
 		if (type === 'thread.started') {
-			modelId = event.model ?? undefined;
-			return [`[session] model=${modelId ?? 'codex'} tools=0`];
+			if (event.model) modelId = event.model;
+			return [`[session] model=${modelId ?? 'codex'}`];
 		}
 
 		// A turn wraps one user→assistant exchange (tool calls included), so a
@@ -828,22 +855,39 @@ function renderCodexItem(item: CodexItem): string[] {
 	}
 
 	if (kind === 'command_execution') {
-		const out: string[] = [];
 		const cmd = (item.command ?? '').replace(/\s+/g, ' ').trim();
-		if (cmd) out.push(`[tool] shell(${cmd})`);
+		// No command means no `[tool]` line to own a result, and an orphan result line
+		// would be paired with somebody else's call. Drop the item instead.
+		if (!cmd) return [];
 		const output = (item.aggregated_output ?? item.output ?? '').replace(/\s+/g, ' ').trim();
-		if (output) {
-			const isError = typeof item.exit_code === 'number' && item.exit_code !== 0;
-			out.push(`${isError ? '[tool-error]' : '[tool-result]'} ${output}`);
-		}
-		return out;
+		const isError =
+			item.status === 'failed' || (typeof item.exit_code === 'number' && item.exit_code !== 0);
+		return [`[tool] shell(${cmd})`, labelledResult(isError, output)];
 	}
 
 	if (kind === 'mcp_tool_call' || kind === 'tool_call') {
-		return [formatToolUse(item.name ?? 'tool', item.arguments ?? item.args)];
+		const failed = item.status === 'failed' || item.error != null;
+		const body = failed
+			? extractErrorMessage(item.error ?? undefined)
+			: extractToolResultText(item.result?.content);
+		return [
+			formatToolUse(codexToolName(item), item.arguments ?? item.args),
+			labelledResult(failed, body.replace(/\s+/g, ' ').trim()),
+		];
 	}
 
 	return [];
+}
+
+/**
+ * Name an MCP tool call the way Claude Code names one, so the client renders both
+ * through the same `mcp__<server>__<tool>` display. Codex splits the two halves
+ * across `server` and `tool`; the `name` fallback serves the older `tool_call`
+ * spelling, which carries neither.
+ */
+function codexToolName(item: CodexItem): string {
+	if (item.server && item.tool) return `mcp__${item.server}__${item.tool}`;
+	return item.tool ?? item.name ?? 'tool';
 }
 
 // ---------------------------------------------------------------------------
@@ -963,7 +1007,8 @@ function createGeminiParser(price: PriceModelFn): AgentStreamParser {
 		flushText(out);
 
 		if (type === 'init') {
-			out.push(`[session] model=${event.model ?? 'gemini'} tools=0`);
+			// As with Codex, no `tools=`: the count was never reported, so don't invent one.
+			out.push(`[session] model=${event.model ?? 'gemini'}`);
 			return out;
 		}
 
@@ -1790,11 +1835,21 @@ function stringifyArg(value: unknown): string {
 }
 
 function formatToolResult(block: ClaudeContentBlock): string {
-	const label = block.is_error ? '[tool-error]' : '[tool-result]';
 	const body = extractToolResultText(block.content);
-	const collapsed = body.replace(/\s+/g, ' ').trim();
-	if (collapsed === '') return label;
-	return `${label} ${collapsed}`;
+	return labelledResult(block.is_error === true, body.replace(/\s+/g, ' ').trim());
+}
+
+/**
+ * A `[tool-result]`/`[tool-error]` line for an already-collapsed body.
+ *
+ * An empty body still emits the bare label. The client pairs a result with its call
+ * FIFO and has no correlation id, so a call whose result line is omitted stays
+ * pending forever AND leaves the queue misaligned - every later result is then
+ * attached to the wrong call. Emitting the label is what keeps that queue honest.
+ */
+function labelledResult(isError: boolean, collapsedBody: string): string {
+	const label = isError ? '[tool-error]' : '[tool-result]';
+	return collapsedBody === '' ? label : `${label} ${collapsedBody}`;
 }
 
 function extractToolResultText(content: unknown): string {

--- a/packages/server/test/agent-chat-parser.test.ts
+++ b/packages/server/test/agent-chat-parser.test.ts
@@ -4,6 +4,7 @@ import {
 	type AgentChatTurnEvent,
 	createAgentChatParser,
 	createAgentStreamParser,
+	type PriceModelFn,
 } from '../src/services/agent-stream-parser';
 
 /**
@@ -15,6 +16,12 @@ import {
  */
 
 const line = (event: unknown) => `${JSON.stringify(event)}\n`;
+
+/** Prices `codex-x` only; every other model is unknown and costs nothing. */
+const price: PriceModelFn = (model, tokens) =>
+	model === 'codex-x'
+		? Math.round(((tokens.inputTokens ?? 0) * 0.00001 + (tokens.outputTokens ?? 0) * 0.00003) * 100)
+		: 0;
 
 /** Collect both onStdout + flush output for an array of event objects. */
 function feed(parser: ReturnType<typeof createAgentChatParser>, events: unknown[]) {
@@ -142,14 +149,27 @@ describe('agent-chat-parser — Codex', () => {
 		const parser = createAgentChatParser(AgentRuntime.Codex);
 		const events = feed(parser, [
 			{ type: 'item.completed', item: { type: 'command_execution', command: 'ls' } },
-			{ type: 'item.completed', item: { type: 'mcp_tool_call', name: 'search' } },
-			{ type: 'item.completed', item: { type: 'tool_call' } }, // no name → 'tool'
+			// Codex names an MCP tool with `tool`; `name` serves the older spelling.
+			{ type: 'item.completed', item: { type: 'mcp_tool_call', server: 'hezo', tool: 'get_task' } },
+			{ type: 'item.completed', item: { type: 'tool_call', name: 'search' } },
+			{ type: 'item.completed', item: { type: 'tool_call' } }, // neither → 'tool'
 		]);
 		expect(events).toEqual([
 			{ toolActivity: 'shell' },
+			{ toolActivity: 'get_task' },
 			{ toolActivity: 'search' },
 			{ toolActivity: 'tool' },
 		]);
+	});
+
+	it('prices a chat turn from the run model when the stream names none', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex, price, 'codex-x');
+		feed(parser, [
+			{ type: 'thread.started', thread_id: 't1' },
+			{ type: 'turn.completed', usage: { input_tokens: 1000, output_tokens: 100 } },
+		]);
+		// 1000*0.00001 + 100*0.00003 = $0.013 → 1 cent.
+		expect(parser.getUsage()?.costCents).toBe(1);
 	});
 
 	it('captures usage from turn.completed, folding reasoning into output', () => {

--- a/packages/server/test/agent-stream-parser-branches.test.ts
+++ b/packages/server/test/agent-stream-parser-branches.test.ts
@@ -442,7 +442,7 @@ describe('Claude Code — user/result edge arms', () => {
 describe('Codex — thread.started + item edge arms', () => {
 	it('falls back to model=codex when thread.started carries no model', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Codex);
-		expect(feed(parser, [{ type: 'thread.started' }])).toBe('[session] model=codex tools=0\n');
+		expect(feed(parser, [{ type: 'thread.started' }])).toBe('[session] model=codex\n');
 	});
 
 	it('defaults turn.completed usage fields to zero when usage is absent', () => {
@@ -452,7 +452,7 @@ describe('Codex — thread.started + item edge arms', () => {
 		expect(parser.getUsage()).toEqual({ inputTokens: 0, outputTokens: 0, costCents: 0 });
 	});
 
-	it('renders a command with output but no command string (cmd empty arm)', () => {
+	it('drops a command with output but no command string (cmd empty arm)', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Codex);
 		const out = feed(parser, [
 			{
@@ -460,16 +460,28 @@ describe('Codex — thread.started + item edge arms', () => {
 				item: { type: 'command_execution', output: 'just output', exit_code: 0 },
 			},
 		]);
-		// No [tool] shell(...) line since command was empty; only the result.
-		expect(out).toBe('[tool-result] just output\n');
+		// With no command there is no [tool] line for the result to belong to, and an
+		// orphan result would be paired with an unrelated call. The item is dropped.
+		expect(out).toBe('');
 	});
 
-	it('renders a command string with no output (output empty arm)', () => {
+	it('renders a command string with no output as a bare result label', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Codex);
 		const out = feed(parser, [
 			{ type: 'item.completed', item: { type: 'command_execution', command: 'true' } },
 		]);
-		expect(out).toBe('[tool] shell(true)\n');
+		expect(out).toBe('[tool] shell(true)\n[tool-result]\n');
+	});
+
+	it('marks a failed command_execution as an error even with a zero exit_code', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Codex);
+		const out = feed(parser, [
+			{
+				type: 'item.completed',
+				item: { type: 'command_execution', command: 'x', output: 'boom', status: 'failed' },
+			},
+		]);
+		expect(out).toBe('[tool] shell(x)\n[tool-error] boom\n');
 	});
 
 	it('treats a non-numeric exit_code as success (typeof number false arm)', () => {
@@ -496,7 +508,7 @@ describe('Codex — thread.started + item edge arms', () => {
 	it('falls back to tool name "tool" when a tool_call item has no name', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Codex);
 		const out = feed(parser, [{ type: 'item.completed', item: { type: 'tool_call' } }]);
-		expect(out).toBe('[tool] tool()\n');
+		expect(out).toBe('[tool] tool()\n[tool-result]\n');
 	});
 
 	it('renders agent_message via the text field directly', () => {
@@ -547,7 +559,7 @@ describe('Codex — thread.started + item edge arms', () => {
 describe('Gemini — message/tool/result edge arms', () => {
 	it('falls back to model=gemini when init has no model', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Gemini);
-		expect(feed(parser, [{ type: 'init' }])).toBe('[session] model=gemini tools=0\n');
+		expect(feed(parser, [{ type: 'init' }])).toBe('[session] model=gemini\n');
 	});
 
 	it('reads message text from the text field when content is absent', () => {
@@ -974,7 +986,7 @@ describe('JSONL framing arms', () => {
 	it('flush() renders a buffered final event that had no trailing newline', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Gemini);
 		parser.onStdout('{"type":"init","model":"g"}');
-		expect(parser.flush()).toBe('[session] model=g tools=0\n');
+		expect(parser.flush()).toBe('[session] model=g\n');
 	});
 
 	it('onStderr passes bytes through unchanged for a real runtime parser', () => {

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -345,6 +345,123 @@ describe('agent-stream-parser', () => {
 			expect(parser.onStdout(`${JSON.stringify(event)}\n`)).toBe('Hello world\n');
 		});
 
+		it('renders an mcp tool call as a call line and its result', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			// The shape Codex actually emits: the tool is named by server + tool, and the
+			// item carries its own outcome, so both lines come from the one event.
+			const event = {
+				type: 'item.completed',
+				item: {
+					type: 'mcp_tool_call',
+					server: 'hezo',
+					tool: 'get_skill',
+					arguments: { slug: 'deep-research' },
+					status: 'completed',
+					result: { content: [{ type: 'text', text: 'Skill body' }] },
+				},
+			};
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			// mcp__<server>__<tool> is Claude Code's naming, so the log view renders both
+			// runtimes' MCP calls through the same display.
+			expect(out).toBe(
+				'[tool] mcp__hezo__get_skill(slug=deep-research)\n[tool-result] Skill body\n',
+			);
+		});
+
+		it('renders a failed mcp tool call as a tool-error', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const event = {
+				type: 'item.completed',
+				item: {
+					type: 'mcp_tool_call',
+					server: 'hezo',
+					tool: 'read_project_doc',
+					arguments: { filename: 'missing.md' },
+					status: 'failed',
+					error: { message: 'document not found' },
+				},
+			};
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			expect(out).toBe(
+				'[tool] mcp__hezo__read_project_doc(filename=missing.md)\n[tool-error] document not found\n',
+			);
+		});
+
+		it('resolves every tool call in a mixed run, in order', () => {
+			// The regression this guards: the client pairs results with calls FIFO and has
+			// no correlation id, so one call left without a result silently attaches the
+			// NEXT call's result to it and misreports every tool after it.
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const mcp = (tool: string, text: string) => ({
+				type: 'item.completed',
+				item: {
+					type: 'mcp_tool_call',
+					server: 'hezo',
+					tool,
+					arguments: {},
+					status: 'completed',
+					result: { content: [{ type: 'text', text }] },
+				},
+			});
+			const shell = {
+				type: 'item.completed',
+				item: {
+					type: 'command_execution',
+					command: 'ls',
+					aggregated_output: 'file1',
+					exit_code: 0,
+				},
+			};
+			const out = [mcp('get_task', 'first'), shell, mcp('list_comments', 'second')]
+				.map((e) => parser.onStdout(`${JSON.stringify(e)}\n`))
+				.join('');
+			expect(out.split('\n').filter(Boolean)).toEqual([
+				'[tool] mcp__hezo__get_task()',
+				'[tool-result] first',
+				'[tool] shell(ls)',
+				'[tool-result] file1',
+				'[tool] mcp__hezo__list_comments()',
+				'[tool-result] second',
+			]);
+		});
+
+		it('omits a tool count it was never given', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			// Codex's thread.started carries only a thread id. A hardcoded `tools=0` here
+			// read as a measured zero in the log header.
+			const out = parser.onStdout(
+				`${JSON.stringify({ type: 'thread.started', thread_id: 't1' })}\n`,
+			);
+			expect(out).toBe('[session] model=codex\n');
+			expect(out).not.toContain('tools=');
+		});
+
+		it('prices from the run model when the stream names none', () => {
+			// Codex never names a model, so without the run-model floor every Codex run
+			// priced at $0.
+			const parser = createAgentStreamParser(AgentRuntime.Codex, price, 'codex-x');
+			const out = parser.onStdout(
+				`${JSON.stringify({ type: 'thread.started', thread_id: 't1' })}\n`,
+			);
+			expect(out).toBe('[session] model=codex-x\n');
+			parser.onStdout(
+				`${JSON.stringify({
+					type: 'turn.completed',
+					usage: { input_tokens: 1000, output_tokens: 100 },
+				})}\n`,
+			);
+			// 1000*0.00001 + 100*0.00003 = $0.013 → 1 cent.
+			expect(parser.getUsage()?.costCents).toBe(1);
+		});
+
+		it('lets a model named on the stream win over the run model', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex, price, 'stale-model');
+			const out = parser.onStdout(
+				`${JSON.stringify({ type: 'thread.started', model: 'codex-x' })}\n`,
+			);
+			expect(out).toBe('[session] model=codex-x\n');
+		});
+
 		it('renders a command execution as a tool call and result', () => {
 			const parser = createAgentStreamParser(AgentRuntime.Codex);
 			const event = {
@@ -511,7 +628,7 @@ describe('agent-stream-parser', () => {
 		it('renders the init event as a session line', () => {
 			const parser = createAgentStreamParser(AgentRuntime.Gemini);
 			const out = parser.onStdout(`${JSON.stringify({ type: 'init', model: 'gemini-2.5-pro' })}\n`);
-			expect(out).toBe('[session] model=gemini-2.5-pro tools=0\n');
+			expect(out).toBe('[session] model=gemini-2.5-pro\n');
 		});
 	});
 

--- a/packages/web/test/parse-agent-log.test.ts
+++ b/packages/web/test/parse-agent-log.test.ts
@@ -23,6 +23,37 @@ function makeLines(
 	);
 }
 
+test('renders a session header with no tool count', () => {
+	// Codex and Gemini never report how many tools they were given, so their session
+	// line omits `tools=` rather than claiming a measured zero.
+	const blocks = parseAgentLog(makeLines(['[session] model=gpt-5-codex']));
+	expect(blocks).toEqual([
+		{ type: 'session', id: expect.any(Number), model: 'gpt-5-codex', toolCount: null },
+	]);
+});
+
+test('gives each tool call in a mixed run its own result', () => {
+	// Results are paired with calls FIFO, with no correlation id. A call whose result
+	// line is missing does not just stay pending - it swallows the NEXT call's result
+	// and every tool after it reports somebody else's outcome. This is the shape a
+	// Codex run produces once each call carries its own result line.
+	const blocks = parseAgentLog(
+		makeLines([
+			'[tool] mcp__hezo__get_task(task_id=INV-125)',
+			'[tool-result] first',
+			'[tool] shell(ls)',
+			'[tool-result] file1',
+			'[tool] mcp__hezo__read_project_doc(filename=missing.md)',
+			'[tool-error] document not found',
+		]),
+	) as ToolBlock[];
+	expect(blocks.map((b) => [b.name, b.status, b.result])).toEqual([
+		['mcp__hezo__get_task', 'success', 'first'],
+		['shell', 'success', 'file1'],
+		['mcp__hezo__read_project_doc', 'error', 'document not found'],
+	]);
+});
+
 test('parses the session header', () => {
 	const blocks = parseAgentLog(makeLines(['[session] model=deepseek-v4-pro tools=115']));
 	expect(blocks).toEqual([


### PR DESCRIPTION
Every Codex tool call in the Formatted run log showed a permanently **gray** dot, was labelled with the literal string `tool`, and sat under a header reading `codex · 0 tools`. All three came from one function.

## The bug

`renderCodexItem` rendered an `mcp_tool_call` item's call line and dropped the `status` / `result` / `error` the same item carried:

```ts
// the entire branch, before
if (kind === 'mcp_tool_call' || kind === 'tool_call') {
    return [formatToolUse(item.name ?? 'tool', item.arguments ?? item.args)];
}
```

Results are paired with calls **FIFO, with no correlation id** (the persisted log is line-based text; `parse-agent-log.ts` re-derives structure from `[tool]` / `[tool-result]` prefixes). So the damage went past the gray dot: each unresolved call stayed queued and swallowed the *next* call's result, mis-attributing every tool after it. Once a shell command ran, every later result was off by one.

Codex reports the outcome on the **same** `item.completed` event as the call, so both lines are now emitted together and ordering stays exact - no correlation id and no log-format change needed.

## Also fixed on the same path

- **The tool name was dropped.** Upstream's `McpToolCallItem` has no `name` field at all - it splits the name across `server` and `tool` - so `item.name ?? 'tool'` always hit the fallback. Now rendered as `mcp__<server>__<tool>`, matching Claude Code's naming so both runtimes go through the viewer's existing `server / tool` display with no web change.
- **`tools=0` was hardcoded** in the Codex and Gemini session lines. Neither runtime reports a count, and the viewer already hides it when the token is absent - better than printing a zero nobody measured.
- **Every Codex run priced at $0.** `thread.started` carries only a thread id, so `modelId` stayed `undefined` for the whole run and `price(undefined, …)` failed low. The parsers are now seeded with the run's own model, reusing the `runModel` floor already wired for OpenCode; a model named on the stream still wins. Applies to the chat parser too, so CEO chat turns on Codex stop pricing at $0.
- **`command_execution` hardened** so it cannot leave a pending entry: prefer the item's own `status` over `exit_code`, always emit a result line (bare label when output is empty), and drop an item with no command string rather than pushing an orphan result.

## Changes

| File | What |
|---|---|
| `packages/server/src/services/agent-stream-parser.ts` | `CodexItem` gains the fields Codex actually sends; the `mcp_tool_call` and `command_execution` branches emit call + result; new `codexToolName` and shared `labelledResult` helpers; session lines and the model floor |
| `.dev/architecture.md` | Documents the FIFO pairing contract and the per-runtime session-line / model-floor rules |

No web source change - the client parser and log view already handle both a missing tool count and `mcp__server__tool` names.

## Testing

New coverage for the behavior that was wrong, not just that the code runs:

- An `mcp_tool_call` in its real shape renders `[tool] mcp__hezo__get_skill(slug=deep-research)` **and** its `[tool-result]`; a `status: 'failed'` item renders `[tool-error]`.
- **Queue integrity**, server-side and client-side: a mixed `mcp → shell → mcp` run gives each call its own result and status. This is the regression that actually bit.
- The session line omits `tools=`, prices from the run-model floor, and lets a stream-named model win.

```
bun run typecheck                                  # clean
bun run test --skip-browser --pattern agent-       # 745 server + 98 web passed
bun run test --skip-browser --pattern parse-agent  # 27 passed
bun run test --skip-browser --pattern formatted-log # 24 passed
```

Not run here: an end-to-end Codex run against a live key, which provisions a container and bills a completion.

---
_Generated by [Claude Code](https://claude.ai/code/session_014t7nsMvVpFN5TBfRpCwZVs)_