### PR TITLE
feat!: configure the hezo binary with a .cjs config file instead of env vars

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -48,7 +48,7 @@ manager (agents bring their own models and runtimes).
 |---|---|
 | Server | Hono (TypeScript) on the **Bun** runtime |
 | Binary | `bun build --compile` → one cross-platform executable |
-| Database | Behind the `Db` interface (`src/db/database.ts`): **PGlite** (embedded Postgres, in-process, persisted to `~/.hezo/pgdata`) by default, or **external Postgres 14+** via `--database-url`/`HEZO_DATABASE_URL` (node-postgres pool) |
+| Database | Behind the `Db` interface (`src/db/database.ts`): **PGlite** (embedded Postgres, in-process, persisted to `~/.hezo/pgdata`) by default, or **external Postgres 14+** via `--database-url`/`database.url` (node-postgres pool) |
 | Frontend | React 19 + TanStack Router + TanStack Query, Tailwind + Radix UI; bundled into the binary |
 | Realtime | WebSocket row-change events → client invalidates React Query keys |
 | Agent interface | MCP (Streamable HTTP) at `POST /mcp` via `@modelcontextprotocol/sdk` |
@@ -1270,7 +1270,7 @@ The client speaks the Engine API over a Unix socket (Bun `fetch({unix})` for one
 `node:http` `socketPath` for streams), so `tcp://`/`npipe://`/`ssh://` endpoints are
 structurally unsupported and are reported as such rather than silently ignored.
 `services/docker-socket.ts` resolves it, most-explicit first: `--docker-socket` /
-`HEZO_DOCKER_SOCKET` -> `DOCKER_HOST` -> the docker CLI's **current context** (read straight
+`containers.dockerSocket` -> `DOCKER_HOST` -> the docker CLI's **current context** (read straight
 from `${DOCKER_CONFIG:-~/.docker}/config.json` + `contexts/meta/<sha256(name)>/meta.json`,
 no subprocess, `DOCKER_CONTEXT` winning) -> the well-known path per supported runtime
 (`/var/run/docker.sock`, `~/.docker/run`, `~/.colima/<profile>`, `~/.rd`, `~/.orbstack/run`,
@@ -1324,14 +1324,14 @@ probe mounts a scratch dir from the data dir into a throwaway container, has it 
 host-written sentinel and write back, and checks host-side that the write landed: missing
 sentinel (or a write the host never sees) -> `not-mounted`, sentinel visible but write
 refused -> `read-only`. Logged at `error` with the runtime-specific fix but **non-fatal** -
-exiting would take down the UI the operator needs. Opt out with `HEZO_SKIP_MOUNT_CHECK`.
+exiting would take down the UI the operator needs. Opt out with `containers.skipMountCheck`.
 
 **A vault-backed credential defers the open to unlock, and only then.** The provider API
 key lives in the `secrets` vault, encrypted with the master key, which is memory-only — so
 an instance, which comes back **locked** after every restart, cannot read it at the moment
 the backend is chosen. Making that fatal meant a managed backend could not survive a
 restart at all: a stored key read back as "no API key is configured", and a
-`HEZO_DAYTONA_API_KEY` supplied at launch threw "the instance is locked" from
+`containers.daytona.apiKey` supplied at launch threw "the instance is locked" from
 `storeDaytonaApiKey`. Both aborted startup on every boot, and the only workaround was
 passing the master key on the command line — the one thing Hezo never asks an operator to
 persist.
@@ -3831,7 +3831,7 @@ surfaced as `Proxy CONNECT aborted` on every clone. The token rides the
 per-runtime change. This closes the gap where any process reaching the proxy port could drive
 substitution for another run; it does not weaken the red line — an unauthenticated caller only
 ever ships the *unsubstituted* placeholder, which fails upstream, never a real secret. Auth is
-on by default and can be disabled with `--no-egress-proxy-auth` / `HEZO_EGRESS_PROXY_AUTH=0`
+on by default and can be disabled with `--no-egress-proxy-auth` / `egress.proxyAuth: false`
 for a runtime whose HTTP client can't carry proxy credentials.
 
 **Egress MTU.** Containers reach the internet through the host's default-route interface via
@@ -3901,7 +3901,7 @@ so it should never arrive here, but `NO_PROXY` is a client-side convention and a
 that ignored it would otherwise lose its whole tool surface; the run already holds an
 agent JWT for exactly that endpoint, so this grants nothing new, and the port match keeps
 `host.docker.internal:5432` refused. Off-switch: `--egress-allow-private-targets` /
-`HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1`, for an operator whose MCP server or git remote is
+`egress.allowPrivateTargets`, for an operator whose MCP server or git remote is
 genuinely on the LAN. The proxy's own MITM bridge dials loopback directly (`netConnect`),
 not through this path, so it is unaffected.
 
@@ -4903,6 +4903,53 @@ shorter than the image it writes), and the maskable variant had no safe zone at 
 
 ## 12. Build, release, migrations & upgrades
 
+### Configuration resolution
+
+Settings come from a **config file** named by `--config`, and from **CLI flags**. Precedence
+is **flag > file > built-in default**, resolved once by `resolveConfig` (`cli.ts`) into a
+`HezoConfig`. There is no implicit discovery: without `--config`, only defaults and flags
+apply. Environment variables are no longer a configuration mechanism - `HEZO_MASTER_KEY` is
+the single exception (below), and the remaining `HEZO_*` reads are test seams, dev directory
+overrides, container-injected run plumbing, or build/process topology (`HEZO_WORKER`,
+`HEZO_VERSION`).
+
+The file is CommonJS (`module.exports = { … }`), loaded with `createRequire` in
+`config/load.ts`. `createRequire` builds the resolver at runtime, so `bun build --compile`
+never sees a specifier it might try to resolve statically and inline into the binary - a
+plain `require(path)` or `import(path)` would be a bundler input. Because it is real
+JavaScript, the file can compute values at load time; the systemd deploy uses that to read
+its `webUrl` from a side file that `hezo-firstboot` writes, since a `.cjs` object cannot be
+appended to the way an `EnvironmentFile` line could.
+
+Validation is a `.strict()` zod schema (`config/schema.ts`) whose shape is a deep-`Partial`
+of `HezoConfig`, so the file, the type and `docs/deployment/configuration.md` cannot drift.
+Strictness is the point: a silently-ignored `dataDIr` is the specific failure mode a config
+file introduces over flags. Two keys are rejected **by name**, with their own message rather
+than a generic "unrecognized key":
+
+- **`masterKey`** - it must never be written to disk (§ *Never encourage storing the master
+  key on a system* in AGENTS.md). `HEZO_MASTER_KEY` remains the way to unlock a single
+  non-interactive startup: an env var rather than a flag, because a twelve-word phrase in
+  argv is visible in the process list.
+- **`reset`** - it renames the embedded `pgdata` aside, which is a one-off action. In a
+  persistent file it would wipe the database on **every** restart.
+
+**Reaching the resolved config.** `index.ts` publishes it with `setRuntimeConfig()` right
+after resolving, and everything else reads it back through `runtimeConfig()`
+(`config/runtime.ts`). The accessor exists because `index.ts` imports `./app` - and through
+it every service - *before* it resolves anything, so a module-level
+`const X = process.env.Y ?? default` would capture the default and silently ignore the
+operator's file. Read config inside the function that needs it, never into a module-level
+constant. Where a value was previously interpolated into a module-level string
+(`nextHeartbeatAtSql`, `heartbeatIntervalArgDescription`), that string became a function for
+the same reason. `runtimeConfig()` falls back to `DEFAULT_CONFIG` when nothing has been set,
+so a unit test that imports a service without booting the server needs no arrangement.
+
+`hezo backup`, `hezo restore` and `hezo uninstall` accept the same `--config` and share one
+resolver (`resolveSubcommandTargets`), replacing four near-duplicate pickers that had drifted
+- one of them let an empty value win where the others treated empty as unset.
+
+
 **Author-run generators.** Two build steps are **not** wired into `bun run build` or CI, because
 their output is committed and regenerating them requires a tool the ordinary build must not
 depend on: `build:marketplace` (recompiles `marketplace/teams/*.json`, also run by `bun run dev`)
@@ -5195,9 +5242,10 @@ body through `restoreLogicalBackupFromFile`, so a multi-GB backup is never decom
 the header and again for the load, and never held in memory. External startup migrations write a bare logical `.backup.gz` into `<dataDir>/backups/`
 automatically before applying (last 5 kept; a failed backup aborts the migration); the
 embedded path keeps its stronger copy-swap instead. The `hezo backup`/`hezo restore`
-subcommands resolve the data dir with the same precedence as the server (`HEZO_DATA_DIR` >
-`--data-dir` > `~/.hezo`, via `pickDataDir` in `cli.ts`), so a deployment that starts the
-server with `HEZO_DATA_DIR` set needs no extra flag; backup also refuses (with an actionable
+subcommands resolve the data dir with the same precedence as the server (`--data-dir` >
+the `--config` file's `dataDir` > `~/.hezo`, via `resolveSubcommandTargets` in `cli.ts`), so
+a deployment that starts the server with a config file needs only the same `--config`;
+backup also refuses (with an actionable
 message) if the target holds no `_migrations` bookkeeping. Embedded is single-process, so
 backup/restore against the embedded backend are gated by an **advisory instance lock**
 (`db/instance-lock.ts`): the running server writes its OS PID to `<dataDir>/hezo.lock`

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ This starts the **Hezo Server** (port 3100) — the main application with the em
 PGlite database — and the **Vite dev server** for the web UI (port 5173). The production
 binary serves the UI itself from port 3100. In dev the server creates its database under
 `.hezo-dev/pgdata` in the repo root (gitignored), keeping local dev isolated from a
-production instance at `~/.hezo`. Override the location with `--data-dir` or `HEZO_DATA_DIR`.
+production instance at `~/.hezo`. Override the location with `--data-dir`, or `dataDir` in a `--config` file.
 
 ### Server CLI flags
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,8 @@
 | A `.dev/` guide added, renamed or removed | the link from its section here, the `.dev/` bullet under **Layout**, this table | **nothing - on you** |
 | A Bun workaround added or removed, or `BUN_VERSION` moved | its entry in `.dev/bun-issues.md` | **nothing - on you** |
 | A rule this file states | its guide in `.dev/`, if one covers that area - they must not disagree | **nothing - on you** |
-| CLI flag / subcommand / env var / port / default (`src/cli.ts`) | `docs/reference/cli.md`, `docs/deployment/configuration.md`, the CLI table in `packages/server/README.md`, any page showing the command | **nothing - on you** |
+| CLI flag / subcommand / config key / port / default (`src/cli.ts`, `src/config/`) | `docs/reference/cli.md`, `docs/deployment/configuration.md`, the CLI table in `packages/server/README.md`, any page showing the command | **nothing - on you** |
+| A new operator setting | its `config/types.ts` field + `DEFAULT_CONFIG` default, its `config/schema.ts` entry, and its row in `docs/deployment/configuration.md` | a missing type field is a compile error; **an unvalidated or undocumented key is on you** |
 | A sharded, renamed or newly-required CI job | its `*-complete` rollup, a shard-unique matrix artifact name, the `main` ruleset's required checks | **nothing - on you** |
 | A tool added to the container image | the toolset paragraph in `SHARED_INSTRUCTIONS` | **nothing - on you** |
 | A new AI provider (`AiProvider` + `PROVIDER_RUNTIME_ADAPTERS`) | `.dev/architecture.md`, the provider docs, `model_pricing` rows, and a decision on `claudeCodeProviderUsesCustomEndpoint` | **nothing** - an unpriced model silently records $0 |
@@ -302,6 +303,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |
 | Paging (lists and large content) | `mcp/paging.ts` |
 | Shared enums, constants, validation run on both sides | `@hezo/shared` (`types/common.ts`) |
+| A resolved operator setting (from the config file or a flag) | `runtimeConfig()` (`config/runtime.ts`) - never a bare `process.env` read, and never into a module-level `const` |
 | An instance setting | `routes/instance-settings.ts` + the `system-meta` helpers |
 | Date formatting | `packages/web/src/lib/format-date.ts` |
 | Duration formatting (a settled figure, not a live tick) | `formatDuration` (`packages/web/src/lib/format-duration.ts`) |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -38,7 +38,7 @@ real Let's Encrypt cert, no domain required), or a domain you supply via
 `HEZO_DATABASE_URL` (managed Postgres) and/or `HEZO_ASSET_STORAGE_URL`
 (S3-compatible bucket) into `/etc/hezo/deploy.env` before the script runs (the
 cloud-init has commented lines for it) and they're persisted into the service's
-env file — see `docs/deployment/one-click.md` § Using managed data hosting. It never sets the master key: that is generated in the
+config file at `/etc/hezo/hezo.config.cjs` - see `docs/deployment/one-click.md` § Using managed data hosting. It never sets the master key: that is generated in the
 browser on first run and shown once, so the deploy lands you at the setup gate and
 you finish there (master key → admin password → connect a model). Password auth
 makes exposing that URL safe.

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -34,7 +34,7 @@ runcmd:
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into
   # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
-  # provision.sh persists them into the service's env file. sslmode=require encrypts
+  # provision.sh persists them into the service's config file. sslmode=require encrypts
   # without verifying the certificate; for verified TLS use sslmode=verify-full plus
   # &sslrootcert=/etc/hezo/db-ca.crt when the provider signs with its own CA (most do).
   # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -31,11 +31,11 @@
 #                          verifying the certificate; for verified TLS use
 #                          sslmode=verify-full, adding &sslrootcert=/etc/hezo/db-ca.crt
 #                          when the provider signs with its own CA (most do).
-#                          Persisted into /etc/hezo/hezo.env on first provision; omit to
+#                          Persisted into /etc/hezo/hezo.config.cjs on first provision; omit to
 #                          use the embedded database on the VM's disk (the default).
 #   HEZO_ASSET_STORAGE_URL S3-compatible object storage for asset files
 #                          (s3://KEY:SECRET@endpoint/bucket[/prefix]). Persisted into
-#                          /etc/hezo/hezo.env on first provision; omit for local disk.
+#                          /etc/hezo/hezo.config.cjs on first provision; omit for local disk.
 #   HEZO_DATABASE_POOL_SIZE  connection-pool size for the external database (2-100).
 #   HEZO_SWAP_SIZE         size of the swap file this script creates so low-RAM hosts
 #                          don't OOM (default 6G; accepts 6G / 6144M). Set 0 to disable.
@@ -56,7 +56,8 @@ if [[ "${EUID}" -ne 0 ]]; then
 fi
 
 DATA_DIR="/var/lib/hezo"
-ENV_FILE="/etc/hezo/hezo.env"
+CONFIG_FILE="/etc/hezo/hezo.config.cjs"
+WEB_URL_FILE="/etc/hezo/web-url"
 DEPLOY_ENV="/etc/hezo/deploy.env"
 RELEASE_TAG="${HEZO_RELEASE_TAG:-latest}"
 
@@ -228,24 +229,42 @@ chmod +x /usr/local/bin/hezo
 # ---------------------------------------------------------------------------
 install -d -m 700 /etc/hezo
 install -d -m 755 "${DATA_DIR}"
-if [[ ! -f "${ENV_FILE}" ]]; then
-	install -m 600 /dev/null "${ENV_FILE}"
-	cat >"${ENV_FILE}" <<EOF
-HEZO_DATA_DIR=${DATA_DIR}
-# HEZO_WEB_URL is written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
-# Do NOT put your master key in this file. Hezo keeps it in memory only and comes up locked
-# after each restart by design; unlock it from the browser gate. A copy of the key on disk
-# next to the encrypted data would let anyone who reads this box decrypt your vault.
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+	# Mode 600: this file can hold database and object-storage credentials.
+	install -m 600 /dev/null "${CONFIG_FILE}"
+	cat >"${CONFIG_FILE}" <<EOF
+// Hezo configuration. Edit and restart: systemctl restart hezo
+// Reference: https://hezo.ai/docs/deployment/configuration
+//
+// Do NOT put your master key in this file. Hezo keeps it in memory only and comes up
+// locked after each restart by design; unlock it from the browser gate. A copy of the
+// key on disk next to the encrypted data would let anyone who reads this box decrypt
+// your vault.
+const { existsSync, readFileSync } = require('node:fs');
+
+// Written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
+const webUrlFile = '${WEB_URL_FILE}';
+
+module.exports = {
+	dataDir: '${DATA_DIR}',
+	webUrl: existsSync(webUrlFile) ? readFileSync(webUrlFile, 'utf8').trim() : '',
 EOF
 	# Managed data hosting (optional): persist the database / asset-storage settings
-	# provided at provision time so the systemd unit picks them up. To wire them into
-	# an already-provisioned host, edit this file directly and restart hezo — see
+	# provided at provision time. To wire them into an already-provisioned host, edit
+	# this file directly and restart hezo — see
 	# docs/deployment/one-click.md § Using managed data hosting.
-	for key in HEZO_DATABASE_URL HEZO_ASSET_STORAGE_URL HEZO_DATABASE_POOL_SIZE; do
-		if [[ -n "${!key:-}" ]]; then
-			echo "${key}=${!key}" >>"${ENV_FILE}"
-		fi
-	done
+	if [[ -n "${HEZO_DATABASE_URL:-}" || -n "${HEZO_DATABASE_POOL_SIZE:-}" ]]; then
+		{
+			echo "	database: {"
+			[[ -n "${HEZO_DATABASE_URL:-}" ]] && echo "		url: '${HEZO_DATABASE_URL}',"
+			[[ -n "${HEZO_DATABASE_POOL_SIZE:-}" ]] && echo "		poolSize: ${HEZO_DATABASE_POOL_SIZE},"
+			echo "	},"
+		} >>"${CONFIG_FILE}"
+	fi
+	if [[ -n "${HEZO_ASSET_STORAGE_URL:-}" ]]; then
+		echo "	assetStorage: { url: '${HEZO_ASSET_STORAGE_URL}' }," >>"${CONFIG_FILE}"
+	fi
+	echo "};" >>"${CONFIG_FILE}"
 fi
 
 # Persist optional settings the first-boot unit reads (domain override, swap size).
@@ -301,7 +320,8 @@ cat >/usr/local/sbin/hezo-firstboot.sh <<'EOF'
 #!/usr/bin/env bash
 # Runs once, before Caddy and Hezo start. Derives the public HTTPS URL from the
 # host's public IP (via <ip>.sslip.io) unless HEZO_DOMAIN_OVERRIDE is set, then
-# writes it where Caddy and Hezo read it.
+# writes it where Caddy (/etc/caddy/hezo.env) and Hezo (/etc/hezo/web-url, read
+# by /etc/hezo/hezo.config.cjs) each pick it up.
 set -euo pipefail
 
 SENTINEL="/var/lib/hezo/.firstboot-done"
@@ -330,7 +350,8 @@ else
 fi
 
 echo "HEZO_SITE_ADDRESS=${DOMAIN}" >/etc/caddy/hezo.env
-grep -q '^HEZO_WEB_URL=' /etc/hezo/hezo.env || echo "HEZO_WEB_URL=https://${DOMAIN}" >>/etc/hezo/hezo.env
+# The config file reads this path for `webUrl`; a .cjs object cannot be appended to.
+[[ -s /etc/hezo/web-url ]] || echo "https://${DOMAIN}" >/etc/hezo/web-url
 
 install -d /var/lib/hezo
 touch "${SENTINEL}"
@@ -367,8 +388,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/hezo
-EnvironmentFile=/etc/hezo/hezo.env
+ExecStart=/usr/local/bin/hezo --config /etc/hezo/hezo.config.cjs
 Restart=always
 RestartSec=5
 TimeoutStopSec=30
@@ -434,5 +454,5 @@ else
 	systemctl restart caddy
 	systemctl enable --now hezo
 	log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
-	log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"
+	log "  cat /etc/hezo/hezo.config.cjs    # webUrl comes from /etc/hezo/web-url"
 fi

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -25,7 +25,7 @@ for where the data directory lives and how to run Hezo unattended.
 
 If you'd rather run against a managed or self-run **PostgreSQL 14+** - for managed
 backups, more headroom, or your own operational tooling - point Hezo at it with
-`--database-url` / `HEZO_DATABASE_URL` (see
+`--database-url` / `database.url` (see
 [Using an external Postgres](/docs/deployment/configuration#using-an-external-postgres);
 for a cloud deployment there's a step-by-step in
 [Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)).
@@ -34,7 +34,7 @@ database rows move.
 
 Uploaded **asset files** work the same way: they live under `<data-dir>/assets/` by
 default, or in any **S3-compatible bucket** when you set `--asset-storage-url` /
-`HEZO_ASSET_STORAGE_URL` (see
+`assetStorage.url` (see
 [Storing assets in S3-compatible object storage](/docs/deployment/configuration)). With a
 bucket configured, asset bytes live only with your storage provider - stored as plain
 objects (enable the provider's server-side encryption if you want them encrypted at

--- a/docs/containers/overview.md
+++ b/docs/containers/overview.md
@@ -140,7 +140,7 @@ hezo --sandbox-backend daytona --daytona-api-key "<key>"
 ```
 
 ```sh
-HEZO_SANDBOX_BACKEND=daytona HEZO_DAYTONA_API_KEY=<key> hezo
+hezo --config /etc/hezo/hezo.config.cjs   # containers: { backend: 'daytona', daytona: { apiKey: '<key>' } }
 ```
 
 **This sets the service a brand-new instance starts on.** It is a convenience for
@@ -153,7 +153,7 @@ To change an instance once it has booted - stopped or running - use Settings ->
 Containers.
 
 The provider key is the one flag that stays live: passing `--daytona-api-key` (or
-`HEZO_DAYTONA_API_KEY`) at a later startup rotates or supplies the credential for the
+`containers.daytona.apiKey`) at a later startup rotates or supplies the credential for the
 backend already chosen - it never chooses a backend by itself. See
 [Restarting an instance on a managed service](#restarting-an-instance-on-a-managed-service).
 
@@ -172,13 +172,13 @@ If the connection then fails, Hezo records the reason in the server log and stay
 disconnected. It never falls back to local Docker, so container operations report that
 failure instead of running somewhere you did not choose.
 
-Passing `--daytona-api-key` (or `HEZO_DAYTONA_API_KEY`) at startup works on a locked
+Passing `--daytona-api-key` (or `containers.daytona.apiKey`) at startup works on a locked
 instance too. Hezo uses the key straight away for that run and saves it once you unlock,
 so later restarts no longer need it.
 
-See the [CLI reference](/docs/reference/cli#environment-variables) and the
-[Configuration reference](/docs/deployment/configuration) for the full list of flags and
-environment variables.
+See the [CLI reference](/docs/reference/cli#the-config-file) and the
+[Configuration reference](/docs/deployment/configuration) for the full list of settings and
+flags.
 
 ## How much can run at once
 

--- a/docs/containers/remote/daytona.md
+++ b/docs/containers/remote/daytona.md
@@ -32,11 +32,11 @@ app still loads, so you can paste a new key or switch back to local Docker.
 
 You can also set it at startup on a brand-new instance, with
 `--sandbox-backend daytona --daytona-api-key "<key>"` or the matching
-`HEZO_SANDBOX_BACKEND` and `HEZO_DAYTONA_API_KEY` environment variables. That only chooses
+`containers.backend` and `containers.daytona.apiKey` config settings. That only chooses
 what a fresh instance starts on; see
 [Setting the service at startup](/docs/containers/overview#setting-the-service-at-startup).
 
-`--daytona-api-url` (or `HEZO_DAYTONA_API_URL`) points Hezo at a regional or self-hosted
+`--daytona-api-url` (or `containers.daytona.apiUrl`) points Hezo at a regional or self-hosted
 Daytona endpoint instead of the public API.
 
 ## Limits

--- a/docs/containers/remote/overview.md
+++ b/docs/containers/remote/overview.md
@@ -155,8 +155,8 @@ it the same backend settings the server ran with:
 hezo uninstall --yes --sandbox-backend daytona --daytona-api-key "<key>"
 ```
 
-The environment variables work too (`HEZO_SANDBOX_BACKEND`, `HEZO_DAYTONA_API_KEY`,
-`HEZO_DAYTONA_API_URL`). Without them uninstall cleans up local Docker and leaves the
+The config file works too (`containers.backend`, `containers.daytona.apiKey`,
+`containers.daytona.apiUrl`, via `--config`). Without them uninstall cleans up local Docker and leaves the
 remote sandboxes running - and nothing else will remove them, because the sweep that reaps
 unreferenced sandboxes lives in the instance being deleted. If the provider cannot be
 reached, uninstall says so and still removes the data directory; remove the leftovers from

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -29,7 +29,7 @@ key separately and safely (see [Master key & encryption](/docs/security/master-k
 hezo backup                         # whole instance (database + assets) → a bundle directory; stop the server first
 hezo backup --output /safe/place/hezo-backup/   # choose where the bundle goes
 hezo backup --no-assets             # database only → a single .backup.gz file
-HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo backup   # back up a hosted instance, any time
+hezo backup --config /etc/hezo/hezo.config.cjs   # back up a hosted instance, any time
 ```
 
 `hezo backup` writes a **backup bundle** (default `<data-dir>/backups/hezo-<timestamp>/`)
@@ -54,18 +54,18 @@ versioning.
 
 ### Point the command at your data directory
 
-`hezo backup` resolves its data directory the **same way the server does** - `HEZO_DATA_DIR`
+`hezo backup` resolves its data directory the **same way the server does** - the `--config` file
 first, then `--data-dir`, then the default `~/.hezo`. This matters the moment your instance
 does **not** live at the default location.
 
 **If your server runs with a custom data directory, the backup command has to know about it
-too.** Run `hezo backup` in the same environment as the server (so `HEZO_DATA_DIR` is set),
+too.** Run `hezo backup` with the same `--config` the server uses,
 or pass `--data-dir /your/path` explicitly. Otherwise the command falls back to `~/.hezo` - a
 directory your instance never used - and backs up the wrong database instead of yours.
 
 - **systemd / Docker** (the env var is already set for the service): `hezo backup` needs no
   extra flag - run it with the unit's environment (an `EnvironmentFile` / `systemd-run`), or
-  `docker exec <container> hezo backup`, and the same `HEZO_DATA_DIR` resolves your database.
+  `docker exec <container> hezo backup --config <path>`, and the same file resolves your database.
 - **A custom dir passed only as a startup flag** (`hezo --data-dir /var/lib/hezo`): pass the
   **same** `--data-dir /var/lib/hezo` to `hezo backup` (there is no env var to inherit).
 
@@ -87,7 +87,7 @@ versioning/replication and take a `--no-assets` database backup.
 
 ```sh
 hezo restore <bundle-or-file>                              # into the embedded database + local assets
-HEZO_DATABASE_URL=postgres://… hezo restore <bundle>       # database into an external Postgres
+hezo restore <bundle> --database-url postgres://…         # database into an external Postgres
 hezo restore <bundle> --asset-storage-url "s3://…"         # assets into an S3-compatible bucket
 ```
 
@@ -131,17 +131,17 @@ is only ever read, so nothing is removed until you do it yourself.
 ```sh
 # Local → hosted (external Postgres + S3 bucket)
 hezo backup --output move/                               # server stopped
-HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo restore move/
-HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo   # start against the new backends
+hezo restore move/ --database-url postgres://… --asset-storage-url "s3://…"
+hezo --config /etc/hezo/hezo.config.cjs   # start against the new backends
 
 # Hosted → local
-HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo backup --output back/
+hezo backup --config /etc/hezo/hezo.config.cjs --output back/
 hezo restore back/ --data-dir ~/.hezo
 hezo
 ```
 
 Migrate just one side by setting only that target on `restore` (e.g. only
-`HEZO_DATABASE_URL` to move the database while leaving assets where they are), or with
+`--database-url` to move the database while leaving assets where they are), or with
 `--no-assets` / `--no-database`. Your master key is unchanged by a move - the encrypted
 vault travels inside the backup.
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -80,13 +80,16 @@ backups. Each backend is one setting, adoptable independently:
 3. **Set the URL(s) where your service definition reads its environment** - e.g. the
    `EnvironmentFile` of your systemd unit (see
    [Self-hosting](/docs/deployment/self-hosting)), kept root-only (mode 600) since the
-   URLs carry credentials. Prefer the environment variables over the CLI flags - flags
-   are visible in the process list:
+   URLs carry credentials. Prefer the config file over the CLI flags - flags are visible
+   in the process list - and give it mode 600:
 
-   ```sh
-   HEZO_DATABASE_URL="postgres://hezo:••••@db-host:5432/hezo?sslmode=verify-full" \
-   HEZO_ASSET_STORAGE_URL="s3://ACCESS_KEY:SECRET@endpoint/bucket" \
-     hezo --data-dir /var/lib/hezo
+   ```js
+   // /etc/hezo/hezo.config.cjs
+   module.exports = {
+     dataDir: '/var/lib/hezo',
+     database: { url: 'postgres://hezo:••••@db-host:5432/hezo?sslmode=verify-full' },
+     assetStorage: { url: 's3://ACCESS_KEY:SECRET@endpoint/bucket' },
+   };
    ```
 
    Most managed providers sign their database certificates with their own CA, so

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -6,45 +6,199 @@ section: Deployment
 
 # Configuration reference
 
-Most settings can be supplied as a **command-line flag** or an **environment variable**;
-a few are environment-variable only (shown with `-` in the **Flag** column below).
-When a setting supports both and both are present, the **environment variable wins** -
-handy for baking defaults into a service definition while still overriding per run.
+Hezo is configured with a **config file** you point at with `--config`, and with
+**command-line flags**. A flag always wins over the file, and anything neither sets falls
+back to the built-in default.
+
+```sh
+hezo --config /etc/hezo/hezo.config.cjs
+```
+
+There is no automatic search: without `--config`, Hezo runs on the defaults plus whatever
+flags you pass. The one setting that is never read from the file is the master key - see
+[The master key is not a config setting](#the-master-key-is-not-a-config-setting).
+
+## The config file
+
+The file is a CommonJS module that exports an object:
+
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  port: 3100,
+  dataDir: '/var/lib/hezo',
+  webUrl: 'https://hezo.example.com',
+
+  database: { url: 'postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=verify-full' },
+  assetStorage: { url: 's3://ACCESS_KEY:SECRET@endpoint/bucket' },
+};
+```
+
+Only name the settings you want to change; everything else keeps its default. Because it is
+real JavaScript, it can compute values at load time - reading a side file, or branching on
+the host name:
+
+```js
+const { existsSync, readFileSync } = require('node:fs');
+const webUrlFile = '/etc/hezo/web-url';
+
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  webUrl: existsSync(webUrlFile) ? readFileSync(webUrlFile, 'utf8').trim() : '',
+};
+```
+
+A misspelled or unknown key is an **error naming the key**, not something quietly ignored,
+so a typo cannot leave you running a setting you thought you had changed.
+
+**Give the file mode 600 if it carries credentials.** `database.url`,
+`assetStorage.url` and `containers.daytona.apiKey` are secrets:
+
+```sh
+sudo install -d -m 700 /etc/hezo
+sudo install -m 600 /dev/null /etc/hezo/hezo.config.cjs
+```
 
 ## Options
 
-| Flag | Environment variable | Default | Description |
+Nested keys are written in dot form below: `database.url` means
+`{ database: { url: '...' } }`.
+
+### Core
+
+| Setting | Flag | Default | Description |
 |---|---|---|---|
-| `--port <port>` | `HEZO_PORT` | `3100` | Port the server and web app listen on (1-65535). |
-| `--data-dir <path>` | `HEZO_DATA_DIR` | `~/.hezo/` | Where Hezo stores its database, encrypted secrets, and assets. Still required with an external database or S3 asset storage - workspaces and keys live here. |
-| `--database-url <url>` | `HEZO_DATABASE_URL` | - | Connection string for an [external Postgres](#using-an-external-postgres) (`postgres://user:password@host:5432/hezo`). Its `sslmode` follows standard libpq rules - see [TLS and sslmode](#tls-and-sslmode). Omit to use the embedded database under the data directory (the default). |
-| - | `HEZO_DATABASE_POOL_SIZE` | `10` | Connection-pool size for the external database (2-100). Ignored for the embedded database. |
-| `--asset-storage-url <url>` | `HEZO_ASSET_STORAGE_URL` | - | [S3-compatible object storage](#storing-assets-in-s3-compatible-object-storage) for asset files (`s3://KEY:SECRET@endpoint/bucket[/prefix]`). Omit to store assets on the local filesystem under the data directory (the default). |
-| `--sandbox-backend <name>` | `HEZO_SANDBOX_BACKEND` | `docker` | Where agent containers run on a **new** instance: `docker` (the local daemon) or `daytona` (a [managed sandbox service](#running-agent-containers-on-a-managed-sandbox-service)). Once set in Settings -> Containers, the stored choice wins and this is ignored. Selecting a managed backend Hezo cannot reach is fatal at startup - it never falls back to local Docker. |
-| `--daytona-api-key <key>` | `HEZO_DAYTONA_API_KEY` | - | Daytona API key. Required when `--sandbox-backend` is `daytona`. Used only by Hezo itself to reach the provider - it is never placed inside an agent container. |
-| `--daytona-api-url <url>` | `HEZO_DAYTONA_API_URL` | Daytona's public API | Daytona API base URL, for a regional or self-hosted endpoint. |
-| - | `HEZO_AGENT_BASE_IMAGE` | the release's published image | Container image every project's agents run in, overriding the default for this instance. Must be a reference the backend in use can pull, e.g. `ghcr.io/hezo-ai/agent-base:0.42.0`. Mainly for running a development server against a managed sandbox service, where the default is built into the local Docker daemon and a managed service has nothing to pull. A project that names its own base image keeps it. |
-| `--master-key <phrase>` | `HEZO_MASTER_KEY` | - | The twelve-word master key, to set up or unlock without the web gate. |
-| `--web-url <url>` | `HEZO_WEB_URL` | same origin | Public base URL, used so account sign-ins redirect back correctly. |
-| `--reset` | `HEZO_RESET` | off | Start fresh with an empty **embedded** database (the existing `pgdata` is renamed aside, not deleted). Not applicable with `--database-url` - recreate an external database with your provider's tools. |
-| `--no-open` | `HEZO_OPEN` | on | Auto-open the web app in your browser on startup. On by default; automatically skipped in environments without a browser (CI, containers, SSH, headless Linux). Also governs the Windows dialog shown when no container runtime is installed. Pass `--no-open` or set `HEZO_OPEN=0` to disable. |
-| `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
-| `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them - for debugging a crashed container. |
-| `--docker-socket <path>` | `HEZO_DOCKER_SOCKET` | auto | Path to the container runtime's Unix socket. By default Hezo finds it: `DOCKER_HOST`, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Set it only when the daemon listens somewhere none of those cover. Unix sockets only - `tcp://` and `npipe://` are not supported. See [Container runtimes](/docs/deployment/container-runtimes). |
-| - | `DOCKER_HOST` | - | Standard Docker environment variable, honoured when it points at a `unix://` socket. Takes effect only if `--docker-socket` / `HEZO_DOCKER_SOCKET` is unset. |
-| - | `HEZO_SKIP_MOUNT_CHECK` | off | Skip the boot check that verifies agent containers get a writable view of the data directory. The check is a diagnosis, not a dependency - skipping it hides the warning, it does not make a read-only mount work. |
-| `--egress-allow-private-targets` | `HEZO_EGRESS_ALLOW_PRIVATE_TARGETS` | off | Allow agent egress through the proxy to reach loopback, link-local and private (RFC1918) addresses. Blocked by default: the proxy runs on the host, so without the guard an agent could tunnel to Hezo's own API, its database, or any host-bound daemon. The check is made on the address a hostname resolves to, not on the name. Enable only when an MCP server or git remote your agents genuinely need lives on your LAN. |
-| `--no-egress-proxy-auth` | `HEZO_EGRESS_PROXY_AUTH` | on | Per-run egress-proxy authentication. On by default: each run's `HTTP(S)_PROXY` URL carries a random token the proxy verifies before substituting any secret, so a process that reaches the proxy address can't drive substitution for another run. Only disable to unblock a runtime whose HTTP client can't send proxy credentials - the secret red line still holds either way (an unauthenticated caller only ships unsubstituted placeholders, which fail upstream). Pass `--no-egress-proxy-auth` or set `HEZO_EGRESS_PROXY_AUTH=0`. |
-| `--version` | - | - | Print the Hezo version and exit (also `hezo version`). |
-| `--disable-telemetry` | `HEZO_TELEMETRY_ENABLED` | on | Turn off the anonymous daily usage report (see [Anonymous usage telemetry](#anonymous-usage-telemetry)). On by default; pass `--disable-telemetry` or set `HEZO_TELEMETRY_ENABLED=0`. |
-| `--telemetry-endpoint <url>` | `HEZO_TELEMETRY_ENDPOINT` | `https://hezo.ai/api/telemetry` | Where the daily report is sent. Point it at your own collector to keep the data in-house. |
-| - | `HEZO_TELEMETRY_CRON` | `0 0 5 * * *` | Cron schedule (seconds-precision) for the daily telemetry report. |
-| - | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, the background download, and the "Install & restart" banner). When disabled the banner instead links to the GitHub release page. |
-| - | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. A running instance also stages as soon as it detects an update, so the banner's "Install & restart" is instant. |
-| `--auto-install-updates` | `HEZO_AUTO_INSTALL_UPDATES` | off | Install staged updates automatically: once a newer release is downloaded and verified, Hezo gracefully restarts onto it without waiting for "Install & restart" in the web UI. The restart is deferred while agent runs are in flight, and only happens where in-app auto-update is available at all (the self-managed binary - not inside a container). The instance comes back **unlocked**: the unlock key is handed to the new process in memory, never written to disk. See [Updating](/docs/deployment/self-hosting#updating). |
-| - | `HEZO_AUTO_INSTALL_CRON` | `0 */5 * * * *` | Cron schedule (seconds-precision) for the auto-install check that restarts onto a staged update once no agent runs are in flight. Only registered when auto-install is enabled. |
-| - | `HEZO_PRICING_REFRESH_CRON` | `0 0 2 * * *` | Cron schedule (seconds-precision) for the daily model-pricing refresh from [pricepertoken.com](https://pricepertoken.com). Pricing also refreshes at startup; a failed refresh keeps the existing rates. |
-| - | `HEZO_MODEL_PIN_REFRESH_CRON` | `0 0 3 * * *` | Cron schedule (seconds-precision) for the daily re-read of each connected provider's model catalog, which keeps the model a **newly added** connection starts on current. Connections you already have keep the model you chose. A provider Hezo cannot reach keeps its previous default. |
+| - | `--config <path>` | - | Path to the config file. Without it, only defaults and flags apply. |
+| `port` | `--port <port>` | `3100` | Port the server and web app listen on (1-65535). |
+| `dataDir` | `--data-dir <path>` | `~/.hezo/` | Where Hezo stores its database, encrypted secrets, and assets. Still required with an external database or S3 asset storage - workspaces and keys live here. |
+| `webUrl` | `--web-url <url>` | same origin | Public base URL, used so account sign-ins redirect back correctly. |
+| `logLevel` | `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
+| `open` | `--no-open` | on | Auto-open the web app in your browser on startup. Automatically skipped in environments without a browser (CI, containers, SSH, headless Linux). Also governs the Windows dialog shown when no container runtime is installed. |
+| - | `--reset` | off | Start fresh with an empty **embedded** database (the existing `pgdata` is renamed aside, not deleted). A flag only - see [Why `reset` is not a config setting](#why-reset-is-not-a-config-setting). Not applicable with an external database - recreate that with your provider's tools. |
+| - | `--version` | - | Print the Hezo version and exit (also `hezo version`). |
+
+### Database
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `database.url` | `--database-url <url>` | - | Connection string for an [external Postgres](#using-an-external-postgres) (`postgres://user:password@host:5432/hezo`). Its `sslmode` follows standard libpq rules - see [TLS and sslmode](#tls-and-sslmode). Omit to use the embedded database under the data directory (the default). |
+| `database.poolSize` | - | `10` | Connection-pool size for the external database (2-100). Ignored for the embedded database. |
+
+### Asset storage
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `assetStorage.url` | `--asset-storage-url <url>` | - | [S3-compatible object storage](#storing-assets-in-s3-compatible-object-storage) for asset files (`s3://KEY:SECRET@endpoint/bucket[/prefix]`). Omit to store assets on the local filesystem under the data directory (the default). |
+
+### Containers
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `containers.backend` | `--sandbox-backend <name>` | `docker` | Where agent containers run on a **new** instance: `docker` (the local daemon) or `daytona` (a [managed sandbox service](#running-agent-containers-on-a-managed-sandbox-service)). Once set in Settings -> Containers, the stored choice wins and this is ignored. Selecting a managed backend Hezo cannot reach is fatal at startup - it never falls back to local Docker. |
+| `containers.daytona.apiKey` | `--daytona-api-key <key>` | - | Daytona API key. Required when the backend is `daytona`. Used only by Hezo itself to reach the provider - it is never placed inside an agent container. |
+| `containers.daytona.apiUrl` | `--daytona-api-url <url>` | Daytona's public API | Daytona API base URL, for a regional or self-hosted endpoint. |
+| `containers.dockerSocket` | `--docker-socket <path>` | auto | Path to the container runtime's Unix socket. By default Hezo finds it: `DOCKER_HOST`, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Set it only when the daemon listens somewhere none of those cover. Unix sockets only - `tcp://` and `npipe://` are not supported. See [Container runtimes](/docs/deployment/container-runtimes). |
+| `containers.dockerRequestTimeoutMs` | - | `10000` | Ceiling on a single call to the Docker daemon, so a wedged one cannot stall the container-sync loop. Raise it for a slow host. |
+| `containers.keepOld` | `--keep-old-containers` | off | Keep old project containers instead of removing them - for debugging a crashed container. |
+| `containers.skipMountCheck` | - | off | Skip the boot check that verifies agent containers get a writable view of the data directory. The check is a diagnosis, not a dependency - skipping it hides the warning, it does not make a read-only mount work. |
+| `containers.agentBaseImage` | - | the release's published image | Container image every project's agents run in, overriding the default for this instance. Must be a reference the backend in use can pull, e.g. `ghcr.io/hezo-ai/agent-base:0.42.0`. Mainly for running a development server against a managed sandbox service, where the default is built into the local Docker daemon and a managed service has nothing to pull. A project that names its own base image keeps it. |
+| - | `DOCKER_HOST` (environment) | - | Standard Docker environment variable, honoured when it points at a `unix://` socket. Takes effect only if `containers.dockerSocket` / `--docker-socket` is unset. |
+
+### Egress
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `egress.allowPrivateTargets` | `--egress-allow-private-targets` | off | Allow agent egress through the proxy to reach loopback, link-local and private (RFC1918) addresses. Blocked by default: the proxy runs on the host, so without the guard an agent could tunnel to Hezo's own API, its database, or any host-bound daemon. The check is made on the address a hostname resolves to, not on the name. Enable only when an MCP server or git remote your agents genuinely need lives on your LAN. |
+| `egress.proxyAuth` | `--no-egress-proxy-auth` | on | Per-run egress-proxy authentication. On by default: each run's `HTTP(S)_PROXY` URL carries a random token the proxy verifies before substituting any secret, so a process that reaches the proxy address can't drive substitution for another run. Only disable to unblock a runtime whose HTTP client can't send proxy credentials - the secret red line still holds either way (an unauthenticated caller only ships unsubstituted placeholders, which fail upstream). |
+| `egress.debug` | - | off | Per-connection proxy lifecycle tracing. Diagnostic only, and very noisy. |
+
+### Telemetry and updates
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `telemetry.enabled` | `--disable-telemetry` | on | The anonymous daily usage report (see [Anonymous usage telemetry](#anonymous-usage-telemetry)). Pass `--disable-telemetry` or set `telemetry.enabled: false`. |
+| `telemetry.endpoint` | `--telemetry-endpoint <url>` | `https://hezo.ai/api/telemetry` | Where the daily report is sent. Point it at your own collector to keep the data in-house. |
+| `updates.disabled` | - | off | Disable the in-app auto-update (release check, the background download, and the "Install & restart" banner). When disabled the banner instead links to the GitHub release page. |
+| `updates.autoInstall` | `--auto-install-updates` | off | Install staged updates automatically: once a newer release is downloaded and verified, Hezo gracefully restarts onto it without waiting for "Install & restart" in the web UI. The restart is deferred while agent runs are in flight, and only happens where in-app auto-update is available at all (the self-managed binary - not inside a container). The instance comes back **unlocked**: the unlock key is handed to the new process in memory, never written to disk. See [Updating](/docs/deployment/self-hosting#updating). |
+
+### Marketplace and connectors
+
+| Setting | Flag | Default | Description |
+|---|---|---|---|
+| `marketplace.ref` | - | `main` | Git ref the [team marketplace](/docs/concepts/marketplace) is fetched from. Point it at a branch or tag to pin the catalog. |
+| `marketplace.baseUrl` | - | `https://raw.githubusercontent.com` | Base URL the marketplace is fetched from, for a fork or an internal mirror. |
+| `github.oauthClientId` | - | Hezo's public OAuth app | Client id for the GitHub connector's device flow. Register your own GitHub OAuth app and name it here to keep the authorization under your own organization's control. |
+
+### Background job schedules
+
+All schedules are **seconds-precision six-field** cron expressions
+(`second minute hour day month weekday`). The defaults suit a normal instance; change one
+only when you have a reason to.
+
+| Setting | Default | Description |
+|---|---|---|
+| `jobs.wakeupCron` | `*/5 * * * * *` | Delivery of queued agent wakeups. |
+| `jobs.heartbeatCron` | `*/5 * * * * *` | Scan for agents whose heartbeat interval is due. |
+| `jobs.wakeupCoalescingMs` | `2000` | Window in which repeated wakeups for one agent collapse into a single run. |
+| `jobs.heartbeatCooldownSec` | `60` | Quiet window after a run before that agent is heartbeat-eligible again. Prevents back-to-back runs when the configured interval is shorter than the run itself. |
+| `jobs.heartbeatFloorMin` | `60` | Lowest heartbeat cadence the scheduler honours, in minutes. Raising it clamps every agent up to it, and the web UI's cadence options will under-report the new floor. |
+| `jobs.containerSyncCron` | `* * * * * *` | Container status reconciliation. Every second keeps the dashboard snappy; slow it down on a CPU-starved host. |
+| `jobs.containerIdleStopCron` | `15 * * * * *` | Idle-container reaper. |
+| `jobs.orphanDetectionCron` | `*/30 * * * * *` | Detection of runs whose container disappeared. |
+| `jobs.orphanContainerSweepCron` | `45 */10 * * * *` | Removal of containers this instance created that no project points at any more. On a managed backend an orphan bills until it is swept. |
+| `jobs.connectorHealthCron` | `0 */5 * * * *` | OAuth token renewal and hosted-connector re-probing. |
+| `jobs.budgetResumeCron` | `*/30 * * * * *` | Re-evaluation of budget-paused agents, so a rolling window that has rolled over frees them. |
+| `jobs.inboxArchiveCron` | `0 0 3 * * *` | Inbox archiving sweep. |
+| `jobs.inboxRetentionDays` | `30` | How long archived inbox items are kept, in days. |
+| `jobs.pricingRefreshCron` | `0 0 2 * * *` | Daily model-pricing refresh from [pricepertoken.com](https://pricepertoken.com). Pricing also refreshes at startup; a failed refresh keeps the existing rates. |
+| `jobs.modelPinRefreshCron` | `0 0 3 * * *` | Daily re-read of each connected provider's model catalog, which keeps the model a **newly added** connection starts on current. Connections you already have keep the model you chose. A provider Hezo cannot reach keeps its previous default. |
+| `jobs.updateCheckCron` | `0 0 4 * * *` | Daily check that downloads and stages a newer release. A running instance also stages as soon as it detects an update, so the banner's "Install & restart" is instant. |
+| `jobs.autoInstallCron` | `0 */5 * * * *` | Auto-install check that restarts onto a staged update once no agent runs are in flight. Only registered when `updates.autoInstall` is on. |
+| `jobs.telemetryCron` | `0 0 5 * * *` | Daily telemetry report. |
+| `jobs.dbMaintenanceCron` | `0 30 4 * * *` | Planner-statistics refresh and scheduler bookkeeping sweep. |
+
+### Run-log compaction
+
+Compaction is started by an operator from the Storage settings page; these control how it
+drains once running. Nothing here starts a pass on its own.
+
+| Setting | Default | Description |
+|---|---|---|
+| `logCompaction.cron` | `*/10 * * * * *` | Drain tick. Cheap when idle - it only does work while a pass is active. |
+| `logCompaction.batch` | `50` | Runs compacted per batch. |
+| `logCompaction.maxPerTick` | `500` | Runs compacted per tick before yielding to the next. |
+| `logCompaction.preservedBytes` | `12288` | Trailing bytes of each old run's log kept - the slice holding the end-of-run summary and the token/cost line. Everything before it is discarded. |
+
+### Live chat
+
+| Setting | Default | Description |
+|---|---|---|
+| `chat.healthIntervalMs` | `10000` | How often a live chat session verifies its container is still healthy. |
+
+## The master key is not a config setting
+
+The master key is **never** read from the config file, and Hezo rejects a `masterKey` key
+with an error rather than accepting it. It is kept in memory only, which is what makes
+encryption at rest meaningful: a copy of the key on disk next to the encrypted data would
+let anyone who reads the host decrypt your vault.
+
+Hezo starts **locked** by design; you unlock it from the browser gate. To unlock a single
+non-interactive startup, pass the phrase to that one invocation with `HEZO_MASTER_KEY` (an
+environment variable rather than a flag, because flags are visible in the process list):
+
+```sh
+HEZO_MASTER_KEY="your twelve word master key phrase here" hezo --config /etc/hezo/hezo.config.cjs
+```
+
+Never persist it - not to a config file, an env file, a service definition, or a shell
+profile. See [Master key & encryption](/docs/security/master-key).
+
+## Why `reset` is not a config setting
+
+`--reset` renames the existing embedded `pgdata` aside and starts with an empty database.
+That is a one-off action, so it is a flag only and Hezo rejects a `reset` key in the config
+file: a persistent file carrying it would wipe your database on **every** restart rather
+than once.
 
 ## Examples
 
@@ -57,17 +211,23 @@ hezo --port 8080 --data-dir /var/lib/hezo
 Unlock a single startup non-interactively by passing the master key to that one
 invocation (Hezo normally starts **locked** and you unlock from the browser gate):
 
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  webUrl: 'https://hezo.example.com',
+};
+```
+
 ```sh
 HEZO_MASTER_KEY="your twelve word master key phrase here" \
-HEZO_DATA_DIR=/var/lib/hezo \
-HEZO_WEB_URL=https://hezo.example.com \
-  hezo
+  hezo --config /etc/hezo/hezo.config.cjs
 ```
 
 Pass `HEZO_MASTER_KEY` inline like this only for a one-off launch - **never persist it**
-to an env file, a service definition, or anywhere on the host. The master key is kept in
-memory only so a copy of your disk can't decrypt your data; writing it to disk defeats
-that. See [Master key & encryption](/docs/security/master-key).
+to the config file, an env file, a service definition, or anywhere on the host. The master
+key is kept in memory only so a copy of your disk can't decrypt your data; writing it to
+disk defeats that. See [Master key & encryption](/docs/security/master-key).
 
 ## Using an external Postgres
 
@@ -79,9 +239,12 @@ directory - no external database to run. If you'd rather use a managed/hosted Po
 or, for the cloud-init deploy,
 [Using managed data hosting](/docs/deployment/one-click#using-managed-data-hosting)):
 
-```sh
-HEZO_DATABASE_URL="postgres://hezo:••••@db.internal:5432/hezo?sslmode=verify-full" \
-  hezo --data-dir /var/lib/hezo
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  database: { url: 'postgres://hezo:••••@db.internal:5432/hezo?sslmode=verify-full' },
+};
 ```
 
 On first start Hezo checks the server version, then creates its schema by applying its
@@ -104,8 +267,8 @@ Requirements and recommendations:
   (PgBouncer in transaction mode) break session-scoped advisory locks.
 - **One Hezo server per database.** Concurrent startups coordinate migrations safely,
   but running two live servers against one database is not supported.
-- The connection string carries credentials: prefer the environment variable over the
-  flag (flags are visible in the process list), and never commit it to a repo.
+- The connection string carries credentials: prefer the config file over the flag (flags
+  are visible in the process list), give the file mode 600, and never commit it to a repo.
 - `hezo backup` / `hezo restore` work against an external database too - including
   **moving an existing embedded instance to hosted Postgres** (and back). See
   [Backup & recovery](/docs/deployment/backup-and-recovery).
@@ -142,9 +305,16 @@ it - this is the recommended setup:
 ```sh
 # DigitalOcean: Databases → your cluster → Connection details → Download CA certificate
 sudo install -m 644 ca-certificate.crt /etc/hezo/db-ca.crt
+```
 
-HEZO_DATABASE_URL="postgres://hezo:••••@db-postgresql-lon1-12345-do-user-0.db.ondigitalocean.com:25060/hezo?sslmode=verify-full&sslrootcert=/etc/hezo/db-ca.crt" \
-  hezo --data-dir /var/lib/hezo
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  database: {
+    url: 'postgres://hezo:••••@db-postgresql-lon1-12345-do-user-0.db.ondigitalocean.com:25060/hezo?sslmode=verify-full&sslrootcert=/etc/hezo/db-ca.crt',
+  },
+};
 ```
 
 The `PGSSLMODE` environment variable is honoured only when the connection string carries
@@ -160,9 +330,14 @@ stateless - point Hezo at any **S3-compatible** store (deployment walkthroughs:
 [Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)
 and [Using managed data hosting](/docs/deployment/one-click#using-managed-data-hosting)):
 
-```sh
-HEZO_ASSET_STORAGE_URL="s3://ACCESS_KEY:SECRET@s3.eu-west-1.amazonaws.com/my-bucket/hezo-assets?region=eu-west-1" \
-  hezo --data-dir /var/lib/hezo
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  assetStorage: {
+    url: 's3://ACCESS_KEY:SECRET@s3.eu-west-1.amazonaws.com/my-bucket/hezo-assets?region=eu-west-1',
+  },
+};
 ```
 
 One URL carries the whole configuration:
@@ -194,8 +369,8 @@ Recommendations:
   encrypted at rest.
 - **One Hezo server per bucket/prefix.** Two live servers sharing a prefix is not
   supported (same posture as the database).
-- The URL carries credentials: prefer the environment variable over the flag (flags are
-  visible in the process list), and never commit it to a repo.
+- The URL carries credentials: prefer the config file over the flag (flags are visible in
+  the process list), give the file mode 600, and never commit it to a repo.
 
 ### Switching an existing instance
 
@@ -206,13 +381,13 @@ existing assets into a bucket:
 
 1. Stop the server.
 2. Back up the instance: `hezo backup --output move/`. If your data directory isn't the
-   default, point the command at it - `hezo backup` reads `HEZO_DATA_DIR` (so a deployment
-   that already sets it needs nothing extra), or pass `--data-dir`. This writes the
-   database and every asset file into `move/`.
+   default, point the command at it - `hezo backup` accepts the same `--config` as the
+   server (so a deployment that already has a config file needs only that), or pass
+   `--data-dir`. This writes the database and every asset file into `move/`.
 3. Restore into the bucket: `hezo restore move/ --asset-storage-url "s3://…"` - add
    `--database-url` as well if you're also moving to hosted Postgres. Restored blobs are
    checksum-verified against the database rows.
-4. Start the server with `HEZO_ASSET_STORAGE_URL` set.
+4. Start the server with `assetStorage.url` set in your config file.
 
 Moving back to local storage is the same, restoring without `--asset-storage-url`. The
 backup only reads the source, so your original assets stay in place until you remove them
@@ -227,14 +402,14 @@ while the server is stopped - `aws s3 sync /var/lib/hezo/assets/ s3://my-bucket/
 
 Every agent run executes inside a container. By default that container runs on the local
 Docker daemon, which is why a Docker-compatible runtime is a prerequisite for a normal
-install. `--sandbox-backend` (or `HEZO_SANDBOX_BACKEND`) starts a **brand-new** instance
-on a managed sandbox service instead, and Docker stops being required at all.
+install. `--sandbox-backend` (or `containers.backend`) starts a **brand-new** instance on
+a managed sandbox service instead, and Docker stops being required at all.
 
-The flags only choose what a brand-new instance starts on. The first startup records the
-choice, and from then on the stored setting wins: the flags are ignored on later startups
-- Hezo logs that it ignored them if they disagree - so restarting with different
-environment variables never switches an existing instance. Switching, in either
-direction, is done from Settings -> Containers at any time, no restart needed. See
+These only choose what a brand-new instance starts on. The first startup records the
+choice, and from then on the stored setting wins: the launch settings are ignored on later
+startups - Hezo logs that it ignored them if they disagree - so restarting with a different
+config file never switches an existing instance. Switching, in either direction, is done
+from Settings -> Containers at any time, no restart needed. See
 [Switching at any time](/docs/containers/overview#switching-at-any-time).
 
 [Remote containers](/docs/containers/remote/overview) covers what changes when you do:
@@ -248,16 +423,22 @@ Today the one managed backend is **Daytona**:
 hezo --sandbox-backend daytona --daytona-api-key "dtn_..."
 ```
 
-or, as environment variables:
+or, in the config file:
 
-```sh
-HEZO_SANDBOX_BACKEND=daytona
-HEZO_DAYTONA_API_KEY=dtn_...
-HEZO_DAYTONA_API_URL=https://app.daytona.io/api   # optional: a regional endpoint
+```js
+module.exports = {
+  containers: {
+    backend: 'daytona',
+    daytona: {
+      apiKey: 'dtn_...',
+      apiUrl: 'https://app.daytona.io/api', // optional: a regional endpoint
+    },
+  },
+};
 ```
 
-Add `--daytona-api-url` (or `HEZO_DAYTONA_API_URL`) only if you are pointed at a regional
-or self-hosted endpoint; it defaults to Daytona's public API.
+Set `apiUrl` (or `--daytona-api-url`) only if you are pointed at a regional or self-hosted
+endpoint; it defaults to Daytona's public API.
 
 The provider API key is stored **encrypted in the secrets vault** and read only by Hezo
 itself to drive the provider's control plane - it never enters an agent container.
@@ -278,9 +459,14 @@ Dockerfile in your working tree - which is what makes edits to it take effect on
 restart. A managed sandbox service cannot see that image; it pulls from a registry. So
 point the instance at a published image instead:
 
-```sh
-HEZO_AGENT_BASE_IMAGE=ghcr.io/hezo-ai/agent-base:0.42.0 \
-HEZO_SANDBOX_BACKEND=daytona HEZO_DAYTONA_API_KEY=dtn_... bun run dev
+```js
+module.exports = {
+  containers: {
+    backend: 'daytona',
+    agentBaseImage: 'ghcr.io/hezo-ai/agent-base:0.42.0',
+    daytona: { apiKey: 'dtn_...' },
+  },
+};
 ```
 
 That applies to every project. A project that names its own base image on its Container
@@ -329,16 +515,18 @@ small **anonymous** usage report once a day. It is **on by default** and easy to
 details; user identities; secrets; or any monetary/cost figure. Aggregated numbers from all
 opted-in installs are shown publicly at [hezo.ai/stats](https://hezo.ai/stats).
 
-**Turn it off** with the flag or the environment variable:
+**Turn it off** with the flag or the config file:
 
 ```sh
 hezo --disable-telemetry
-# or
-HEZO_TELEMETRY_ENABLED=0 hezo
+```
+
+```js
+module.exports = { telemetry: { enabled: false } };
 ```
 
 You can also keep the data in-house by pointing `--telemetry-endpoint` (or
-`HEZO_TELEMETRY_ENDPOINT`) at your own collector.
+`telemetry.endpoint`) at your own collector.
 
 ## See also
 

--- a/docs/deployment/container-runtimes.md
+++ b/docs/deployment/container-runtimes.md
@@ -47,14 +47,14 @@ just print the guidance below and exit: launched from Explorer it owns its conso
 which closes with the process, so you would never get to read it. Instead a dialog explains
 why a container runtime is required, and clicking **OK** opens
 [Docker Desktop in the Microsoft Store](https://apps.microsoft.com/detail/xp8cbj40xlbwkx).
-Install it, start it, then start Hezo again. `--no-open` (or `HEZO_OPEN=0`) suppresses the
+Install it, start it, then start Hezo again. `--no-open` (or `open: false`) suppresses the
 dialog along with the browser, and it never appears over SSH, in CI or in a container.
 
 ## How Hezo finds the daemon
 
 At startup Hezo works through these in order and uses the first socket that answers:
 
-1. `--docker-socket` / `HEZO_DOCKER_SOCKET`, if you set one.
+1. `--docker-socket` / `containers.dockerSocket`, if you set one.
 2. `DOCKER_HOST`, if it is set to a `unix://` socket.
 3. The **current docker context** (what `docker context show` reports), read from the
    docker CLI's own configuration. This is how a Colima or Rancher Desktop install is
@@ -78,7 +78,7 @@ When your daemon listens somewhere none of the above cover:
 ```sh
 hezo --docker-socket /path/to/docker.sock
 # or
-HEZO_DOCKER_SOCKET=/path/to/docker.sock hezo
+hezo --config /etc/hezo/hezo.config.cjs   # containers: { dockerSocket: '/path/to/docker.sock' }
 ```
 
 Hezo connects over a **Unix socket only**. `tcp://`, `npipe://` and `ssh://` endpoints are
@@ -111,7 +111,7 @@ For the other runtimes:
 Hezo checks this at boot by mounting a scratch directory into a throwaway container and
 writing to it. If the mount is missing or read-only it logs the fix above and keeps
 running, so you can correct the host configuration and restart without losing the web UI.
-To skip the check entirely, set `HEZO_SKIP_MOUNT_CHECK=1` - note that this only hides the
+To skip the check entirely, set `containers.skipMountCheck: true` - note that this only hides the
 diagnosis, it does not make the mount work.
 
 If you keep the data directory somewhere else (`--data-dir`), share that path instead.

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -169,12 +169,14 @@ the credentials out of user data entirely, deploy without them and use the post-
 path instead.
 
 **Post-boot, or on an existing server** - the same two settings go into
-`/etc/hezo/hezo.env` (root-only, mode 600 - the file the systemd unit reads). SSH in
+`/etc/hezo/hezo.config.cjs` (root-only, mode 600 - the file the systemd unit reads). SSH in
 and:
 
 ```sh
-echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' | sudo tee -a /etc/hezo/hezo.env >/dev/null
-echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' | sudo tee -a /etc/hezo/hezo.env >/dev/null
+sudo $EDITOR /etc/hezo/hezo.config.cjs
+# add, inside module.exports:
+#   database: { url: 'postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' },
+#   assetStorage: { url: 's3://ACCESS_KEY:SECRET@endpoint/bucket' },
 sudo systemctl restart hezo
 ```
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -83,20 +83,26 @@ command -v hezo                        # note the absolute path, e.g. /usr/local
 sudo mkdir -p /var/lib/hezo            # a stable data directory
 ```
 
-**2. Put non-secret settings in an env file.** Create an env file for the
-service - the data directory and, if the instance is reached via a URL beyond
-`localhost`, its HTTPS address:
+**2. Put the settings in a config file.** Create a config file for the service -
+the data directory and, if the instance is reached via a URL beyond `localhost`,
+its HTTPS address:
 
 ```sh
 sudo install -d -m 700 /etc/hezo
-sudo install -m 600 /dev/null /etc/hezo/hezo.env
+sudo install -m 600 /dev/null /etc/hezo/hezo.config.cjs
 ```
 
-```sh
-# /etc/hezo/hezo.env
-HEZO_DATA_DIR=/var/lib/hezo
-# HEZO_WEB_URL=https://hezo.example.com   # the HTTPS URL it's reached at (omit for localhost-only use)
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  dataDir: '/var/lib/hezo',
+  // webUrl: 'https://hezo.example.com',   // the HTTPS URL it's reached at (omit for localhost-only use)
+};
 ```
+
+Mode 600 because this file is where a database or object-storage URL would go, and
+those carry credentials. See the
+[Configuration reference](/docs/deployment/configuration) for every setting.
 
 > **Never put your master key in this file** (or anywhere else on the server).
 > The master key is deliberately kept in memory only - a copy on disk next to the
@@ -115,8 +121,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/hezo
-EnvironmentFile=/etc/hezo/hezo.env
+ExecStart=/usr/local/bin/hezo --config /etc/hezo/hezo.config.cjs
 Restart=always
 RestartSec=5
 TimeoutStopSec=30
@@ -264,13 +269,13 @@ aborted and recovered automatically, and connected browsers reconnect on their o
 
 Auto-update applies to the self-managed single binary. It is disabled when Hezo
 runs inside a container (update the image instead) and can be turned off with
-`HEZO_DISABLE_AUTO_UPDATE`. The daily check schedule is configurable via
-`HEZO_UPDATE_CHECK_CRON`. See [Configuration](/docs/deployment/configuration).
+`updates.disabled` in your config file. The daily check schedule is configurable via
+`jobs.updateCheckCron`. See [Configuration](/docs/deployment/configuration).
 
 ### Installing updates automatically
 
 For a hands-off server, start Hezo with `--auto-install-updates` (or
-`HEZO_AUTO_INSTALL_UPDATES=1`) and it installs staged updates by itself: once a
+`updates.autoInstall: true`) and it installs staged updates by itself: once a
 newer release has been downloaded and verified, Hezo waits until no agent runs
 are in flight and then performs the same graceful restart as the **Install &
 restart** button - no click needed. If agents are busy, the install is retried
@@ -286,7 +291,7 @@ Two things to know before enabling it:
   to avoid that (see [Master key & encryption](/docs/security/master-key)).
 - It only takes effect where in-app auto-update works at all: the self-managed
   single binary, not inside a container (update the image instead), and not
-  with `HEZO_DISABLE_AUTO_UPDATE` set.
+  with `updates.disabled` set.
 
 ### Updating manually
 

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -19,7 +19,7 @@ tools into.
 - **Base URL:** your instance's address. Running locally with default settings that's
   `http://localhost:3100`; a deployed instance is its **HTTPS** URL - its own domain
   behind the TLS reverse proxy, not necessarily port 3100. (The port Hezo itself listens
-  on is set by `--port` / `HEZO_PORT`, default `3100`.)
+  on is set by `--port` / the config file's `port`, default `3100`.)
 - **Endpoint:** `POST <base-url>/mcp`
 - **Transport:** Streamable HTTP
 - **Authentication:** an `Authorization: Bearer <token>` header, where the token is a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,10 +23,11 @@ container runtime must be installed and running first - Hezo checks at startup a
 with install/start guidance if no daemon is reachable (see
 [Installation](/docs/getting-started/installation) and
 [Container runtimes](/docs/deployment/container-runtimes)). See the
-[Configuration reference](/docs/deployment/configuration) for the full table of flags and
-their environment-variable equivalents. The most common:
+[Configuration reference](/docs/deployment/configuration) for the full table of settings
+and their flags. The most common:
 
 ```sh
+hezo --config /etc/hezo/hezo.config.cjs   # load settings from a config file
 hezo --port 8080                 # listen on a different port
 hezo --data-dir /var/lib/hezo    # use a specific data directory
 hezo --database-url postgres://user:pass@host:5432/hezo   # use an external Postgres instead of the embedded database
@@ -43,21 +44,21 @@ hezo --disable-telemetry         # turn off the anonymous daily usage report (on
 ```
 
 By default the database is embedded and lives under the data directory. With
-`--database-url` (or `HEZO_DATABASE_URL`) Hezo runs against an external PostgreSQL 14+
-instead - see [Using an external Postgres](/docs/deployment/configuration) for
+`--database-url` (or `database.url` in the config file) Hezo runs against an external
+PostgreSQL 14+ instead - see [Using an external Postgres](/docs/deployment/configuration) for
 requirements (TLS, latency, pooling) and
 [TLS and sslmode](/docs/deployment/configuration#tls-and-sslmode) for what each `sslmode`
 protects against.
 
 Uploaded asset files live under the data directory by default. With
-`--asset-storage-url` (or `HEZO_ASSET_STORAGE_URL`) they live in any S3-compatible
-bucket instead - see
+`--asset-storage-url` (or `assetStorage.url` in the config file) they live in any
+S3-compatible bucket instead - see
 [Storing assets in S3-compatible object storage](/docs/deployment/configuration) for the
 URL format and how to move an existing instance.
 
 Agent containers run on the local Docker daemon by default. With `--sandbox-backend`
-(or `HEZO_SANDBOX_BACKEND`) they run on a managed sandbox service instead, and Docker
-is no longer a prerequisite - see [Containers](/docs/containers/overview) and
+(or `containers.backend` in the config file) they run on a managed sandbox service
+instead, and Docker is no longer a prerequisite - see [Containers](/docs/containers/overview) and
 [Running agent containers on a managed sandbox service](/docs/deployment/configuration).
 A managed backend Hezo cannot reach is fatal at startup: it reports the problem and
 exits rather than silently falling back to local Docker.
@@ -76,14 +77,14 @@ bind loopback only. See
 
 Hezo finds the runtime's socket by itself - `DOCKER_HOST`, then the current docker context,
 then the well-known path for each supported runtime - and names the one it used in the
-startup log. Set `--docker-socket` (or `HEZO_DOCKER_SOCKET`) only when the daemon listens
+startup log. Set `--docker-socket` (or `containers.dockerSocket`) only when the daemon listens
 somewhere none of those cover; Unix sockets only, so `tcp://` and `npipe://` endpoints are
 not supported. See [Container runtimes](/docs/deployment/container-runtimes).
 
 On a desktop machine Hezo opens the web app in your default browser once the server is
 ready. It skips this automatically in environments without a browser - CI, containers,
 SSH sessions, and headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`) - and logs where to
-point your browser instead. Use `--no-open` (or `HEZO_OPEN=0`) to turn it off. The same
+point your browser instead. Use `--no-open` (or `open: false`) to turn it off. The same
 flag governs the Windows dialog Hezo shows when no container runtime is installed
 ([Container runtimes](/docs/deployment/container-runtimes)).
 
@@ -100,16 +101,16 @@ uploaded asset file - as a **backup bundle** directory (default
 tree, and a `manifest.json`. The bundle restores onto either storage backend, which is
 how you move an instance's database and assets between local storage and hosted
 providers (external Postgres and an S3-compatible bucket). Point `--asset-storage-url`
-(or `HEZO_ASSET_STORAGE_URL`) at the source bucket when the instance already keeps its
+(or `assetStorage.url`) at the source bucket when the instance already keeps its
 assets in S3.
 
 - `--no-assets` - database only. Writes the single portable `.backup.gz` file (default
   `<data-dir>/backups/hezo-<timestamp>.backup.gz`) instead of a bundle.
 - `--no-database` - assets only. Writes a bundle with just the asset files.
 
-`--data-dir` (or `HEZO_DATA_DIR`) must point at the same data directory the instance
-runs with. The env var is read exactly as the server reads it, so a deployment that sets
-`HEZO_DATA_DIR` (systemd, Docker) needs no extra flag - omit `--data-dir` and the backup
+`--data-dir` (or `dataDir` in the `--config` file) must point at the same data directory
+the instance runs with. The file is read exactly as the server reads it, so a deployment
+that has one (systemd, Docker) needs only `--config` - omit `--data-dir` and the backup
 targets the running instance's embedded database. Pointing at a directory with no Hezo
 database is refused with a clear error rather than silently backing up an empty one.
 
@@ -138,7 +139,7 @@ The target database must be empty unless `--wipe` is passed. Restored asset blob
 verified by checksum against the database rows; `--strict-assets` fails if any blob has
 no matching row. `--no-assets` / `--no-database` restore only one half of a bundle.
 Backups taken by a newer Hezo are refused - upgrade first. Like `hezo backup`, restore
-reads `--data-dir` from `HEZO_DATA_DIR` when the flag is omitted.
+reads the data directory from the `--config` file when the flag is omitted.
 
 Restore prints its progress as it goes - a line per step, plus a live counter with a
 percentage and an estimated time remaining while it loads rows and copies asset files. In a
@@ -179,8 +180,8 @@ created. It does **not** remove the `hezo` binary itself.
 
 If the instance ran its containers on a **remote sandbox service**, pass the same backend
 settings the server used (`--sandbox-backend daytona` plus the API key, or the matching
-`HEZO_SANDBOX_BACKEND` / `HEZO_DAYTONA_API_KEY` / `HEZO_DAYTONA_API_URL` environment
-variables). Without them uninstall cleans up local Docker and leaves the remote sandboxes
+`containers.backend` / `containers.daytona.apiKey` / `containers.daytona.apiUrl` settings
+via `--config`). Without them uninstall cleans up local Docker and leaves the remote sandboxes
 running, and nothing else will remove them: the sweep that reaps unreferenced sandboxes
 lives in the instance you are deleting. If the provider cannot be reached, uninstall says
 so and still removes the data directory.
@@ -193,36 +194,57 @@ ACLs and deletes the tree cleanly.
 Stop the server first - uninstall **refuses while a server is running** against the data
 directory (removing it under a live server corrupts the database). Deletion is
 irreversible, so it requires an explicit `--yes`; without it, the command prints exactly
-what would be removed and deletes nothing. Like `hezo backup`, it reads `--data-dir` from
-`HEZO_DATA_DIR` when the flag is omitted. Back up anything you want to keep with
+what would be removed and deletes nothing. Like `hezo backup`, it accepts the same
+`--config` as the server, so a deployment with a config file needs no `--data-dir`. Back
+up anything you want to keep with
 `hezo backup` first - see [Backup & recovery](/docs/deployment/backup-and-recovery).
 
-## Environment variables
+## The config file
 
-Every flag above has an environment-variable equivalent, and a few settings are
-environment-variable only. **When both are present, the environment variable wins** -
-handy for baking defaults into a service definition while still overriding per run. The
-[Configuration reference](/docs/deployment/configuration#options) carries the complete
-table with defaults and descriptions; the ones most often set outside a shell are:
+Settings live in a CommonJS file you point at with `--config`:
 
-| Variable | Flag | What it sets |
-|---|---|---|
-| `HEZO_PORT` | `--port` | Port the server and web app listen on. |
-| `HEZO_DATA_DIR` | `--data-dir` | Where Hezo stores its database, encrypted secrets, and assets. |
-| `HEZO_DATABASE_URL` | `--database-url` | Connection string for an external Postgres. |
-| `HEZO_ASSET_STORAGE_URL` | `--asset-storage-url` | S3-compatible object storage for asset files. |
-| `HEZO_SANDBOX_BACKEND` | `--sandbox-backend` | Where agent containers run on a **new** instance: `docker` or `daytona`. Ignored once a service has been chosen in Settings -> Containers. See [Containers](/docs/containers/overview). |
-| `HEZO_DAYTONA_API_KEY` | `--daytona-api-key` | Daytona API key, required when the backend is `daytona`. Used only by Hezo to reach the provider; it never enters an agent container. See [Daytona](/docs/containers/remote/daytona). |
-| `HEZO_DAYTONA_API_URL` | `--daytona-api-url` | Daytona API base URL, for a regional or self-hosted endpoint. |
-| `HEZO_MASTER_KEY` | `--master-key` | The twelve-word master key, for a single non-interactive startup. Do not persist it to disk - see [Master key](/docs/security/master-key). |
-| `HEZO_WEB_URL` | `--web-url` | Public base URL, so account sign-ins redirect back correctly. |
-| `HEZO_LOG_LEVEL` | `--log-level` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
-| `HEZO_OPEN` | `--no-open` | Set to `0` to stop the web app opening in your browser on startup, and to suppress the Windows "no container runtime" dialog. |
-| `HEZO_TELEMETRY_ENABLED` | `--disable-telemetry` | Set to `0` to turn off the anonymous daily usage report. |
+```sh
+hezo --config /etc/hezo/hezo.config.cjs
+```
 
-The container variables are the ones that behave differently from the rest: they seed a
-**new** instance and are then superseded by the stored setting, because the container
-service is switchable while Hezo is running.
+```js
+// /etc/hezo/hezo.config.cjs
+module.exports = {
+  port: 3100,
+  dataDir: '/var/lib/hezo',
+  webUrl: 'https://hezo.example.com',
+  database: { url: 'postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=verify-full' },
+};
+```
+
+**A flag always wins over the file**, and anything neither sets falls back to the built-in
+default. There is no automatic search - without `--config` Hezo runs on defaults plus
+flags. An unknown or misspelled key is an error naming the key, not something quietly
+ignored. Give the file mode 600 if it carries a database, object-storage, or provider
+credential.
+
+The [Configuration reference](/docs/deployment/configuration#options) carries the complete
+table with defaults and descriptions. `hezo backup`, `hezo restore` and `hezo uninstall`
+accept the same `--config`, so they reach the same data directory and backends the server
+uses.
+
+The container settings behave differently from the rest: they seed a **new** instance and
+are then superseded by the stored setting, because the container service is switchable
+while Hezo is running.
+
+### The master key is never in the file
+
+`HEZO_MASTER_KEY` is the one setting still supplied through the environment, for a single
+non-interactive startup. Hezo rejects a `masterKey` key in the config file: the key is held
+in memory only, and a copy on disk beside the encrypted data would defeat encryption at
+rest. `--reset` is likewise a flag only - in a persistent file it would wipe the database
+on every restart.
+
+```sh
+HEZO_MASTER_KEY="your twelve word master key phrase here" hezo --config /etc/hezo/hezo.config.cjs
+```
+
+See [Master key & encryption](/docs/security/master-key).
 
 ## Info
 
@@ -233,7 +255,7 @@ hezo --version       # print the Hezo version and exit
 
 ## See also
 
-- [Configuration reference](/docs/deployment/configuration) - every flag and variable.
+- [Configuration reference](/docs/deployment/configuration) - every setting and flag.
 - [Containers](/docs/containers/overview) - where agent containers run, and switching service.
 - [MCP API reference](/docs/reference/mcp-api) - every tool the built-in MCP server exposes.
 - [Installation](/docs/getting-started/installation) - getting the binary.

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -45,8 +45,11 @@ to do it (see [Keep it off the server](#keep-it-off-the-server) below).
 The master key's protection comes entirely from where it *isn't*: it lives in memory only
 and is **never written to disk**, so the encrypted data directory is useless to anyone who
 copies it without the phrase. **Don't undo that by storing the key on the server yourself** -
-not in an env file (`/etc/hezo/hezo.env`), the systemd unit, a shell profile, a same-host
-secrets file, or a note in the repo. A copy of the phrase sitting next to the encrypted
+not in the config file (`/etc/hezo/hezo.config.cjs`), an env file, the systemd unit, a
+shell profile, a same-host secrets file, or a note in the repo. Hezo refuses a `masterKey`
+key in the config file for exactly this reason. Note that Bun also auto-loads a `.env` from
+the working directory, so a `HEZO_MASTER_KEY` line there is picked up like any other - the
+same rule applies. A copy of the phrase sitting next to the encrypted
 vault means a stolen disk image, a leaked backup, or anyone who can read the box can decrypt
 everything - exactly what encryption at rest is meant to prevent.
 

--- a/docs/security/secret-protection.md
+++ b/docs/security/secret-protection.md
@@ -110,7 +110,7 @@ itself.
 
 If an MCP server or a git remote your agents genuinely need lives on your local network,
 start Hezo with `--egress-allow-private-targets` (or
-`HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1`) to lift the restriction.
+`egress.allowPrivateTargets`) to lift the restriction.
 
 ## How secrets get in
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -22,31 +22,32 @@ bun install
 bun run dev
 ```
 
-Starts the server on port 3100 with hot reload. In dev, PGlite data persists at `.hezo-dev/pgdata` in the repo root (gitignored) between restarts, isolated from a production instance; the production binary uses `~/.hezo`. Override with `--data-dir` or `HEZO_DATA_DIR`.
+Starts the server on port 3100 with hot reload. In dev, PGlite data persists at `.hezo-dev/pgdata` in the repo root (gitignored) between restarts, isolated from a production instance; the production binary uses `~/.hezo`. Override with `--data-dir`, or `dataDir` in a `--config` file.
 
 ## CLI Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port <n>` | `3100` | HTTP listen port (env: `HEZO_PORT`) |
-| `--data-dir <path>` | `~/.hezo` | Data directory for the embedded database and assets (env: `HEZO_DATA_DIR`) |
-| `--database-url <url>` | - | External Postgres connection string; omit for the embedded database (env: `HEZO_DATABASE_URL`) |
-| `--asset-storage-url <url>` | - | S3-compatible object storage for asset files (`s3://KEY:SECRET@endpoint/bucket[/prefix]`); omit to store assets under the data directory (env: `HEZO_ASSET_STORAGE_URL`) |
-| `--sandbox-backend <name>` | `docker` | Where agent containers run: `docker` (the local daemon) or `daytona` (a managed sandbox service). A managed backend that cannot be reached is fatal at startup - Hezo never falls back to local Docker (env: `HEZO_SANDBOX_BACKEND`) |
-| `--daytona-api-key <key>` | - | Daytona API key, required when `--sandbox-backend` is `daytona` (env: `HEZO_DAYTONA_API_KEY`) |
-| `--daytona-api-url <url>` | Daytona's public API | Daytona API base URL, for a regional or self-hosted endpoint (env: `HEZO_DAYTONA_API_URL`) |
-| `--master-key <phrase>` | - | Twelve-word master key to set up/unlock on startup (env: `HEZO_MASTER_KEY`) |
-| `--web-url <url>` | same origin | Public base URL for sign-in redirects (env: `HEZO_WEB_URL`) |
-| `--reset` | `false` | Start fresh (existing `pgdata` is renamed aside, not deleted) (env: `HEZO_RESET`) |
-| `--no-open` | open on | Auto-open the web app in the browser on startup (on by default; skipped automatically in CI/containers/SSH/headless Linux). Disable with `--no-open` or `HEZO_OPEN=0` |
-| `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` (env: `HEZO_LOG_LEVEL`) |
-| `--keep-old-containers` | `false` | Keep old project containers instead of removing them, for debugging (env: `HEZO_KEEP_OLD_CONTAINERS`) |
-| `--docker-socket <path>` | auto | Path to the container runtime's Unix socket. By default Hezo finds it: `DOCKER_HOST`, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Unix sockets only - `tcp://` and `npipe://` are not supported (env: `HEZO_DOCKER_SOCKET`) |
-| `--egress-allow-private-targets` | blocked | Allow agent egress through the proxy to reach loopback, link-local and private addresses. Blocked by default so an agent can't tunnel to Hezo's own API or database. Enable only for an MCP server or git remote on your LAN (env: `HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1`) |
-| `--no-egress-proxy-auth` | auth on | Per-run egress-proxy authentication. On by default: each run's `HTTP(S)_PROXY` URL carries a token the proxy verifies before substituting secrets. Only disable to unblock a runtime whose HTTP client can't send proxy credentials - the secret red line still holds (env: `HEZO_EGRESS_PROXY_AUTH=0`) |
-| `--auto-install-updates` | `false` | Install staged updates automatically: gracefully restart onto a downloaded-and-verified newer release without the web UI's "Install & restart", deferring while agent runs are in flight. Only effective where in-app auto-update is available (self-managed binary, not in a container); the instance comes back unlocked - the unlock key is handed to the relaunched process in memory, never written to disk (env: `HEZO_AUTO_INSTALL_UPDATES`) |
-| `--disable-telemetry` | telemetry on | Turn off the anonymous daily usage report (aggregate counts only - no names, content, or costs). On by default (env: `HEZO_TELEMETRY_ENABLED=0`) |
-| `--telemetry-endpoint <url>` | `https://hezo.ai/api/telemetry` | Where the daily usage report is sent; point at your own collector to keep data in-house (env: `HEZO_TELEMETRY_ENDPOINT`) |
+| `--config <path>` | - | Path to a config file (CommonJS: `module.exports = { … }`). A flag always wins over the file; without `--config` only defaults and flags apply |
+| `--port <n>` | `3100` | HTTP listen port (config: `port`) |
+| `--data-dir <path>` | `~/.hezo` | Data directory for the embedded database and assets (config: `dataDir`) |
+| `--database-url <url>` | - | External Postgres connection string; omit for the embedded database (config: `database.url`) |
+| `--asset-storage-url <url>` | - | S3-compatible object storage for asset files (`s3://KEY:SECRET@endpoint/bucket[/prefix]`); omit to store assets under the data directory (config: `assetStorage.url`) |
+| `--sandbox-backend <name>` | `docker` | Where agent containers run: `docker` (the local daemon) or `daytona` (a managed sandbox service). A managed backend that cannot be reached is fatal at startup - Hezo never falls back to local Docker (config: `containers.backend`) |
+| `--daytona-api-key <key>` | - | Daytona API key, required when `--sandbox-backend` is `daytona` (config: `containers.daytona.apiKey`) |
+| `--daytona-api-url <url>` | Daytona's public API | Daytona API base URL, for a regional or self-hosted endpoint (config: `containers.daytona.apiUrl`) |
+| `--master-key <phrase>` | - | Twelve-word master key to set up/unlock on startup (env: `HEZO_MASTER_KEY`). Never read from the config file - it must not be written to disk |
+| `--web-url <url>` | same origin | Public base URL for sign-in redirects (config: `webUrl`) |
+| `--reset` | `false` | Start fresh (existing `pgdata` is renamed aside, not deleted). Flag only - in a config file it would wipe on every restart |
+| `--no-open` | open on | Auto-open the web app in the browser on startup (on by default; skipped automatically in CI/containers/SSH/headless Linux). Disable with `--no-open` or `open: false` |
+| `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` (config: `logLevel`) |
+| `--keep-old-containers` | `false` | Keep old project containers instead of removing them, for debugging (config: `containers.keepOld`) |
+| `--docker-socket <path>` | auto | Path to the container runtime's Unix socket. By default Hezo finds it: `DOCKER_HOST`, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Unix sockets only - `tcp://` and `npipe://` are not supported (config: `containers.dockerSocket`) |
+| `--egress-allow-private-targets` | blocked | Allow agent egress through the proxy to reach loopback, link-local and private addresses. Blocked by default so an agent can't tunnel to Hezo's own API or database. Enable only for an MCP server or git remote on your LAN (config: `egress.allowPrivateTargets`) |
+| `--no-egress-proxy-auth` | auth on | Per-run egress-proxy authentication. On by default: each run's `HTTP(S)_PROXY` URL carries a token the proxy verifies before substituting secrets. Only disable to unblock a runtime whose HTTP client can't send proxy credentials - the secret red line still holds (config: `egress.proxyAuth`) |
+| `--auto-install-updates` | `false` | Install staged updates automatically: gracefully restart onto a downloaded-and-verified newer release without the web UI's "Install & restart", deferring while agent runs are in flight. Only effective where in-app auto-update is available (self-managed binary, not in a container); the instance comes back unlocked - the unlock key is handed to the relaunched process in memory, never written to disk (config: `updates.autoInstall`) |
+| `--disable-telemetry` | telemetry on | Turn off the anonymous daily usage report (aggregate counts only - no names, content, or costs). On by default (config: `telemetry.enabled`) |
+| `--telemetry-endpoint <url>` | `https://hezo.ai/api/telemetry` | Where the daily usage report is sent; point at your own collector to keep data in-house (config: `telemetry.endpoint`) |
 | `--version` | - | Print the Hezo version and exit (also `hezo version`) |
 
 ## Master Key

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,118 +1,63 @@
-import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import {
 	DEFAULT_DATA_DIR,
-	DEFAULT_PORT,
 	deriveAuthKeyPair,
 	deriveUnlockKey,
 	validateMnemonic,
 } from '@hezo/shared';
 import { Command } from 'commander';
+import { loadConfigFile } from './config/load';
+import type { ConfigFile } from './config/schema';
+import { DEFAULT_CONFIG, type HezoConfig, resolveDataDir } from './config/types';
 import { createStreamProgressReporter, formatBytes } from './lib/progress';
-import { DEFAULT_TELEMETRY_ENDPOINT } from './services/telemetry';
 import { HEZO_VERSION } from './version';
 
-export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
+export type { HezoConfig, LogLevelName } from './config/types';
 
-export interface HezoConfig {
-	port: number;
+/**
+ * Read the `--config <path>` option off an already-parsed command. Every
+ * command accepts it, and a command that was given none resolves from the
+ * built-in defaults alone.
+ */
+function readConfigFile(opts: Record<string, unknown>): ConfigFile {
+	const path = opts.config;
+	return typeof path === 'string' && path.length > 0 ? loadConfigFile(path) : {};
+}
+
+/**
+ * Resolve the settings the backup/restore/uninstall subcommands share, with the
+ * same flag > config file > default precedence the server uses.
+ *
+ * One resolver rather than a picker per setting: the four this replaced had
+ * drifted apart, and the one in `runUninstall` let an *empty* value win where
+ * the others treated empty as unset.
+ */
+interface SubcommandTargets {
 	dataDir: string;
-	/**
-	 * External Postgres connection string (`--database-url` / `HEZO_DATABASE_URL`).
-	 * Unset → the embedded PGlite database under `<dataDir>/pgdata`. The raw value
-	 * carries credentials: it must never be logged or exposed un-redacted (see
-	 * `redactDatabaseUrl` in `lib/db-info.ts`) and never passed into `buildApp`.
-	 */
 	databaseUrl?: string;
-	/**
-	 * S3-compatible asset storage URL (`--asset-storage-url` /
-	 * `HEZO_ASSET_STORAGE_URL`). Unset → asset blobs on the local filesystem
-	 * under `<dataDir>/assets`. The raw value carries credentials: it must never
-	 * be logged or exposed un-redacted (see `redactAssetStorageUrl` in
-	 * `lib/asset-storage-info.ts`) and never passed into `buildApp`.
-	 */
 	assetStorageUrl?: string;
-	/**
-	 * Where agent containers run (`--sandbox-backend` / `HEZO_SANDBOX_BACKEND`):
-	 * `docker` (default, the local daemon) or a managed sandbox service. Selecting
-	 * a managed backend Hezo cannot reach is **fatal at startup** - it never falls
-	 * back to local Docker, because an instance that silently degraded would look
-	 * healthy while running somewhere the operator did not choose.
-	 */
-	sandboxBackend?: string;
-	/**
-	 * Daytona API key (`--daytona-api-key` / `HEZO_DAYTONA_API_KEY`), required
-	 * when `sandboxBackend` is `daytona`. Used only by trusted server code to
-	 * reach the provider control plane - it is never placed in an agent
-	 * container, and never logged (see `redactSandboxApiUrl`).
-	 */
-	daytonaApiKey?: string;
-	/** Daytona API base URL, for a regional or self-hosted endpoint. */
-	daytonaApiUrl?: string;
-	masterKey?: { unlockKeyHex: string; publicKeyHex: string };
-	webUrl: string;
-	reset: boolean;
-	open: boolean;
-	logLevel: LogLevelName;
-	keepOldContainers: boolean;
-	/**
-	 * Install staged updates automatically (`--auto-install-updates` /
-	 * `HEZO_AUTO_INSTALL_UPDATES`). Once a newer release is downloaded and
-	 * verified, the server gracefully restarts onto it by itself instead of
-	 * waiting for a superuser's "Install & restart" — deferring while agent runs
-	 * are in flight. Only effective where the in-app update flow is available at
-	 * all (the self-managed compiled binary, not inside a container).
-	 */
-	autoInstallUpdates: boolean;
-	/**
-	 * Explicit path to the container runtime's Unix socket (`--docker-socket` /
-	 * `HEZO_DOCKER_SOCKET`). Unset by default, in which case the startup preflight
-	 * discovers it: `DOCKER_HOST`, then the docker CLI's current context, then the
-	 * well-known path for each supported runtime (Docker Engine/Desktop, Colima,
-	 * Rancher Desktop, OrbStack, Lima, rootless Docker). Set it only when the
-	 * daemon listens somewhere none of those cover.
-	 */
-	dockerSocket?: string;
-	/**
-	 * Require a per-run token on every request to the egress proxy. On by
-	 * default: each run's `HTTP(S)_PROXY` URL carries a random token that the
-	 * proxy checks (constant-time) before substituting any secret, so a
-	 * co-resident process that reaches the proxy address can't drive
-	 * substitution for another run. Disable only to unblock a runtime whose HTTP
-	 * client can't carry proxy credentials — the secret red line still holds
-	 * either way (an unauthenticated caller only ships unsubstituted
-	 * placeholders). `--no-egress-proxy-auth` / `HEZO_EGRESS_PROXY_AUTH=0`.
-	 */
-	egressProxyAuth: boolean;
-	/**
-	 * Permit proxied agent egress to loopback / link-local / private addresses.
-	 * Off by default: the egress proxy runs in the host's network namespace, so
-	 * without the guard an agent could tunnel to Hezo's own API, its database, or
-	 * any host-bound daemon. Enable only when an MCP server or git remote the
-	 * agents legitimately need lives on the LAN.
-	 * `--egress-allow-private-targets` / `HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1`.
-	 */
-	egressAllowPrivateTargets: boolean;
-	/**
-	 * Anonymous daily usage telemetry. On by default (opt-out): once a day the
-	 * server POSTs aggregate counts (projects, tasks, tokens, AI-provider mix,
-	 * version) — no names, content, or costs — to `endpoint`, keyed by a random
-	 * per-install id. Disabled with `--disable-telemetry` / `HEZO_TELEMETRY_ENABLED=0`.
-	 */
-	telemetry: {
-		enabled: boolean;
-		endpoint: string;
+}
+
+function resolveSubcommandTargets(opts: Record<string, unknown>): SubcommandTargets {
+	const file = readConfigFile(opts);
+	const flag = (value: unknown): string | undefined =>
+		typeof value === 'string' && value.length > 0 ? value : undefined;
+	return {
+		dataDir: resolveDataDir(flag(opts.dataDir) ?? file.dataDir ?? DEFAULT_DATA_DIR),
+		databaseUrl: flag(opts.databaseUrl) ?? file.database?.url,
+		assetStorageUrl: flag(opts.assetStorageUrl) ?? file.assetStorage?.url,
 	};
 }
 
-function resolveDataDir(raw: string): string {
-	return raw.startsWith('~') ? resolve(homedir(), raw.slice(2)) : resolve(raw);
-}
+/** The `--config` option text, identical on every command that accepts one. */
+const CONFIG_OPTION_DESC =
+	'Path to a Hezo config file (a CommonJS module: module.exports = { … }). Settings in it are ' +
+	'overridden by any flag you also pass.';
 
 export interface DevDataDir {
 	dataDir: string;
 	/**
-	 * True only when neither HEZO_DATA_DIR nor --data-dir was set — `bun run dev`
+	 * True only when neither --data-dir nor a config file set one — `bun run dev`
 	 * must then forward the project-local default to the server it spawns, which
 	 * would otherwise fall back to the production default (~/.hezo).
 	 */
@@ -120,48 +65,24 @@ export interface DevDataDir {
 }
 
 /**
- * Resolve the data dir for `bun run dev`. Mirrors parseConfig's precedence
- * (env HEZO_DATA_DIR > --data-dir > default) but swaps the production default
+ * Resolve the data dir for `bun run dev`. Mirrors resolveConfig's precedence
+ * (--data-dir > config file > default) but swaps the production default
  * (~/.hezo) for a project-local dir so local dev never shares the production
- * database. Both env and CLI values flow through resolveDataDir, so a leading
- * `~` expands exactly as the server does. An empty env value is treated as
- * unset, matching parseConfig's `pick`.
+ * database.
  */
 export function resolveDevDataDir(
 	defaultDir: string,
 	cliDataDir: string | undefined,
-	env: NodeJS.ProcessEnv = process.env,
+	configPath?: string,
 ): DevDataDir {
-	const envValue = env.HEZO_DATA_DIR;
-	if (envValue !== undefined && envValue !== '') {
-		return { dataDir: resolveDataDir(envValue), usedDefault: false };
-	}
 	if (cliDataDir !== undefined && cliDataDir !== '') {
 		return { dataDir: resolveDataDir(cliDataDir), usedDefault: false };
 	}
+	const fromFile = configPath ? loadConfigFile(configPath).dataDir : undefined;
+	if (fromFile !== undefined && fromFile !== '') {
+		return { dataDir: resolveDataDir(fromFile), usedDefault: false };
+	}
 	return { dataDir: resolve(defaultDir), usedDefault: true };
-}
-
-function parsePort(raw: string): number {
-	const n = Number.parseInt(raw, 10);
-	if (Number.isNaN(n) || n < 1 || n > 65535) {
-		throw new Error(`Invalid port: ${raw}. Must be 1-65535.`);
-	}
-	return n;
-}
-
-function parseLogLevel(raw: string): LogLevelName {
-	const lower = raw.toLowerCase();
-	if (lower === 'debug' || lower === 'info' || lower === 'warn' || lower === 'error') {
-		return lower;
-	}
-	throw new Error(`Invalid log level: ${raw}. Must be debug | info | warn | error.`);
-}
-
-function parseBool(raw: string): boolean {
-	if (raw === '') return true;
-	const lower = raw.toLowerCase();
-	return lower !== '0' && lower !== 'false' && lower !== 'no' && lower !== 'off';
 }
 
 /**
@@ -195,48 +116,6 @@ export function runVersion(
 		return true;
 	}
 	return false;
-}
-
-/** Env wins over flag, mirroring parseConfig's `pick` for subcommands. */
-function pickDatabaseUrl(
-	cliValue: unknown,
-	env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-	const e = env.HEZO_DATABASE_URL;
-	if (e !== undefined && e !== '') return e;
-	if (typeof cliValue === 'string' && cliValue.length > 0) return cliValue;
-	return undefined;
-}
-
-/** As `pickDatabaseUrl`, for the asset-storage URL on the backup/restore subcommands. */
-function pickAssetStorageUrl(
-	cliValue: unknown,
-	env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-	const e = env.HEZO_ASSET_STORAGE_URL;
-	if (e !== undefined && e !== '') return e;
-	if (typeof cliValue === 'string' && cliValue.length > 0) return cliValue;
-	return undefined;
-}
-
-/**
- * Resolve the data directory for the backup/restore subcommands, honouring
- * `HEZO_DATA_DIR` (env wins over `--data-dir`, then the default) exactly as
- * `parseConfig` does for the server — and mirroring `pickDatabaseUrl` /
- * `pickAssetStorageUrl` in these same commands, which already read their env.
- *
- * Without this, a production instance started with `HEZO_DATA_DIR=/var/lib/hezo`
- * (a systemd/docker deployment that never passes `--data-dir`) would make
- * `hezo backup` fall back to the default `~/.hezo`; `openPersistentDb` then
- * silently creates a fresh, empty database there, and the dump crashes with a
- * bare `relation "_migrations" does not exist`. Reading the env var keeps the
- * subcommand pointed at the same embedded database the server uses.
- */
-function pickDataDir(cliValue: unknown, env: NodeJS.ProcessEnv = process.env): string {
-	const e = env.HEZO_DATA_DIR;
-	if (e !== undefined && e !== '') return resolveDataDir(e);
-	if (typeof cliValue === 'string' && cliValue.length > 0) return resolveDataDir(cliValue);
-	return resolveDataDir(DEFAULT_DATA_DIR);
 }
 
 /**
@@ -313,12 +192,10 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 			'--output <path>',
 			'Output path: a bundle directory (default <data-dir>/backups/hezo-<timestamp>), or a .backup.gz file with --no-assets',
 		)
-		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
-		.option('--database-url <url>', 'External Postgres connection string (env: HEZO_DATABASE_URL)')
-		.option(
-			'--asset-storage-url <url>',
-			'S3-compatible asset storage to read blobs from (env: HEZO_ASSET_STORAGE_URL)',
-		)
+		.option('--config <path>', CONFIG_OPTION_DESC)
+		.option('--data-dir <path>', `Data directory (default ${DEFAULT_DATA_DIR})`)
+		.option('--database-url <url>', 'External Postgres connection string')
+		.option('--asset-storage-url <url>', 'S3-compatible asset storage to read blobs from')
 		.option('--no-assets', 'Back up the database only — skip asset files')
 		.option('--no-database', 'Back up asset files only — skip the database')
 		.parse(argv.slice(3), { from: 'user' });
@@ -329,9 +206,7 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	if (!withAssets && !withDatabase) {
 		throw new Error('Nothing to back up: --no-assets and --no-database cannot be combined.');
 	}
-	const dataDir = pickDataDir(opts.dataDir);
-	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
-	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
+	const { dataDir, databaseUrl, assetStorageUrl } = resolveSubcommandTargets(opts);
 
 	// Embedded backend: never open a second cluster over a live server's files.
 	if (!databaseUrl) await assertNoLiveEmbeddedServer(dataDir, 'backup');
@@ -471,15 +346,10 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 			'Restore a backup: a "hezo backup" bundle (database + assets), or a logical .backup.gz',
 		)
 		.argument('<backup>', 'path to a backup bundle directory or file')
-		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
-		.option(
-			'--database-url <url>',
-			'External Postgres connection string to restore into (env: HEZO_DATABASE_URL)',
-		)
-		.option(
-			'--asset-storage-url <url>',
-			'S3-compatible asset storage to restore blobs into (env: HEZO_ASSET_STORAGE_URL)',
-		)
+		.option('--config <path>', CONFIG_OPTION_DESC)
+		.option('--data-dir <path>', `Data directory (default ${DEFAULT_DATA_DIR})`)
+		.option('--database-url <url>', 'External Postgres connection string to restore into')
+		.option('--asset-storage-url <url>', 'S3-compatible asset storage to restore blobs into')
 		.option('--wipe', 'Drop the existing schema in the target database before restoring')
 		.option('--no-assets', 'Restore the database only — skip asset files in a bundle')
 		.option('--no-database', 'Restore asset files only — skip the database in a bundle')
@@ -493,9 +363,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 
 	const opts = program.opts();
 	const backupPath = resolve(program.args[0]);
-	const dataDir = pickDataDir(opts.dataDir);
-	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
-	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
+	const { dataDir, databaseUrl, assetStorageUrl } = resolveSubcommandTargets(opts);
 
 	// Embedded target: refuse to write over the files of a live server.
 	if (!databaseUrl) await assertNoLiveEmbeddedServer(dataDir, 'restore');
@@ -696,20 +564,24 @@ export async function runUninstall(
 		.description(
 			"Remove Hezo's data directory (all projects, the database, backups, settings) and the containers it created",
 		)
-		.option('--data-dir <path>', 'Data directory to remove (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
+		.option('--config <path>', CONFIG_OPTION_DESC)
+		.option('--data-dir <path>', `Data directory to remove (default ${DEFAULT_DATA_DIR})`)
 		.option('--yes', 'Confirm removal — required; without it nothing is deleted')
 		// The instance's own backend, so its containers are removed wherever they
 		// actually ran. Defaults to Docker, matching the server's default.
 		.option(
 			'--sandbox-backend <name>',
-			'Backend the instance ran containers on: docker (default) or daytona (env: HEZO_SANDBOX_BACKEND)',
+			'Backend the instance ran containers on: docker (default) or daytona',
 		)
-		.option('--daytona-api-key <key>', 'Daytona API key (env: HEZO_DAYTONA_API_KEY)')
-		.option('--daytona-api-url <url>', 'Daytona API base URL (env: HEZO_DAYTONA_API_URL)')
+		.option('--daytona-api-key <key>', 'Daytona API key')
+		.option('--daytona-api-url <url>', 'Daytona API base URL')
 		.parse(argv.slice(3), { from: 'user' });
 
 	const opts = program.opts();
-	const dataDir = pickDataDir(opts.dataDir);
+	const { dataDir } = resolveSubcommandTargets(opts);
+	// The instance's own backend, so its containers are removed wherever they
+	// actually ran — read from the same config file the server was started with.
+	const containers = readConfigFile(opts).containers;
 
 	const { existsSync } = await import('node:fs');
 	if (!existsSync(dataDir)) {
@@ -753,10 +625,10 @@ export async function runUninstall(
 	// fatal — Docker may already be stopped.
 	const removeContainers = deps.removeContainers ?? defaultRemoveProvisionedContainers;
 	const backendOpts: SandboxBackendOptions = {
-		backend: process.env.HEZO_SANDBOX_BACKEND ?? opts.sandboxBackend,
-		daytonaApiKey: process.env.HEZO_DAYTONA_API_KEY ?? opts.daytonaApiKey,
-		daytonaApiUrl: process.env.HEZO_DAYTONA_API_URL ?? opts.daytonaApiUrl,
-		dockerSocket: process.env.HEZO_DOCKER_SOCKET ?? opts.dockerSocket,
+		backend: opts.sandboxBackend ?? containers?.backend,
+		daytonaApiKey: opts.daytonaApiKey ?? containers?.daytona?.apiKey,
+		daytonaApiUrl: opts.daytonaApiUrl ?? containers?.daytona?.apiUrl,
+		dockerSocket: opts.dockerSocket ?? containers?.dockerSocket,
 	};
 	const managed = (backendOpts.backend ?? 'docker') !== 'docker';
 	try {
@@ -794,112 +666,131 @@ export async function runUninstall(
 }
 
 /**
- * Central configuration resolution. Each option can be set via either a CLI
- * flag or an env var; the env var takes precedence when both are present. The
- * defaults defined here are the final fallback. This is the only place where
- * config values are resolved — subsystems (logger level, container removal
- * gate, etc.) receive their slice and apply it locally at startup.
+ * Central configuration resolution: **CLI flag > config file > built-in default**.
+ *
+ * The flag wins because it is the more specific, more immediate instruction -
+ * you type it to override the file you already wrote. `--config` names the file;
+ * without it only defaults and flags apply.
+ *
+ * Two settings are deliberately unreachable from the file (`schema.ts` rejects
+ * them by name): `masterKey`, which must never be written to disk, and `reset`,
+ * which would wipe the database on every restart rather than once.
+ *
+ * This is the only place config values are resolved. Subsystems take their slice
+ * from the returned object, or read it back through `runtimeConfig()`.
  */
-export function parseConfig(
+export function resolveConfig(
 	argv: string[] = process.argv,
 	env: NodeJS.ProcessEnv = process.env,
 ): HezoConfig {
 	const program = new Command()
 		.name('hezo')
 		.description('Hezo server — self-hosted AI agent management platform')
-		.option('--port <port>', 'Server port (env: HEZO_PORT)', String(DEFAULT_PORT))
-		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
+		.option('--config <path>', CONFIG_OPTION_DESC)
+		.option('--port <port>', `Server port (default ${DEFAULT_CONFIG.port})`)
+		.option('--data-dir <path>', `Data directory (default ${DEFAULT_DATA_DIR})`)
 		.option(
 			'--database-url <url>',
-			'External Postgres connection string (postgres://user:password@host:5432/db). Omit to use the embedded database under the data directory. (env: HEZO_DATABASE_URL)',
+			'External Postgres connection string (postgres://user:password@host:5432/db). Omit to use the embedded database under the data directory.',
 		)
 		.option(
 			'--asset-storage-url <url>',
-			'S3-compatible object storage for asset files (s3://ACCESS_KEY:SECRET@endpoint/bucket[/prefix]?region=…&pathStyle=…). Works with AWS S3, MinIO, R2, Spaces, B2, and any other S3-compatible store. Omit to store assets on the local filesystem under the data directory. (env: HEZO_ASSET_STORAGE_URL)',
+			'S3-compatible object storage for asset files (s3://ACCESS_KEY:SECRET@endpoint/bucket[/prefix]?region=…&pathStyle=…). Works with AWS S3, MinIO, R2, Spaces, B2, and any other S3-compatible store. Omit to store assets on the local filesystem under the data directory.',
 		)
 		.option(
 			'--sandbox-backend <name>',
-			'Where agent containers run: docker (default, the local daemon) or daytona (a managed sandbox service). Selecting a managed backend that cannot be reached is fatal at startup - Hezo never falls back to local Docker. (env: HEZO_SANDBOX_BACKEND)',
+			'Where agent containers run: docker (default, the local daemon) or daytona (a managed sandbox service). Selecting a managed backend that cannot be reached is fatal at startup - Hezo never falls back to local Docker.',
 		)
 		.option(
 			'--daytona-api-key <key>',
-			'Daytona API key, required when --sandbox-backend is daytona (env: HEZO_DAYTONA_API_KEY)',
+			'Daytona API key, required when --sandbox-backend is daytona',
 		)
 		.option(
 			'--daytona-api-url <url>',
-			'Daytona API base URL, for a regional or self-hosted endpoint. Defaults to the public API. (env: HEZO_DAYTONA_API_URL)',
+			'Daytona API base URL, for a regional or self-hosted endpoint. Defaults to the public API.',
 		)
 		.option(
 			'--master-key <phrase>',
-			'The 12-word master key phrase for setup/unlock (env: HEZO_MASTER_KEY)',
+			'The 12-word master key phrase for setup/unlock (env: HEZO_MASTER_KEY). Never accepted from the config file - the master key must not be written to disk.',
 		)
-		.option('--web-url <url>', 'Web UI base URL for redirects (env: HEZO_WEB_URL)', '')
-		.option('--reset', 'Reset database and start fresh (env: HEZO_RESET)')
-		.option('--no-open', 'Do not auto-open the browser on startup (env: HEZO_OPEN=0)')
+		.option('--web-url <url>', 'Web UI base URL for redirects')
 		.option(
-			'--log-level <level>',
-			'Log level: debug | info | warn | error (env: HEZO_LOG_LEVEL)',
-			'info',
+			'--reset',
+			'Reset the embedded database and start fresh. A flag only: it renames the existing pgdata aside on the one invocation you pass it, so it is never accepted from the config file.',
 		)
+		.option('--no-open', 'Do not auto-open the browser on startup')
+		.option('--log-level <level>', 'Log level: debug | info | warn | error')
 		.option(
 			'--keep-old-containers',
-			'Skip removal of old containers on rebuild/teardown/provision — useful for inspecting crashed containers via `docker logs` / `docker inspect`. Subsequent rebuilds will fail with a name conflict until the operator removes them manually. (env: HEZO_KEEP_OLD_CONTAINERS)',
+			'Skip removal of old containers on rebuild/teardown/provision — useful for inspecting crashed containers via `docker logs` / `docker inspect`. Subsequent rebuilds will fail with a name conflict until the operator removes them manually.',
 		)
 		.option(
 			'--docker-socket <path>',
-			"Path to the container runtime's Unix socket. By default Hezo finds it automatically: DOCKER_HOST, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Set this only when the daemon listens somewhere none of those cover. Unix sockets only - tcp:// and npipe:// are not supported. (env: HEZO_DOCKER_SOCKET)",
+			"Path to the container runtime's Unix socket. By default Hezo finds it automatically: DOCKER_HOST, then the docker CLI's current context, then the well-known path for each supported runtime (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless Docker). Set this only when the daemon listens somewhere none of those cover. Unix sockets only - tcp:// and npipe:// are not supported.",
 		)
 		.option(
 			'--no-egress-proxy-auth',
-			"Disable per-run egress proxy authentication. On by default: each run's HTTP(S)_PROXY URL carries a token the proxy verifies before substituting secrets. Only disable to unblock a runtime whose HTTP client cannot send proxy credentials — the secret red line still holds (an unauthenticated caller only ships unsubstituted placeholders). (env: HEZO_EGRESS_PROXY_AUTH=0)",
+			"Disable per-run egress proxy authentication. On by default: each run's HTTP(S)_PROXY URL carries a token the proxy verifies before substituting secrets. Only disable to unblock a runtime whose HTTP client cannot send proxy credentials — the secret red line still holds (an unauthenticated caller only ships unsubstituted placeholders).",
 		)
 		.option(
 			'--egress-allow-private-targets',
-			"Allow agent egress through the proxy to reach loopback, link-local and private (RFC1918) addresses. Blocked by default: the proxy runs on the host, so without the guard an agent could tunnel to Hezo's own API, its database, or any host-bound daemon. Enable only when an MCP server or git remote your agents genuinely need lives on the LAN. (env: HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1)",
+			"Allow agent egress through the proxy to reach loopback, link-local and private (RFC1918) addresses. Blocked by default: the proxy runs on the host, so without the guard an agent could tunnel to Hezo's own API, its database, or any host-bound daemon. Enable only when an MCP server or git remote your agents genuinely need lives on the LAN.",
 		)
 		.option(
 			'--auto-install-updates',
-			'Install updates automatically: once a newer release is downloaded and verified, gracefully restart onto it without waiting for "Install & restart" in the web UI (in-flight agent runs delay the restart). Only takes effect where in-app auto-update is available — the self-managed binary, not inside a container. The instance comes back unlocked: the in-memory unlock key is handed to the relaunched process over IPC, never written to disk. (env: HEZO_AUTO_INSTALL_UPDATES)',
+			'Install updates automatically: once a newer release is downloaded and verified, gracefully restart onto it without waiting for "Install & restart" in the web UI (in-flight agent runs delay the restart). Only takes effect where in-app auto-update is available — the self-managed binary, not inside a container. The instance comes back unlocked: the in-memory unlock key is handed to the relaunched process over IPC, never written to disk.',
 		)
 		.option(
 			'--disable-telemetry',
-			'Disable anonymous daily usage telemetry (aggregate counts only — no names, content, or costs). On by default. (env: HEZO_TELEMETRY_ENABLED=0)',
+			'Disable anonymous daily usage telemetry (aggregate counts only — no names, content, or costs). On by default.',
 		)
 		.option(
 			'--telemetry-endpoint <url>',
-			`Override the telemetry collection endpoint (default ${DEFAULT_TELEMETRY_ENDPOINT}). (env: HEZO_TELEMETRY_ENDPOINT)`,
+			`Override the telemetry collection endpoint (default ${DEFAULT_CONFIG.telemetry.endpoint}).`,
 		)
 		.parse(argv);
 
 	const cli = program.opts();
+	const file = readConfigFile(cli);
+	const d = DEFAULT_CONFIG;
+	const configPath = typeof cli.config === 'string' && cli.config ? resolve(cli.config) : undefined;
 
-	// Env var > CLI value > default. For value-bearing options the CLI value
-	// is a string; for flags it's a boolean (commander sets `true` when the
-	// flag is present, `undefined` otherwise).
-	const pick = (envName: string, cliValue: unknown): string | undefined => {
-		const e = env[envName];
-		if (e !== undefined && e !== '') return e;
-		if (typeof cliValue === 'string' && cliValue.length > 0) return cliValue;
-		return undefined;
-	};
-	const pickBool = (envName: string, cliValue: unknown): boolean => {
-		const e = env[envName];
-		if (e !== undefined) return parseBool(e);
-		return cliValue === true;
-	};
-	// Like pickBool but defaults to ON. Commander's `--no-open` sets cli.open to
-	// false when passed and true otherwise, so the only way to disable via CLI is
-	// `--no-open`; the env var still wins when set.
-	const pickOpen = (envName: string, cliValue: unknown): boolean => {
-		const e = env[envName];
-		if (e !== undefined && e !== '') return parseBool(e);
-		return cliValue !== false;
-	};
+	// Commander cannot tell "flag absent" from "flag equals its default" on a
+	// negatable boolean (--no-open stores true when absent, false when passed), so
+	// every option asks the parser where its value came from instead of inspecting
+	// the value. That one test works for value options and booleans alike.
+	const passed = (key: string): boolean => program.getOptionValueSource(key) === 'cli';
+	const str = (key: string): string | undefined =>
+		passed(key) && typeof cli[key] === 'string' && cli[key].length > 0
+			? (cli[key] as string)
+			: undefined;
+	const bool = (key: string): boolean | undefined => (passed(key) ? cli[key] === true : undefined);
+	// --no-x flags: commander stores false on the positive key when passed.
+	const negatable = (key: string): boolean | undefined =>
+		passed(key) ? cli[key] !== false : undefined;
 
-	const masterKeyRaw = pick('HEZO_MASTER_KEY', cli.masterKey);
+	const port = ((): number => {
+		const raw = str('port');
+		if (raw === undefined) return file.port ?? d.port;
+		const n = Number.parseInt(raw, 10);
+		if (Number.isNaN(n) || n < 1 || n > 65535) {
+			throw new Error(`Invalid port: ${raw}. Must be 1-65535.`);
+		}
+		return n;
+	})();
 
-	const databaseUrl = pick('HEZO_DATABASE_URL', cli.databaseUrl);
-	const reset = pickBool('HEZO_RESET', cli.reset);
+	const logLevel = ((): HezoConfig['logLevel'] => {
+		const raw = str('logLevel');
+		if (raw === undefined) return file.logLevel ?? d.logLevel;
+		const lower = raw.toLowerCase();
+		if (lower === 'debug' || lower === 'info' || lower === 'warn' || lower === 'error') {
+			return lower;
+		}
+		throw new Error(`Invalid log level: ${raw}. Must be debug | info | warn | error.`);
+	})();
+
+	const databaseUrl = str('databaseUrl') ?? file.database?.url;
+	const reset = bool('reset') ?? false;
 	if (databaseUrl && reset) {
 		throw new Error(
 			'--reset applies to the embedded database only (it renames a corrupt pgdata aside). ' +
@@ -907,44 +798,73 @@ export function parseConfig(
 		);
 	}
 
-	// Telemetry defaults ON. The env var (when set) wins; otherwise the only way
-	// to disable via CLI is the explicit `--disable-telemetry` flag.
-	const telemetryEnabled = ((): boolean => {
-		const e = env.HEZO_TELEMETRY_ENABLED;
-		if (e !== undefined && e !== '') return parseBool(e);
-		return cli.disableTelemetry !== true;
+	const masterKeyRaw = ((): string | undefined => {
+		// The one setting the config file may not carry, so the env var stays the
+		// way to unlock a single non-interactive startup: a flag would put a
+		// twelve-word key in the process list.
+		const e = env.HEZO_MASTER_KEY;
+		if (e !== undefined && e !== '') return e;
+		return str('masterKey');
 	})();
 
 	return {
-		port: parsePort(pick('HEZO_PORT', cli.port) ?? String(DEFAULT_PORT)),
-		dataDir: resolveDataDir(pick('HEZO_DATA_DIR', cli.dataDir) ?? DEFAULT_DATA_DIR),
-		databaseUrl,
-		assetStorageUrl: pick('HEZO_ASSET_STORAGE_URL', cli.assetStorageUrl),
-		sandboxBackend: pick('HEZO_SANDBOX_BACKEND', cli.sandboxBackend),
-		daytonaApiKey: pick('HEZO_DAYTONA_API_KEY', cli.daytonaApiKey),
-		daytonaApiUrl: pick('HEZO_DAYTONA_API_URL', cli.daytonaApiUrl),
-		masterKey: masterKeyRaw ? parseMasterKey(masterKeyRaw) : undefined,
-		webUrl: pick('HEZO_WEB_URL', cli.webUrl) ?? '',
-		reset,
-		// Auto-open is on by default; headless detection at startup decides whether
-		// a browser actually launches. HEZO_OPEN=0 / --no-open disables it. With
-		// `--no-open` commander sets cli.open=false; absent, it defaults to true.
-		open: pickOpen('HEZO_OPEN', cli.open),
-		logLevel: parseLogLevel(pick('HEZO_LOG_LEVEL', cli.logLevel) ?? 'info'),
-		keepOldContainers: pickBool('HEZO_KEEP_OLD_CONTAINERS', cli.keepOldContainers),
-		autoInstallUpdates: pickBool('HEZO_AUTO_INSTALL_UPDATES', cli.autoInstallUpdates),
-		dockerSocket: pick('HEZO_DOCKER_SOCKET', cli.dockerSocket),
-		// Egress-proxy auth defaults ON. The env var (when set) wins; otherwise
-		// `--no-egress-proxy-auth` sets cli.egressProxyAuth=false, absent it is true.
-		egressProxyAuth: pickOpen('HEZO_EGRESS_PROXY_AUTH', cli.egressProxyAuth),
-		egressAllowPrivateTargets: pickBool(
-			'HEZO_EGRESS_ALLOW_PRIVATE_TARGETS',
-			cli.egressAllowPrivateTargets,
-		),
-		telemetry: {
-			enabled: telemetryEnabled,
-			endpoint:
-				pick('HEZO_TELEMETRY_ENDPOINT', cli.telemetryEndpoint) ?? DEFAULT_TELEMETRY_ENDPOINT,
+		port,
+		dataDir: resolveDataDir(str('dataDir') ?? file.dataDir ?? DEFAULT_DATA_DIR),
+		webUrl: str('webUrl') ?? file.webUrl ?? d.webUrl,
+		logLevel,
+		open: negatable('open') ?? file.open ?? d.open,
+
+		database: {
+			url: databaseUrl,
+			poolSize: file.database?.poolSize ?? d.database.poolSize,
 		},
+		assetStorage: { url: str('assetStorageUrl') ?? file.assetStorage?.url },
+		containers: {
+			backend: str('sandboxBackend') ?? file.containers?.backend,
+			dockerSocket: str('dockerSocket') ?? file.containers?.dockerSocket,
+			dockerRequestTimeoutMs:
+				file.containers?.dockerRequestTimeoutMs ?? d.containers.dockerRequestTimeoutMs,
+			keepOld: bool('keepOldContainers') ?? file.containers?.keepOld ?? d.containers.keepOld,
+			skipMountCheck: file.containers?.skipMountCheck ?? d.containers.skipMountCheck,
+			agentBaseImage: file.containers?.agentBaseImage,
+			daytona: {
+				apiKey: str('daytonaApiKey') ?? file.containers?.daytona?.apiKey,
+				apiUrl:
+					str('daytonaApiUrl') ?? file.containers?.daytona?.apiUrl ?? d.containers.daytona.apiUrl,
+			},
+		},
+		egress: {
+			proxyAuth: negatable('egressProxyAuth') ?? file.egress?.proxyAuth ?? d.egress.proxyAuth,
+			allowPrivateTargets:
+				bool('egressAllowPrivateTargets') ??
+				file.egress?.allowPrivateTargets ??
+				d.egress.allowPrivateTargets,
+			debug: file.egress?.debug ?? d.egress.debug,
+		},
+		telemetry: {
+			// The only CLI half is the positive `--disable-telemetry`, so a passed
+			// flag means off and everything else defers to the file, then the default.
+			enabled:
+				(passed('disableTelemetry') ? false : undefined) ??
+				file.telemetry?.enabled ??
+				d.telemetry.enabled,
+			endpoint: str('telemetryEndpoint') ?? file.telemetry?.endpoint ?? d.telemetry.endpoint,
+		},
+		updates: {
+			disabled: file.updates?.disabled ?? d.updates.disabled,
+			autoInstall: bool('autoInstallUpdates') ?? file.updates?.autoInstall ?? d.updates.autoInstall,
+		},
+		marketplace: {
+			ref: file.marketplace?.ref ?? d.marketplace.ref,
+			baseUrl: file.marketplace?.baseUrl ?? d.marketplace.baseUrl,
+		},
+		github: { oauthClientId: file.github?.oauthClientId ?? d.github.oauthClientId },
+		jobs: { ...d.jobs, ...file.jobs },
+		logCompaction: { ...d.logCompaction, ...file.logCompaction },
+		chat: { ...d.chat, ...file.chat },
+
+		reset,
+		masterKey: masterKeyRaw ? parseMasterKey(masterKeyRaw) : undefined,
+		configPath,
 	};
 }

--- a/packages/server/src/config/load.ts
+++ b/packages/server/src/config/load.ts
@@ -1,0 +1,39 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { type ConfigFile, ConfigFileError, validateConfigFile } from './schema';
+
+/**
+ * Require the config file from disk, outside the compiled bundle.
+ *
+ * `createRequire` produces the resolver at runtime, so `bun build --compile`
+ * never sees a specifier it could try to resolve statically and inline into the
+ * binary. A bare `require(path)` or `import(path)` would be a bundler input.
+ */
+const requireExternal = createRequire(import.meta.url);
+
+/**
+ * Load and validate the `--config` file. Returns only what the file actually
+ * set; `resolveConfig` overlays it on the defaults and then the CLI flags.
+ *
+ * The file is CommonJS (`module.exports = { … }`) and is real JavaScript, so it
+ * may compute values at load time - reading a side file, branching on hostname.
+ * Anything it throws surfaces to the operator as-is.
+ */
+export function loadConfigFile(path: string): ConfigFile {
+	const absolute = resolve(path);
+	let exported: unknown;
+	try {
+		exported = requireExternal(absolute);
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		// Report our own path rather than relaying the module resolver's message,
+		// which names the compiled binary's internal `/$bunfs/root/...` entry point
+		// as the requiring module and reads as a Hezo bug rather than a typo.
+		if (code === 'MODULE_NOT_FOUND') {
+			throw new ConfigFileError(`No config file at ${absolute} (--config).`);
+		}
+		const message = err instanceof Error ? err.message : String(err);
+		throw new ConfigFileError(`Could not load the config file at ${absolute}: ${message}`);
+	}
+	return validateConfigFile(absolute, exported);
+}

--- a/packages/server/src/config/runtime.ts
+++ b/packages/server/src/config/runtime.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_CONFIG, type HezoConfig } from './types';
+
+/**
+ * The process-wide resolved configuration.
+ *
+ * `index.ts` sets this immediately after `resolveConfig()`, before `startup()`.
+ * It has to be an accessor rather than a value threaded through every caller
+ * because service modules are imported before that call runs (`index.ts` imports
+ * `./app` first), so anything reading config at module scope would read it too
+ * early. Read it inside the function that needs it, never into a module-level
+ * `const`.
+ */
+let current: HezoConfig | null = null;
+
+export function setRuntimeConfig(config: HezoConfig): void {
+	current = config;
+}
+
+/**
+ * The resolved config, or the built-in defaults when nothing has been set - the
+ * case for a unit test that imports a service without booting the server. That
+ * mirrors the `process.env.X ?? default` reads this replaced, so no test has to
+ * arrange config it does not care about.
+ */
+export function runtimeConfig(): HezoConfig {
+	return current ?? DEFAULT_CONFIG;
+}
+
+/** Restore the unset state. Tests only, so one spec's override cannot leak into the next. */
+export function resetRuntimeConfig(): void {
+	current = null;
+}

--- a/packages/server/src/config/schema.ts
+++ b/packages/server/src/config/schema.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod';
+import type { HezoConfig } from './types';
+
+/**
+ * The config file's accepted shape: a deep-`Partial` of {@link HezoConfig},
+ * minus the two keys that must never live in a file (see `REJECTED_KEYS`).
+ *
+ * Every object is `.strict()`, so an unknown or misspelled key is a hard error
+ * naming the key. A silently-ignored `dataDIr` is the specific failure mode a
+ * config file introduces over flags, and rejecting it costs nothing.
+ */
+
+const cron = z.string().trim().min(1).describe('a seconds-precision six-field cron expression');
+
+const positiveInt = z.int().positive();
+
+const databaseSchema = z
+	.object({
+		url: z.string().min(1).optional(),
+		// Matches parsePoolSize in db/open.ts - a pool below 2 deadlocks the
+		// migration path, and above 100 exhausts most managed Postgres plans.
+		poolSize: z.int().min(2).max(100).optional(),
+	})
+	.strict();
+
+const assetStorageSchema = z.object({ url: z.string().min(1).optional() }).strict();
+
+const daytonaSchema = z
+	.object({ apiKey: z.string().min(1).optional(), apiUrl: z.url().optional() })
+	.strict();
+
+const containersSchema = z
+	.object({
+		backend: z.string().min(1).optional(),
+		dockerSocket: z.string().min(1).optional(),
+		dockerRequestTimeoutMs: positiveInt.optional(),
+		keepOld: z.boolean().optional(),
+		skipMountCheck: z.boolean().optional(),
+		agentBaseImage: z.string().min(1).optional(),
+		daytona: daytonaSchema.optional(),
+	})
+	.strict();
+
+const egressSchema = z
+	.object({
+		proxyAuth: z.boolean().optional(),
+		allowPrivateTargets: z.boolean().optional(),
+		debug: z.boolean().optional(),
+	})
+	.strict();
+
+const telemetrySchema = z
+	.object({ enabled: z.boolean().optional(), endpoint: z.url().optional() })
+	.strict();
+
+const updatesSchema = z
+	.object({ disabled: z.boolean().optional(), autoInstall: z.boolean().optional() })
+	.strict();
+
+const marketplaceSchema = z
+	.object({ ref: z.string().min(1).optional(), baseUrl: z.url().optional() })
+	.strict();
+
+const githubSchema = z.object({ oauthClientId: z.string().min(1).optional() }).strict();
+
+const jobsSchema = z
+	.object({
+		wakeupCron: cron.optional(),
+		heartbeatCron: cron.optional(),
+		inboxArchiveCron: cron.optional(),
+		pricingRefreshCron: cron.optional(),
+		modelPinRefreshCron: cron.optional(),
+		updateCheckCron: cron.optional(),
+		autoInstallCron: cron.optional(),
+		telemetryCron: cron.optional(),
+		budgetResumeCron: cron.optional(),
+		connectorHealthCron: cron.optional(),
+		containerSyncCron: cron.optional(),
+		containerIdleStopCron: cron.optional(),
+		orphanDetectionCron: cron.optional(),
+		orphanContainerSweepCron: cron.optional(),
+		dbMaintenanceCron: cron.optional(),
+		wakeupCoalescingMs: positiveInt.optional(),
+		heartbeatCooldownSec: z.int().min(0).optional(),
+		heartbeatFloorMin: positiveInt.optional(),
+		inboxRetentionDays: positiveInt.optional(),
+	})
+	.strict();
+
+const logCompactionSchema = z
+	.object({
+		cron: cron.optional(),
+		batch: positiveInt.optional(),
+		maxPerTick: positiveInt.optional(),
+		preservedBytes: positiveInt.optional(),
+	})
+	.strict();
+
+const chatSchema = z.object({ healthIntervalMs: positiveInt.optional() }).strict();
+
+export const configFileSchema = z
+	.object({
+		port: z.int().min(1).max(65535).optional(),
+		dataDir: z.string().min(1).optional(),
+		webUrl: z.string().optional(),
+		logLevel: z.enum(['debug', 'info', 'warn', 'error']).optional(),
+		open: z.boolean().optional(),
+
+		database: databaseSchema.optional(),
+		assetStorage: assetStorageSchema.optional(),
+		containers: containersSchema.optional(),
+		egress: egressSchema.optional(),
+		telemetry: telemetrySchema.optional(),
+		updates: updatesSchema.optional(),
+		marketplace: marketplaceSchema.optional(),
+		github: githubSchema.optional(),
+		jobs: jobsSchema.optional(),
+		logCompaction: logCompactionSchema.optional(),
+		chat: chatSchema.optional(),
+	})
+	.strict();
+
+/** What the config file may set: everything in {@link HezoConfig} bar the rejected keys. */
+export type ConfigFile = z.infer<typeof configFileSchema>;
+
+/**
+ * Keys that are structurally valid but must never appear in a config file, each
+ * with the reason an operator needs to hear. `.strict()` would already reject
+ * them as unknown, but "Unrecognized key: masterKey" invites the reader to
+ * conclude they spelled it wrong and go looking for the right spelling.
+ */
+const REJECTED_KEYS: Record<string, string> = {
+	masterKey:
+		'the master key must never be written to disk. Hezo keeps it in memory only, so a copy ' +
+		'of your disk cannot decrypt your data. Unlock from the browser gate, or pass it to a ' +
+		'single startup with HEZO_MASTER_KEY or --master-key.',
+	reset:
+		'"reset" wipes the embedded database, so a config file carrying it would wipe on every ' +
+		'restart. Pass --reset on the one invocation that should start fresh.',
+};
+
+/** A config-file validation failure, already formatted for an operator to read. */
+export class ConfigFileError extends Error {}
+
+function formatIssues(path: string, issues: z.core.$ZodIssue[]): string {
+	const lines = issues.map((issue) => {
+		const where = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+		return `  ${where}: ${issue.message}`;
+	});
+	return `${path} is not a valid Hezo config file:\n${lines.join('\n')}`;
+}
+
+/**
+ * Validate the object a config file exported. Throws {@link ConfigFileError}
+ * with every problem listed, rather than the first one.
+ */
+export function validateConfigFile(path: string, exported: unknown): ConfigFile {
+	if (exported === null || typeof exported !== 'object' || Array.isArray(exported)) {
+		throw new ConfigFileError(
+			`${path} must export a configuration object, e.g. "module.exports = { port: 3100 }" ` +
+				`(got ${Array.isArray(exported) ? 'an array' : typeof exported}).`,
+		);
+	}
+
+	for (const [key, reason] of Object.entries(REJECTED_KEYS)) {
+		if (key in exported) throw new ConfigFileError(`${path} sets "${key}", but ${reason}`);
+	}
+
+	const parsed = configFileSchema.safeParse(exported);
+	if (!parsed.success) throw new ConfigFileError(formatIssues(path, parsed.error.issues));
+	return parsed.data;
+}

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -1,0 +1,340 @@
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import {
+	CONNECTOR_CAPABILITIES,
+	DEFAULT_DATA_DIR,
+	DEFAULT_PORT,
+	HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT,
+	LOG_COMPACTION_PRESERVED_TAIL_BYTES,
+} from '@hezo/shared';
+
+export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Where daily telemetry reports are posted unless the config file overrides it.
+ * Defined here rather than in `services/telemetry.ts` so `DEFAULT_CONFIG` stays
+ * free of service imports - every service reaches config through
+ * `runtimeConfig()`, and a service import here would close that loop.
+ * `services/telemetry.ts` re-exports it under its historical name.
+ */
+export const DEFAULT_TELEMETRY_ENDPOINT = 'https://hezo.ai/api/telemetry';
+
+/** Daytona's public control plane. Re-exported by `sandbox/daytona/client.ts`; see above. */
+export const DEFAULT_DAYTONA_API_URL = 'https://app.daytona.io/api';
+
+/**
+ * The public GitHub OAuth app Hezo ships with. An instance that registers its
+ * own app points `github.oauthClientId` at it; everyone else uses this. Read
+ * from the connector registry so the id has one home.
+ */
+export const DEFAULT_GITHUB_OAUTH_CLIENT_ID =
+	CONNECTOR_CAPABILITIES.github.deviceAuth?.clientIdDefault ?? '';
+
+/** External Postgres connection pool. */
+export interface DatabaseConfig {
+	/**
+	 * External Postgres connection string. Unset -> the embedded PGlite database
+	 * under `<dataDir>/pgdata`. The raw value carries credentials: it must never
+	 * be logged or exposed un-redacted (see `redactDatabaseUrl` in
+	 * `lib/db-info.ts`) and never passed into `buildApp`.
+	 */
+	url?: string;
+	/** Pool size for an external database (2-100). Ignored for the embedded one. */
+	poolSize: number;
+}
+
+export interface AssetStorageConfig {
+	/**
+	 * S3-compatible asset storage URL. Unset -> asset blobs on the local
+	 * filesystem under `<dataDir>/assets`. Carries credentials; redact with
+	 * `redactAssetStorageUrl` in `lib/asset-storage-info.ts`.
+	 */
+	url?: string;
+}
+
+export interface DaytonaConfig {
+	/**
+	 * Daytona API key, required when `containers.backend` is `daytona`. Used only
+	 * by trusted server code to reach the provider control plane - it is never
+	 * placed in an agent container, and never logged.
+	 */
+	apiKey?: string;
+	/** Daytona API base URL, for a regional or self-hosted endpoint. */
+	apiUrl: string;
+}
+
+export interface ContainersConfig {
+	/**
+	 * Where agent containers run: `docker` (the local daemon) or a managed sandbox
+	 * service. Selecting a managed backend Hezo cannot reach is **fatal at
+	 * startup** - it never falls back to local Docker, because an instance that
+	 * silently degraded would look healthy while running somewhere the operator
+	 * did not choose. Seeds a new instance only; once set in Settings -> Containers
+	 * the stored choice wins.
+	 */
+	backend?: string;
+	/**
+	 * Explicit path to the container runtime's Unix socket. Unset by default, in
+	 * which case the startup preflight discovers it: `DOCKER_HOST`, then the docker
+	 * CLI's current context, then the well-known path for each supported runtime
+	 * (Docker Engine/Desktop, Colima, Rancher Desktop, OrbStack, Lima, rootless
+	 * Docker). Set it only when the daemon listens somewhere none of those cover.
+	 */
+	dockerSocket?: string;
+	/** Ceiling on a single docker daemon call, so a wedged one cannot stall the sync loop. */
+	dockerRequestTimeoutMs: number;
+	/**
+	 * Skip removal of old containers on rebuild/teardown/provision - useful for
+	 * inspecting crashed containers. Subsequent rebuilds fail with a name conflict
+	 * until the operator removes them manually.
+	 */
+	keepOld: boolean;
+	/**
+	 * Skip the boot check that verifies agent containers get a writable view of the
+	 * data directory. The check is a diagnosis, not a dependency - skipping it hides
+	 * the warning, it does not make a read-only mount work.
+	 */
+	skipMountCheck: boolean;
+	/**
+	 * Container image every project's agents run in, overriding the default for this
+	 * instance. Must be a reference the backend in use can pull. Mainly for running a
+	 * development server against a managed sandbox service, where the default is built
+	 * into the local Docker daemon and a managed service has nothing to pull. A project
+	 * that names its own base image keeps it.
+	 */
+	agentBaseImage?: string;
+	daytona: DaytonaConfig;
+}
+
+export interface EgressConfig {
+	/**
+	 * Require a per-run token on every request to the egress proxy. On by default:
+	 * each run's `HTTP(S)_PROXY` URL carries a random token that the proxy checks
+	 * (constant-time) before substituting any secret, so a co-resident process that
+	 * reaches the proxy address can't drive substitution for another run. Disable
+	 * only to unblock a runtime whose HTTP client can't carry proxy credentials -
+	 * the secret red line still holds either way (an unauthenticated caller only
+	 * ships unsubstituted placeholders).
+	 */
+	proxyAuth: boolean;
+	/**
+	 * Permit proxied agent egress to loopback / link-local / private addresses. Off
+	 * by default: the egress proxy runs in the host's network namespace, so without
+	 * the guard an agent could tunnel to Hezo's own API, its database, or any
+	 * host-bound daemon. Enable only when an MCP server or git remote the agents
+	 * legitimately need lives on the LAN.
+	 */
+	allowPrivateTargets: boolean;
+	/** Per-connection proxy lifecycle tracing. Diagnostic only; very noisy. */
+	debug: boolean;
+}
+
+export interface TelemetryConfig {
+	/**
+	 * Anonymous daily usage telemetry. On by default (opt-out): once a day the
+	 * server POSTs aggregate counts (projects, tasks, tokens, AI-provider mix,
+	 * version) - no names, content, or costs - to `endpoint`, keyed by a random
+	 * per-install id.
+	 */
+	enabled: boolean;
+	endpoint: string;
+}
+
+export interface UpdatesConfig {
+	/**
+	 * Disable the in-app auto-update entirely: the release check, the background
+	 * download, and the "Install & restart" banner. When disabled the banner instead
+	 * links to the GitHub release page.
+	 */
+	disabled: boolean;
+	/**
+	 * Install staged updates automatically. Once a newer release is downloaded and
+	 * verified, the server gracefully restarts onto it by itself instead of waiting
+	 * for a superuser's "Install & restart" - deferring while agent runs are in
+	 * flight. Only effective where the in-app update flow is available at all (the
+	 * self-managed compiled binary, not inside a container).
+	 */
+	autoInstall: boolean;
+}
+
+export interface MarketplaceConfig {
+	/** Git ref the team marketplace is fetched from. */
+	ref: string;
+	/** Base URL the marketplace is fetched from, for a fork or a mirror. */
+	baseUrl: string;
+}
+
+export interface GithubConfig {
+	/**
+	 * OAuth app client id used for the GitHub connector's device flow. Defaults to
+	 * the public app Hezo ships with; point it at your own OAuth app to keep the
+	 * authorization under your organization's control.
+	 */
+	oauthClientId: string;
+}
+
+/**
+ * Background job cadences and the tuning that goes with them. Crons are
+ * seconds-precision six-field expressions.
+ */
+export interface JobsConfig {
+	wakeupCron: string;
+	heartbeatCron: string;
+	inboxArchiveCron: string;
+	pricingRefreshCron: string;
+	modelPinRefreshCron: string;
+	updateCheckCron: string;
+	autoInstallCron: string;
+	telemetryCron: string;
+	budgetResumeCron: string;
+	connectorHealthCron: string;
+	containerSyncCron: string;
+	containerIdleStopCron: string;
+	orphanDetectionCron: string;
+	orphanContainerSweepCron: string;
+	dbMaintenanceCron: string;
+	/** Window in which repeated wakeups for one agent collapse into a single run. */
+	wakeupCoalescingMs: number;
+	/** Quiet window after a run before the agent becomes heartbeat-eligible again. */
+	heartbeatCooldownSec: number;
+	/**
+	 * Lowest heartbeat cadence the scheduler honours, in minutes. Raising it above
+	 * the default clamps every agent up to it.
+	 */
+	heartbeatFloorMin: number;
+	/** How long archived inbox items are kept, in days. */
+	inboxRetentionDays: number;
+}
+
+export interface LogCompactionConfig {
+	cron: string;
+	/** Runs compacted per batch. */
+	batch: number;
+	/** Runs compacted per cron tick, bounding an unindexed scan that runs often. */
+	maxPerTick: number;
+	/**
+	 * Bytes of each old run's log kept when it is compacted - the trailing slice
+	 * holding the agent's end-of-run summary and its `[done] … tokens=… cost=…` line.
+	 */
+	preservedBytes: number;
+}
+
+export interface ChatConfig {
+	/** Cadence of the live-chat container health check. */
+	healthIntervalMs: number;
+}
+
+/**
+ * The fully resolved configuration: built-in defaults, overlaid with the
+ * `--config` file, overlaid with the CLI flags actually passed.
+ *
+ * The config file's accepted shape is a deep-`Partial` of this type minus
+ * `masterKey` and `reset` (see `schema.ts`), so the file, the type and the docs
+ * cannot drift apart.
+ */
+export interface HezoConfig {
+	port: number;
+	dataDir: string;
+	/** Public base URL, used so account sign-ins redirect back correctly. Empty -> same origin. */
+	webUrl: string;
+	logLevel: LogLevelName;
+	/**
+	 * Auto-open the web app in a browser at startup. Headless detection at startup
+	 * decides whether a browser actually launches.
+	 */
+	open: boolean;
+
+	database: DatabaseConfig;
+	assetStorage: AssetStorageConfig;
+	containers: ContainersConfig;
+	egress: EgressConfig;
+	telemetry: TelemetryConfig;
+	updates: UpdatesConfig;
+	marketplace: MarketplaceConfig;
+	github: GithubConfig;
+	jobs: JobsConfig;
+	logCompaction: LogCompactionConfig;
+	chat: ChatConfig;
+
+	/**
+	 * The `--config` file this was resolved from, absolute, or undefined when none
+	 * was given. Reported at startup so an operator who meant to pass `--config` and
+	 * forgot can see that they are running on defaults.
+	 */
+	configPath?: string;
+	/**
+	 * Start fresh with an empty embedded database (the existing `pgdata` is renamed
+	 * aside, not deleted). **`--reset` only** - never a config-file key, because a
+	 * persistent file carrying it would wipe the database on every restart.
+	 */
+	reset: boolean;
+	/**
+	 * Derived from the twelve-word master key phrase, for a single non-interactive
+	 * startup. **`HEZO_MASTER_KEY` / `--master-key` only** - never a config-file key.
+	 * The master key is kept in memory only; a copy on disk next to the encrypted
+	 * data would let anyone who reads the host decrypt the vault.
+	 */
+	masterKey?: { unlockKeyHex: string; publicKeyHex: string };
+}
+
+/** Expand a leading `~` and make the path absolute. */
+export function resolveDataDir(raw: string): string {
+	return raw.startsWith('~') ? resolve(homedir(), raw.slice(2)) : resolve(raw);
+}
+
+/**
+ * Every built-in default, in one place. This is the base of the
+ * flag > config file > default merge, and the documented default column in
+ * `docs/deployment/configuration.md` is generated from the same values.
+ */
+export const DEFAULT_CONFIG: HezoConfig = {
+	port: DEFAULT_PORT,
+	dataDir: resolveDataDir(DEFAULT_DATA_DIR),
+	webUrl: '',
+	logLevel: 'info',
+	open: true,
+
+	database: { poolSize: 10 },
+	assetStorage: {},
+	containers: {
+		dockerRequestTimeoutMs: 10_000,
+		keepOld: false,
+		skipMountCheck: false,
+		daytona: { apiUrl: DEFAULT_DAYTONA_API_URL },
+	},
+	egress: { proxyAuth: true, allowPrivateTargets: false, debug: false },
+	telemetry: { enabled: true, endpoint: DEFAULT_TELEMETRY_ENDPOINT },
+	updates: { disabled: false, autoInstall: false },
+	marketplace: { ref: 'main', baseUrl: 'https://raw.githubusercontent.com' },
+	github: { oauthClientId: DEFAULT_GITHUB_OAUTH_CLIENT_ID },
+	jobs: {
+		wakeupCron: '*/5 * * * * *',
+		heartbeatCron: '*/5 * * * * *',
+		inboxArchiveCron: '0 0 3 * * *',
+		pricingRefreshCron: '0 0 2 * * *',
+		modelPinRefreshCron: '0 0 3 * * *',
+		updateCheckCron: '0 0 4 * * *',
+		autoInstallCron: '0 */5 * * * *',
+		telemetryCron: '0 0 5 * * *',
+		budgetResumeCron: '*/30 * * * * *',
+		connectorHealthCron: '0 */5 * * * *',
+		containerSyncCron: '* * * * * *',
+		containerIdleStopCron: '15 * * * * *',
+		orphanDetectionCron: '*/30 * * * * *',
+		orphanContainerSweepCron: '45 */10 * * * *',
+		dbMaintenanceCron: '0 30 4 * * *',
+		wakeupCoalescingMs: 2_000,
+		heartbeatCooldownSec: 60,
+		heartbeatFloorMin: HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT,
+		inboxRetentionDays: 30,
+	},
+	logCompaction: {
+		cron: '*/10 * * * * *',
+		batch: 50,
+		maxPerTick: 500,
+		preservedBytes: LOG_COMPACTION_PRESERVED_TAIL_BYTES,
+	},
+	chat: { healthIntervalMs: 10_000 },
+
+	reset: false,
+};

--- a/packages/server/src/db/open.ts
+++ b/packages/server/src/db/open.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { runtimeConfig } from '../config/runtime';
 import { redactDatabaseUrl, type StorageInfo } from '../lib/db-info';
 import { logger } from '../logger';
 import { openPersistentDb } from './client';
@@ -32,17 +33,10 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function parsePoolSize(raw: string | undefined): number | undefined {
-	if (!raw) return undefined;
-	const n = Number.parseInt(raw, 10);
-	if (Number.isNaN(n)) return undefined;
-	return Math.min(Math.max(n, 2), 100);
-}
-
 /**
  * The single startup entry for the storage layer: embedded PGlite when no URL
  * is configured (the default — zero change for existing installs), external
- * Postgres via `--database-url` / `HEZO_DATABASE_URL` otherwise. External
+ * Postgres via `--database-url` / the config file's `database.url` otherwise. External
  * failures throw `ExternalDbError` whose message carries operator guidance
  * and only ever the REDACTED form of the URL.
  */
@@ -72,13 +66,13 @@ export async function openDatabase(options: OpenDatabaseOptions): Promise<Opened
 	}
 	if (scheme !== 'postgres:' && scheme !== 'postgresql:') {
 		throw new ExternalDbError(
-			'HEZO_DATABASE_URL / --database-url must be a postgres:// or postgresql:// ' +
+			"--database-url / the config file's database.url must be a postgres:// or postgresql:// " +
 				'connection string (e.g. postgres://user:password@host:5432/hezo).',
 		);
 	}
 
 	const { PostgresDb } = await import('./drivers/postgres');
-	const max = parsePoolSize(process.env.HEZO_DATABASE_POOL_SIZE);
+	const max = runtimeConfig().database.poolSize;
 
 	let db: import('./drivers/postgres').PostgresDb | null = null;
 	let lastError: unknown;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,9 @@ import { existsSync } from 'node:fs';
 import { AuthType, WsClientAction } from '@hezo/shared';
 import { app } from './app';
 import { AssetStorageError } from './assets/errors';
-import { parseConfig, runBackup, runRestore, runUninstall, runVersion } from './cli';
+import { resolveConfig, runBackup, runRestore, runUninstall, runVersion } from './cli';
+import { setRuntimeConfig } from './config/runtime';
+import type { HezoConfig } from './config/types';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
 import type { Db } from './db/database';
@@ -114,7 +116,22 @@ if (await runUninstall()) {
 	process.exit(0);
 }
 
-const config = parseConfig();
+// A bad config file or flag is operator error, not a crash: print what is wrong
+// and exit. Without this the throw reaches the uncaughtException handler and the
+// operator gets a stack trace through `/$bunfs/root/hezo` above the one line that
+// actually tells them which key to fix.
+const config = ((): HezoConfig => {
+	try {
+		return resolveConfig();
+	} catch (err) {
+		console.error(`\n${err instanceof Error ? err.message : String(err)}\n`);
+		process.exit(1);
+	}
+})();
+// Publish it before anything reads config back through `runtimeConfig()`. Service
+// modules were imported above (via `./app`), so they must read it lazily, not at
+// module scope — see config/runtime.ts.
+setRuntimeConfig(config);
 setLogLevel(config.logLevel);
 
 // Self-update supervisor. A compiled binary with auto-update enabled runs as a
@@ -128,7 +145,7 @@ if (!process.env.HEZO_WORKER && isAutoUpdateEnabled()) {
 	await runSupervisor(config.dataDir);
 }
 
-setKeepOldContainers(config.keepOldContainers);
+setKeepOldContainers(config.containers.keepOld);
 
 // Graceful shutdown on termination signals (the supervisor forwards these to the
 // worker). Close the runtime cleanly, then exit 0 so the supervisor sees a

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -161,7 +161,7 @@ import {
 	insertGoalSuggestionComment,
 } from '../services/goal-suggestion';
 import { listGoals, recordGoalProgress } from '../services/goals';
-import { HEARTBEAT_INTERVAL_FLOOR_MIN } from '../services/heartbeat-schedule';
+import { heartbeatIntervalFloorMin } from '../services/heartbeat-schedule';
 import {
 	buildHirePayloadPatch,
 	type HirePayloadPatchInput,
@@ -1049,8 +1049,10 @@ const MAX_BATCH_AGENT_SYSTEM_PROMPTS = 50;
  * `docs/reference/mcp-api.md`, `/SKILL.md` and `llms.txt`, so it uses hyphens,
  * never em or en dashes.
  */
-const HEARTBEAT_INTERVAL_ARG_DESCRIPTION =
-	`How often this agent wakes to look for work, in minutes. Ask the admin for the cadence rather than assuming one - it drives both how fast the agent picks up work and how much it spends. Minimum ${HEARTBEAT_INTERVAL_FLOOR_MIN}; a lower value is rejected. Typical choices: ${HEARTBEAT_INTERVAL_FLOOR_MIN} for a fast-moving role, 720 (12 hours) for a steady one, 1440 (daily) for an occasional reviewer.` as const;
+function heartbeatIntervalArgDescription(): string {
+	const floor = heartbeatIntervalFloorMin();
+	return `How often this agent wakes to look for work, in minutes. Ask the admin for the cadence rather than assuming one - it drives both how fast the agent picks up work and how much it spends. Minimum ${floor}; a lower value is rejected. Typical choices: ${floor} for a fast-moving role, 720 (12 hours) for a steady one, 1440 (daily) for an occasional reviewer.`;
+}
 
 async function buildMcpCreateTaskCaller(
 	db: Db,
@@ -2366,9 +2368,9 @@ export function registerTools(
 			heartbeat_interval_min: z
 				.number()
 				.int()
-				.min(HEARTBEAT_INTERVAL_FLOOR_MIN)
+				.min(heartbeatIntervalFloorMin())
 				.optional()
-				.describe(`Updated heartbeat interval. ${HEARTBEAT_INTERVAL_ARG_DESCRIPTION}`),
+				.describe(`Updated heartbeat interval. ${heartbeatIntervalArgDescription()}`),
 			monthly_budget_cents: z.number().optional().describe('Updated monthly budget in cents'),
 			touches_code: z.boolean().optional().describe('Whether this agent reads/writes repo code'),
 		},
@@ -2474,8 +2476,8 @@ export function registerTools(
 			heartbeat_interval_min: z
 				.number()
 				.int()
-				.min(HEARTBEAT_INTERVAL_FLOOR_MIN)
-				.describe(HEARTBEAT_INTERVAL_ARG_DESCRIPTION),
+				.min(heartbeatIntervalFloorMin())
+				.describe(heartbeatIntervalArgDescription()),
 			daily_budget_cents: z.number().optional().describe('Daily budget in cents'),
 			weekly_budget_cents: z.number().optional().describe('Weekly budget in cents'),
 			monthly_budget_cents: z.number().optional().describe('Monthly budget in cents'),

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -78,7 +78,7 @@ import {
 	restoreRevision,
 	upsertDocument,
 } from '../services/documents';
-import { HAS_ACTIONABLE_WORK_SQL, NEXT_HEARTBEAT_AT_SQL } from '../services/heartbeat-schedule';
+import { HAS_ACTIONABLE_WORK_SQL, nextHeartbeatAtSql } from '../services/heartbeat-schedule';
 import {
 	type HireProposalInput,
 	insertHireApproval,
@@ -113,7 +113,7 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.touches_code,
 	ma.runtime_status, ma.admin_status, ma.last_heartbeat_at, ma.reports_to,
 	ma.mcp_servers, ma.model_override_provider, ma.model_override_model, ma.updated_at,
-	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at,
+	${nextHeartbeatAtSql()} AS next_heartbeat_at,
 	${HAS_ACTIONABLE_WORK_SQL} AS has_actionable_work`;
 
 /**

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -14,7 +14,7 @@ import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { requireTeamAccessForResource } from '../middleware/auth';
 import { resolveApproval } from '../services/approval-resolve';
-import { HEARTBEAT_INTERVAL_FLOOR_MIN } from '../services/heartbeat-schedule';
+import { heartbeatIntervalFloorMin } from '../services/heartbeat-schedule';
 import { buildHirePayloadPatch, type HirePayloadPatchInput } from '../services/hire-proposal';
 import { authoredPromptError } from '../services/prompt-style-guard';
 
@@ -241,12 +241,12 @@ approvalsRoutes.patch('/approvals/:approvalId', async (c) => {
 	// reject it here as prepareHireProposal does on the create paths.
 	if (
 		body.heartbeat_interval_min !== undefined &&
-		body.heartbeat_interval_min < HEARTBEAT_INTERVAL_FLOOR_MIN
+		body.heartbeat_interval_min < heartbeatIntervalFloorMin()
 	) {
 		return err(
 			c,
 			'INVALID_REQUEST',
-			`heartbeat_interval_min must be at least ${HEARTBEAT_INTERVAL_FLOOR_MIN} minutes`,
+			`heartbeat_interval_min must be at least ${heartbeatIntervalFloorMin()} minutes`,
 			400,
 		);
 	}

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -22,6 +22,7 @@ import {
 	WsMessageType,
 	wsRoom,
 } from '@hezo/shared';
+import { runtimeConfig } from '../config/runtime';
 import type { DomainEventBus } from '../events/bus';
 import { trackBackground } from '../lib/background';
 import { loadChatMessageAttachments } from '../lib/chat-attachments';
@@ -92,8 +93,6 @@ const CHAT_WORKING_DIR = '/workspace';
  * happen. Failing fast with a message they can act on beats a longer silence.
  */
 const CHAT_CREDENTIAL_WAIT_MS = 60_000;
-/** How often to verify the live session's container is still healthy. */
-const HEALTH_INTERVAL_MS = Number(process.env.HEZO_CHAT_HEALTH_INTERVAL_MS ?? 10_000);
 
 const CHAT_GUIDE = `# Live Chat
 
@@ -468,7 +467,7 @@ export class ChatSessionManager {
 		if (this.healthTimer) return;
 		this.healthTimer = setInterval(() => {
 			trackBackground(this.checkHealth().catch((e) => log.error('health check failed', e)));
-		}, HEALTH_INTERVAL_MS);
+		}, runtimeConfig().chat.healthIntervalMs);
 	}
 
 	async stop(): Promise<void> {

--- a/packages/server/src/services/docker-preflight.ts
+++ b/packages/server/src/services/docker-preflight.ts
@@ -87,7 +87,7 @@ export interface DockerPreflightResult {
 }
 
 export interface DockerPreflightOptions {
-	/** `--docker-socket` / `HEZO_DOCKER_SOCKET`. */
+	/** `--docker-socket` / the config file's `containers.dockerSocket`. */
 	override?: string;
 	env?: NodeJS.ProcessEnv;
 	/** Injectable for tests; defaults to a real ping over the candidate's socket. */
@@ -162,7 +162,7 @@ const START_INSTRUCTIONS = [
 const OVERRIDE_HINT = [
 	'Daemon listening on a socket Hezo did not check? Point it there:',
 	'',
-	'  hezo --docker-socket /path/to/docker.sock   (env: HEZO_DOCKER_SOCKET)',
+	'  hezo --docker-socket /path/to/docker.sock   (or containers.dockerSocket in your config file)',
 ];
 
 /**
@@ -222,7 +222,7 @@ export function formatDockerPreflightMessage(
 			'Hezo talks to the daemon over a Unix socket, so tcp://, npipe:// and ssh://',
 			'endpoints are not supported. Point it at the socket file instead:',
 			'',
-			'  hezo --docker-socket /path/to/docker.sock   (env: HEZO_DOCKER_SOCKET)',
+			'  hezo --docker-socket /path/to/docker.sock   (or containers.dockerSocket in your config file)',
 			'',
 			`More detail: ${CONTAINER_RUNTIMES_DOCS_URL}`,
 		].join('\n');

--- a/packages/server/src/services/docker-socket.ts
+++ b/packages/server/src/services/docker-socket.ts
@@ -235,7 +235,7 @@ export function wellKnownDockerSockets(lookup: DockerSocketLookup): DockerSocket
 }
 
 export interface DockerSocketCandidatesOptions {
-	/** `--docker-socket` / `HEZO_DOCKER_SOCKET`. Wins over everything else. */
+	/** `--docker-socket` / the config file's `containers.dockerSocket`. Wins over everything else. */
 	override?: string;
 	env?: NodeJS.ProcessEnv;
 	home?: string;

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -59,6 +59,8 @@ export type {
 	ProcessEnvMarker,
 } from './sandbox/types';
 
+import { runtimeConfig } from '../config/runtime';
+
 /** Cap on a hijack response's header block - a daemon that never terminates them is broken, not slow. */
 const MAX_HIJACK_HEADER_BYTES = 64 * 1024;
 
@@ -67,15 +69,9 @@ const API_VERSION = 'v1.44';
 /**
  * Hard ceiling for docker daemon calls made by the cron-driven sync loop.
  * A wedged Unix-socket fetch would otherwise stall the container-sync iteration
- * indefinitely. Override via DOCKER_REQUEST_TIMEOUT_MS to widen for slow hosts.
+ * indefinitely. Override via `containers.dockerRequestTimeoutMs` to widen for slow hosts.
  */
-const DEFAULT_DOCKER_REQUEST_TIMEOUT_MS = 10_000;
-const DOCKER_REQUEST_TIMEOUT_MS = (() => {
-	const raw = process.env.DOCKER_REQUEST_TIMEOUT_MS;
-	if (!raw) return DEFAULT_DOCKER_REQUEST_TIMEOUT_MS;
-	const parsed = Number.parseInt(raw, 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DOCKER_REQUEST_TIMEOUT_MS;
-})();
+const dockerRequestTimeoutMs = (): number => runtimeConfig().containers.dockerRequestTimeoutMs;
 
 /**
  * Upper bound on the run-process kill exec (`killRunProcesses`). The kill loop
@@ -609,7 +605,7 @@ export class DockerClient implements ContainerEngine {
 		);
 	}
 
-	async ping(timeoutMs: number = DOCKER_REQUEST_TIMEOUT_MS): Promise<boolean> {
+	async ping(timeoutMs: number = dockerRequestTimeoutMs()): Promise<boolean> {
 		try {
 			const res = await this.request('GET', '/_ping', undefined, AbortSignal.timeout(timeoutMs));
 			return res.ok;
@@ -758,7 +754,7 @@ export class DockerClient implements ContainerEngine {
 			'GET',
 			`/containers/${containerId}/json`,
 			undefined,
-			AbortSignal.timeout(DOCKER_REQUEST_TIMEOUT_MS),
+			AbortSignal.timeout(dockerRequestTimeoutMs()),
 		);
 		if (res.status === 404) {
 			await res.text();
@@ -825,7 +821,7 @@ export class DockerClient implements ContainerEngine {
 			'GET',
 			`/containers/${containerId}/stats?stream=false&one-shot=true`,
 			undefined,
-			AbortSignal.timeout(DOCKER_REQUEST_TIMEOUT_MS),
+			AbortSignal.timeout(dockerRequestTimeoutMs()),
 		);
 		if (res.status === 404) {
 			await res.text();

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -19,6 +19,7 @@ import { connect as netConnect, type Socket } from 'node:net';
 import { rootCertificates } from 'node:tls';
 import type { CA } from 'mockttp/dist/util/certificates';
 import { getCA } from 'mockttp/dist/util/certificates';
+import { runtimeConfig } from '../../config/runtime';
 import type { MasterKeyManager } from '../../crypto/master-key';
 import type { Db } from '../../db/database';
 import { ref } from '../../lib/log-ref';
@@ -57,8 +58,8 @@ const log = logger.child('egress-proxy');
 /** When set, the proxy emits per-connection lifecycle traces (socket open/close/
  * error/timeout per leg, plus the host→dialed-port→owner of each CONNECT). Off by
  * default; the only reliable way to pin Bun's connection-accounting divergences,
- * which Node/vitest never reproduce. Enable in a real run with `HEZO_EGRESS_DEBUG=1`. */
-const EGRESS_DEBUG = !!process.env.HEZO_EGRESS_DEBUG;
+ * which Node/vitest never reproduce. Enable with `egress.debug` in the config file. */
+const egressDebug = (): boolean => runtimeConfig().egress.debug;
 
 /** Connection-management headers scoped to a single transport hop, which a proxy
  * must not relay to the upstream (RFC 7230 §6.1). `proxy-*` are dropped
@@ -418,10 +419,10 @@ class RunProxyInstance {
 		this.upstreamHttpAgent = new HttpAgent({ keepAlive: false });
 	}
 
-	/** Debug-gated lifecycle logging. Enable with `HEZO_EGRESS_DEBUG=1` to trace
+	/** Debug-gated lifecycle logging. Enable with `egress.debug` in the config file to trace
 	 * which connection leg dies and when. */
 	private dbg(msg: string, meta: Record<string, unknown> = {}): void {
-		if (!EGRESS_DEBUG) return;
+		if (!egressDebug()) return;
 		log.info(`[egress-dbg] ${msg}`, {
 			run: ref(this.cfg.scope.label, this.cfg.runId),
 			...meta,
@@ -438,7 +439,7 @@ class RunProxyInstance {
 		}
 		this.liveSockets.add(sock);
 		sock.once('close', () => this.liveSockets.delete(sock));
-		if (EGRESS_DEBUG) {
+		if (egressDebug()) {
 			const at = Date.now();
 			// An upstream socket is still connecting when its request first emits it,
 			// so its ports aren't populated yet; defer the open log to `connect` so it
@@ -657,7 +658,7 @@ class RunProxyInstance {
 			client.destroy();
 			return;
 		}
-		if (EGRESS_DEBUG) {
+		if (egressDebug()) {
 			// The cross-host cert leak (a host served another host's leaf cert) shows
 			// up here: the port about to be dialed must be owned by THIS host's server
 			// and no other. Log the owner(s) so a mis-route is caught red-handed.

--- a/packages/server/src/services/heartbeat-schedule.ts
+++ b/packages/server/src/services/heartbeat-schedule.ts
@@ -4,6 +4,7 @@ import {
 	HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT,
 	TERMINAL_TASK_STATUSES,
 } from '@hezo/shared';
+import { runtimeConfig } from '../config/runtime';
 
 /**
  * Lower bound on how often a heartbeat can fire, regardless of an agent's
@@ -15,12 +16,10 @@ import {
  * displayed countdown matches the cadence the scheduler actually enforces.
  * Coerced NaN-safe because it is interpolated into SQL below.
  */
-const rawFloorMin = Number(
-	process.env.HEZO_HEARTBEAT_FLOOR_MIN ?? HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT,
-);
-export const HEARTBEAT_INTERVAL_FLOOR_MIN = Number.isFinite(rawFloorMin)
-	? rawFloorMin
-	: HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT;
+export function heartbeatIntervalFloorMin(): number {
+	const configured = runtimeConfig().jobs.heartbeatFloorMin;
+	return Number.isFinite(configured) ? configured : HEARTBEAT_INTERVAL_FLOOR_MIN_DEFAULT;
+}
 
 // Fixed enum values from `@hezo/shared` — safe to interpolate as a Postgres
 // array literal.
@@ -42,12 +41,14 @@ const TERMINAL_TASK_STATUSES_PG = `{${TERMINAL_TASK_STATUSES.join(',')}}`;
  * `member_agents AS ma`. The interpolated values are a coerced number and fixed
  * enum constants (no user input).
  */
-export const NEXT_HEARTBEAT_AT_SQL = `CASE
+export function nextHeartbeatAtSql(): string {
+	return `CASE
 	WHEN ma.admin_status <> '${AgentAdminStatus.Enabled}'::agent_admin_status THEN NULL
 	WHEN ma.runtime_status = ANY('${BUDGET_PAUSE_ARRAY_PG}'::agent_runtime_status[]) THEN NULL
 	WHEN ma.last_heartbeat_at IS NULL THEN now()
-	ELSE ma.last_heartbeat_at + (GREATEST(ma.heartbeat_interval_min, ${HEARTBEAT_INTERVAL_FLOOR_MIN}) || ' minutes')::interval
+	ELSE ma.last_heartbeat_at + (GREATEST(ma.heartbeat_interval_min, ${heartbeatIntervalFloorMin()}) || ' minutes')::interval
 END`;
+}
 
 /**
  * SQL boolean — does this agent have an actionable task *right now*? Mirrors the

--- a/packages/server/src/services/hire-proposal.ts
+++ b/packages/server/src/services/hire-proposal.ts
@@ -12,7 +12,7 @@ import { checkHumanNameAvailable } from '../lib/agent-identity';
 import { budgetWindowsError } from '../lib/budget-validation';
 import { resolveAgentId } from '../lib/resolve';
 import { toSlug } from '../lib/slug';
-import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
+import { heartbeatIntervalFloorMin } from './heartbeat-schedule';
 import { authoredPromptError } from './prompt-style-guard';
 
 const DEFAULT_MONTHLY_BUDGET_CENTS = 3000;
@@ -85,10 +85,10 @@ export async function prepareHireProposal(
 	// makes the field required at its own boundary.
 	if (
 		input.heartbeat_interval_min !== undefined &&
-		input.heartbeat_interval_min < HEARTBEAT_INTERVAL_FLOOR_MIN
+		input.heartbeat_interval_min < heartbeatIntervalFloorMin()
 	) {
 		return {
-			error: `heartbeat_interval_min must be at least ${HEARTBEAT_INTERVAL_FLOOR_MIN} minutes`,
+			error: `heartbeat_interval_min must be at least ${heartbeatIntervalFloorMin()} minutes`,
 		};
 	}
 

--- a/packages/server/src/services/image-registry.ts
+++ b/packages/server/src/services/image-registry.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runtimeConfig } from '../config/runtime';
 import { logger } from '../logger';
 import { IS_PACKAGED_BUILD } from '../version';
 import type { ContainerEngine } from './docker';
@@ -55,14 +56,12 @@ const LOCAL_IMAGES: Record<string, LocalImageSpec> = {
  *
  * Set it to the image CI published for the branch under test:
  *
- *   HEZO_AGENT_BASE_IMAGE=ghcr.io/hezo-ai/agent-base:<sha> bun run dev
+ *   containers.agentBaseImage: 'ghcr.io/hezo-ai/agent-base:<sha>'
  *
  * It applies on every backend, not just managed ones - on Docker it pulls that
  * exact image instead of building locally, which is the honest way to test
  * against what CI produced rather than against your working tree.
  */
-export const AGENT_BASE_IMAGE_OVERRIDE_ENV = 'HEZO_AGENT_BASE_IMAGE';
-
 /**
  * The published agent-base ref to fetch, or `null` when none should exist. Only a
  * compiled release binary (`IS_PACKAGED_BUILD`) uses the published image; dev
@@ -73,14 +72,14 @@ export const AGENT_BASE_IMAGE_OVERRIDE_ENV = 'HEZO_AGENT_BASE_IMAGE';
  * `packaged` param defaults to the module constant but is injectable so the logic
  * is unit-testable without env munging.
  *
- * {@link AGENT_BASE_IMAGE_OVERRIDE_ENV} wins over both, because the case it
+ * The `containers.agentBaseImage` override wins over both, because the case it
  * exists for is precisely the one where the build-type default is wrong.
  */
 export function publishedAgentBaseRef(
 	packaged: boolean = IS_PACKAGED_BUILD,
-	env: NodeJS.ProcessEnv = process.env,
+	overrideImage: string | undefined = runtimeConfig().containers.agentBaseImage,
 ): string | null {
-	const override = env[AGENT_BASE_IMAGE_OVERRIDE_ENV]?.trim();
+	const override = overrideImage?.trim();
 	if (override) return override;
 	return packaged ? `${AGENT_BASE_GHCR_REPO}:latest` : null;
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -22,6 +22,7 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import { Cron } from 'cron-async';
+import { runtimeConfig } from '../config/runtime';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { Db } from '../db/database';
 import type { DomainEventBus } from '../events/bus';
@@ -73,7 +74,7 @@ import {
 import type { ContainerEngine, ContainerProcessInfo } from './docker';
 import type { EgressProxy } from './egress';
 import { getDueGoals } from './goals';
-import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
+import { heartbeatIntervalFloorMin } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
 import { refreshModelPins } from './model-pins';
 import { noWorkCooldownActive } from './no-work-backoff';
@@ -287,7 +288,6 @@ export interface JobManagerDeps {
 	requestUpdateRestart?: () => Promise<void>;
 }
 
-const COALESCING_WINDOW_MS = Number(process.env.HEZO_WAKEUP_COALESCING_MS ?? 2_000);
 /**
  * Deferrals released per wakeups tick by {@link JobManager.releaseSatisfiedDeferrals}.
  *
@@ -296,30 +296,21 @@ const COALESCING_WINDOW_MS = Number(process.env.HEZO_WAKEUP_COALESCING_MS ?? 2_0
  * statement. Comfortably above what a single repo setup can strand.
  */
 const DEFERRAL_RELEASE_LIMIT = 20;
-const WAKEUP_CRON = process.env.HEZO_WAKEUP_CRON ?? '*/5 * * * * *';
-const HEARTBEAT_CRON = process.env.HEZO_HEARTBEAT_CRON ?? '*/5 * * * * *';
-const INBOX_ARCHIVE_CRON = process.env.HEZO_INBOX_ARCHIVE_CRON ?? '0 0 3 * * *';
 // Daily model-pricing refresh from the pricepertoken.com catalog. Failures
 // log and leave the existing rows — the boot-time refresh / next tick retries.
-const PRICING_REFRESH_CRON = process.env.HEZO_PRICING_REFRESH_CRON ?? '0 0 2 * * *';
 // Daily re-read of each configured provider's model catalog, moving the pinned
 // default a NEW credential starts on. Existing configs are never touched. An
 // hour after the pricing refresh so a newly pinned model already has a rate row.
-const MODEL_PIN_REFRESH_CRON = process.env.HEZO_MODEL_PIN_REFRESH_CRON ?? '0 0 3 * * *';
 // Daily check for a newer release; when auto-update is enabled and one is found,
 // download+verify+stage it so an operator "Update & restart" is instant.
-const UPDATE_CHECK_CRON = process.env.HEZO_UPDATE_CHECK_CRON ?? '0 0 4 * * *';
 // Frequent because it is cheap (reads the local state file; no network) — it exists so a
 // deferred install (agent runs in flight at staging time) retries minutes later, not next day.
-const AUTO_INSTALL_CRON = process.env.HEZO_AUTO_INSTALL_CRON ?? '0 */5 * * * *';
 // Anonymous daily usage telemetry report — runs at 5am UTC, after the update
 // check, when telemetry is enabled (opt-out, default on).
-const TELEMETRY_CRON = process.env.HEZO_TELEMETRY_CRON ?? '0 0 5 * * *';
 // How often to re-evaluate budget-paused agents. Spend is summed over rolling
 // UTC windows, so a daily/weekly/monthly window rolling over silently frees an
 // agent's budget with no event — this sweep notices and lifts the reactive
 // pause so the heartbeat scheduler (which skips paused agents) resumes it.
-const BUDGET_RESUME_CRON = process.env.HEZO_BUDGET_RESUME_CRON ?? '*/30 * * * * *';
 // Re-refresh OAuth tokens on the clock, not only when an agent run happens to
 // make a proxied call. `refreshExpiringTokens` is otherwise reached ONLY from the
 // egress substitution path, so on an idle instance nothing renews a token and
@@ -329,7 +320,6 @@ const BUDGET_RESUME_CRON = process.env.HEZO_BUDGET_RESUME_CRON ?? '*/30 * * * * 
 // an hour, each candidate costs a provider round-trip, and the resolver's own
 // failure backoff already tops out at 15 minutes, so it - not this cadence - is
 // what bounds retries against a permanently dead connection.
-const CONNECTOR_HEALTH_CRON = process.env.HEZO_CONNECTOR_HEALTH_CRON ?? '0 */5 * * * *';
 /** Connections re-checked per tick — a bound, not a target; ordered soonest-to-
  *  expire, so the next tick continues where this one stopped. */
 const CONNECTOR_HEALTH_BATCH_LIMIT = 25;
@@ -354,7 +344,6 @@ const CONNECTOR_PROBE_INTERVAL_MS = 6 * 60 * 60_000;
 // (wakeups, heartbeats, container-sync) compound into sustained load that
 // slows page loads enough to time out browser/component specs. Both are env-
 // configurable so the E2E server can dial them down — see playwright.config.ts.
-const CONTAINER_SYNC_CRON = process.env.HEZO_CONTAINER_SYNC_CRON ?? '* * * * * *';
 
 /**
  * Idle-container reaper cadence: once a minute (offset to :15 to avoid the
@@ -362,7 +351,6 @@ const CONTAINER_SYNC_CRON = process.env.HEZO_CONTAINER_SYNC_CRON ?? '* * * * * *
  * window elapse" — changes on minute granularity, so a faster tick would only
  * burn queries. Env-overridable so E2E can dial it down.
  */
-const CONTAINER_IDLE_STOP_CRON = process.env.HEZO_CONTAINER_IDLE_STOP_CRON ?? '15 * * * * *';
 
 /** Containers stopped per idle-stop tick — a bound, not a target; the next
  * tick continues where this one stopped. */
@@ -372,7 +360,6 @@ const IDLE_STOP_BATCH_LIMIT = 10;
  * finishes what this one did not; the bound is there so a teardown that keeps
  * failing cannot turn every startup into a full engine sweep. */
 const ARCHIVED_RETIREMENT_SCAN_LIMIT = 25;
-const ORPHAN_DETECTION_CRON = process.env.HEZO_ORPHAN_DETECTION_CRON ?? '*/30 * * * * *';
 
 /**
  * Orphaned-container sweep cadence: every 10 minutes. What it watches - a
@@ -382,35 +369,29 @@ const ORPHAN_DETECTION_CRON = process.env.HEZO_ORPHAN_DETECTION_CRON ?? '*/30 * 
  * orphan bills until somebody notices, which fails as a cost rather than as an
  * error and so needs a sweep rather than an alert.
  */
-const ORPHAN_CONTAINER_SWEEP_CRON =
-	process.env.HEZO_ORPHAN_CONTAINER_SWEEP_CRON ?? '45 */10 * * * *';
 // The reactive budget pauses, which the heartbeat scheduler must not wake (the
 // budget-resume sweep lifts them back to `idle` once the window rolls over).
 // Disabled agents are filtered separately via `admin_status`. Postgres array
 // literal for the `<> ALL(...)` / `= ANY(...)` enum-array params.
 const BUDGET_PAUSE_STATUSES_PG = `{${BUDGET_PAUSE_STATUSES.join(',')}}`;
-const INBOX_RETENTION_DAYS = Number(process.env.HEZO_INBOX_RETENTION_DAYS ?? 30);
 // Drain tick for agent run-log compaction. Cheap when idle (a single
 // `system_meta` read); only does work while a compaction pass is active, which
 // the operator starts from the DB panel. Frequent so a started pass makes
 // visible progress and resumes promptly after a restart.
-const LOG_COMPACTION_CRON = process.env.HEZO_LOG_COMPACTION_CRON ?? '*/10 * * * * *';
 
 // Database housekeeping: refresh planner statistics on the embedded backend and
 // sweep terminal scheduler bookkeeping. Nightly, off-peak - neither is urgent,
 // and both are cheap enough that the point is only to stop them never running.
 // Statistics drift on the scale of days, not seconds.
-const DB_MAINTENANCE_CRON = process.env.HEZO_DB_MAINTENANCE_CRON ?? '0 30 4 * * *';
 
 /** Rate limit on the "job is overrunning its interval" warning. */
 const SKIP_WARN_INTERVAL_MS = 60_000;
-// Lower bound on how often a heartbeat can fire (`HEARTBEAT_INTERVAL_FLOOR_MIN`,
+// Lower bound on how often a heartbeat can fire (`heartbeatIntervalFloorMin`,
 // from ./heartbeat-schedule) is shared with the agents API's computed
 // `next_heartbeat_at` so the UI countdown matches the cadence enforced here.
 // Quiet window after a run completes before that agent is eligible for another
 // heartbeat. Prevents back-to-back runs when the configured interval is shorter
 // than the run itself.
-const HEARTBEAT_POST_RUN_COOLDOWN_SEC = Number(process.env.HEZO_HEARTBEAT_COOLDOWN_SEC ?? 60);
 
 export class JobManager {
 	private cron: Cron;
@@ -668,88 +649,92 @@ export class JobManager {
 	start(): void {
 		if (this.started) return;
 		this.started = true;
+		// Read once here, not at module scope: this file is imported before
+		// `index.ts` publishes the resolved config, so a module-level read would
+		// capture the defaults and silently ignore the operator's file.
+		const { jobs } = runtimeConfig();
 		this.cron.createJob('wakeups', {
-			cron: WAKEUP_CRON,
+			cron: jobs.wakeupCron,
 			log: cronLog,
 			onTick: () => this.guarded('wakeups', () => this.processWakeups()),
 		});
 		this.cron.createJob('heartbeats', {
-			cron: HEARTBEAT_CRON,
+			cron: jobs.heartbeatCron,
 			log: cronLog,
 			onTick: () => this.guarded('heartbeats', () => this.processScheduledHeartbeats()),
 		});
 		this.cron.createJob('orphan-detection', {
-			cron: ORPHAN_DETECTION_CRON,
+			cron: jobs.orphanDetectionCron,
 			log: cronLog,
 			onTick: () => this.guarded('orphan-detection', () => this.detectOrphanedRuns()),
 		});
 		this.cron.createJob('container-sync', {
-			cron: CONTAINER_SYNC_CRON,
+			cron: jobs.containerSyncCron,
 			log: cronLog,
 			onTick: () => this.guarded('container-sync', () => this.syncContainerStatuses()),
 		});
 		this.cron.createJob('container-idle-stop', {
-			cron: CONTAINER_IDLE_STOP_CRON,
+			cron: jobs.containerIdleStopCron,
 			log: cronLog,
 			onTick: () => this.guarded('container-idle-stop', () => this.stopIdleContainers()),
 		});
 		this.cron.createJob('orphan-container-sweep', {
-			cron: ORPHAN_CONTAINER_SWEEP_CRON,
+			cron: jobs.orphanContainerSweepCron,
 			log: cronLog,
 			onTick: () => this.guarded('orphan-container-sweep', () => this.reapOrphanedContainers()),
 		});
 		this.cron.createJob('inbox-archive', {
-			cron: INBOX_ARCHIVE_CRON,
+			cron: jobs.inboxArchiveCron,
 			log: cronLog,
 			onTick: () => this.guarded('inbox-archive', () => this.archiveInboxItems()),
 		});
 		this.cron.createJob('log-compaction', {
-			cron: LOG_COMPACTION_CRON,
+			cron: runtimeConfig().logCompaction.cron,
 			log: cronLog,
 			onTick: () => this.guarded('log-compaction', () => this.compactRunLogs()),
 		});
 		this.cron.createJob('budget-resume', {
-			cron: BUDGET_RESUME_CRON,
+			cron: jobs.budgetResumeCron,
 			log: cronLog,
 			onTick: () => this.guarded('budget-resume', () => this.processBudgetResumes()),
 		});
 		this.cron.createJob('connector-health', {
-			cron: CONNECTOR_HEALTH_CRON,
+			cron: jobs.connectorHealthCron,
 			log: cronLog,
 			onTick: () => this.guarded('connector-health', () => this.sweepConnectorHealth()),
 		});
 		this.cron.createJob('db-maintenance', {
-			cron: DB_MAINTENANCE_CRON,
+			cron: jobs.dbMaintenanceCron,
 			log: cronLog,
 			onTick: () => this.guarded('db-maintenance', () => this.runDbMaintenance()),
 		});
 		this.cron.createJob('update-check', {
-			cron: UPDATE_CHECK_CRON,
+			cron: jobs.updateCheckCron,
 			log: cronLog,
 			onTick: () => this.guarded('update-check', () => this.checkForUpdate()),
 		});
 		if (this.deps.autoInstallUpdates && (this.deps.isSupervisedWorker ?? isSupervisedWorker)()) {
 			this.cron.createJob('auto-install-update', {
-				cron: AUTO_INSTALL_CRON,
+				cron: jobs.autoInstallCron,
 				log: cronLog,
 				onTick: () => this.guarded('auto-install-update', () => this.autoInstallStagedUpdate()),
 			});
 		}
 		if (this.deps.pricing) {
 			this.cron.createJob('pricing-refresh', {
-				cron: PRICING_REFRESH_CRON,
+				cron: jobs.pricingRefreshCron,
 				log: cronLog,
 				onTick: () => this.guarded('pricing-refresh', () => this.refreshPricing()),
 			});
 		}
 		this.cron.createJob('model-pin-refresh', {
-			cron: MODEL_PIN_REFRESH_CRON,
+			cron: jobs.modelPinRefreshCron,
 			log: cronLog,
 			onTick: () => this.guarded('model-pin-refresh', () => this.refreshModelPins()),
 		});
 		if (this.deps.telemetry?.enabled) {
 			this.cron.createJob('telemetry', {
-				cron: TELEMETRY_CRON,
+				cron: jobs.telemetryCron,
 				log: cronLog,
 				onTick: () => this.guarded('telemetry', () => this.runTelemetry()),
 			});
@@ -1820,7 +1805,9 @@ export class JobManager {
 	private async processWakeups(): Promise<void> {
 		const { db } = this.deps;
 		await this.releaseSatisfiedDeferrals();
-		const coalescingCutoff = new Date(Date.now() - COALESCING_WINDOW_MS).toISOString();
+		const coalescingCutoff = new Date(
+			Date.now() - runtimeConfig().jobs.wakeupCoalescingMs,
+		).toISOString();
 
 		const wakeups = await db.query<{
 			id: string;
@@ -2019,8 +2006,8 @@ export class JobManager {
 			[
 				AgentAdminStatus.Enabled,
 				BUDGET_PAUSE_STATUSES_PG,
-				HEARTBEAT_INTERVAL_FLOOR_MIN,
-				HEARTBEAT_POST_RUN_COOLDOWN_SEC,
+				heartbeatIntervalFloorMin(),
+				runtimeConfig().jobs.heartbeatCooldownSec,
 			],
 		);
 
@@ -3388,8 +3375,8 @@ export class JobManager {
 			[memberId],
 		);
 		const chainCooldownMin = Math.max(
-			agentRow.rows[0]?.heartbeat_interval_min ?? HEARTBEAT_INTERVAL_FLOOR_MIN,
-			HEARTBEAT_INTERVAL_FLOOR_MIN,
+			agentRow.rows[0]?.heartbeat_interval_min ?? heartbeatIntervalFloorMin(),
+			heartbeatIntervalFloorMin(),
 		);
 		const isInstanceAgent = (INSTANCE_AGENT_SLUGS as readonly string[]).includes(agentSlug);
 		const params: unknown[] = [memberId];
@@ -3782,7 +3769,7 @@ export class JobManager {
 
 	private async archiveInboxItems(): Promise<void> {
 		const { archiveOldInboxItems } = await import('./inbox-archive');
-		const count = await archiveOldInboxItems(this.deps.db, INBOX_RETENTION_DAYS);
+		const count = await archiveOldInboxItems(this.deps.db, runtimeConfig().jobs.inboxRetentionDays);
 		if (count > 0) {
 			log.debug(`Archived ${count} inbox item(s)`);
 		}

--- a/packages/server/src/services/log-compaction.ts
+++ b/packages/server/src/services/log-compaction.ts
@@ -25,6 +25,7 @@ import {
 	LOG_COMPACTION_RETENTION_MAX_DAYS,
 	LOG_COMPACTION_RETENTION_MIN_DAYS,
 } from '@hezo/shared';
+import { runtimeConfig } from '../config/runtime';
 import type { Db } from '../db/database';
 import {
 	readRunLogTail,
@@ -41,14 +42,6 @@ const log = logger.child('log-compaction');
 export const LOG_COMPACTION_ACTIVE_KEY = 'log_compaction:active';
 export const LOG_COMPACTION_LAST_KEY = 'log_compaction:last';
 
-/** Rows compacted per batch. Each run commits on its own - see compactRunLogsBatch. */
-const LOG_COMPACTION_BATCH = Number(process.env.HEZO_LOG_COMPACTION_BATCH ?? 50);
-/** Upper bound on rows a single cron tick processes before yielding to the next. */
-const LOG_COMPACTION_MAX_PER_TICK = Number(process.env.HEZO_LOG_COMPACTION_MAX_PER_TICK ?? 500);
-/** Trailing bytes of each old log kept (summary + outcome). Deploy-time tunable. */
-const PRESERVED_BYTES = Number(
-	process.env.HEZO_LOG_COMPACTION_PRESERVED_BYTES ?? LOG_COMPACTION_PRESERVED_TAIL_BYTES,
-);
 /**
  * A log is worth compacting once its stored (compressed) size crosses Postgres's
  * ~2KB TOAST threshold — below that the whole log fits in line and trimming it
@@ -126,7 +119,7 @@ export function computeCompactedLog(
 		originalLength?: number;
 	} = {},
 ): string {
-	const preserved = opts.preservedBytes ?? PRESERVED_BYTES;
+	const preserved = opts.preservedBytes ?? runtimeConfig().logCompaction.preservedBytes;
 	if ((opts.originalLength ?? logText.length) <= preserved) return logText;
 
 	// Keep the trailing `preserved` chars, then advance past the first partial
@@ -240,7 +233,7 @@ export async function compactRunLogsBatch(
 	db: Db,
 	opts: { olderThanDays: number; limit?: number },
 ): Promise<{ processed: number; bytesReclaimed: number }> {
-	const limit = opts.limit ?? LOG_COMPACTION_BATCH;
+	const limit = opts.limit ?? runtimeConfig().logCompaction.batch;
 	// Ids and sizes only. This used to select each candidate's full `log_text`,
 	// so one batch materialized up to 50 x 10 MB in a single result set purely to
 	// keep a 12 KB tail from each.
@@ -269,7 +262,7 @@ export async function compactRunLogsBatch(
 	// (a run's delete+insert), and a failure part-way leaves the remaining runs
 	// for the next pass rather than rolling back the work already done.
 	for (const row of rows.rows) {
-		const tail = await readRunLogTail(db, row.id, PRESERVED_BYTES);
+		const tail = await readRunLogTail(db, row.id, runtimeConfig().logCompaction.preservedBytes);
 		const compacted = computeCompactedLog(tail.text, {
 			invocationCommand: row.invocation_command,
 			originalLength: row.log_length,
@@ -376,7 +369,7 @@ export async function reclaimRunLogSpace(db: Db, backend: StorageBackend): Promi
 
 /**
  * One cron tick of the drain loop. No-op unless a pass is active. Processes up
- * to `LOG_COMPACTION_MAX_PER_TICK` rows this tick (updating the progress marker
+ * to `logCompaction.maxPerTick` rows this tick (updating the progress marker
  * after each batch), then yields — the next tick continues where it left off.
  * When a batch drains the backlog, reclaims space (recording the real on-disk
  * bytes freed) and clears the marker.
@@ -388,8 +381,8 @@ export async function runLogCompactionTick(
 	let state = await getActiveCompaction(db);
 	if (!state) return;
 
-	const batchSize = opts.batchSize ?? LOG_COMPACTION_BATCH;
-	const maxRunsPerTick = opts.maxRunsPerTick ?? LOG_COMPACTION_MAX_PER_TICK;
+	const batchSize = opts.batchSize ?? runtimeConfig().logCompaction.batch;
+	const maxRunsPerTick = opts.maxRunsPerTick ?? runtimeConfig().logCompaction.maxPerTick;
 	let processedThisTick = 0;
 
 	while (processedThisTick < maxRunsPerTick) {

--- a/packages/server/src/services/marketplace.ts
+++ b/packages/server/src/services/marketplace.ts
@@ -22,16 +22,13 @@ import {
 	toMarketplaceIndexEntry,
 } from '@hezo/shared';
 import { z } from 'zod';
+import { runtimeConfig } from '../config/runtime';
 import { logger } from '../logger';
 
 const log = logger.child('marketplace');
 
 /** The repo whose committed `marketplace/` a production instance fetches. */
 const REPO = 'hezo-ai/hezo';
-/** Git ref the marketplace is fetched from — `main` so updates flow independently of releases. */
-const REF = process.env.HEZO_MARKETPLACE_REF ?? 'main';
-/** Base URL override (tests / self-hosting); defaults to GitHub raw. */
-const BASE_URL = process.env.HEZO_MARKETPLACE_BASE_URL ?? 'https://raw.githubusercontent.com';
 const TTL_MS = 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 8000;
 
@@ -165,9 +162,10 @@ async function fetchJson(url: string): Promise<unknown | null> {
 
 /** Fetch `marketplace/<path>` from GitHub raw, trying `main` then `master`. */
 async function fetchFromGitHub(path: string): Promise<unknown | null> {
-	const refs = REF === 'main' ? ['main', 'master'] : [REF];
+	const { ref: configuredRef, baseUrl } = runtimeConfig().marketplace;
+	const refs = configuredRef === 'main' ? ['main', 'master'] : [configuredRef];
 	for (const ref of refs) {
-		const body = await fetchJson(`${BASE_URL}/${REPO}/${ref}/marketplace/${path}`);
+		const body = await fetchJson(`${baseUrl}/${REPO}/${ref}/marketplace/${path}`);
 		if (body !== null) return body;
 	}
 	return null;

--- a/packages/server/src/services/mount-preflight.ts
+++ b/packages/server/src/services/mount-preflight.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { runtimeConfig } from '../config/runtime';
 import { logger } from '../logger';
 import type { DockerClient } from './docker';
 import { getResolvedDockerSocket } from './docker-socket';
@@ -11,12 +12,6 @@ const log = logger.child('mount-preflight');
 
 /**
  * Operator opt-out for the boot-time bind-mount check. For a setup whose host
- * path sharing this probe can't model, or who doesn't want a throwaway container
- * booted each start. Never surfaced in the failure guidance - it suppresses the
- * diagnosis, it doesn't fix the underlying problem.
- */
-export const SKIP_MOUNT_CHECK_ENV = 'HEZO_SKIP_MOUNT_CHECK';
-
 /** Where the runtime-specific mount guidance lives. */
 export const CONTAINER_RUNTIMES_DOCS_URL = 'https://hezo.ai/docs/deployment/container-runtimes';
 
@@ -226,7 +221,7 @@ export async function checkContainerMounts(
 	deps: MountCheckDeps,
 ): Promise<MountOutcome | 'skipped'> {
 	const env = deps.env ?? process.env;
-	if (env.HEZO_SKIP_DOCKER || env[SKIP_MOUNT_CHECK_ENV]) return 'skipped';
+	if (env.HEZO_SKIP_DOCKER || runtimeConfig().containers.skipMountCheck) return 'skipped';
 
 	try {
 		const { image, preferPull } = resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE);

--- a/packages/server/src/services/no-work-backoff.ts
+++ b/packages/server/src/services/no-work-backoff.ts
@@ -1,6 +1,6 @@
 import { WakeupSource } from '@hezo/shared';
 import type { Db } from '../db/database';
-import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
+import { heartbeatIntervalFloorMin } from './heartbeat-schedule';
 
 /**
  * Wakeup sources the no-work backoff never suppresses.
@@ -89,7 +89,7 @@ export async function noWorkCooldownActive(
 		 ) AS cooldown
 		 FROM last_run lr
 		 JOIN member_agents ma ON ma.id = $1`,
-		[memberId, taskId, HEARTBEAT_INTERVAL_FLOOR_MIN],
+		[memberId, taskId, heartbeatIntervalFloorMin()],
 	);
 
 	return r.rows[0]?.cooldown === true;

--- a/packages/server/src/services/oauth/device-flow.ts
+++ b/packages/server/src/services/oauth/device-flow.ts
@@ -1,4 +1,5 @@
 import type { DeviceAuthConfig } from '@hezo/shared';
+import { runtimeConfig } from '../../config/runtime';
 
 export type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
@@ -47,20 +48,18 @@ export interface ResolvedDeviceAuth {
 /**
  * Resolve a capability's static {@link DeviceAuthConfig} into concrete runtime
  * values: apply the optional base-URL origin override (tests / self-hosted
- * Enterprise) and pick the client_id from the env var, falling back to the
- * committed public dev client_id outside production. Throws when no client_id
- * is configured so the failure is explicit rather than a silent empty request.
+ * Enterprise) and take the client_id from `github.oauthClientId`, which defaults
+ * to the public app Hezo ships with. Throws when no client_id is configured so
+ * the failure is explicit rather than a silent empty request.
  */
 export function resolveDeviceAuth(cfg: DeviceAuthConfig): ResolvedDeviceAuth {
 	const baseOverride = cfg.baseUrlEnv ? process.env[cfg.baseUrlEnv] : undefined;
 	const applyBase = (url: string): string =>
 		baseOverride ? new URL(new URL(url).pathname, baseOverride).toString() : url;
 
-	const clientId =
-		process.env[cfg.clientIdEnv] ||
-		(process.env.NODE_ENV === 'production' ? '' : (cfg.clientIdDefault ?? ''));
+	const clientId = runtimeConfig().github.oauthClientId || (cfg.clientIdDefault ?? '');
 	if (!clientId) {
-		throw new Error(`no OAuth client_id configured (set ${cfg.clientIdEnv})`);
+		throw new Error('no OAuth client_id configured (set github.oauthClientId)');
 	}
 
 	return {

--- a/packages/server/src/services/sandbox/backend-store.ts
+++ b/packages/server/src/services/sandbox/backend-store.ts
@@ -136,7 +136,7 @@ export interface StartupBackendResolution {
  * this point would fire on every single boot: reading a stored provider key
  * would fail ("no API key is configured", for a key that is plainly on file),
  * and writing a flag-supplied one would fail outright ("the instance is
- * locked"). Between them they made `HEZO_DAYTONA_API_KEY` unusable in exactly
+ * locked"). Between them they made `containers.daytona.apiKey` unusable in exactly
  * the setup that needs it - an operator who put it in their launch env and
  * unlocks from the browser. So the vault write is opportunistic and the vault
  * read is allowed to defer; both are completed on unlock.
@@ -170,7 +170,7 @@ export async function resolveStartupBackend(
 	// not ask for, and had nothing to connect it to.
 	if (requested && stored && requested !== stored) {
 		log.warn(
-			`Ignoring --sandbox-backend / HEZO_SANDBOX_BACKEND=${requested}: this instance is set to ` +
+			`Ignoring --sandbox-backend / containers.backend=${requested}: this instance is set to ` +
 				`${stored}, and the stored setting wins so a stale launch script cannot undo a switch ` +
 				'made from the Containers page. Change it in Settings -> Containers.',
 		);
@@ -180,8 +180,8 @@ export async function resolveStartupBackend(
 		// a later switch is a real use, so this is a warning rather than an
 		// inference about what the operator meant.
 		log.warn(
-			'HEZO_DAYTONA_API_KEY is set but containers run on local Docker. The key selects no ' +
-				'backend on its own - add --sandbox-backend daytona / HEZO_SANDBOX_BACKEND=daytona to ' +
+			'A Daytona API key is set but containers run on local Docker. The key selects no ' +
+				'backend on its own - add --sandbox-backend daytona / containers.backend: "daytona" to ' +
 				'run on Daytona, or switch from Settings -> Containers. The key is saved either way.',
 		);
 	}

--- a/packages/server/src/services/sandbox/errors.ts
+++ b/packages/server/src/services/sandbox/errors.ts
@@ -63,7 +63,7 @@ export class SandboxImageNotPullableError extends Error {
 				"reference, built into a Docker daemon's own image store and published to no registry, " +
 				'so a managed sandbox service has nothing to pull.\n' +
 				'Point this instance at a published image - ' +
-				'HEZO_AGENT_BASE_IMAGE=ghcr.io/hezo-ai/agent-base:<version-or-sha> - which applies to ' +
+				'containers.agentBaseImage: "ghcr.io/hezo-ai/agent-base:<version-or-sha>" - which applies to ' +
 				"every project, or set one project's base image on its Container settings. Running on " +
 				'the local Docker backend instead needs no image configuration.',
 		);

--- a/packages/server/src/services/sandbox/open.ts
+++ b/packages/server/src/services/sandbox/open.ts
@@ -22,14 +22,14 @@ const CONNECT_RETRY_DELAYS_MS = [2000, 4000];
  * How an operator actually gets out of a bad credential, on either surface this
  * error reaches - the boot log and the Containers switch dialog.
  *
- * It used to end "drop --sandbox-backend / HEZO_SANDBOX_BACKEND to run
+ * It used to end "drop --sandbox-backend / containers.backend to run
  * containers on local Docker", which is **false**: the backend is a stored
  * setting that the flag only seeds, so removing the flag changes nothing on an
  * instance that has already chosen a provider. Following it leaves the operator
  * with the same failure and the belief that they are now on Docker.
  */
 const KEY_RECOVERY_HINT =
-	'Supply a working key with --daytona-api-key / HEZO_DAYTONA_API_KEY, or set one from ' +
+	'Supply a working key with --daytona-api-key / containers.daytona.apiKey, or set one from ' +
 	'Settings -> Containers. The key is used for this startup and saved once the instance ' +
 	'is unlocked.';
 
@@ -115,7 +115,7 @@ export async function openSandboxBackend(
 		() =>
 			`Cannot reach the configured Daytona API at ${redacted}.\n` +
 			'Check that the API key is valid and not expired, that it carries the sandbox ' +
-			'permission scopes, and that --daytona-api-url / HEZO_DAYTONA_API_URL points at the ' +
+			'permission scopes, and that --daytona-api-url / containers.daytona.apiUrl points at the ' +
 			`right region.\n${KEY_RECOVERY_HINT}`,
 		'Daytona',
 	);
@@ -160,7 +160,7 @@ async function dockerPreflightWithRetry(
 		}
 		const message =
 			`${formatDockerPreflightMessage({ ...result, status: result.status })}\n\n` +
-			'Alternatively, set --sandbox-backend / HEZO_SANDBOX_BACKEND to run containers ' +
+			'Alternatively, set --sandbox-backend / containers.backend to run containers ' +
 			'on a managed sandbox service instead of a local daemon.';
 		// Same message either way; the narrower type only tells the fatal-exit path
 		// that this is the one failure the operator may never get to read.
@@ -201,7 +201,7 @@ function resolveBackendName(raw?: string): SandboxBackend {
 	if (!isSandboxBackend(value)) {
 		throw new SandboxBackendError(
 			`Unknown sandbox backend "${raw}".\n` +
-				`Set --sandbox-backend / HEZO_SANDBOX_BACKEND to one of: ${SANDBOX_BACKENDS.join(', ')}.`,
+				`Set --sandbox-backend / containers.backend to one of: ${SANDBOX_BACKENDS.join(', ')}.`,
 		);
 	}
 	return value;

--- a/packages/server/src/services/updater.ts
+++ b/packages/server/src/services/updater.ts
@@ -16,6 +16,7 @@ import { basename, dirname, join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { UpdateState } from '@hezo/shared';
+import { runtimeConfig } from '../config/runtime';
 import { logger } from '../logger';
 import { HEZO_VERSION } from '../version';
 
@@ -91,7 +92,7 @@ export function isRunningInContainer(): boolean {
  * the image, not the binary, should be updated).
  */
 export function isAutoUpdateEnabled(): boolean {
-	if (process.env.HEZO_DISABLE_AUTO_UPDATE) return false;
+	if (runtimeConfig().updates.disabled) return false;
 	if (!isCompiledBinary()) return false;
 	if (isRunningInContainer()) return false;
 	return true;

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -165,6 +165,14 @@ export interface StartupResult {
 export async function startup(config: HezoConfig): Promise<StartupResult> {
 	mkdirSync(config.dataDir, { recursive: true });
 	log.info(`Using data directory: ${config.dataDir}`);
+	// Name the file, or say plainly that there is none: `--config` has no implicit
+	// search, so an operator who wrote a config file and forgot the flag would
+	// otherwise see a silently default-configured server.
+	log.info(
+		config.configPath
+			? `Using config file: ${config.configPath}`
+			: 'No config file (--config not given); using defaults plus any flags',
+	);
 
 	if (config.telemetry?.enabled) {
 		log.info(
@@ -177,7 +185,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	setStartupPhase('database');
 	const opened = await openDatabase({
 		dataDir: config.dataDir,
-		databaseUrl: config.databaseUrl,
+		databaseUrl: config.database.url,
 		reset: config.reset,
 	});
 	let db = opened.db;
@@ -235,7 +243,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	setStartupPhase('asset-storage');
 	const { store: assetStore, info: assetStorageInfo } = await openAssetStorage({
 		dataDir: config.dataDir,
-		assetStorageUrl: config.assetStorageUrl,
+		assetStorageUrl: config.assetStorage.url,
 	});
 
 	// Runtime model pricing: load the table into memory (migrations bake in a
@@ -280,9 +288,9 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	} else {
 		const { resolveStartupBackend } = await import('./services/sandbox/backend-store.js');
 		const resolved = await resolveStartupBackend(db, masterKeyManager, {
-			backend: config.sandboxBackend,
-			daytonaApiKey: config.daytonaApiKey,
-			daytonaApiUrl: config.daytonaApiUrl,
+			backend: config.containers.backend,
+			daytonaApiKey: config.containers.daytona.apiKey,
+			daytonaApiUrl: config.containers.daytona.apiUrl,
 		});
 		deferredBackend = resolved;
 		if (resolved.deferred) {
@@ -309,7 +317,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 				// An operator who pinned a socket did so because discovery does not
 				// reach their daemon; dropping it here would silently ignore the flag
 				// and send them round the discovery loop it exists to bypass.
-				dockerSocket: config.dockerSocket,
+				dockerSocket: config.containers.dockerSocket,
 			}));
 		}
 	}
@@ -359,8 +367,8 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		db,
 		masterKeyManager,
 		ca: egressCA,
-		authEnabled: config.egressProxyAuth,
-		allowPrivateTargets: config.egressAllowPrivateTargets,
+		authEnabled: config.egress.proxyAuth,
+		allowPrivateTargets: config.egress.allowPrivateTargets,
 		// Hezo's own MCP/asset endpoint as a container addresses it. Already in the
 		// run's NO_PROXY, so it should never reach the proxy — but NO_PROXY is a
 		// client-side convention, and a runtime that ignores it would otherwise have
@@ -396,7 +404,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		pricing,
 		storageBackend: storageInfo.backend,
 		telemetry: config.telemetry,
-		autoInstallUpdates: config.autoInstallUpdates,
+		autoInstallUpdates: config.updates.autoInstall,
 	});
 	const chatSessionManager = new ChatSessionManager({
 		db,

--- a/packages/server/test/cli-backup-restore.test.ts
+++ b/packages/server/test/cli-backup-restore.test.ts
@@ -31,6 +31,17 @@ function makeTempDir(): string {
 	return dir;
 }
 
+let configSeq = 0;
+/**
+ * Write a config file and return its path. `require` caches by resolved path, so
+ * each call gets its own filename rather than rewriting a shared one.
+ */
+function writeConfig(obj: unknown): string {
+	const path = join(makeTempDir(), `hezo.${configSeq++}.config.cjs`);
+	writeFileSync(path, `module.exports = ${JSON.stringify(obj)};`);
+	return path;
+}
+
 /** Boot a fully migrated embedded instance under `dataDir` and seed a marker team. */
 async function seedMigratedDataDir(dataDir: string): Promise<void> {
 	const opened = await openDatabase({ dataDir });
@@ -88,35 +99,14 @@ async function seedAssetInDataDir(dataDir: string): Promise<SeededAsset> {
 
 describe('hezo backup / hezo restore subcommands', () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
-	let prevDatabaseUrl: string | undefined;
-	let prevAssetStorageUrl: string | undefined;
-	let prevDataDir: string | undefined;
-
-	beforeAll(() => {
-		prevDatabaseUrl = process.env.HEZO_DATABASE_URL;
-		prevAssetStorageUrl = process.env.HEZO_ASSET_STORAGE_URL;
-		prevDataDir = process.env.HEZO_DATA_DIR;
-		delete process.env.HEZO_DATABASE_URL;
-		delete process.env.HEZO_ASSET_STORAGE_URL;
-		delete process.env.HEZO_DATA_DIR;
-	});
 
 	afterAll(async () => {
-		if (prevDatabaseUrl === undefined) delete process.env.HEZO_DATABASE_URL;
-		else process.env.HEZO_DATABASE_URL = prevDatabaseUrl;
-		if (prevAssetStorageUrl === undefined) delete process.env.HEZO_ASSET_STORAGE_URL;
-		else process.env.HEZO_ASSET_STORAGE_URL = prevAssetStorageUrl;
-		if (prevDataDir === undefined) delete process.env.HEZO_DATA_DIR;
-		else process.env.HEZO_DATA_DIR = prevDataDir;
 		for (const sim of sims) await sim.destroy();
 		for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
-		delete process.env.HEZO_DATABASE_URL;
-		delete process.env.HEZO_ASSET_STORAGE_URL;
-		delete process.env.HEZO_DATA_DIR;
 	});
 
 	it('runBackup/runRestore return false when another (or no) subcommand is invoked', async () => {
@@ -207,10 +197,12 @@ describe('hezo backup / hezo restore subcommands', () => {
 		).rejects.toThrow('process.exit(1)');
 		expect(said('.backup.gz')).toBe(true);
 
-		// Env variant — HEZO_DATABASE_URL wins over the (absent) flag.
+		// Config-file variant — the file supplies the URL when no flag does.
 		errorSpy.mockClear();
-		process.env.HEZO_DATABASE_URL = 'postgres://u:p@h:5432/db';
-		await expect(runRestore(argv('restore', fakeTar))).rejects.toThrow('process.exit(1)');
+		const cfg = writeConfig({ database: { url: 'postgres://u:p@h:5432/db' } });
+		await expect(runRestore(argv('restore', fakeTar, '--config', cfg))).rejects.toThrow(
+			'process.exit(1)',
+		);
 		expect(said('.backup.gz')).toBe(true);
 	});
 
@@ -245,7 +237,7 @@ describe('hezo backup / hezo restore subcommands', () => {
 		expect(restoredBlob.equals(asset.content)).toBe(true);
 	}, 120_000);
 
-	it('migrates a bundle’s assets into an S3-compatible bucket named by env', async () => {
+	it('migrates a bundle’s assets into an S3-compatible bucket named by the config file', async () => {
 		const sourceDir = makeTempDir();
 		await seedMigratedDataDir(sourceDir);
 		const asset = await seedAssetInDataDir(sourceDir);
@@ -256,9 +248,11 @@ describe('hezo backup / hezo restore subcommands', () => {
 
 		const sim = await createS3Sim();
 		sims.push(sim);
-		// HEZO_ASSET_STORAGE_URL (env) resolves the target store, mirroring --database-url.
-		process.env.HEZO_ASSET_STORAGE_URL = sim.storeUrl();
-		expect(await runRestore(argv('restore', bundleDir, '--data-dir', makeTempDir()))).toBe(true);
+		// assetStorage.url in the config file resolves the target store, mirroring --database-url.
+		const cfg = writeConfig({ assetStorage: { url: sim.storeUrl() } });
+		expect(
+			await runRestore(argv('restore', bundleDir, '--data-dir', makeTempDir(), '--config', cfg)),
+		).toBe(true);
 		expect(sim.objects.get(`${asset.projectId}/${asset.assetId}`)?.body.equals(asset.content)).toBe(
 			true,
 		);
@@ -306,26 +300,37 @@ describe('hezo backup / hezo restore subcommands', () => {
 		).rejects.toThrow(/Nothing to back up/);
 	});
 
-	it('resolves the data dir from HEZO_DATA_DIR when --data-dir is not passed', async () => {
-		// Reproduces the production report: an instance started with
-		// HEZO_DATA_DIR (systemd/docker) never passes --data-dir, so backup must
-		// read the env var rather than fall back to the default ~/.hezo and crash
-		// on a freshly-created empty database (`relation "_migrations" does not exist`).
+	it('resolves the data dir from the --config file when --data-dir is not passed', async () => {
+		// Reproduces the production report: an instance started from a config file
+		// (systemd/docker) never passes --data-dir, so backup must read the same
+		// file rather than fall back to the default ~/.hezo and crash on a
+		// freshly-created empty database (`relation "_migrations" does not exist`).
 		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const sourceDir = makeTempDir();
 		await seedMigratedDataDir(sourceDir);
-		process.env.HEZO_DATA_DIR = sourceDir;
 
-		const output = join(makeTempDir(), 'env-datadir.backup.gz');
-		expect(await runBackup(argv('backup', '--no-assets', '--output', output))).toBe(true);
+		const output = join(makeTempDir(), 'config-datadir.backup.gz');
+		expect(
+			await runBackup(
+				argv(
+					'backup',
+					'--no-assets',
+					'--output',
+					output,
+					'--config',
+					writeConfig({ dataDir: sourceDir }),
+				),
+			),
+		).toBe(true);
 		const header = await peekLogicalBackupHeaderFromFile(output);
 		expect(header?.formatVersion).toBe(1);
 		expect(header?.migrations.length).toBeGreaterThan(0);
 
-		// Restore also honours HEZO_DATA_DIR (no --data-dir flag) into a fresh dir.
+		// Restore also honours the file's dataDir (no --data-dir flag) into a fresh dir.
 		const targetDir = makeTempDir();
-		process.env.HEZO_DATA_DIR = targetDir;
-		expect(await runRestore(argv('restore', output))).toBe(true);
+		expect(
+			await runRestore(argv('restore', output, '--config', writeConfig({ dataDir: targetDir }))),
+		).toBe(true);
 		const restored = await openDatabase({ dataDir: targetDir });
 		try {
 			expect(await teamSlugs(restored.db)).toContain('backup-probe');
@@ -335,7 +340,7 @@ describe('hezo backup / hezo restore subcommands', () => {
 	}, 120_000);
 
 	it('fails with an actionable error (not a bare _migrations error) on a data dir with no Hezo database', async () => {
-		// A wrong --data-dir / HEZO_DATA_DIR (or a never-started instance) opens an
+		// A wrong --data-dir / config dataDir (or a never-started instance) opens an
 		// empty PGlite database; backup must explain that rather than surface the raw
 		// `relation "_migrations" does not exist`.
 		const emptyDir = makeTempDir();

--- a/packages/server/test/cli-uninstall.test.ts
+++ b/packages/server/test/cli-uninstall.test.ts
@@ -38,19 +38,14 @@ function seedProjectTree(dataDir: string): string {
 	return projectDir;
 }
 
-let prevDataDir: string | undefined;
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-	prevDataDir = process.env.HEZO_DATA_DIR;
-	delete process.env.HEZO_DATA_DIR;
 	logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
 afterEach(() => {
 	vi.restoreAllMocks();
-	if (prevDataDir === undefined) delete process.env.HEZO_DATA_DIR;
-	else process.env.HEZO_DATA_DIR = prevDataDir;
 	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -123,12 +118,15 @@ describe('hezo uninstall subcommand', () => {
 		expect(existsSync(dataDir)).toBe(false);
 	});
 
-	it('reads HEZO_DATA_DIR when --data-dir is omitted', async () => {
+	it('reads the data dir from the --config file when --data-dir is omitted', async () => {
 		const dataDir = makeDataDir();
 		seedProjectTree(dataDir);
-		process.env.HEZO_DATA_DIR = dataDir;
+		const cfg = join(makeDataDir(), 'hezo.config.cjs');
+		writeFileSync(cfg, `module.exports = ${JSON.stringify({ dataDir })};`);
 
-		expect(await runUninstall(argv('uninstall', '--yes'), noContainers)).toBe(true);
+		expect(await runUninstall(argv('uninstall', '--yes', '--config', cfg), noContainers)).toBe(
+			true,
+		);
 		expect(existsSync(dataDir)).toBe(false);
 	});
 

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -1,8 +1,9 @@
-import { homedir } from 'node:os';
-import { resolve } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { deriveAuthKeyPair, deriveUnlockKey } from '@hezo/shared';
-import { describe, expect, it } from 'vitest';
-import { parseConfig, resolveDevDataDir, runVersion } from '../src/cli';
+import { afterAll, describe, expect, it } from 'vitest';
+import { resolveConfig, resolveDevDataDir, runVersion } from '../src/cli';
 import { HEZO_VERSION } from '../src/version';
 
 // Canonical BIP39 vector — parseMasterKey only accepts a valid mnemonic.
@@ -13,116 +14,147 @@ const PHRASE =
 const argv = (...flags: string[]) => ['bun', 'src/index.ts', ...flags];
 
 // Always pass an empty env so the test outcomes do not depend on the host
-// process having or not having HEZO_* vars set.
+// process having or not having HEZO_* vars set. HEZO_MASTER_KEY is the only
+// setting still read from it.
 const EMPTY_ENV: NodeJS.ProcessEnv = {};
 
-describe('parseConfig', () => {
-	it('leaves databaseUrl unset by default (embedded database)', () => {
-		expect(parseConfig(argv(), EMPTY_ENV).databaseUrl).toBeUndefined();
+// Config files are real modules on disk — `require` caches by resolved path, so
+// each one needs its own name rather than a rewritten shared file.
+const configDir = mkdtempSync(join(tmpdir(), 'hezo-cli-config-'));
+let configSeq = 0;
+afterAll(() => rmSync(configDir, { recursive: true, force: true }));
+
+/** Write a config file and return its path. */
+function configFile(body: string): string {
+	const path = join(configDir, `hezo.${configSeq++}.config.cjs`);
+	writeFileSync(path, body);
+	return path;
+}
+
+/** Build argv that loads a config file exporting `obj`. */
+const withConfig = (obj: unknown, ...flags: string[]) =>
+	argv('--config', configFile(`module.exports = ${JSON.stringify(obj)};`), ...flags);
+
+describe('resolveConfig', () => {
+	it('leaves the database URL unset by default (embedded database)', () => {
+		expect(resolveConfig(argv(), EMPTY_ENV).database.url).toBeUndefined();
 	});
 
-	it('accepts --database-url and lets HEZO_DATABASE_URL win over the flag', () => {
+	it('accepts --database-url and lets the flag win over the config file', () => {
 		expect(
-			parseConfig(argv('--database-url', 'postgres://u:p@h:5432/db'), EMPTY_ENV).databaseUrl,
+			resolveConfig(argv('--database-url', 'postgres://u:p@h:5432/db'), EMPTY_ENV).database.url,
 		).toBe('postgres://u:p@h:5432/db');
 		expect(
-			parseConfig(argv('--database-url', 'postgres://cli@h/db'), {
-				HEZO_DATABASE_URL: 'postgres://env@h/db',
-			}).databaseUrl,
-		).toBe('postgres://env@h/db');
+			resolveConfig(
+				withConfig(
+					{ database: { url: 'postgres://file@h/db' } },
+					'--database-url',
+					'postgres://cli@h/db',
+				),
+				EMPTY_ENV,
+			).database.url,
+		).toBe('postgres://cli@h/db');
 	});
 
 	it('rejects --reset combined with an external database URL', () => {
 		expect(() =>
-			parseConfig(argv('--database-url', 'postgres://u:p@h/db', '--reset'), EMPTY_ENV),
+			resolveConfig(argv('--database-url', 'postgres://u:p@h/db', '--reset'), EMPTY_ENV),
 		).toThrow('embedded database only');
 		expect(() =>
-			parseConfig(argv('--reset'), { HEZO_DATABASE_URL: 'postgres://u:p@h/db' }),
+			resolveConfig(withConfig({ database: { url: 'postgres://u:p@h/db' } }, '--reset'), EMPTY_ENV),
 		).toThrow('embedded database only');
 	});
 
 	it('returns defaults when no args provided', () => {
-		const config = parseConfig(argv(), EMPTY_ENV);
+		const config = resolveConfig(argv(), EMPTY_ENV);
 		expect(config.port).toBe(3100);
 		expect(config.dataDir).toBe(resolve(homedir(), '.hezo'));
 		expect(config.masterKey).toBeUndefined();
 		expect(config.reset).toBe(false);
 		expect(config.open).toBe(true);
 		expect(config.logLevel).toBe('info');
-		expect(config.keepOldContainers).toBe(false);
-		expect(config.autoInstallUpdates).toBe(false);
+		expect(config.containers.keepOld).toBe(false);
+		expect(config.updates.autoInstall).toBe(false);
 		expect(config.telemetry.enabled).toBe(true);
 		expect(config.telemetry.endpoint).toBe('https://hezo.ai/api/telemetry');
 	});
 
 	it('enables auto-install of updates with --auto-install-updates', () => {
-		expect(parseConfig(argv('--auto-install-updates'), EMPTY_ENV).autoInstallUpdates).toBe(true);
+		expect(resolveConfig(argv('--auto-install-updates'), EMPTY_ENV).updates.autoInstall).toBe(true);
 	});
 
-	it('enables auto-install of updates with HEZO_AUTO_INSTALL_UPDATES', () => {
-		expect(parseConfig(argv(), { HEZO_AUTO_INSTALL_UPDATES: '1' }).autoInstallUpdates).toBe(true);
-	});
-
-	it('lets HEZO_AUTO_INSTALL_UPDATES=0 override the --auto-install-updates flag', () => {
+	it('enables auto-install of updates from the config file', () => {
 		expect(
-			parseConfig(argv('--auto-install-updates'), { HEZO_AUTO_INSTALL_UPDATES: '0' })
-				.autoInstallUpdates,
-		).toBe(false);
+			resolveConfig(withConfig({ updates: { autoInstall: true } }), EMPTY_ENV).updates.autoInstall,
+		).toBe(true);
+	});
+
+	it('lets the --auto-install-updates flag win over a config file that disables it', () => {
+		expect(
+			resolveConfig(
+				withConfig({ updates: { autoInstall: false } }, '--auto-install-updates'),
+				EMPTY_ENV,
+			).updates.autoInstall,
+		).toBe(true);
 	});
 
 	it('disables telemetry with --disable-telemetry', () => {
-		const config = parseConfig(argv('--disable-telemetry'), EMPTY_ENV);
+		const config = resolveConfig(argv('--disable-telemetry'), EMPTY_ENV);
 		expect(config.telemetry.enabled).toBe(false);
 	});
 
-	it('disables telemetry with HEZO_TELEMETRY_ENABLED=0', () => {
-		const config = parseConfig(argv(), { HEZO_TELEMETRY_ENABLED: '0' });
+	it('disables telemetry from the config file', () => {
+		const config = resolveConfig(withConfig({ telemetry: { enabled: false } }), EMPTY_ENV);
 		expect(config.telemetry.enabled).toBe(false);
 	});
 
-	it('lets HEZO_TELEMETRY_ENABLED override the --disable-telemetry flag', () => {
-		const config = parseConfig(argv('--disable-telemetry'), { HEZO_TELEMETRY_ENABLED: '1' });
-		expect(config.telemetry.enabled).toBe(true);
+	it('lets --disable-telemetry win over a config file that enables it', () => {
+		const config = resolveConfig(
+			withConfig({ telemetry: { enabled: true } }, '--disable-telemetry'),
+			EMPTY_ENV,
+		);
+		expect(config.telemetry.enabled).toBe(false);
 	});
 
-	it('overrides the telemetry endpoint via flag and env', () => {
+	it('overrides the telemetry endpoint via flag and config file', () => {
 		expect(
-			parseConfig(argv('--telemetry-endpoint', 'https://x.test/t'), EMPTY_ENV).telemetry.endpoint,
+			resolveConfig(argv('--telemetry-endpoint', 'https://x.test/t'), EMPTY_ENV).telemetry.endpoint,
 		).toBe('https://x.test/t');
 		expect(
-			parseConfig(argv(), { HEZO_TELEMETRY_ENDPOINT: 'https://env.test/t' }).telemetry.endpoint,
-		).toBe('https://env.test/t');
+			resolveConfig(withConfig({ telemetry: { endpoint: 'https://file.test/t' } }), EMPTY_ENV)
+				.telemetry.endpoint,
+		).toBe('https://file.test/t');
 	});
 
 	it('parses --port', () => {
-		const config = parseConfig(argv('--port', '8080'), EMPTY_ENV);
+		const config = resolveConfig(argv('--port', '8080'), EMPTY_ENV);
 		expect(config.port).toBe(8080);
 	});
 
 	it('throws on non-numeric port', () => {
-		expect(() => parseConfig(argv('--port', 'abc'), EMPTY_ENV)).toThrow('Invalid port');
+		expect(() => resolveConfig(argv('--port', 'abc'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('throws on port below valid range', () => {
-		expect(() => parseConfig(argv('--port', '0'), EMPTY_ENV)).toThrow('Invalid port');
+		expect(() => resolveConfig(argv('--port', '0'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('throws on port above valid range', () => {
-		expect(() => parseConfig(argv('--port', '99999'), EMPTY_ENV)).toThrow('Invalid port');
+		expect(() => resolveConfig(argv('--port', '99999'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('parses --data-dir with absolute path', () => {
-		const config = parseConfig(argv('--data-dir', '/custom/path'), EMPTY_ENV);
+		const config = resolveConfig(argv('--data-dir', '/custom/path'), EMPTY_ENV);
 		expect(config.dataDir).toBe('/custom/path');
 	});
 
 	it('resolves tilde in --data-dir', () => {
-		const config = parseConfig(argv('--data-dir', '~/custom'), EMPTY_ENV);
+		const config = resolveConfig(argv('--data-dir', '~/custom'), EMPTY_ENV);
 		expect(config.dataDir).toBe(resolve(homedir(), 'custom'));
 	});
 
 	it('derives unlock key + auth public key from a --master-key phrase', () => {
-		const config = parseConfig(argv('--master-key', PHRASE), EMPTY_ENV);
+		const config = resolveConfig(argv('--master-key', PHRASE), EMPTY_ENV);
 		expect(config.masterKey).toEqual({
 			unlockKeyHex: deriveUnlockKey(PHRASE),
 			publicKeyHex: deriveAuthKeyPair(PHRASE).publicKeyHex,
@@ -130,51 +162,54 @@ describe('parseConfig', () => {
 	});
 
 	it('rejects a --master-key that is not a valid mnemonic', () => {
-		expect(() => parseConfig(argv('--master-key', 'not-a-phrase'), EMPTY_ENV)).toThrow(
+		expect(() => resolveConfig(argv('--master-key', 'not-a-phrase'), EMPTY_ENV)).toThrow(
 			'Invalid master key',
 		);
 		// A raw derived hex key is no longer accepted either — it could never
 		// enroll the auth public key.
-		expect(() => parseConfig(argv('--master-key', 'ab'.repeat(32)), EMPTY_ENV)).toThrow(
+		expect(() => resolveConfig(argv('--master-key', 'ab'.repeat(32)), EMPTY_ENV)).toThrow(
 			'Invalid master key',
 		);
 	});
 
 	it('parses --reset', () => {
-		const config = parseConfig(argv('--reset'), EMPTY_ENV);
+		const config = resolveConfig(argv('--reset'), EMPTY_ENV);
 		expect(config.reset).toBe(true);
 	});
 
 	it('defaults open to true and disables it with --no-open', () => {
-		expect(parseConfig(argv(), EMPTY_ENV).open).toBe(true);
-		expect(parseConfig(argv('--no-open'), EMPTY_ENV).open).toBe(false);
+		expect(resolveConfig(argv(), EMPTY_ENV).open).toBe(true);
+		expect(resolveConfig(argv('--no-open'), EMPTY_ENV).open).toBe(false);
 	});
 
-	it('lets HEZO_OPEN override the default and --no-open', () => {
-		// Env wins over both the default and the CLI flag.
-		expect(parseConfig(argv(), { HEZO_OPEN: '0' }).open).toBe(false);
-		expect(parseConfig(argv(), { HEZO_OPEN: 'false' }).open).toBe(false);
-		expect(parseConfig(argv('--no-open'), { HEZO_OPEN: '1' }).open).toBe(true);
-		// An empty env value falls through to the CLI/default.
-		expect(parseConfig(argv(), { HEZO_OPEN: '' }).open).toBe(true);
+	it('lets the config file disable open, and --no-open win over a file that enables it', () => {
+		expect(resolveConfig(withConfig({ open: false }), EMPTY_ENV).open).toBe(false);
+		expect(resolveConfig(withConfig({ open: true }, '--no-open'), EMPTY_ENV).open).toBe(false);
 	});
 
 	it('parses --log-level', () => {
-		const config = parseConfig(argv('--log-level', 'debug'), EMPTY_ENV);
+		const config = resolveConfig(argv('--log-level', 'debug'), EMPTY_ENV);
 		expect(config.logLevel).toBe('debug');
 	});
 
 	it('throws on invalid --log-level', () => {
-		expect(() => parseConfig(argv('--log-level', 'trace'), EMPTY_ENV)).toThrow('Invalid log level');
+		expect(() => resolveConfig(argv('--log-level', 'trace'), EMPTY_ENV)).toThrow(
+			'Invalid log level',
+		);
 	});
 
 	it('parses --keep-old-containers', () => {
-		const config = parseConfig(argv('--keep-old-containers'), EMPTY_ENV);
-		expect(config.keepOldContainers).toBe(true);
+		const config = resolveConfig(argv('--keep-old-containers'), EMPTY_ENV);
+		expect(config.containers.keepOld).toBe(true);
+	});
+
+	it('reads the master key from HEZO_MASTER_KEY, the one setting still on the env', () => {
+		const config = resolveConfig(argv(), { HEZO_MASTER_KEY: PHRASE });
+		expect(config.masterKey?.unlockKeyHex).toBe(deriveUnlockKey(PHRASE));
 	});
 
 	it('handles multiple flags combined', () => {
-		const config = parseConfig(
+		const config = resolveConfig(
 			argv(
 				'--port',
 				'9000',
@@ -194,35 +229,72 @@ describe('parseConfig', () => {
 		expect(config.open).toBe(false);
 	});
 
-	describe('env vars take precedence over CLI args', () => {
-		it('HEZO_PORT overrides --port', () => {
-			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '9090' });
+	describe('CLI flags take precedence over the config file', () => {
+		it('--port overrides the file', () => {
+			expect(resolveConfig(withConfig({ port: 9090 }, '--port', '8080'), EMPTY_ENV).port).toBe(
+				8080,
+			);
+		});
+
+		it('--data-dir overrides the file', () => {
+			expect(
+				resolveConfig(withConfig({ dataDir: '/file/path' }, '--data-dir', '/cli/path'), EMPTY_ENV)
+					.dataDir,
+			).toBe('/cli/path');
+		});
+
+		it('--log-level overrides the file', () => {
+			expect(
+				resolveConfig(withConfig({ logLevel: 'warn' }, '--log-level', 'debug'), EMPTY_ENV).logLevel,
+			).toBe('debug');
+		});
+
+		it('the file applies when the flag is absent', () => {
+			const config = resolveConfig(
+				withConfig({ port: 9090, logLevel: 'warn', containers: { keepOld: true } }),
+				EMPTY_ENV,
+			);
 			expect(config.port).toBe(9090);
-		});
-
-		it('HEZO_DATA_DIR overrides --data-dir', () => {
-			const config = parseConfig(argv('--data-dir', '/cli/path'), { HEZO_DATA_DIR: '/env/path' });
-			expect(config.dataDir).toBe('/env/path');
-		});
-
-		it('HEZO_LOG_LEVEL overrides --log-level', () => {
-			const config = parseConfig(argv('--log-level', 'debug'), { HEZO_LOG_LEVEL: 'warn' });
 			expect(config.logLevel).toBe('warn');
+			expect(config.containers.keepOld).toBe(true);
 		});
 
-		it('HEZO_KEEP_OLD_CONTAINERS overrides absence of CLI flag', () => {
-			const config = parseConfig(argv(), { HEZO_KEEP_OLD_CONTAINERS: '1' });
-			expect(config.keepOldContainers).toBe(true);
+		it('falls back to the built-in default for anything neither sets', () => {
+			const config = resolveConfig(withConfig({ port: 9090 }), EMPTY_ENV);
+			expect(config.logLevel).toBe('info');
+			expect(config.jobs.wakeupCron).toBe('*/5 * * * * *');
+			expect(config.database.poolSize).toBe(10);
 		});
 
-		it('HEZO_RESET=false overrides --reset', () => {
-			const config = parseConfig(argv('--reset'), { HEZO_RESET: 'false' });
-			expect(config.reset).toBe(false);
-		});
-
-		it('empty env value falls through to CLI', () => {
-			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '' });
-			expect(config.port).toBe(8080);
+		it('applies the previously env-only settings from the file', () => {
+			const config = resolveConfig(
+				withConfig({
+					database: { poolSize: 42 },
+					jobs: { heartbeatCron: '0 0 * * * *', inboxRetentionDays: 7 },
+					logCompaction: { batch: 5 },
+					marketplace: { ref: 'my-fork' },
+					github: { oauthClientId: 'Iv1.deadbeef' },
+					containers: { skipMountCheck: true, agentBaseImage: 'ghcr.io/me/agent:1' },
+					egress: { debug: true },
+					updates: { disabled: true },
+					chat: { healthIntervalMs: 250 },
+				}),
+				EMPTY_ENV,
+			);
+			expect(config.database.poolSize).toBe(42);
+			expect(config.jobs.heartbeatCron).toBe('0 0 * * * *');
+			expect(config.jobs.inboxRetentionDays).toBe(7);
+			// A partial group keeps the defaults for the keys it does not name.
+			expect(config.jobs.wakeupCron).toBe('*/5 * * * * *');
+			expect(config.logCompaction.batch).toBe(5);
+			expect(config.logCompaction.maxPerTick).toBe(500);
+			expect(config.marketplace.ref).toBe('my-fork');
+			expect(config.github.oauthClientId).toBe('Iv1.deadbeef');
+			expect(config.containers.skipMountCheck).toBe(true);
+			expect(config.containers.agentBaseImage).toBe('ghcr.io/me/agent:1');
+			expect(config.egress.debug).toBe(true);
+			expect(config.updates.disabled).toBe(true);
+			expect(config.chat.healthIntervalMs).toBe(250);
 		});
 	});
 });
@@ -257,38 +329,48 @@ describe('resolveDevDataDir', () => {
 	// `bun run dev` passes an absolute project-local default here.
 	const DEFAULT = '/repo/.hezo-dev';
 
-	it('uses the project-local default when neither env nor flag is set', () => {
-		const r = resolveDevDataDir(DEFAULT, undefined, EMPTY_ENV);
+	it('uses the project-local default when neither flag nor config file sets one', () => {
+		const r = resolveDevDataDir(DEFAULT, undefined, undefined);
 		expect(r.dataDir).toBe(resolve(DEFAULT));
 		expect(r.usedDefault).toBe(true);
 	});
 
 	it('honors --data-dir over the default', () => {
-		const r = resolveDevDataDir(DEFAULT, '/cli/path', EMPTY_ENV);
+		const r = resolveDevDataDir(DEFAULT, '/cli/path', undefined);
 		expect(r.dataDir).toBe('/cli/path');
 		expect(r.usedDefault).toBe(false);
 	});
 
-	it('HEZO_DATA_DIR wins over --data-dir', () => {
-		const r = resolveDevDataDir(DEFAULT, '/cli/path', { HEZO_DATA_DIR: '/env/path' });
-		expect(r.dataDir).toBe('/env/path');
+	it('--data-dir wins over the config file', () => {
+		const path = configFile("module.exports = { dataDir: '/file/path' };");
+		const r = resolveDevDataDir(DEFAULT, '/cli/path', path);
+		expect(r.dataDir).toBe('/cli/path');
 		expect(r.usedDefault).toBe(false);
 	});
 
-	it('expands a leading ~ in HEZO_DATA_DIR like the server does', () => {
-		const r = resolveDevDataDir(DEFAULT, undefined, { HEZO_DATA_DIR: '~/custom' });
+	it("uses the config file's dataDir when no flag is given", () => {
+		const path = configFile("module.exports = { dataDir: '/file/path' };");
+		const r = resolveDevDataDir(DEFAULT, undefined, path);
+		expect(r.dataDir).toBe('/file/path');
+		expect(r.usedDefault).toBe(false);
+	});
+
+	it('expands a leading ~ from the config file like the server does', () => {
+		const path = configFile("module.exports = { dataDir: '~/custom' };");
+		const r = resolveDevDataDir(DEFAULT, undefined, path);
 		expect(r.dataDir).toBe(resolve(homedir(), 'custom'));
 		expect(r.usedDefault).toBe(false);
 	});
 
 	it('expands a leading ~ in --data-dir', () => {
-		const r = resolveDevDataDir(DEFAULT, '~/custom', EMPTY_ENV);
+		const r = resolveDevDataDir(DEFAULT, '~/custom', undefined);
 		expect(r.dataDir).toBe(resolve(homedir(), 'custom'));
 		expect(r.usedDefault).toBe(false);
 	});
 
-	it('ignores an empty HEZO_DATA_DIR and falls back to the default', () => {
-		const r = resolveDevDataDir(DEFAULT, undefined, { HEZO_DATA_DIR: '' });
+	it('falls back to the default when the config file sets no dataDir', () => {
+		const path = configFile('module.exports = { port: 1234 };');
+		const r = resolveDevDataDir(DEFAULT, undefined, path);
 		expect(r.dataDir).toBe(resolve(DEFAULT));
 		expect(r.usedDefault).toBe(true);
 	});

--- a/packages/server/test/config-file.test.ts
+++ b/packages/server/test/config-file.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { loadConfigFile } from '../src/config/load';
+import { resetRuntimeConfig, runtimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
+
+// `require` caches by resolved path, so every fixture needs its own filename
+// rather than one file rewritten between cases.
+const dir = mkdtempSync(join(tmpdir(), 'hezo-config-file-'));
+let seq = 0;
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+function write(body: string): string {
+	const path = join(dir, `c${seq++}.cjs`);
+	writeFileSync(path, body);
+	return path;
+}
+
+describe('loadConfigFile', () => {
+	it('loads a plain object export', () => {
+		const path = write("module.exports = { port: 4321, logLevel: 'debug' };");
+		expect(loadConfigFile(path)).toEqual({ port: 4321, logLevel: 'debug' });
+	});
+
+	it('loads nested groups', () => {
+		const path = write(
+			"module.exports = { database: { url: 'postgres://h/db', poolSize: 20 }, jobs: { wakeupCron: '* * * * * *' } };",
+		);
+		expect(loadConfigFile(path)).toEqual({
+			database: { url: 'postgres://h/db', poolSize: 20 },
+			jobs: { wakeupCron: '* * * * * *' },
+		});
+	});
+
+	it('runs the file as real JavaScript, so it can compute values', () => {
+		// The property a `.cjs` config buys over a static format: an operator can
+		// read a side file, which is how the systemd deploy supplies its webUrl.
+		const side = join(dir, 'side-value');
+		writeFileSync(side, '  https://hezo.example.com\n');
+		const path = write(
+			`const { readFileSync } = require('node:fs');\nmodule.exports = { webUrl: readFileSync(${JSON.stringify(side)}, 'utf8').trim() };`,
+		);
+		expect(loadConfigFile(path).webUrl).toBe('https://hezo.example.com');
+	});
+
+	it('names the path, not the compiled binary, when the file is missing', () => {
+		const missing = join(dir, 'does-not-exist.cjs');
+		// The module resolver's own message blames `/$bunfs/root/…` as the requiring
+		// module in a compiled binary, which reads as a Hezo bug rather than a typo.
+		expect(() => loadConfigFile(missing)).toThrow(/No config file at .*does-not-exist\.cjs/);
+		expect(() => loadConfigFile(missing)).not.toThrow(/bunfs/);
+	});
+
+	it('surfaces a syntax error in the file', () => {
+		const path = write('module.exports = { port: ;;; };');
+		expect(() => loadConfigFile(path)).toThrow(/Could not load the config file/);
+	});
+
+	it('surfaces an error the file itself throws', () => {
+		const path = write("throw new Error('operator blew up');");
+		expect(() => loadConfigFile(path)).toThrow(/operator blew up/);
+	});
+
+	it('rejects a non-object export', () => {
+		expect(() => loadConfigFile(write('module.exports = 42;'))).toThrow(
+			/must export a configuration object/,
+		);
+		expect(() => loadConfigFile(write('module.exports = [1, 2];'))).toThrow(/an array/);
+	});
+
+	describe('validation', () => {
+		it('names an unknown key rather than ignoring it', () => {
+			// The specific failure a config file introduces over flags: a typo that
+			// silently does nothing. `.strict()` turns it into an error naming the key.
+			const path = write("module.exports = { dataDIr: '/oops' };");
+			expect(() => loadConfigFile(path)).toThrow(/dataDIr/);
+		});
+
+		it('names an unknown key inside a nested group', () => {
+			const path = write("module.exports = { jobs: { wakuepCron: '* * * * * *' } };");
+			expect(() => loadConfigFile(path)).toThrow(/wakuepCron/);
+		});
+
+		it('rejects a wrong-typed value and says where', () => {
+			const path = write("module.exports = { port: 'three thousand' };");
+			expect(() => loadConfigFile(path)).toThrow(/port/);
+		});
+
+		it('rejects an out-of-range port', () => {
+			expect(() => loadConfigFile(write('module.exports = { port: 99999 };'))).toThrow(/port/);
+		});
+
+		it('rejects a database pool size outside the supported band', () => {
+			expect(() =>
+				loadConfigFile(write('module.exports = { database: { poolSize: 1 } };')),
+			).toThrow(/poolSize/);
+			expect(() =>
+				loadConfigFile(write('module.exports = { database: { poolSize: 500 } };')),
+			).toThrow(/poolSize/);
+		});
+
+		it('reports every problem at once, not just the first', () => {
+			const path = write("module.exports = { port: 99999, logLevel: 'chatty' };");
+			expect(() => loadConfigFile(path)).toThrow(/port[\s\S]*logLevel/);
+		});
+
+		it('refuses a masterKey, explaining why rather than calling it a typo', () => {
+			const path = write("module.exports = { masterKey: 'twelve words here' };");
+			expect(() => loadConfigFile(path)).toThrow(/masterKey/);
+			expect(() => loadConfigFile(path)).toThrow(/never be written to disk/);
+			expect(() => loadConfigFile(path)).toThrow(/HEZO_MASTER_KEY/);
+		});
+
+		it('refuses a reset key, which would wipe the database on every restart', () => {
+			const path = write('module.exports = { reset: true };');
+			expect(() => loadConfigFile(path)).toThrow(/wipe on every[\s\S]*restart/);
+			expect(() => loadConfigFile(path)).toThrow(/--reset/);
+		});
+	});
+});
+
+describe('runtimeConfig', () => {
+	it('serves the built-in defaults until one is set', () => {
+		resetRuntimeConfig();
+		// A unit test that imports a service without booting the server must not
+		// have to arrange config it does not care about.
+		expect(runtimeConfig()).toBe(DEFAULT_CONFIG);
+		expect(runtimeConfig().jobs.wakeupCron).toBe('*/5 * * * * *');
+	});
+
+	it('serves what was set, then goes back to defaults on reset', () => {
+		const custom = { ...DEFAULT_CONFIG, port: 4321 };
+		setRuntimeConfig(custom);
+		expect(runtimeConfig().port).toBe(4321);
+		resetRuntimeConfig();
+		expect(runtimeConfig().port).toBe(DEFAULT_CONFIG.port);
+	});
+});

--- a/packages/server/test/db-open-external-coverage.test.ts
+++ b/packages/server/test/db-open-external-coverage.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import { PostgresDb } from '../src/db/drivers/postgres';
 import { ExternalDbError } from '../src/db/migrate-errors';
 import { openDatabase } from '../src/db/open';
@@ -40,17 +42,12 @@ function fakePostgresDb(opts?: {
 }
 
 describe('openDatabase (external Postgres path)', () => {
-	let prevPoolSize: string | undefined;
-
 	beforeEach(() => {
-		prevPoolSize = process.env.HEZO_DATABASE_POOL_SIZE;
-		delete process.env.HEZO_DATABASE_POOL_SIZE;
 		connectMock.mockReset();
 	});
 
 	afterEach(() => {
-		if (prevPoolSize === undefined) delete process.env.HEZO_DATABASE_POOL_SIZE;
-		else process.env.HEZO_DATABASE_POOL_SIZE = prevPoolSize;
+		resetRuntimeConfig();
 		vi.useRealTimers();
 		setLogLevel('warn');
 	});
@@ -90,26 +87,29 @@ describe('openDatabase (external Postgres path)', () => {
 		expect(opened.storage.display).not.toContain('hezo:sekretpw');
 		expect(opened.storage.display).toContain('db.internal:5432');
 		// No pool-size env → max undefined (driver default applies).
-		expect(connectMock).toHaveBeenCalledWith({ url: URL_WITH_SECRET, max: undefined });
+		expect(connectMock).toHaveBeenCalledWith({
+			url: URL_WITH_SECRET,
+			max: DEFAULT_CONFIG.database.poolSize,
+		});
 		// The preflight actually ran: version gate + gen_random_uuid smoke test.
 		expect(db.query).toHaveBeenCalledTimes(2);
 	});
 
-	it('parses and clamps HEZO_DATABASE_POOL_SIZE (2..100, non-numeric ignored)', async () => {
-		const cases: Array<[string, number | undefined]> = [
-			['5', 5],
-			['1', 2],
-			['500', 100],
-			['abc', undefined],
-		];
-		for (const [raw, expected] of cases) {
+	it('passes the configured database.poolSize through to the driver', async () => {
+		// The 2..100 band is enforced by the config schema now, which *rejects* an
+		// out-of-range value rather than silently clamping it - see
+		// config-file.test.ts. By the time openDatabase runs, the number is valid.
+		for (const poolSize of [2, 5, 100]) {
 			connectMock.mockReset();
 			connectMock.mockResolvedValue(fakePostgresDb());
-			process.env.HEZO_DATABASE_POOL_SIZE = raw;
+			setRuntimeConfig({
+				...DEFAULT_CONFIG,
+				database: { ...DEFAULT_CONFIG.database, poolSize },
+			});
 			await openDatabase({ dataDir: '/unused', databaseUrl: URL_WITH_SECRET });
-			expect(connectMock, `pool size ${raw}`).toHaveBeenCalledWith({
+			expect(connectMock, `pool size ${poolSize}`).toHaveBeenCalledWith({
 				url: URL_WITH_SECRET,
-				max: expected,
+				max: poolSize,
 			});
 		}
 	});

--- a/packages/server/test/docker-preflight.test.ts
+++ b/packages/server/test/docker-preflight.test.ts
@@ -218,7 +218,7 @@ describe('formatDockerPreflightMessage', () => {
 	it('offers the explicit override when discovery came up empty', () => {
 		const msg = formatDockerPreflightMessage(notRunning);
 		expect(msg).toContain('--docker-socket');
-		expect(msg).toContain('HEZO_DOCKER_SOCKET');
+		expect(msg).toContain('containers.dockerSocket');
 	});
 
 	it('explains an unsupported transport and how to point at a socket instead', () => {

--- a/packages/server/test/helpers/config.ts
+++ b/packages/server/test/helpers/config.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CONFIG } from '../../src/config/types';
 import type { HezoConfig } from '../../src/startup';
 
 /**
@@ -16,18 +17,19 @@ import type { HezoConfig } from '../../src/startup';
 export function testHezoConfig(dataDir: string, overrides: Partial<HezoConfig> = {}): HezoConfig {
 	return Object.assign<HezoConfig, Partial<HezoConfig>>(
 		{
+			...DEFAULT_CONFIG,
 			port: 0,
 			dataDir,
-			webUrl: '',
-			reset: false,
 			open: false,
-			logLevel: 'info',
-			keepOldContainers: false,
-			autoInstallUpdates: false,
-			egressProxyAuth: true,
-			// Inert like the rest: the destination guard stays *on*, which is the
-			// production posture. A test that needs to reach a private target says so.
-			egressAllowPrivateTargets: false,
+			containers: { ...DEFAULT_CONFIG.containers, keepOld: false },
+			updates: { ...DEFAULT_CONFIG.updates, autoInstall: false },
+			egress: {
+				...DEFAULT_CONFIG.egress,
+				proxyAuth: true,
+				// Inert like the rest: the destination guard stays *on*, which is the
+				// production posture. A test that needs to reach a private target says so.
+				allowPrivateTargets: false,
+			},
 			telemetry: { enabled: false, endpoint: 'https://example.invalid/telemetry' },
 		},
 		overrides,

--- a/packages/server/test/image-registry.test.ts
+++ b/packages/server/test/image-registry.test.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	AGENT_BASE_GHCR_REPO,
-	AGENT_BASE_IMAGE_OVERRIDE_ENV,
 	BUNDLE_SHA_LABEL,
 	computeBundleSourceHash,
 	findRepoRoot,
@@ -45,54 +44,49 @@ describe('image-registry', () => {
 	});
 
 	describe('publishedAgentBaseRef', () => {
-		// An explicit empty env, so these assert the build-type default rather than
-		// whatever the machine running them happens to export.
+		// An explicit undefined override, so these assert the build-type default
+		// rather than whatever the ambient config happens to carry.
 		it('returns the :latest GHCR ref for a packaged release build', () => {
-			expect(publishedAgentBaseRef(true, {})).toBe(`${AGENT_BASE_GHCR_REPO}:latest`);
+			expect(publishedAgentBaseRef(true, undefined)).toBe(`${AGENT_BASE_GHCR_REPO}:latest`);
 		});
 		it('returns null for an unpackaged (dev/test) build', () => {
-			expect(publishedAgentBaseRef(false, {})).toBeNull();
+			expect(publishedAgentBaseRef(false, undefined)).toBeNull();
 		});
 
-		it('lets HEZO_AGENT_BASE_IMAGE override the dev default', () => {
+		it('lets containers.agentBaseImage override the dev default', () => {
 			// The combination with no other answer: a dev server on a managed
 			// backend. Dev builds agent-base into the local daemon's image store,
 			// which a provider pulling from a registry can never see - so without
 			// this the only route is editing every project by hand, and a newly
 			// created project silently reverts to the local-build sentinel.
 			const pinned = `${AGENT_BASE_GHCR_REPO}:abc123`;
-			expect(publishedAgentBaseRef(false, { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: pinned })).toBe(
-				pinned,
-			);
+			expect(publishedAgentBaseRef(false, pinned)).toBe(pinned);
 		});
 
 		it('lets it override a packaged build too, so CI images can be tested as shipped', () => {
 			const pinned = `${AGENT_BASE_GHCR_REPO}:abc123`;
-			expect(publishedAgentBaseRef(true, { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: pinned })).toBe(pinned);
+			expect(publishedAgentBaseRef(true, pinned)).toBe(pinned);
 		});
 
 		it('ignores an empty or whitespace override rather than resolving to it', () => {
-			// An exported-but-empty variable is a shell accident, not a choice; taking
-			// it literally would resolve every image to the empty string.
-			expect(publishedAgentBaseRef(false, { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: '  ' })).toBeNull();
-			expect(publishedAgentBaseRef(true, { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: '' })).toBe(
-				`${AGENT_BASE_GHCR_REPO}:latest`,
-			);
+			// A key left blank is an accident, not a choice; taking it literally would
+			// resolve every image to the empty string.
+			expect(publishedAgentBaseRef(false, '  ')).toBeNull();
+			expect(publishedAgentBaseRef(true, '')).toBe(`${AGENT_BASE_GHCR_REPO}:latest`);
 		});
 
 		it('flows through resolveAgentBaseImage, so every project picks it up', () => {
 			const pinned = `${AGENT_BASE_GHCR_REPO}:abc123`;
-			const env = { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: pinned };
 			expect(
-				resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE, publishedAgentBaseRef(false, env)),
+				resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE, publishedAgentBaseRef(false, pinned)),
 			).toEqual({ image: pinned, preferPull: true });
 		});
 
 		it('leaves a project that named its own image alone', () => {
 			// The override replaces the *managed default*, not a deliberate choice.
-			const env = { [AGENT_BASE_IMAGE_OVERRIDE_ENV]: `${AGENT_BASE_GHCR_REPO}:abc123` };
+			const pinned = `${AGENT_BASE_GHCR_REPO}:abc123`;
 			expect(
-				resolveAgentBaseImage('ghcr.io/acme/custom:1', publishedAgentBaseRef(false, env)),
+				resolveAgentBaseImage('ghcr.io/acme/custom:1', publishedAgentBaseRef(false, pinned)),
 			).toEqual({ image: 'ghcr.io/acme/custom:1', preferPull: false });
 		});
 	});

--- a/packages/server/test/mount-preflight.test.ts
+++ b/packages/server/test/mount-preflight.test.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import type { DockerClient } from '../src/services/docker';
 import {
 	buildMountProbeScript,
@@ -11,7 +13,6 @@ import {
 	formatMountPreflightMessage,
 	type MountProbeResult,
 	parseMountProbeOutput,
-	SKIP_MOUNT_CHECK_ENV,
 } from '../src/services/mount-preflight';
 import { createStubDocker } from './helpers/app';
 
@@ -118,11 +119,13 @@ describe('formatMountPreflightMessage', () => {
 		}
 	});
 
-	it('never leaks the test-only escape hatches to users', () => {
+	it('never leaks the escape hatches to users', () => {
 		for (const outcome of ['read-only', 'not-mounted'] as const) {
 			const msg = formatMountPreflightMessage(outcome, { dataDir: DATA_DIR });
 			expect(msg).not.toContain('HEZO_SKIP_DOCKER');
-			expect(msg).not.toContain(SKIP_MOUNT_CHECK_ENV);
+			// The opt-out suppresses the diagnosis; it does not fix the mount, so the
+			// failure guidance must never offer it.
+			expect(msg).not.toContain('skipMountCheck');
 		}
 	});
 
@@ -164,15 +167,34 @@ describe('checkContainerMounts', () => {
 		}
 	});
 
-	it('skips under the fake-docker and opt-out env vars without probing', async () => {
-		for (const env of [{ HEZO_SKIP_DOCKER: '1' }, { [SKIP_MOUNT_CHECK_ENV]: '1' }]) {
+	it('skips under the fake-docker env var without probing', async () => {
+		let probed = false;
+		const outcome = await check(
+			async () => {
+				probed = true;
+				throw new Error('should not run');
+			},
+			{ HEZO_SKIP_DOCKER: '1' },
+		);
+		expect(outcome).toBe('skipped');
+		expect(probed).toBe(false);
+	});
+
+	it('skips under the containers.skipMountCheck config key without probing', async () => {
+		setRuntimeConfig({
+			...DEFAULT_CONFIG,
+			containers: { ...DEFAULT_CONFIG.containers, skipMountCheck: true },
+		});
+		try {
 			let probed = false;
 			const outcome = await check(async () => {
 				probed = true;
 				throw new Error('should not run');
-			}, env);
+			}, {});
 			expect(outcome).toBe('skipped');
 			expect(probed).toBe(false);
+		} finally {
+			resetRuntimeConfig();
 		}
 	});
 

--- a/packages/server/test/oauth-device-flow.test.ts
+++ b/packages/server/test/oauth-device-flow.test.ts
@@ -1,5 +1,7 @@
 import type { DeviceAuthConfig } from '@hezo/shared';
 import { afterEach, describe, expect, it } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import {
 	pollDeviceFlow,
 	resolveDeviceAuth,
@@ -9,27 +11,38 @@ import {
 const cfg: DeviceAuthConfig = {
 	deviceCodeUrl: 'https://github.com/login/device/code',
 	tokenUrl: 'https://github.com/login/oauth/access_token',
-	clientIdEnv: 'TEST_DEVICE_CLIENT_ID',
 	clientIdDefault: 'public-dev-id',
 	baseUrlEnv: 'TEST_DEVICE_BASE_URL',
 };
 
 afterEach(() => {
-	delete process.env.TEST_DEVICE_CLIENT_ID;
 	delete process.env.TEST_DEVICE_BASE_URL;
+	resetRuntimeConfig();
 });
 
+/** Publish a config naming its own OAuth client id, as a self-hoster would. */
+function withOauthClientId(oauthClientId: string): void {
+	setRuntimeConfig({ ...DEFAULT_CONFIG, github: { oauthClientId } });
+}
+
 describe('resolveDeviceAuth', () => {
-	it('falls back to the committed dev client_id outside production', () => {
+	it("uses the shipped app's client_id when the instance names none", () => {
+		// The default config carries the public app Hezo ships with, so an instance
+		// that never touches `github.oauthClientId` behaves as it always has.
 		const r = resolveDeviceAuth(cfg);
-		expect(r.clientId).toBe('public-dev-id');
+		expect(r.clientId).toBe(DEFAULT_CONFIG.github.oauthClientId);
 		expect(r.deviceCodeUrl).toBe('https://github.com/login/device/code');
 		expect(r.tokenUrl).toBe('https://github.com/login/oauth/access_token');
 	});
 
-	it('prefers the env client_id override', () => {
-		process.env.TEST_DEVICE_CLIENT_ID = 'env-id';
-		expect(resolveDeviceAuth(cfg).clientId).toBe('env-id');
+	it('prefers the configured github.oauthClientId', () => {
+		withOauthClientId('Iv1.selfhosted');
+		expect(resolveDeviceAuth(cfg).clientId).toBe('Iv1.selfhosted');
+	});
+
+	it("falls back to the capability's own default when the config names none", () => {
+		setRuntimeConfig({ ...DEFAULT_CONFIG, github: { oauthClientId: '' } });
+		expect(resolveDeviceAuth(cfg).clientId).toBe('public-dev-id');
 	});
 
 	it('rewrites endpoint origins when the base-url override is set', () => {
@@ -39,9 +52,10 @@ describe('resolveDeviceAuth', () => {
 		expect(r.tokenUrl).toBe('http://localhost:9999/login/oauth/access_token');
 	});
 
-	it('throws when no client_id is configured', () => {
+	it('throws when no client_id is configured anywhere', () => {
+		setRuntimeConfig({ ...DEFAULT_CONFIG, github: { oauthClientId: '' } });
 		expect(() => resolveDeviceAuth({ ...cfg, clientIdDefault: undefined })).toThrow(
-			/TEST_DEVICE_CLIENT_ID/,
+			/github\.oauthClientId/,
 		);
 	});
 });

--- a/packages/server/test/sandbox-backend-store.test.ts
+++ b/packages/server/test/sandbox-backend-store.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { SandboxBackend } from '@hezo/shared';
 import { Logger } from '@hiddentao/logger';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
 import { DockerClient } from '../src/services/docker';
@@ -53,10 +55,12 @@ const locked = new MasterKeyManager();
  * assert. Documented opt-out rather than a mock, so the rest of the preparation
  * still runs.
  */
-const savedMountCheck = process.env.HEZO_SKIP_MOUNT_CHECK;
 
 beforeAll(async () => {
-	process.env.HEZO_SKIP_MOUNT_CHECK = '1';
+	setRuntimeConfig({
+		...DEFAULT_CONFIG,
+		containers: { ...DEFAULT_CONFIG.containers, skipMountCheck: true },
+	});
 	const ctx = await createTestApp();
 	db = ctx.db;
 	unlocked = ctx.masterKeyManager;
@@ -64,8 +68,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
 	await safeClose(db);
-	if (savedMountCheck === undefined) delete process.env.HEZO_SKIP_MOUNT_CHECK;
-	else process.env.HEZO_SKIP_MOUNT_CHECK = savedMountCheck;
+	resetRuntimeConfig();
 });
 
 afterEach(async () => {
@@ -98,7 +101,7 @@ function captureWarnings(): () => string[] {
 
 describe('resolveStartupBackend on a locked instance', () => {
 	it('carries a launch-supplied key through instead of refusing to boot', async () => {
-		// The exact combination that broke: the operator has HEZO_DAYTONA_API_KEY in
+		// The exact combination that broke: the operator has a Daytona key in
 		// their launch env and unlocks from the browser. The vault write cannot
 		// happen yet, but the key is in hand, so the backend opens normally.
 		await setStoredSandboxBackend(db, SandboxBackend.Daytona);
@@ -150,7 +153,7 @@ describe('resolveStartupBackend on a locked instance', () => {
 		const resolved = await resolveStartupBackend(db, unlocked, { daytonaApiKey: 'dtn_x' });
 
 		expect(resolved.backend).toBe(SandboxBackend.Docker);
-		expect(warnings().join(' ')).toMatch(/HEZO_SANDBOX_BACKEND=daytona/);
+		expect(warnings().join(' ')).toMatch(/containers\.backend: "daytona"/);
 	});
 
 	it('says so when the launch flag disagrees with the stored setting', async () => {
@@ -174,7 +177,7 @@ describe('resolveStartupBackend on a locked instance', () => {
 
 		// Scoped to this module's two warnings rather than "nothing warned at all",
 		// which any unrelated background line would break.
-		expect(warnings().filter((w) => /sandbox-backend|HEZO_SANDBOX_BACKEND/i.test(w))).toEqual([]);
+		expect(warnings().filter((w) => /sandbox-backend|containers\.backend/i.test(w))).toEqual([]);
 	});
 
 	it('still writes the key through when the instance is already unlocked', async () => {

--- a/packages/server/test/sandbox-daytona-engine.test.ts
+++ b/packages/server/test/sandbox-daytona-engine.test.ts
@@ -985,7 +985,7 @@ describe('DaytonaEngine image reference', () => {
 		const err = await new DaytonaEngine(api)
 			.createContainer('hezo-p1', { ...CONFIG, Image: 'hezo/agent-base:latest' })
 			.catch((e) => e);
-		expect(err.message).toContain('HEZO_AGENT_BASE_IMAGE');
+		expect(err.message).toContain('containers.agentBaseImage');
 	});
 
 	it('accepts any published reference, including a project’s own', async () => {

--- a/packages/server/test/sandbox-open.test.ts
+++ b/packages/server/test/sandbox-open.test.ts
@@ -69,7 +69,7 @@ describe('openSandboxBackend is fatal, never degraded', () => {
 		expect(err).toBeInstanceOf(SandboxBackendError);
 		// Names the flag AND its env var, since a deployment may set either.
 		expect(err.message).toContain('--daytona-api-key');
-		expect(err.message).toContain('HEZO_DAYTONA_API_KEY');
+		expect(err.message).toContain('containers.daytona.apiKey');
 	});
 
 	it('reports a missing key before making any network call', async () => {
@@ -222,7 +222,7 @@ describe('openSandboxBackend preflights Docker', () => {
 		vi.spyOn(DockerClient.prototype, 'ping').mockResolvedValue(false);
 		const err = await openSandboxBackend({ backend: 'docker', ...NO_RETRY }).catch((e) => e);
 		expect(err.message).toContain('--sandbox-backend');
-		expect(err.message).toContain('HEZO_SANDBOX_BACKEND');
+		expect(err.message).toContain('containers.backend');
 	});
 
 	it('never surfaces the test-only escape hatch to an operator', async () => {

--- a/packages/server/test/startup-real-docker-branch.test.ts
+++ b/packages/server/test/startup-real-docker-branch.test.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import { waitForBackground } from '../src/lib/background';
 import { DockerClient } from '../src/services/docker';
 import { AGENT_BASE_CONTEXT_DIR } from '../src/services/docker-assets';
@@ -43,11 +45,13 @@ describe('startup real-Docker branch (no daemon required)', () => {
 		savedEnv.HEZO_SKIP_PRICING_REFRESH = process.env.HEZO_SKIP_PRICING_REFRESH;
 		savedEnv.HEZO_SKIP_CONTAINER_CONNECTIVITY_CHECK =
 			process.env.HEZO_SKIP_CONTAINER_CONNECTIVITY_CHECK;
-		savedEnv.HEZO_SKIP_MOUNT_CHECK = process.env.HEZO_SKIP_MOUNT_CHECK;
 		delete process.env.HEZO_SKIP_DOCKER;
 		process.env.HEZO_SKIP_PRICING_REFRESH = '1';
 		process.env.HEZO_SKIP_CONTAINER_CONNECTIVITY_CHECK = '1';
-		process.env.HEZO_SKIP_MOUNT_CHECK = '1';
+		setRuntimeConfig({
+			...DEFAULT_CONFIG,
+			containers: { ...DEFAULT_CONFIG.containers, skipMountCheck: true },
+		});
 		dataDir = mkdtempSync(join(tmpdir(), 'hezo-real-docker-'));
 	});
 

--- a/packages/server/test/updater-branches-cov.test.ts
+++ b/packages/server/test/updater-branches-cov.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { UpdateState } from '@hezo/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetRuntimeConfig, setRuntimeConfig } from '../src/config/runtime';
+import { DEFAULT_CONFIG } from '../src/config/types';
 import {
 	applyStagedUpdate,
 	currentAssetName,
@@ -34,12 +36,10 @@ function setPlatform(platform: string): () => void {
 }
 
 describe('availability predicates', () => {
-	const savedDisable = process.env.HEZO_DISABLE_AUTO_UPDATE;
 	const savedWorker = process.env.HEZO_WORKER;
 
 	afterEach(() => {
-		if (savedDisable === undefined) delete process.env.HEZO_DISABLE_AUTO_UPDATE;
-		else process.env.HEZO_DISABLE_AUTO_UPDATE = savedDisable;
+		resetRuntimeConfig();
 		if (savedWorker === undefined) delete process.env.HEZO_WORKER;
 		else process.env.HEZO_WORKER = savedWorker;
 	});
@@ -54,22 +54,22 @@ describe('availability predicates', () => {
 		expect(isRunningInContainer()).toBe(existsSync('/.dockerenv'));
 	});
 
-	it('HEZO_DISABLE_AUTO_UPDATE force-disables the feature regardless of everything else', () => {
-		process.env.HEZO_DISABLE_AUTO_UPDATE = '1';
+	it('updates.disabled force-disables the feature regardless of everything else', () => {
+		setRuntimeConfig({ ...DEFAULT_CONFIG, updates: { ...DEFAULT_CONFIG.updates, disabled: true } });
 		process.env.HEZO_WORKER = '1';
 		expect(isAutoUpdateEnabled()).toBe(false);
 		expect(isSupervisedWorker()).toBe(false);
 	});
 
-	it('with no disable flag, availability under Node hinges only on the container check', () => {
-		delete process.env.HEZO_DISABLE_AUTO_UPDATE;
+	it('with updates enabled, availability under Node hinges only on the container check', () => {
+		resetRuntimeConfig();
 		// isCompiledBinary() is true under Node (above), so the container gate is
 		// the only remaining condition.
 		expect(isAutoUpdateEnabled()).toBe(!isRunningInContainer());
 	});
 
 	it('isSupervisedWorker requires HEZO_WORKER=1 on top of the feature gate', () => {
-		delete process.env.HEZO_DISABLE_AUTO_UPDATE;
+		resetRuntimeConfig();
 		delete process.env.HEZO_WORKER;
 		expect(isSupervisedWorker()).toBe(false);
 		process.env.HEZO_WORKER = '0';

--- a/packages/shared/src/types/connector-capabilities.ts
+++ b/packages/shared/src/types/connector-capabilities.ts
@@ -17,15 +17,14 @@ export type McpTransport = 'http' | 'sse' | 'stdio';
  * Microsoft). The device flow needs only a pre-registered *public* client_id —
  * no redirect URI, no client secret — so it works on any self-hosted origin.
  *
- * Endpoints are plain public URLs. `clientIdEnv` names the env var holding the
- * instance's client_id; `clientIdDefault` is an optional committed public dev
- * fallback used outside production. `baseUrlEnv`, when set, lets tests (and
+ * Endpoints are plain public URLs. `clientIdDefault` is the client_id used when
+ * the instance does not name its own via `github.oauthClientId` in the config
+ * file. `baseUrlEnv`, when set, lets tests (and
  * self-hosted GitHub Enterprise) redirect the endpoint origins.
  */
 export interface DeviceAuthConfig {
 	deviceCodeUrl: string;
 	tokenUrl: string;
-	clientIdEnv: string;
 	clientIdDefault?: string;
 	baseUrlEnv?: string;
 }
@@ -97,7 +96,6 @@ export const CONNECTOR_CAPABILITIES: Record<string, ConnectorCapability> = {
 		deviceAuth: {
 			deviceCodeUrl: 'https://github.com/login/device/code',
 			tokenUrl: 'https://github.com/login/oauth/access_token',
-			clientIdEnv: 'GITHUB_OAUTH_CLIENT_ID',
 			clientIdDefault: 'Ov23liauGSJTHUoWbslf',
 			baseUrlEnv: 'GITHUB_OAUTH_BASE_URL',
 		},

--- a/packages/shared/test/types.test.ts
+++ b/packages/shared/test/types.test.ts
@@ -32,7 +32,8 @@ describe('connector capabilities', () => {
 		expect(gh?.displayName).toBe('GitHub');
 		expect(gh?.allowedHosts).toContain('github.com');
 		expect(gh?.scopes).toContain('repo');
-		expect(gh?.deviceAuth?.clientIdEnv).toBe('GITHUB_OAUTH_CLIENT_ID');
+		expect(gh?.deviceAuth?.clientIdDefault).toBeTruthy();
+		expect(gh?.deviceAuth?.deviceCodeUrl).toBe('https://github.com/login/device/code');
 	});
 
 	it('returns undefined for an unknown connector', () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,8 +8,12 @@ const WEB_PORT = 5174;
 const TEST_DATA_DIR = join(tmpdir(), 'hezo-e2e-test');
 // Cron cadences and telemetry for the spawned server. Absolute because the
 // server runs with cwd=packages/server, and passed as --config rather than env
-// because these are operator settings, not test-only switches.
-const E2E_CONFIG_FILE = resolve(import.meta.dirname, 'test/browser/hezo.e2e.config.cjs');
+// because these are operator settings, not test-only switches. Resolved from
+// process.cwd() (Playwright is invoked from the repo root — AGENTS.md) rather
+// than import.meta: Playwright loads this config through a CJS pipeline, and any
+// `import.meta` in it flips the file to ESM, where the wrapper's `exports` is
+// undefined and the whole config fails to load.
+const E2E_CONFIG_FILE = resolve(process.cwd(), 'test/browser/hezo.e2e.config.cjs');
 
 // The master-key-gate spec owns its own backend lifecycle (boot, kill,
 // restart on :3102), so it gets a dedicated vite instance proxying there —

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,15 @@
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { defineConfig } from '@playwright/test';
 import { TEST_MNEMONIC } from './test/browser/constants';
 
 const SERVER_PORT = 3101;
 const WEB_PORT = 5174;
 const TEST_DATA_DIR = join(tmpdir(), 'hezo-e2e-test');
+// Cron cadences and telemetry for the spawned server. Absolute because the
+// server runs with cwd=packages/server, and passed as --config rather than env
+// because these are operator settings, not test-only switches.
+const E2E_CONFIG_FILE = resolve(import.meta.dirname, 'test/browser/hezo.e2e.config.cjs');
 
 // The master-key-gate spec owns its own backend lifecycle (boot, kill,
 // restart on :3102), so it gets a dedicated vite instance proxying there —
@@ -135,7 +139,7 @@ export default defineConfig({
 	],
 	webServer: [
 		{
-			command: `bun run src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --reset --no-open`,
+			command: `bun run src/index.ts -- --config ${E2E_CONFIG_FILE} --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --reset --no-open`,
 			cwd: './packages/server',
 			// `Bun.serve` opens the port before `startup()` finishes registering
 			// routes, so a port-only check races against route mounting and the
@@ -165,15 +169,6 @@ export default defineConfig({
 				// log in via the challenge dance instead of running setup. Env var
 				// rather than a flag: a 12-word phrase is hostile to shell quoting.
 				HEZO_MASTER_KEY: TEST_MNEMONIC,
-				HEZO_WAKEUP_COALESCING_MS: '100',
-				HEZO_WAKEUP_CRON: '* * * * * *',
-				HEZO_HEARTBEAT_CRON: '* * * * * *',
-				// Wakeups/heartbeats stay at 1Hz so agent-flow specs react promptly,
-				// but container-status reconciliation has no sub-second consumer here
-				// (fake docker sets status synchronously on create/start). Drop it from
-				// 1Hz to every 10s so it stops compounding CPU load on the 2-core runner
-				// — the largest cheap win against the page-load-timeout flakes.
-				HEZO_CONTAINER_SYNC_CRON: '*/10 * * * * *',
 				// Skip the team coherence-review enqueue path that Captain processes
 				// on every team / agent-roster mutation. The review touches multiple
 				// agents synthetically (~30-60s per team setup) and no e2e test asserts
@@ -190,9 +185,6 @@ export default defineConfig({
 				// That is a suite-wide layout change driven by a third party's release
 				// schedule, and it took the browser tier red on the day 0.39.0 landed.
 				HEZO_SKIP_UPDATE_CHECK: '1',
-				// Telemetry defaults on; a CI run crossing the daily cron window
-				// would fire a real outbound report. Tests never phone home.
-				HEZO_TELEMETRY_ENABLED: '0',
 			},
 		},
 		{

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -34,17 +34,19 @@ const program = new Command()
 	.allowExcessArguments()
 	.option('--reset', 'Reset the server database')
 	.option('--data-dir <path>', 'Data directory')
+	.option('--config <path>', 'Hezo config file, forwarded to the server')
 	.parse();
 
 const opts = program.opts();
 
 // Default to a project-local, gitignored dir (<repo>/.hezo-dev) so local dev
-// never shares the production database at ~/.hezo. An explicit --data-dir or
-// HEZO_DATA_DIR still wins (and is then already visible to the spawned server).
+// never shares the production database at ~/.hezo. An explicit --data-dir, or a
+// dataDir in the --config file, still wins (and is then already visible to the
+// spawned server, which receives the same flags).
 const { dataDir, usedDefault } = resolveDevDataDir(
 	resolve(ROOT, '.hezo-dev'),
 	opts.dataDir,
-	process.env,
+	opts.config,
 );
 
 if (opts.reset) {
@@ -67,9 +69,8 @@ const webPort = process.env.HEZO_WEB_PORT ?? '5173';
 // forward every flag through untouched.
 const hasWebUrl = forwardedArgs.some((a) => a === '--web-url' || a.startsWith('--web-url='));
 // Auto-open is the server's default, but dev is restarted constantly — spawning
-// a browser tab each time is noise. Suppress it by default; HEZO_OPEN=1 in the
-// inherited env still wins (the env var takes precedence over this flag), and we
-// don't double-pass if the caller already forwarded --no-open.
+// a browser tab each time is noise. Suppress it by default, unless the caller
+// already forwarded --no-open (we must not double-pass it).
 const hasNoOpen = forwardedArgs.includes('--no-open');
 const serverArgs: string[] = [
 	...(hasNoOpen ? [] : ['--no-open']),

--- a/test/browser/hezo.e2e.config.cjs
+++ b/test/browser/hezo.e2e.config.cjs
@@ -1,0 +1,21 @@
+// Config for the server the browser suite spawns (playwright.config.ts passes
+// --config). Only settings that need to differ from production defaults live
+// here; the test-only switches stay env vars, since they are not operator
+// configuration and must never appear in a real instance's config file.
+module.exports = {
+	// Telemetry defaults on; a CI run crossing the daily cron window would fire a
+	// real outbound report. Tests never phone home.
+	telemetry: { enabled: false },
+	jobs: {
+		// 1Hz so agent-flow specs react promptly.
+		wakeupCron: '* * * * * *',
+		heartbeatCron: '* * * * * *',
+		wakeupCoalescingMs: 100,
+		// Wakeups/heartbeats stay at 1Hz, but container-status reconciliation has no
+		// sub-second consumer here (fake docker sets status synchronously on
+		// create/start). Drop it from 1Hz to every 10s so it stops compounding CPU
+		// load on the 2-core runner - the largest cheap win against the
+		// page-load-timeout flakes.
+		containerSyncCron: '*/10 * * * * *',
+	},
+};

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -49,6 +49,10 @@ async function startGateServer(opts: { reset: boolean }): Promise<void> {
 		'run',
 		'src/index.ts',
 		'--',
+		// Same config the playwright.config.ts webServer uses; telemetry off so
+		// tests never phone home.
+		'--config',
+		resolve(process.cwd(), 'test/browser/hezo.e2e.config.cjs'),
 		'--port',
 		String(GATE_SERVER_PORT),
 		'--data-dir',
@@ -68,8 +72,6 @@ async function startGateServer(opts: { reset: boolean }): Promise<void> {
 			// No boot key — the whole point is exercising the in-browser setup.
 			// (Empty string reads as unset in the CLI's env resolution.)
 			HEZO_MASTER_KEY: '',
-			// Tests never phone home (matches the playwright.config.ts webServer).
-			HEZO_TELEMETRY_ENABLED: '0',
 			HEZO_SKIP_UPDATE_CHECK: '1',
 		},
 		stdio: 'ignore',


### PR DESCRIPTION
Settings now come from a CommonJS config file named by `--config`, plus CLI flags. Precedence is **flag > file > built-in default**, resolved once by `resolveConfig` into a `HezoConfig`. There is no implicit discovery: without `--config`, only defaults and flags apply.

```js
// /etc/hezo/hezo.config.cjs
module.exports = {
  port: 3100,
  dataDir: '/var/lib/hezo',
  webUrl: 'https://hezo.example.com',
  database: { url: 'postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=verify-full' },
};
```

```sh
hezo --config /etc/hezo/hezo.config.cjs
```

## Why

Configuration had grown into a sprawl. Only **19** settings were resolved centrally in `parseConfig`; roughly **25 more** were read as bare `process.env.X ?? default` at module scope, and **20 of those were documented nowhere** - 16 cron schedules, the log-compaction and heartbeat tuning, inbox retention, the database pool size. Four near-duplicate precedence helpers existed for the subcommands, one of which let an *empty* env value win where the others treated empty as unset. Deployment shipped a secret-bearing `EnvironmentFile` that the first-boot script appended to with `grep`/`echo`.

Now there is one file the operator owns, one resolver in the codebase, and every operator-facing setting has a documented default.

## What is in the file

Everything operator-facing, including the ~20 settings documented here for the first time. Nested by subsystem: `database`, `assetStorage`, `containers` (+ `containers.daytona`), `egress`, `telemetry`, `updates`, `marketplace`, `github`, `jobs`, `logCompaction`, `chat`.

**Two keys are rejected by name**, each with its own message rather than a generic "unrecognized key":

- **`masterKey`** - it must never be written to disk. `HEZO_MASTER_KEY` remains the way to unlock a single non-interactive startup: an env var rather than a flag, because a twelve-word phrase in argv is visible in the process list.
- **`reset`** - it renames the embedded `pgdata` aside, a one-off action. In a persistent file it would wipe the database on **every** restart.

Env vars that stay: test seams (`HEZO_SKIP_DOCKER`, `HEZO_TEST_*`, `HEZO_E2E_*`), dev directory overrides (`HEZO_AGENTS_DIR` and friends), container-injected run plumbing (`HEZO_AGENT_TOKEN`, `HEZO_SECRET_*`, …), process topology (`HEZO_WORKER`, `HEZO_VERSION`), third-party standards (`DOCKER_HOST`, `PGSSLMODE`, `CI`), and the `deploy/` provisioning script's own inputs (`HEZO_SWAP_SIZE`, `HEZO_DOMAIN_OVERRIDE`, …), which configure the installer rather than the binary.

## How it works

**Loading.** `createRequire` in `config/load.ts` builds the resolver at runtime, so `bun build --compile` never sees a specifier it might resolve statically and inline into the binary. This was verified against a real compiled binary before the rest was written - a bare `require(path)` or `import(path)` would be a bundler input.

**Validation.** A `.strict()` zod schema whose shape is a deep-`Partial` of `HezoConfig`, so the file, the type and the docs cannot drift. Strictness is the point: a silently-ignored `dataDIr` is the specific failure mode a config file introduces over flags. Errors list every problem at once and exit 1 cleanly, without a stack trace.

**Reaching it.** `index.ts` publishes the resolved config with `setRuntimeConfig()`; everything else reads it back through `runtimeConfig()`. The accessor is necessary because `index.ts` imports `./app` - and through it every service - *before* it resolves anything, so a module-level `const X = process.env.Y ?? default` would capture the default and silently ignore the operator's file. Where a value was previously interpolated into a module-level string (`nextHeartbeatAtSql`, the hire tools' heartbeat description), that string became a function for the same reason.

**It is real JavaScript**, so the file can compute values at load time. The systemd deploy uses that to read its `webUrl` from a side file `hezo-firstboot` writes, since a `.cjs` object cannot be appended to the way an `EnvironmentFile` line could.

## Two adjacent things this had to answer

- **`GITHUB_OAUTH_CLIENT_ID` becomes `github.oauthClientId`.** Its old production branch was unreachable - nothing sets `NODE_ENV=production` in the build, the systemd unit or Docker - so every instance already used the committed default. That default is now explicit, and a self-hoster can point at their own OAuth app. **Behaviour is unchanged**; setting `NODE_ENV=production` instead would have broken the GitHub connector for every existing self-hoster.
- **The four duplicated subcommand pickers collapse into one resolver**, removing the empty-value inconsistency as a side effect. `backup`, `restore` and `uninstall` all take the same `--config`.

## Verification

- Compiled-binary smoke test: config file drives the port; `--port` overrides it; missing file, `masterKey`, `reset`, an unknown key and multiple type errors each exit 1 with a clean message naming the problem.
- New `config-file.test.ts` (17 tests) covers loading, computed values, every rejection, and `runtimeConfig()` defaulting.
- `cli.test.ts` rewritten: the old "env vars take precedence over CLI args" block is now flag-beats-file, plus coverage of the previously-env-only settings.
- Server tier green except 5 pre-existing failures that need a Docker daemon; each was confirmed to fail identically at the base commit in a clean worktree.
- `bun run typecheck`, `bun run build`, `bunx biome check`, and the docs-links / docs-terminology / docs-bundle guards all pass.

## Migration

Existing deployments must move their settings into a config file and update their systemd unit - `provision.sh` now writes `/etc/hezo/hezo.config.cjs` and drops `EnvironmentFile=`. `HEZO_MASTER_KEY` is unchanged. Full before/after in [`docs/deployment/configuration.md`](https://github.com/hezo-ai/hezo/blob/claude/hezo-config-file-migration-ujqhky/docs/deployment/configuration.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NDrexZoV8zUL7He8TfvAg

---
_Generated by [Claude Code](https://claude.ai/code/session_012NDrexZoV8zUL7He8TfvAg)_