### PR TITLE
feat(opencode): pair tool results, one run summary, always-on reasoning

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3329,8 +3329,9 @@ failed open.
 global `medium`. Each runtime maps it natively: `claude_code` appends
 `think`/`think hard`/`ultrathink`; `codex` passes `-c model_reasoning_effort=`; `gemini`
 sets `GEMINI_REASONING_EFFORT`; `kimi` sets `KIMI_MODEL_THINKING_EFFORT` (it has no
-`minimal`, which maps to `low`); `opencode`/`grok` steer effort through the portable prompt
-directive. It's also exposed as `HEZO_AGENT_EFFORT`.
+`minimal`, which maps to `low`); `opencode` writes `reasoning.effort` onto the run's model in
+its per-run `opencode.json` (see below); `grok` steers effort through the portable prompt
+directive alone. It's also exposed as `HEZO_AGENT_EFFORT`.
 
 **Per-runtime wiring** lives in the MCP injectors (`services/mcp-injectors/`, six
 adapters in `index.ts`: ClaudeCode, Codex, Gemini, OpenCode, Grok, Kimi). Each builds the
@@ -3407,6 +3408,20 @@ abutting with no separator, since deltas are appended raw. The handoff net posts
 verbatim, so an entire run's thinking went out as one comment. Anything that is not another
 `text` delta now ends the message.
 
+**OpenCode reports a tool only once, when it has finished.** Its `--format json` stream carries
+no pending/running tool states: one `tool_use` event per call, arriving at completion with the
+arguments and the output together on `part.state`. The parser therefore renders both lines from
+that single event - `[tool]` plus `[tool-result]`, or `[tool-error]` when `state.status` is
+`error` - which is what pairs FIFO in `parse-agent-log.ts` and turns the viewer's status dot
+green. Emitting only the call left every OpenCode tool row showing a grey pending dot forever,
+and reading the arguments off the event root rather than `part.state.input` rendered them all
+as `name()`. Its `step_finish` is likewise per step, distinguished by `part.reason`
+(`tool-calls` = more steps follow, `stop` = last), so only a terminal step renders a `[done]`
+line while every step's counts are still summed - one run summary rather than a full-width
+success banner between each pair of tool calls. Because OpenCode is documented to sometimes
+exit before its final `step_finish` (sst/opencode#26855, #31435), the parser writes that
+summary from `flush()` if no `[done]` was reached, rather than losing it with the event.
+
 **Runtime timeout hardening.** Each CLI ships default timeouts that would cut off Hezo's
 legitimately long agent/background work; every runtime is relaxed at its own config surface
 (no exact cross-runtime env analog exists for Claude Code's `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`).
@@ -3420,7 +3435,16 @@ built-in provider are silently ignored by Codex's vacant-only merge) and only dr
 reconnect/retry, not a kill, so they're left at default. **Gemini** (`settings.json`) sets
 `tools.shell.inactivityTimeout = 0` (disables the 5-min kill of a silent shell command) and a
 per-MCP-server `timeout`. **OpenCode** (`opencode.json`) raises the per-MCP-server `timeout`
-from its 5 s (!) default to 10 min; its bash tool has a non-configurable 10-min hard cap.
+from its 5 s (!) default to 10 min; its bash tool has a non-configurable 10-min hard cap. The
+same file carries the run's reasoning effort, since the CLI exposes no flag or env var for it:
+`provider.<key>.models.<id>.options.reasoning.effort`, keyed on the run's own model with the
+OpenCode provider prefix taken back off (`opencodeModelKey`). OpenCode merges that entry with
+its built-in models.dev catalog, and `options` passes straight to the AI-SDK provider, so the
+value reaches OpenRouter's unified reasoning parameter. Hezo's effort ladder maps onto it 1:1
+and never emits `none`, so every OpenCode run reasons; a run that pins no model gets no block
+at all, because the models map has no wildcard key and a guessed one would configure a model
+the run is not using. `RUNTIME_STREAM_ARGS` pairs it with `--thinking`, which is what puts the
+resulting reasoning parts on the `--format json` stream for the log.
 **Grok** (`config.toml`) raises `[toolset.bash].timeout_secs` and per-`[mcp_servers.*]`
 `startup_timeout_sec` (its bash already auto-backgrounds on timeout rather than killing).
 **Kimi Code** (`mcp.json`) raises per-server `startupTimeoutMs`/`toolTimeoutMs` from its 30 s /

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -32,6 +32,11 @@ Kimi, DeepSeek, and Z.ai run through Claude Code against their Anthropic-compati
 endpoints; OpenRouter runs through the **OpenCode** CLI; and Ollama and LM Studio run
 through Claude Code against your own machine.
 
+Every runtime is asked to reason, at the effort level the agent is configured for. On
+OpenRouter through OpenCode that reasoning is always on: the run asks the model to think at
+its own effort level rather than answering straight away, and the thinking shows in the run
+log alongside the tool calls. A model that cannot reason simply ignores the request.
+
 Where the Runtime column lists more than one, you choose which one that credential runs on.
 The first is the default, and you never have to pick: adding a key without touching the
 setting runs it on the default.

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, relative } from 'node:path';
 import {
 	AGENT_RUNTIME_LABELS,
+	type AgentEffort,
 	AgentRuntime,
 	AiAuthMethod,
 	type AiProvider,
@@ -424,7 +425,7 @@ export interface RunContext {
 	runtimeType: AgentRuntime;
 	/** How the runtime receives {@link taskPrompt} - see RUNTIME_PROMPT_DELIVERY. */
 	promptDelivery: PromptDelivery;
-	effort: string;
+	effort: AgentEffort;
 	effortApplication: EffortRuntimeApplication;
 	agentJwt: string;
 	subscriptionMount: SubscriptionMount | null;
@@ -639,7 +640,7 @@ export interface RuntimeInvocationInput {
 	 * instead of the prompt body. Callers that inline it in the prompt pass null.
 	 */
 	systemPrompt?: string | null;
-	effort: string;
+	effort: AgentEffort;
 	effortApplication: EffortRuntimeApplication;
 	modelOverride: string | null;
 	sshSocketContainerPath: string | null;
@@ -763,6 +764,7 @@ export async function buildRuntimeInvocation(
 		containerHomeDir: homeMount?.containerDir ?? null,
 		provider,
 		runModel: modelOverride,
+		effort,
 		projectDocSlugs,
 		stopJudge,
 		systemPrompt,

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -1053,12 +1053,29 @@ function priceGeminiModels(stats: GeminiStats | undefined, price: PriceModelFn):
 // ---------------------------------------------------------------------------
 // Generic JSONL parser (OpenCode)
 //
-// This CLI emits JSONL whose event shapes vary by version and aren't fully
-// documented, so rather than guess a single rigid schema this parser probes a
-// broad set of conventional field names. It renders assistant text, tool
-// activity, thinking, and errors when recognizable, and captures token usage
-// from whatever terminal event carries it. Unknown events are dropped so the
-// log stays clean. Replace with a bespoke parser once a real run is captured.
+// This CLI emits JSONL whose event shapes have shifted across versions and
+// aren't fully documented, so rather than commit to one rigid schema this parser
+// probes a broad set of conventional field names. It renders assistant text,
+// tool activity, thinking, and errors when recognizable, and captures token
+// usage from whatever terminal event carries it. Unknown events are dropped so
+// the log stays clean.
+//
+// The shapes a current run actually emits, which the probes above are layered
+// on top of rather than replaced by:
+//
+//   tool_use    part.tool, part.state.{status,input,output,error}. Emitted ONCE
+//               per call, only when the call has finished - the JSON stream
+//               carries no pending/running tool states - so the call and its
+//               result are rendered together as a `[tool]` + `[tool-result]`
+//               pair, which is what pairs FIFO in `parse-agent-log.ts` and turns
+//               the viewer's status dot green.
+//   step_finish part.reason ('tool-calls' = more steps follow, 'stop' = last),
+//               part.tokens.{input,output,reasoning}, part.tokens.cache.{read,write}.
+//               OpenCode emits one per step, so only the terminal one renders a
+//               `[done]` line; every step's counts are still summed.
+//   text        part.text
+//   reasoning   part.text (reaches the stream only with `--thinking`)
+//   error       error.name, error.data.message
 // ---------------------------------------------------------------------------
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -1118,6 +1135,32 @@ function extractGenericTool(event: Record<string, unknown>, type: string): strin
 	const partName = part ? firstString(part, ['name', 'tool', 'tool_name']) : undefined;
 	if (looksToolish || name || partName) return name ?? partName ?? 'tool';
 	return null;
+}
+
+/**
+ * Render a tool call, with its result when the event carries one.
+ *
+ * OpenCode reports a tool only once it has finished, putting the arguments and
+ * the output together on `part.state`, so both lines are emitted here - the same
+ * shape Codex's `command_execution` arm produces. An event with no `part.state`
+ * (every other probe-matched shape) still renders the single `[tool]` line it
+ * always did, and its dot stays pending because nothing ever reports a result.
+ */
+function renderGenericTool(event: Record<string, unknown>, name: string): string[] {
+	const part = isRecord(event.part) ? event.part : undefined;
+	const state = part && isRecord(part.state) ? part.state : undefined;
+	const input = state?.input ?? event.input ?? event.arguments ?? event.args;
+	const out = [formatToolUse(name, input)];
+	if (!state) return out;
+
+	const failed = state.status === 'error' || Boolean(state.error);
+	const label = failed ? '[tool-error]' : '[tool-result]';
+	const body =
+		(failed ? extractErrorMessage(state.error as { message?: string } | string | undefined) : '') ||
+		extractToolResultText(state.output ?? state.result);
+	const collapsed = body.replace(/\s+/g, ' ').trim();
+	out.push(collapsed === '' ? label : `${label} ${collapsed}`);
+	return out;
 }
 
 /** One event's token counts, before they are folded into a run total. */
@@ -1211,11 +1254,21 @@ function createGenericJsonlParser(
 	let tokens: GenericTokenBuckets | null = null;
 	let modelId: string | undefined = fallbackModelId;
 	let finalMessage: string | null = null;
+	let doneEmitted = false;
+
+	// The running total rather than the terminal step's own counts: the line reads
+	// as what the whole run spent, which is what it is once several steps report.
+	const doneLine = (total: GenericTokenBuckets, status: string): string => {
+		doneEmitted = true;
+		const soFar = priceGenericUsage(total, price, modelId);
+		return `[done] ${status} tokens=${soFar.inputTokens}/${soFar.outputTokens}`;
+	};
 
 	const renderEvent = (raw: unknown): string[] => {
 		if (!isRecord(raw)) return [];
 		const event = raw;
 		const type = typeof event.type === 'string' ? event.type : '';
+		const part = isRecord(event.part) ? event.part : undefined;
 		const model = firstString(event, ['model']);
 		if (model) modelId = model;
 
@@ -1231,14 +1284,17 @@ function createGenericJsonlParser(
 		}
 
 		if (/reason|think/i.test(type)) {
-			const t = firstString(event, ['text', 'content', 'thinking']);
+			// Probed on the part as well as the root: OpenCode carries a reasoning
+			// block's text at `part.text`, so a root-only probe found nothing and
+			// dropped every thinking block the run produced.
+			const t =
+				firstString(event, ['text', 'content', 'thinking']) ??
+				(part ? firstString(part, ['text', 'content', 'thinking']) : undefined);
 			return t ? [formatThinking(t)] : [];
 		}
 
 		const toolName = extractGenericTool(event, type);
-		if (toolName) {
-			return [formatToolUse(toolName, event.input ?? event.arguments ?? event.args)];
-		}
+		if (toolName) return renderGenericTool(event, toolName);
 
 		const text = extractGenericText(event);
 		if (text) {
@@ -1247,20 +1303,42 @@ function createGenericJsonlParser(
 		}
 
 		if (captured && GENERIC_TERMINAL_RE.test(type)) {
-			// The running total rather than this step's own counts: the line reads as
-			// the run's cost so far, which is what it is once several steps report.
-			const soFar = priceGenericUsage(tokens ?? captured, price, modelId);
-			return [`[done] success tokens=${soFar.inputTokens}/${soFar.outputTokens}`];
+			// OpenCode emits a step_finish per step, and `reason` says which kind:
+			// `tool-calls` means the model is going round again, so rendering a
+			// `[done]` there put a run-summary banner between every pair of tool
+			// calls. Only a terminal step gets the line; the counts from every step
+			// are already folded into `tokens` above either way. An event that names
+			// no reason (an older shape, or a `result`/`turn.completed` event) is
+			// treated as terminal, which is what it was before this existed.
+			const reason = part
+				? firstString(part, ['reason', 'finish_reason', 'stop_reason'])
+				: undefined;
+			if (reason === 'tool-calls') return [];
+			return [doneLine(tokens ?? captured, reason === 'error' ? 'error' : 'success')];
 		}
 		return [];
 	};
 
-	return createJsonlParser(
+	const base = createJsonlParser(
 		renderEvent,
 		() => (tokens ? priceGenericUsage(tokens, price, modelId) : null),
 		() => null,
 		() => finalMessage,
 	);
+
+	return {
+		...base,
+		// OpenCode is documented to exit before emitting its final `step_finish`
+		// under some container setups (sst/opencode#26855, #31435). Now that the
+		// intermediate steps no longer render one, such a run would end with no
+		// `[done]` line at all - so the summary is written here from the totals the
+		// steps did report rather than being lost with the missing event.
+		flush(): string {
+			const tail = base.flush();
+			if (doneEmitted || !tokens) return tail;
+			return `${tail}${doneLine(tokens, 'success')}\n`;
+		},
+	};
 }
 
 function createGenericChatParser(

--- a/packages/server/src/services/effort.ts
+++ b/packages/server/src/services/effort.ts
@@ -22,8 +22,11 @@
  *   - `gemini`: the `GEMINI_REASONING_EFFORT` env var.
  *   - `kimi`: the `KIMI_MODEL_THINKING_EFFORT` env var. Kimi Code accepts
  *     `low|medium|high|xhigh|max`; it has no `minimal`, which maps to `low`.
- *   - `opencode` / `grok`: no stable native knob, so effort is steered through
- *     the prompt directive alone.
+ *   - `opencode`: `reasoning.effort` on the run's model in the per-run
+ *     `opencode.json` (written by that runtime's MCP injector, which is the only
+ *     place holding the model id the config map is keyed on).
+ *   - `grok`: no stable native knob, so effort is steered through the prompt
+ *     directive alone.
  */
 
 import {
@@ -92,6 +95,24 @@ const KIMI_THINKING_EFFORT: Record<AgentEffort, string> = {
 	[AgentEffort.Max]: 'max',
 };
 
+/**
+ * OpenCode's models are reached through OpenRouter, whose unified `reasoning`
+ * parameter takes `none|minimal|low|medium|high|xhigh|max`. Hezo's ladder is a
+ * subset spelled identically, so the mapping is 1:1 - and because `none` is
+ * never produced, every OpenCode run asks the model to reason.
+ *
+ * A model that cannot reason ignores the parameter: OpenRouter only rejects an
+ * unsupported parameter when the caller sets `require_parameters`, which nothing
+ * here does.
+ */
+export const OPENCODE_REASONING_EFFORT: Record<AgentEffort, string> = {
+	[AgentEffort.Minimal]: 'minimal',
+	[AgentEffort.Low]: 'low',
+	[AgentEffort.Medium]: 'medium',
+	[AgentEffort.High]: 'high',
+	[AgentEffort.Max]: 'max',
+};
+
 const GENERIC_PROMPT_DIRECTIVE: Record<AgentEffort, string> = {
 	[AgentEffort.Minimal]: '',
 	[AgentEffort.Low]: 'Think briefly before answering.',
@@ -120,14 +141,17 @@ export function applyEffortToRuntime(
 				extraEnv: [`GEMINI_REASONING_EFFORT=${effort}`],
 				promptDirective: GENERIC_PROMPT_DIRECTIVE[effort],
 			};
-		// OpenCode (`--variant`) exposes model-dependent reasoning knobs whose
-		// accepted values aren't stable across versions, so steer effort through the
-		// prompt directive — the portable lever every runtime honors.
+		// OpenCode's native knob is `reasoning.effort` on the run's model, written
+		// into the per-run `opencode.json` by its MCP injector (OPENCODE_REASONING_EFFORT
+		// above) — not a CLI flag, since `--variant` names a variant that has to be
+		// declared in that same config first. The injector is the only place holding
+		// the model id the config map is keyed on, so nothing lands in extraArgs here.
+		// The prompt directive rides along as it does for Codex and Kimi.
 		case AgentRuntime.OpenCode:
 			return { extraArgs: [], extraEnv: [], promptDirective: GENERIC_PROMPT_DIRECTIVE[effort] };
 		// Grok exposes `--reasoning-effort`, but its accepted values aren't
 		// documented/stable across the 0.2.x betas, so steer effort through the
-		// portable prompt directive like OpenCode.
+		// portable prompt directive alone.
 		case AgentRuntime.Grok:
 			return { extraArgs: [], extraEnv: [], promptDirective: GENERIC_PROMPT_DIRECTIVE[effort] };
 		// Kimi Code exposes a real, documented thinking-effort knob as an env var

--- a/packages/server/src/services/mcp-injectors/opencode.ts
+++ b/packages/server/src/services/mcp-injectors/opencode.ts
@@ -1,5 +1,8 @@
 import { join } from 'node:path';
+import { OPENCODE_PROVIDER_KEY, opencodeModelKey } from '@hezo/shared';
+import { OPENCODE_REASONING_EFFORT } from '../effort';
 import type {
+	McpAdapterContext,
 	McpHttpDescriptor,
 	McpInjection,
 	McpStdioDescriptor,
@@ -10,9 +13,13 @@ import type {
  * OpenCode runtime adapter.
  *
  * Writes a per-run `opencode.json` (pointed at via the `OPENCODE_CONFIG` env
- * var) carrying the MCP server block. Remote MCP servers use `type:"remote"`
- * with an inline `Authorization` header; local ones use `type:"local"` with a
- * command array.
+ * var) carrying the MCP server block and the run's reasoning effort. Remote MCP
+ * servers use `type:"remote"` with an inline `Authorization` header; local ones
+ * use `type:"local"` with a command array.
+ *
+ * This file is also where OpenCode's effort lands: the CLI has no reasoning flag
+ * or env var, so the level resolved for the run is written as `reasoning.effort`
+ * on the model the run was launched with. See {@link buildReasoningProviders}.
  *
  * Unlike the other runtimes, OpenCode has NO completeness Stop-hook judge: its
  * plugin API cannot block-and-continue the agent loop in headless `opencode
@@ -42,9 +49,24 @@ interface OpencodeLocalServer {
 
 type OpencodeServer = OpencodeRemoteServer | OpencodeLocalServer;
 
+/**
+ * A model entry in OpenCode's provider block. `options` is passed straight to the
+ * AI-SDK provider, so `reasoning` reaches OpenRouter's unified reasoning
+ * parameter. OpenCode merges this with its built-in models.dev catalog rather
+ * than replacing it, so naming one model here leaves every other model intact.
+ */
+interface OpencodeModel {
+	options: { reasoning: { effort: string } };
+}
+
+interface OpencodeProvider {
+	models: Record<string, OpencodeModel>;
+}
+
 interface OpencodeConfig {
 	$schema: string;
 	mcp?: Record<string, OpencodeServer>;
+	provider?: Record<string, OpencodeProvider>;
 	/**
 	 * OpenCode's tool gate. Unlike the other runtimes this is **top-level**, not a
 	 * key on the server entry (whose only switch is the whole-server `enabled`) —
@@ -75,6 +97,32 @@ function buildRemoteServer(d: McpHttpDescriptor): OpencodeRemoteServer {
 	};
 	if (Object.keys(headers).length > 0) server.headers = headers;
 	return server;
+}
+
+/**
+ * The `provider` block carrying the run's reasoning effort, or null when there is
+ * nothing to key it on.
+ *
+ * Keyed on the run's own model because OpenCode's `models` map has no wildcard:
+ * a guessed key configures a model the run is not using, which is worse than no
+ * block at all. So a run that pins no model (and takes whatever OpenCode's own
+ * default is) reasons at that model's default instead.
+ */
+function buildReasoningProviders(ctx: McpAdapterContext): Record<string, OpencodeProvider> | null {
+	const { provider, runModel, effort } = ctx;
+	if (!provider || !effort) return null;
+	const providerKey = OPENCODE_PROVIDER_KEY[provider];
+	const model = runModel?.trim();
+	if (!providerKey || !model) return null;
+	return {
+		[providerKey]: {
+			models: {
+				[opencodeModelKey(provider, model)]: {
+					options: { reasoning: { effort: OPENCODE_REASONING_EFFORT[effort] } },
+				},
+			},
+		},
+	};
 }
 
 function buildLocalServer(d: McpStdioDescriptor): OpencodeLocalServer {
@@ -121,6 +169,9 @@ export const opencodeAdapter: RuntimeMcpAdapter = {
 			}
 			if (Object.keys(tools).length > 0) config.tools = tools;
 		}
+
+		const providers = buildReasoningProviders(ctx);
+		if (providers) config.provider = providers;
 
 		const contents = `${JSON.stringify(config, null, 2)}\n`;
 		const configContainerPath = join(ctx.containerHomeDir, CONFIG_BASENAME);

--- a/packages/server/src/services/mcp-injectors/types.ts
+++ b/packages/server/src/services/mcp-injectors/types.ts
@@ -1,4 +1,4 @@
-import type { AiProvider } from '@hezo/shared';
+import type { AgentEffort, AiProvider } from '@hezo/shared';
 
 /**
  * Normalized MCP server descriptor passed by the agent runner. Per-runtime
@@ -138,6 +138,13 @@ export interface McpAdapterContext {
 	 * {@link judgeModelForProvider}). Absent/null falls back to the constant.
 	 */
 	runModel?: string | null;
+	/**
+	 * The run's resolved effort level. Only the OpenCode adapter reads it: OpenCode
+	 * has no CLI flag or env var for reasoning, so its effort is written as
+	 * `reasoning.effort` on the run's model inside the `opencode.json` this adapter
+	 * already emits. Absent leaves the reasoning block off entirely.
+	 */
+	effort?: AgentEffort;
 	/**
 	 * Whether this invocation gets the completeness Stop-hook judge. Absent or
 	 * true emits it, so every task run keeps it; false omits it on each of the

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -688,6 +688,108 @@ describe('agent-stream-parser — generic (opencode)', () => {
 		for (const e of STEP_FINISHES) parser.onStdout(`${JSON.stringify(e)}\n`);
 		expect(parser.getUsage()?.costCents).toBeGreaterThan(0);
 	});
+
+	// A completed tool call as OpenCode reports it: one event per call, arriving
+	// only once the call has finished, with the arguments and the output together
+	// on `part.state`.
+	const toolUse = (over: Record<string, unknown> = {}) => ({
+		type: 'tool_use',
+		part: {
+			type: 'tool',
+			callID: 'call_1',
+			tool: 'hezo_list_comments',
+			state: {
+				status: 'completed',
+				input: { task_id: 'HEZO-12' },
+				output: 'comment 1\ncomment 2',
+				title: 'List comments',
+				...over,
+			},
+		},
+	});
+
+	it('renders a completed tool call and its result as a pair', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		const out = parser.onStdout(`${JSON.stringify(toolUse())}\n`);
+		// The pair is what `parse-agent-log.ts` matches FIFO to turn the viewer's
+		// status dot green; a lone `[tool]` line leaves it pending forever.
+		expect(out).toBe(
+			'[tool] hezo_list_comments(task_id=HEZO-12)\n[tool-result] comment 1 comment 2\n',
+		);
+	});
+
+	it('renders a failed tool call as a tool-error carrying its message', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		const out = parser.onStdout(
+			`${JSON.stringify(toolUse({ status: 'error', output: undefined, error: 'task not found' }))}\n`,
+		);
+		expect(out).toBe('[tool] hezo_list_comments(task_id=HEZO-12)\n[tool-error] task not found\n');
+	});
+
+	it('emits a bare tool-result label when the call produced no output', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		const out = parser.onStdout(`${JSON.stringify(toolUse({ output: '' }))}\n`);
+		expect(out).toBe('[tool] hezo_list_comments(task_id=HEZO-12)\n[tool-result]\n');
+	});
+
+	it('still renders a lone tool line for an event carrying no state', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		const out = parser.onStdout(
+			`${JSON.stringify({ type: 'tool_use', name: 'bash', input: { command: 'ls' } })}\n`,
+		);
+		expect(out).toBe('[tool] bash(command=ls)\n');
+	});
+
+	// OpenCode emits a step_finish per step. Only the last one is the run's
+	// summary; the intermediate ones used to render a full-width success banner
+	// between every pair of tool calls.
+	const stepFinish = (reason: string, input: number, output: number) => ({
+		type: 'step_finish',
+		part: { type: 'step-finish', reason, tokens: { input, output, cache: { read: 0, write: 0 } } },
+	});
+
+	it('renders one done line for the terminal step, not one per step', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		expect(parser.onStdout(`${JSON.stringify(stepFinish('tool-calls', 100, 10))}\n`)).toBe('');
+		expect(parser.onStdout(`${JSON.stringify(stepFinish('tool-calls', 200, 20))}\n`)).toBe('');
+		// The line carries the whole run's totals, so suppressing the intermediate
+		// steps must not have dropped their counts.
+		expect(parser.onStdout(`${JSON.stringify(stepFinish('stop', 300, 30))}\n`)).toBe(
+			'[done] success tokens=600/60\n',
+		);
+		expect(parser.flush()).toBe('');
+	});
+
+	it('reports an error reason on the done line', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		expect(parser.onStdout(`${JSON.stringify(stepFinish('error', 5, 1))}\n`)).toBe(
+			'[done] error tokens=5/1\n',
+		);
+	});
+
+	it('writes the done line on flush when the terminal step never arrived', () => {
+		// OpenCode is documented to exit before its final step_finish under some
+		// container setups; without this the run would show no summary at all.
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		expect(parser.onStdout(`${JSON.stringify(stepFinish('tool-calls', 100, 10))}\n`)).toBe('');
+		expect(parser.flush()).toBe('[done] success tokens=100/10\n');
+	});
+
+	it('writes no done line on flush when the run reported no usage at all', () => {
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		parser.onStdout(`${JSON.stringify({ type: 'message', text: 'hi' })}\n`);
+		expect(parser.flush()).toBe('');
+	});
+
+	it('renders a reasoning block whose text sits on the part', () => {
+		// `--thinking` puts these on the stream; a root-only probe found nothing
+		// and dropped every thinking block the run produced.
+		const parser = createAgentStreamParser(AgentRuntime.OpenCode);
+		const out = parser.onStdout(
+			`${JSON.stringify({ type: 'reasoning', part: { type: 'reasoning', text: 'weighing it up' } })}\n`,
+		);
+		expect(out).toBe('[thinking] weighing it up\n');
+	});
 });
 
 describe('getFinalAssistantMessage', () => {

--- a/packages/server/test/mcp-injectors.test.ts
+++ b/packages/server/test/mcp-injectors.test.ts
@@ -1,4 +1,4 @@
-import { AgentRuntime, AiProvider } from '@hezo/shared';
+import { AgentEffort, AgentRuntime, AiProvider } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import { MCP_ADAPTERS, type McpDescriptor, validateInjection } from '../src/services/mcp-injectors';
 import type { McpInjectionFile } from '../src/services/mcp-injectors/types';
@@ -598,6 +598,98 @@ describe('opencode adapter', () => {
 		const injection = adapter.build([], { hostHomeDir: HOME, containerHomeDir: HOME });
 		const config = JSON.parse(injection.files[0].contents) as { mcp?: unknown };
 		expect(config.mcp).toBeUndefined();
+	});
+
+	// OpenCode has no reasoning flag or env var, so the run's effort is written
+	// onto its model here. The map key is the UNQUALIFIED id: `--model` takes
+	// `openrouter/<id>`, the config map does not, and a config keyed on the
+	// qualified form silently configures nothing.
+	const reasoningOf = (ctx: Parameters<typeof adapter.build>[1]) =>
+		(
+			JSON.parse(adapter.build([HEZO_DESCRIPTOR], ctx).files[0].contents) as {
+				provider?: Record<string, { models: Record<string, { options: unknown }> }>;
+			}
+		).provider;
+
+	it('writes the run effort as reasoning.effort on the run model', () => {
+		expect(
+			reasoningOf({
+				hostHomeDir: HOME,
+				containerHomeDir: HOME,
+				provider: AiProvider.OpenRouter,
+				runModel: 'deepseek/deepseek-v3.2',
+				effort: AgentEffort.Max,
+			}),
+		).toEqual({
+			openrouter: {
+				models: { 'deepseek/deepseek-v3.2': { options: { reasoning: { effort: 'max' } } } },
+			},
+		});
+	});
+
+	it('strips the opencode provider prefix off an already-qualified model id', () => {
+		expect(
+			reasoningOf({
+				hostHomeDir: HOME,
+				containerHomeDir: HOME,
+				provider: AiProvider.OpenRouter,
+				runModel: 'openrouter/deepseek/deepseek-v3.2',
+				effort: AgentEffort.Medium,
+			}),
+		).toEqual({
+			openrouter: {
+				models: { 'deepseek/deepseek-v3.2': { options: { reasoning: { effort: 'medium' } } } },
+			},
+		});
+	});
+
+	it('never asks for no reasoning, even at the lowest effort', () => {
+		const provider = reasoningOf({
+			hostHomeDir: HOME,
+			containerHomeDir: HOME,
+			provider: AiProvider.OpenRouter,
+			runModel: 'deepseek/deepseek-v3.2',
+			effort: AgentEffort.Minimal,
+		});
+		expect(provider?.openrouter.models['deepseek/deepseek-v3.2'].options).toEqual({
+			reasoning: { effort: 'minimal' },
+		});
+	});
+
+	it('omits the provider block when the run pins no model', () => {
+		// OpenCode's models map has no wildcard key, so there is nothing to key the
+		// block on — configuring a guessed model would target one the run is not using.
+		expect(
+			reasoningOf({
+				hostHomeDir: HOME,
+				containerHomeDir: HOME,
+				provider: AiProvider.OpenRouter,
+				effort: AgentEffort.High,
+			}),
+		).toBeUndefined();
+	});
+
+	it('omits the provider block for a provider OpenCode does not address', () => {
+		expect(
+			reasoningOf({
+				hostHomeDir: HOME,
+				containerHomeDir: HOME,
+				provider: AiProvider.Anthropic,
+				runModel: 'claude-sonnet-4-5',
+				effort: AgentEffort.High,
+			}),
+		).toBeUndefined();
+	});
+
+	it('omits the provider block when no effort was resolved', () => {
+		expect(
+			reasoningOf({
+				hostHomeDir: HOME,
+				containerHomeDir: HOME,
+				provider: AiProvider.OpenRouter,
+				runModel: 'deepseek/deepseek-v3.2',
+			}),
+		).toBeUndefined();
 	});
 
 	it('renders a local (stdio) MCP server with its command array and environment', () => {

--- a/packages/server/test/provider-runtime.test.ts
+++ b/packages/server/test/provider-runtime.test.ts
@@ -3,8 +3,10 @@ import {
 	AiProvider,
 	claudeCodeModelArg,
 	opencodeModelArg,
+	opencodeModelKey,
 	PROVIDER_TO_RUNTIME,
 	providerDirectUpstreamHosts,
+	RUNTIME_STREAM_ARGS,
 } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 
@@ -47,6 +49,18 @@ describe('opencodeModelArg', () => {
 
 	it('returns the model unchanged for providers without an OpenCode key', () => {
 		expect(opencodeModelArg(AiProvider.Anthropic, 'claude-opus-4-6')).toBe('claude-opus-4-6');
+	});
+
+	it('opencodeModelKey takes the prefix back off for the config map', () => {
+		expect(opencodeModelKey(AiProvider.OpenRouter, 'openrouter/x-ai/grok')).toBe('x-ai/grok');
+		expect(opencodeModelKey(AiProvider.OpenRouter, 'x-ai/grok')).toBe('x-ai/grok');
+		expect(opencodeModelKey(AiProvider.Anthropic, 'claude-opus-4-6')).toBe('claude-opus-4-6');
+	});
+
+	it('asks OpenCode to stream the model reasoning it is now always told to do', () => {
+		// `--thinking` is what puts reasoning parts on the `--format json` stream;
+		// without it a run reasons invisibly and the log shows no thinking blocks.
+		expect(RUNTIME_STREAM_ARGS[AgentRuntime.OpenCode]).toEqual(['--format', 'json', '--thinking']);
 	});
 });
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -2051,6 +2051,20 @@ export function opencodeModelArg(provider: AiProvider, model: string): string {
 }
 
 /**
+ * The key a model is addressed by inside an `opencode.json` `provider.<key>.models`
+ * map - the same id `opencodeModelArg` qualifies, with the provider prefix taken
+ * back off. The two directions live together because they are one fact read twice:
+ * `--model` wants `openrouter/deepseek/deepseek-v4-pro`, the config map wants
+ * `deepseek/deepseek-v4-pro`, and a config keyed on the qualified form silently
+ * configures nothing.
+ */
+export function opencodeModelKey(provider: AiProvider, model: string): string {
+	const key = OPENCODE_PROVIDER_KEY[provider];
+	if (!key) return model;
+	return model.startsWith(`${key}/`) ? model.slice(key.length + 1) : model;
+}
+
+/**
  * Every CLI a provider can be driven by, DEFAULT FIRST. The order is the
  * contract the picker renders in, so the first entry is always the one
  * preselected for a credential that stores no explicit choice.
@@ -2484,8 +2498,13 @@ export const RUNTIME_STREAM_ARGS: Record<AgentRuntime, readonly string[]> = {
 	[AgentRuntime.Codex]: ['--json'],
 	[AgentRuntime.Gemini]: ['--output-format', 'stream-json'],
 	// OpenCode `run --format json` emits raw JSON events whose terminal event
-	// carries token usage.
-	[AgentRuntime.OpenCode]: ['--format', 'json'],
+	// carries token usage. `--thinking` puts the model's reasoning parts on that
+	// stream too, so the run log shows them (the parser renders them as
+	// `[thinking]`); without it a run reasons invisibly. The CLI is installed
+	// unpinned in the agent image, so an upstream rename of this flag would fail
+	// every OpenCode run on an unknown argument - check it first if OpenCode runs
+	// start dying at exec.
+	[AgentRuntime.OpenCode]: ['--format', 'json', '--thinking'],
 	// Grok's `streaming-json` emits thought/text/end events. Unlike the others
 	// its stream carries NO token usage — cost is recovered post-run from the
 	// `--debug-file` tracing spans (added per-run in the runner). See

--- a/packages/shared/test/common.test.ts
+++ b/packages/shared/test/common.test.ts
@@ -33,6 +33,7 @@ import {
 	normalizeAssetFolder,
 	normalizeAssetPath,
 	opencodeModelArg,
+	opencodeModelKey,
 	parseProviderModels,
 	providerDirectUpstreamHosts,
 	qualifiedMcpToolName,
@@ -354,6 +355,18 @@ describe('provider helpers', () => {
 		);
 		expect(opencodeModelArg(AiProvider.OpenRouter, 'openrouter/x')).toBe('openrouter/x');
 		expect(opencodeModelArg(AiProvider.Anthropic, 'claude-opus-4')).toBe('claude-opus-4');
+	});
+
+	it('opencodeModelKey is the inverse of opencodeModelArg', () => {
+		// `--model` wants the qualified id, the `provider.<key>.models` map wants the
+		// bare one; a config keyed on the qualified form configures nothing.
+		for (const model of ['anthropic/claude', 'openrouter/anthropic/claude']) {
+			expect(opencodeModelKey(AiProvider.OpenRouter, model)).toBe('anthropic/claude');
+			expect(
+				opencodeModelArg(AiProvider.OpenRouter, opencodeModelKey(AiProvider.OpenRouter, model)),
+			).toBe('openrouter/anthropic/claude');
+		}
+		expect(opencodeModelKey(AiProvider.Anthropic, 'claude-opus-4')).toBe('claude-opus-4');
 	});
 
 	it('claudeCodeProviderUsesCustomEndpoint is true only for the third-party Claude Code providers', () => {


### PR DESCRIPTION
## What

Fixes how an OpenCode run reads in the formatted log view, and makes OpenCode actually ask its models to reason.

**Log view.** Three things were wrong, all in the OpenCode stream parser:

- Every tool row showed a **grey pending dot forever**. The viewer turns the dot green only when a `[tool-result]` pairs with the `[tool]` line (FIFO, `parse-agent-log.ts`), and the parser never emitted one.
- Tool args rendered as `name()`. The parser probed the event root while OpenCode puts them on `part.state.input`.
- A full-width `success … in / … out` **banner appeared between every pair of tool calls**. OpenCode emits a `step_finish` per step and each one matched the terminal-event probe, so the run's end-of-run summary fired several times per run.

OpenCode reports a tool **once, at completion**, with the arguments and the output together on `part.state` - there are no pending/running tool states in its JSON stream. So both lines are now rendered from that single event (`[tool]` + `[tool-result]`, or `[tool-error]` when `state.status` is `error`), the same shape Codex's `command_execution` arm already produces. `step_finish` carries `part.reason` (`tool-calls` = more steps follow, `stop` = last), so only a terminal step renders `[done]` while every step's counts are still summed into the run total.

OpenCode is documented to sometimes exit before its final `step_finish` in a container ([#26855](https://github.com/anomalyco/opencode/issues/26855), [#31435](https://github.com/anomalyco/opencode/issues/31435)); now that the intermediate steps no longer render one, that summary is written from `flush()` if it never arrived rather than lost with the event.

**Reasoning.** OpenCode had no native effort knob wired at all - effort was steered by prompt directive alone, since the CLI exposes no reasoning flag or env var. The run's resolved effort now lands as `reasoning.effort` on its model in the per-run `opencode.json` the injector already writes:

```json
"provider": { "openrouter": { "models": {
  "deepseek/deepseek-v4-pro-0813": { "options": { "reasoning": { "effort": "max" } } }
} } }
```

`options` passes straight to the AI-SDK provider, so the value reaches OpenRouter's unified reasoning parameter, and OpenCode merges the entry with its built-in models.dev catalog rather than replacing it. Hezo's ladder maps 1:1 onto OpenRouter's and never emits `none`, so every OpenCode run reasons. `--thinking` joins `RUNTIME_STREAM_ARGS` so the resulting reasoning parts reach the stream, and the parser now reads a reasoning block's text off `part` (it only probed the root before, which dropped every one).

## Notes

- The map key is the **unqualified** model id: `--model` takes `openrouter/<id>`, the config map does not. New `opencodeModelKey` in `@hezo/shared` is the inverse of `opencodeModelArg`, so the two directions live together.
- A run that pins no model gets **no** reasoning block: OpenCode's `models` map has no wildcard key, and a guessed one would configure a model the run is not using.
- The lenient field probes stay as the fallback - OpenCode's shapes have shifted across versions - so every existing generic-probe path is unchanged.
- `--thinking` is the one new blast-radius item: the CLI is installed unpinned in the agent image, so an upstream rename would fail every OpenCode run at exec. Commented at the declaration as the first thing to check.
- No web change was needed; the viewer is runtime-agnostic and already renders the green dot the moment a result pairs.

## Test plan

- New OpenCode parser cases in `agent-stream-parser.test.ts` from the real event shapes: completed/failed/empty-output tool pairs, the no-`part.state` fallback, one `[done]` across three `step_finish` steps carrying the **summed** totals, the `error` reason, the flush fallback, and a reasoning block whose text sits on `part`.
- New `mcp-injectors.test.ts` cases: the reasoning block for a known provider + model + effort, the prefix-stripped key, no `none` at the lowest effort, and omission for a missing model / non-OpenCode provider / missing effort.
- `opencodeModelKey` round-trip in `packages/shared/test/common.test.ts` and `provider-runtime.test.ts`; `RUNTIME_STREAM_ARGS[OpenCode]` asserted.
- Ran locally: `typecheck`, `build`, `biome check`, the docs guards, and the agent-runner / chat-session / web log-view suites - all green.
- **Not covered by the suite:** a live OpenRouter run is the only way to confirm OpenCode accepts `--thinking` and that declaring `provider.openrouter.models.<id>` does not disturb its env-based `OPENROUTER_API_KEY` discovery. Worth one real run before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3LRCcm1AQ3RNhMDKYtv7s)_