### PR TITLE
feat(tasks): pin the task breadcrumb to the top on desktop

### DIFF
--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Check, ChevronRight, Loader2, Pencil, X } from 'lucide-react';
-import { useState } from 'react';
+import { type RefObject, useEffect, useRef, useState } from 'react';
 import { useAgentLookup } from '../../hooks/use-agent-lookup';
 import { type Task, useTaskAncestors, type useUpdateTask } from '../../hooks/use-tasks';
 import { formatDuration } from '../../lib/format-duration';
@@ -24,8 +24,39 @@ interface TaskHeaderProps {
 }
 
 /**
+ * True once the element behind `ref` has scrolled out of the top of the shell
+ * scroller - which, for the sentinel marking the breadcrumb's resting place,
+ * means the pinned breadcrumb is now covering content rather than sitting in
+ * the page flow.
+ *
+ * Reading the breadcrumb's own rect on every scroll event would force a layout
+ * flush per frame on a thread that runs to hundreds of comments, so this asks
+ * the question with one IntersectionObserver over a zero-height sentinel.
+ */
+function useScrolledPast(ref: RefObject<HTMLElement | null>): boolean {
+	const [scrolledPast, setScrolledPast] = useState(false);
+	useEffect(() => {
+		// The component-test harness stubs IntersectionObserver to a no-op, so the
+		// crumb keeps its resting look there; the browser spec covers the pinning.
+		if (typeof IntersectionObserver === 'undefined') return;
+		const el = ref.current;
+		if (!el) return;
+		// <main> is the scroll container - the window never scrolls (see __root.tsx).
+		const io = new IntersectionObserver(
+			([entry]) => setScrolledPast(entry ? !entry.isIntersecting : false),
+			{ root: document.querySelector('main') },
+		);
+		io.observe(el);
+		return () => io.disconnect();
+	}, [ref]);
+	return scrolledPast;
+}
+
+/**
  * Top-of-page header for a task: a breadcrumb of ancestor tasks ending in the
- * current identifier, then the title, an inline mono metadata row (status ·
+ * current identifier - pinned to the top of the shell scroller at `lg`+, so a
+ * long thread never leaves the reader without the task's identity or a way back
+ * to the list - then the title, an inline mono metadata row (status ·
  * priority · assignee) with a runs · duration · cost summary, the queued-wakeup
  * chip, and the description card. The title renames in place and the description
  * edits in place; both are recorded on the task thread as meta comments by the
@@ -52,11 +83,26 @@ export function TaskHeader({
 	const assigneeAgent = task.assignee_id ? agentsByMemberId.get(task.assignee_id) : undefined;
 	const { t } = useI18n();
 	const [editingDescription, setEditingDescription] = useState(false);
+	// Drives the pinned crumb's hairline: absent at rest so the page keeps its
+	// clean top edge, drawn once content is passing underneath.
+	const restingSentinelRef = useRef<HTMLDivElement>(null);
+	const pinned = useScrolledPast(restingSentinelRef);
 	return (
 		<>
+			{/* Marks where the breadcrumb rests. `-mb-px` keeps it out of the layout. */}
+			<div ref={restingSentinelRef} aria-hidden="true" className="h-px w-full -mb-px" />
+			{/* Desktop pins the crumb to the top of the scrolling <main>; below `lg` it
+			    scrolls away with the rest, where vertical space is the scarce thing.
+			    `top` clears the project banners stickied above it in the same scroller,
+			    reading the height ContainerStatusBanner publishes - the idiom the task
+			    meta rail already uses. z-10 stays under those banners (z-20 and up) and
+			    over the content column, which carries no z-index of its own. */}
 			<nav
 				aria-label="Breadcrumb"
-				className="mb-1 flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-2"
+				data-pinned={pinned ? 'true' : 'false'}
+				className={`mb-1 flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-2 lg:sticky lg:top-[var(--container-banner-h,0px)] lg:z-10 lg:-mt-3 lg:mb-0 lg:border-b lg:border-transparent lg:bg-bg lg:pt-3 lg:pb-2 lg:transition-[border-color,box-shadow] lg:duration-150 ${
+					pinned ? 'lg:border-border lg:shadow-xs' : ''
+				}`}
 				data-testid="task-breadcrumb"
 			>
 				<span className="flex items-center gap-x-1">

--- a/test/browser/task-breadcrumb-sticky.spec.ts
+++ b/test/browser/task-breadcrumb-sticky.spec.ts
@@ -1,0 +1,131 @@
+// Real CSS layout plus a viewport-conditional rule (testing decision tree,
+// points 1 & 2): the breadcrumb's pinning is `position: sticky` resolving
+// against the shell <main> scroller, asserted through `boundingBox()` before and
+// after a real scroll, and it is deliberately desktop-only, which happy-dom
+// cannot decide because it runs no media queries against a layout pass. The
+// crumb's links and ancestor rendering stay covered by the component tests in
+// packages/web/test/task-breadcrumb.test.tsx.
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+/** Enough comments that the thread overflows <main> at both viewports. */
+const COMMENT_COUNT = 30;
+
+async function seedTaskWithLongThread(page: Page, token: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const projRes = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Breadcrumb Sticky'),
+		description: 'Sticky breadcrumb test.',
+	});
+	const project = ((await projRes.json()) as { data: { id: string; slug: string } }).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Task with a long thread', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	// Anything the assignee posts later appends at the bottom of the thread, so it
+	// can only make the page taller - never move the crumb these tests measure.
+	const BATCH = 10;
+	for (let start = 0; start < COMMENT_COUNT; start += BATCH) {
+		const batch = Array.from(
+			{ length: Math.min(BATCH, COMMENT_COUNT - start) },
+			(_, i) => start + i,
+		);
+		await Promise.all(
+			batch.map((i) =>
+				page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+					headers,
+					data: {
+						content_type: 'text',
+						content: { text: `seeded comment ${i}. ${'lorem ipsum '.repeat(8)}` },
+					},
+				}),
+			),
+		);
+	}
+
+	return { project, task };
+}
+
+/** Scrolls <main> and returns where it actually landed. */
+async function scrollMain(page: Page, top: number): Promise<number> {
+	const main = page.locator('main').first();
+	await main.evaluate((el, y) => el.scrollTo({ top: y, behavior: 'instant' }), top);
+	return main.evaluate((el) => el.scrollTop);
+}
+
+test('desktop: the breadcrumb stays pinned to the top while the thread scrolls', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	test.setTimeout(60_000);
+	await page.setViewportSize({ width: 1280, height: 800 });
+	const { project, task } = await seedTaskWithLongThread(page, sharedWorkspace.token);
+
+	await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+	await waitForPageLoad(page);
+
+	const crumb = page.getByTestId('task-breadcrumb');
+	await expect(crumb).toBeVisible({ timeout: 20000 });
+
+	const before = await crumb.boundingBox();
+	expect(before).not.toBeNull();
+	// At rest the crumb carries no hairline - the page keeps its clean top edge.
+	await expect(crumb).toHaveAttribute('data-pinned', 'false');
+
+	const scrolled = await scrollMain(page, 600);
+	// Proves the thread genuinely overflowed and we moved a meaningful amount.
+	expect(scrolled).toBeGreaterThan(300);
+
+	// Pinned: still on screen, and within a few px of where it started. Without
+	// sticky it would be ~600px above the fold by now.
+	await expect(crumb).toBeInViewport();
+	const after = await crumb.boundingBox();
+	expect(after).not.toBeNull();
+	if (before && after) expect(Math.abs(after.y - before.y)).toBeLessThan(30);
+
+	// The task's identifier is still readable while deep in the thread, and the
+	// hairline is now drawn because content is passing underneath.
+	await expect(crumb).toContainText(task.identifier);
+	await expect(crumb).toHaveAttribute('data-pinned', 'true');
+
+	// Back at the top it lets go of the hairline again.
+	await scrollMain(page, 0);
+	await expect(crumb).toHaveAttribute('data-pinned', 'false');
+});
+
+test('mobile: the breadcrumb scrolls away with the page', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	test.setTimeout(60_000);
+	await page.setViewportSize({ width: 375, height: 800 });
+	const { project, task } = await seedTaskWithLongThread(page, sharedWorkspace.token);
+
+	await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+	await waitForPageLoad(page);
+
+	const crumb = page.getByTestId('task-breadcrumb');
+	await expect(crumb).toBeVisible({ timeout: 20000 });
+
+	const before = await crumb.boundingBox();
+	expect(before).not.toBeNull();
+
+	const scrolled = await scrollMain(page, 600);
+	expect(scrolled).toBeGreaterThan(300);
+
+	// Vertical space is the scarce thing on a phone, so the crumb goes with the
+	// rest of the page rather than holding a band at the top.
+	await expect(crumb).not.toBeInViewport();
+	const after = await crumb.boundingBox();
+	if (before && after) expect(after.y).toBeLessThan(before.y - 300);
+});


### PR DESCRIPTION
The breadcrumb scrolled away with the title, so a task with a long thread left the reader with nothing naming the task and no link back to the list.

At `lg`+ the crumb now sticks to the top of the shell scroller. Below `lg` nothing changes - vertical space is the scarce thing on a phone, and the mobile task page carries its own back affordance.

## How it works

- **Sticky, not fixed.** The crumb is a child of the task content column inside the scrolling `<main>`, so `position: sticky` pins it with no measuring and no layout shift.
- **It clears the project banners.** The container, budget and connector banners are already sticky at the top of that same scroller, so `top` reads `var(--container-banner-h, 0px)` - the offset idiom `task-sidebar.tsx` already uses for its sticky rail. `z-10` keeps the crumb under those banners (z-20 and up) and over the content column, which carries no z-index of its own.
- **The hairline is conditional.** At rest the crumb has no border, so the page keeps the clean top edge it has today; the rule and its faint shadow fade in only once content is passing underneath. A zero-height sentinel at the crumb's resting place plus one `IntersectionObserver` answers that question - reading the crumb's own rect on every scroll event would force a layout flush per frame on a thread that runs to hundreds of comments.

Resting layout is unchanged apart from 5px more space between the crumb and the title at `lg`, which the bar's own bottom padding and hairline account for.

## Tests

`test/browser/task-breadcrumb-sticky.spec.ts` - real sticky layout and a viewport-conditional rule are points 1 and 2 of the browser-vs-component decision tree, so this is a Playwright spec rather than a component test. It asserts:

- desktop: the crumb's `boundingBox()` holds across a 600px scroll of `<main>`, the identifier stays readable, and the hairline appears on scroll and lets go at the top;
- mobile: the crumb leaves the viewport with the rest of the page.

Both pass locally. The existing `task-breadcrumb` / `task-reparent` component tests are untouched and green - the markup and links did not change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QM9gdNDsDNXmCRcj4dDusw)_