### PR TITLE
fix(runs): stop a cancelled run silently dropping the work it was woken for

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2323,12 +2323,45 @@ moment the row is inserted, so a run whose host-side driver still owns it (waiti
 credential lock or on container capacity, say) is skipped and only a row whose driver has
 vanished is failed. Both of those waits are bounded and finalize themselves, so a driver
 that still owns a row is one that will settle it. The two
-kinds are distinguished only by their recorded `error` (`Never started: …` vs
-`Orphaned: nothing was driving this run any more …`); the retry/approval escalation is
-shared. Neither verdict claims a process check - there is none to make, since a run's work
+kinds are distinguished by their recorded `error` (`Never started: …` vs
+`Orphaned: nothing was driving this run any more …`) and, for the never-started arm, by
+`heartbeat_runs.cancel_reason`. That column is the structural half: `cancelled` covers both
+somebody choosing to stop a run (`operator_terminated`, `work_withdrawn`) and the instance
+giving up on one (`handed_back`, `abandoned`), and only `abandoned` leaves work owed with
+nothing carrying it. Behaviour hangs off `RUN_CANCEL_BEHAVIOUR` (`@hezo/shared`) rather than
+a status test at each reader, so the Retry button appears on exactly that one case. Deriving
+it from the `error` prose was the alternative, and `requeueContainerKilledRuns` already does
+that (`WHERE error = 'container_error'`) - a control signal built on a sentence, in an area
+whose sentences get reworded.
+
+**The two arms no longer share an escalation ladder.** A never-started run spent no strike,
+so gating it on the process-loss budget was a defect: `retryOrEscalateLostRun` reads
+`process_loss_retry_count` for its ceiling, `createHeartbeatRun` inherits that count down an
+orphan-retry lineage, and the never-started arm never incremented it - an inherited 2 turned
+every later never-start into a permanent dead end that filed one approval (guarded
+`NOT EXISTS` per member) and queued nothing again. `handBackNeverStartedWork` is its own
+bounded ladder: hand the original wakeup back (free, unbounded, the dispatcher owns the
+work), else mint one replacement naming the task (bounded, and it spends the strike it
+reads), else abandon. The replacement carries the **original wakeup's `source`**, because
+`timer` is in `GATED_WAKEUP_SOURCES` and is not exempt from the no-work backoff while
+`mention` is neither - the old fallback silently downgraded a teammate's direct ask into a
+wakeup the dependency gate could park indefinitely. It names its lineage under
+`previous_run_id` rather than `previous_failure.run_id`, since only the latter carries
+`inheritsLossBudget` in `RUN_LINEAGE_SOURCES`. Neither verdict claims a process check - there is none to make, since a run's work
 happens inside a container and liveness is the in-process registry alone. The reap `UPDATE` is
 guarded on a non-terminal status, so a row that settled between the scan and the write keeps
 the cause its own writer recorded rather than being overwritten with the generic one.
+
+**The reap writes twice, and the order is the point.** The first write claims the row and
+records the **verdict** alone - what was observed, true whatever happens next. The work is
+then settled, and a second write appends the **outcome** and `cancel_reason` before the
+broadcast fires, so an open run page receives the final text. Composing both at once is what
+let a row assert "so it was returned to the queue" for a handback that had not been
+attempted yet and could still fail, which made a stranded ask indistinguishable from a
+served one. The sentences live in two `Record` tables in `orphan-detector.ts`, so a new
+outcome is a compile error until someone writes its copy. `abandoned` is additionally the
+only outcome that posts to the thread (`recordRunAbandoned`), because it is the only one a
+reader has to act on.
 `healStaleRunState` is the inverse pass and deliberately counts `queued` as active, so it
 repairs the *surroundings* (execution locks, agent `runtime_status`, claimed wakeups) but
 never the run row itself.
@@ -2360,10 +2393,22 @@ file whenever it likes and the rotated value is read back during teardown - so a
 queues behind a complete run, not behind a token read.
 
 Two properties follow from that, and both were learned the hard way. The wait is **bounded**
-(the same ceiling the capacity park uses) and gives up through the same `finalizeRequeue`,
+and gives up through the same `finalizeRequeue`,
 because an unbounded promise chain had no way for a waiter to leave: a holder that never
 returned parked every later run on that credential permanently, and nothing - not the orphan
 pass, not the run timeout, not an operator Terminate - could recover it short of a restart.
+**Its ceiling is `credentialWaitMaxMs`, not the capacity park's**, though it used to be both.
+The two look alike and are not the same judgement: the park waits for a container slot the
+idle-reclaim cron frees, so it resolves in seconds and giving up early costs nothing, while
+this queues behind a *whole other run* bounded by that run's `run_timeout_min` (60 minutes
+by default). At the park's 180 s a second run on a rotating credential gave up, re-queued,
+redispatched 5 s later and gave up again until the holder finished: a thrash loop that never
+converged. So it is derived from the waiting run's own timeout with headroom (80%, floored
+at the park's ceiling, capped at 30 minutes) - headroom because running to `run_timeout_min`
+itself lets `launchTask`'s wall-clock timer finalize the run `timed_out`, trading one
+errored row for another, which is the same reason the park does not use it raw. FIFO on the
+lock is the correct model; giving up early only randomises who goes next.
+
 And it is taken **before** the pool ladder is asked, because a waiter that already holds a
 container pins memory the pool counts as used and cannot reclaim, for the entire wait. That
 container then sits idle while its own run waits, long enough for a managed backend's idle
@@ -2393,9 +2438,18 @@ a restart mid-park hands every parked row straight to the orphan pass with no dr
 vouch for it - and a restart is exactly when the pool is cold and capacity tightest, so the
 two coincide rather than being independent. That pairing is only tolerable because the
 orphan pass's verdict for a run that never started is itself non-destructive: it finalizes
-the row `Cancelled`, hands the *original* wakeup back to the queue (`claimed` → `queued`,
-mirroring `settleWakeupForRun`) and spends no strike of the lost-run escalation, so the
+the row `Cancelled`, hands the *original* wakeup back to the queue (`claimed` → `queued`)
+and spends no strike of the lost-run escalation, so the
 work is redispatched rather than lost or reported as a failure the operator must act on.
+The handback itself is one seam, `settleWakeupForRun` (`services/wakeup.ts`), shared with
+`JobManager.onAgentComplete`: the two answered the same question separately, which is how
+the sweeper's `claimed` guard ended up missing from the completion path and how both ended
+up stamping `instance_at_capacity` on handbacks that had nothing to do with capacity. The
+seam reports `handback_failed` rather than a bare boolean, so neither caller can assume work
+is queued when it is not. A never-started handback is stamped `run_never_started` and the
+credential give-up `credential_busy`; `BUSY_PROJECTS_SQL` excludes only the two *capacity*
+reasons from its busy set, so a mislabelled handback had the idle pass reclaim the container
+out from under work that was about to run.
 The `running` arm is unchanged and still `Failed` - a process that vanished mid-flight did
 lose work. `capacity-park-grace` in `orphan-detector.test.ts` pins the constant
 relationship so neither can be moved without meeting the assumption. The run's `error`

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2341,13 +2341,22 @@ orphan-retry lineage, and the never-started arm never incremented it - an inheri
 every later never-start into a permanent dead end that filed one approval (guarded
 `NOT EXISTS` per member) and queued nothing again. `handBackNeverStartedWork` is its own
 bounded ladder: hand the original wakeup back (free, unbounded, the dispatcher owns the
-work), else mint one replacement naming the task (bounded, and it spends the strike it
-reads), else abandon. The replacement carries the **original wakeup's `source`**, because
-`timer` is in `GATED_WAKEUP_SOURCES` and is not exempt from the no-work backoff while
-`mention` is neither - the old fallback silently downgraded a teammate's direct ask into a
-wakeup the dependency gate could park indefinitely. It names its lineage under
-`previous_run_id` rather than `previous_failure.run_id`, since only the latter carries
-`inheritsLossBudget` in `RUN_LINEAGE_SOURCES`. Neither verdict claims a process check - there is none to make, since a run's work
+work), else mint one replacement naming the task, else abandon. The replacement carries the
+**original wakeup's `source`**, because `timer` is in `GATED_WAKEUP_SOURCES` and is not
+exempt from the no-work backoff while `mention` is neither - the old fallback silently
+downgraded a teammate's direct ask into a wakeup the dependency gate could park
+indefinitely.
+
+**The second rung's bound only exists because two halves travel together**: it increments
+`process_loss_retry_count` *and* names its lineage under `previous_failure.run_id`, the one
+key `RUN_LINEAGE_SOURCES` gives `inheritsLossBudget`. An earlier revision spent the strike
+but named `previous_run_id`, which does not inherit - so `createHeartbeatRun` handed every
+replacement a count of zero, the increment landed on a terminal row nothing reads again, and
+the ceiling was unreachable through its own lineage however many times it lapped. A test
+that hand-sets the counter cannot see that; `the never-started chain actually climbs, lap by
+lap` drives real laps and asserts the count reaching the ceiling. The first rung stays
+unbounded by design - the wakeup is intact and the dispatcher owns it - which is what `main`
+did too. Neither verdict claims a process check - there is none to make, since a run's work
 happens inside a container and liveness is the in-process registry alone. The reap `UPDATE` is
 guarded on a non-terminal status, so a row that settled between the scan and the write keeps
 the cause its own writer recorded rather than being overwritten with the generic one.
@@ -2377,7 +2386,7 @@ deadline would finalize the run `timed_out`, trading one errored row for another
 while that call is in flight, so the orphan pass leaves the row alone for exactly as long as
 a driver owns it, and the run resumes on the same row rather than being replaced by a second
 one. Returning instead left the row unowned — blocking the retry of its own wakeup through
-`isTaskBusyInDb`, then failing 120 s later as `Orphaned: run never started`, and counting
+`isTaskBusyInDb`, then being reaped 120 s later as a run that never started, and counting
 toward the lost-run escalation. Past the ceiling the row is finalized `Cancelled` (never
 `Failed` — a full instance is not the agent failing) and the wakeup is re-queued. Two
 consequences elsewhere: the idle-stop scan's busy set excludes a parked run
@@ -2403,10 +2412,15 @@ idle-reclaim cron frees, so it resolves in seconds and giving up early costs not
 this queues behind a *whole other run* bounded by that run's `run_timeout_min` (60 minutes
 by default). At the park's 180 s a second run on a rotating credential gave up, re-queued,
 redispatched 5 s later and gave up again until the holder finished: a thrash loop that never
-converged. So it is derived from the waiting run's own timeout with headroom (80%, floored
-at the park's ceiling, capped at 30 minutes) - headroom because running to `run_timeout_min`
-itself lets `launchTask`'s wall-clock timer finalize the run `timed_out`, trading one
-errored row for another, which is the same reason the park does not use it raw. FIFO on the
+converged. So it is derived from the waiting run's own timeout with headroom (80%, capped
+at 15 minutes) - headroom because running to `run_timeout_min` itself lets `launchTask`'s
+wall-clock timer finalize the run `timed_out`, trading one errored row for another, which is
+the same reason the park does not use it raw. **Deliberately unfloored**: an earlier revision
+floored it at the park's 180 s, which inverted that invariant for any `run_timeout_min` of 3
+or less (settable to 1), where a 180 s wait outlives a 60 s timer. And the cap is not
+cosmetic - a dispatch with no spare container takes a `pendingContainerStarts` reservation
+*before* `launchTask` and holds it until the run settles, so every minute of this wait is a
+minute of instance memory budget charged for a container that has not been asked for. FIFO on the
 lock is the correct model; giving up early only randomises who goes next.
 
 And it is taken **before** the pool ladder is asked, because a waiter that already holds a
@@ -2445,8 +2459,15 @@ The handback itself is one seam, `settleWakeupForRun` (`services/wakeup.ts`), sh
 `JobManager.onAgentComplete`: the two answered the same question separately, which is how
 the sweeper's `claimed` guard ended up missing from the completion path and how both ended
 up stamping `instance_at_capacity` on handbacks that had nothing to do with capacity. The
-seam reports `handback_failed` rather than a bare boolean, so neither caller can assume work
-is queued when it is not. A never-started handback is stamped `run_never_started` and the
+seam reports `handback_failed` rather than a bare boolean, and **both callers act on it**:
+each records the outcome on the run row through `recordHandbackOutcome`
+(`services/run-handback.ts`) only once the answer is in, mapping a failed handback to
+`abandoned` plus a thread notice. An earlier revision fixed this on the sweeper alone and
+left `finalizeRequeue` stamping `handed_back` before attempting the handback - reproducing,
+on the completion path, the very defect the sweeper was restructured to remove. That
+recorder is also where first-writer-wins lives: it declines to write over a `cancel_reason`
+somebody else already set, so a human's Terminate is never relabelled as something the
+instance did. A never-started handback is stamped `run_never_started` and the
 credential give-up `credential_busy`; `BUSY_PROJECTS_SQL` excludes only the two *capacity*
 reasons from its busy set, so a mislabelled handback had the idle pass reclaim the container
 out from under work that was about to run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,8 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | "May an uncredentialed hosted MCP reach a run?" | `probed_at IS NOT NULL AND probe_error IS NULL`, written only by `discoverConnectorMethods` (`services/connectors/method-discovery.ts`) and read through `SAAS_CREDENTIALED_SQL` (`services/connectors/connections.ts`) |
 | "Is this run failure worth another attempt?" | `classifyRunFailure` (`services/run-failure-classification.ts`) - unrecognised is permanent, and no row may name a backend |
 | Waking the assignee after an assignment write | `wakeAgentIfAssigned` (`services/wakeup.ts`) |
+| What happens to the work a finished run was woken for | `settleWakeupForRun` (`services/wakeup.ts`) - it reports `handback_failed`, so no caller may assume the work is queued |
+| "Is this cancelled run still owed, and can a human act on it?" | `heartbeat_runs.cancel_reason` read through `RUN_CANCEL_BEHAVIOUR` (`@hezo/shared`) - never the `error` prose |
 | "May this caller move this task's assignee?" | `assertNoBlockingRun` (`lib/reassign-guard.ts`) - not the one-run-per-task check, which is `isTaskBusyInDb` (`services/run-concurrency.ts`) |
 | Serialising async work per key, with or without a bound | `lib/keyed-lock.ts` - `withKeyedLock` for a scope, `acquireKeyedLock` when the wait needs a `signal`/`timeoutMs`. Each family owns its own `KeyedLockRegistry`; never a second mutex |
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -99,11 +99,21 @@ and opening a run and coming back returns you to the view you were in.
 A run waiting its turn shows as queued, not as an error - it keeps its place and starts as
 soon as whatever it is waiting for is free. There are two such waits: for a container to
 free up, and for another run to finish with the same AI provider credential, which some
-subscriptions can only lend to one run at a time. Either way, if the wait outlasts its
-patience the run is recorded as cancelled and the work goes back on the queue to be picked
-up again; that is not a failure, and it is why cancelled runs are their own thing rather
-than errors. Hover the queued run's info icon to see which wait it is in. See
+subscriptions can only lend to one run at a time. The credential wait is the longer of the
+two, because it queues behind a whole other run rather than behind a container being
+reclaimed. Either way, if the wait outlasts its patience the run is recorded as cancelled
+and the work goes back on the queue to be picked up again; that is not a failure, and it is
+why cancelled runs are their own thing rather than errors. Hover the queued run's info icon
+to see which wait it is in. See
 [how much can run at once](/docs/containers/overview#how-much-can-run-at-once).
+
+Cancelled covers one more case, and it is the only one that asks anything of you. If a run
+is queued but never begins - Hezo lost track of it before the agent launched - the work is
+put back on the queue and runs again on its own. Should that keep happening, Hezo stops
+retrying, says so on the run, posts a note in the task, and raises an item in your Inbox.
+That run carries a **Retry** button, which is the only cancelled run that does: a run you
+stopped yourself, or one whose work is already back on the queue, has nothing left to
+press.
 
 ## Per-agent model override
 

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -110,10 +110,11 @@ to see which wait it is in. See
 Cancelled covers one more case, and it is the only one that asks anything of you. If a run
 is queued but never begins - Hezo lost track of it before the agent launched - the work is
 put back on the queue and runs again on its own. Should that keep happening, Hezo stops
-retrying, says so on the run, posts a note in the task, and raises an item in your Inbox.
-That run carries a **Retry** button, which is the only cancelled run that does: a run you
-stopped yourself, or one whose work is already back on the queue, has nothing left to
-press.
+after three attempts, says so on the run, posts a note in the task, and raises an item in
+your Inbox. That run carries a **Retry** button, which is the only cancelled run that does:
+a run you stopped yourself, or one whose work is already back on the queue, has nothing
+left to press. A run like that is not counted as an error, so it does not raise the task's
+error marker; the note in the task and the Inbox item are how you find it.
 
 ## Per-agent model override
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -59,7 +59,8 @@ the **View** control at the top of a task's right-hand panel.
 
 **Conversation** is the default. It shows what people and agents wrote, plus anything
 waiting on someone: a credential request, an approval, a repo-setup choice, and the latest
-failed run with its Retry button. Everything else folds into grouped chips that sit where
+run that still needs a person - one that failed or timed out, or one Hezo gave up on
+starting - with its Retry button. Everything else folds into grouped chips that sit where
 those events happened, labelled with what is inside them - "8 events - 4 failed runs - 4
 changes". Click one to read the rows it holds. An agent working right now gets its own row
 at the foot of the thread, which opens onto its live output.

--- a/packages/server/migrations/066_run_cancel_reason.sql
+++ b/packages/server/migrations/066_run_cancel_reason.sql
@@ -1,0 +1,39 @@
+-------------------------------------------------------------------------------
+-- Why a run was cancelled
+-------------------------------------------------------------------------------
+--
+-- `cancelled` means four different things and the row said which only in prose.
+-- Two of them are a person deciding to stop: an operator pressing Terminate, or
+-- a task being cancelled or re-opened so its pending work is moot. The other two
+-- are the instance giving up on its own: the capacity park and the credential
+-- wait handing their work back, and the orphan sweep reaping a run whose driver
+-- vanished before the agent launched. Only the last of those can leave work owed
+-- with nothing carrying it, and only that one needs a human.
+--
+-- Readers had nowhere to ask. The web offers Retry on `failed`/`timed_out`
+-- alone, so a run the instance abandoned showed a reader a dead row with no
+-- affordance, while an operator's own Terminate would have sprouted one if the
+-- status test were simply widened. Deriving the difference from `error` was the
+-- alternative, and `requeueContainerKilledRuns` already selects on
+-- `error = 'container_error'` - a control signal built on prose, in a change
+-- that rewords run error prose. One column ends both problems.
+--
+-- TEXT rather than a PG enum, matching its two neighbours on this table,
+-- `queued_reason` and `no_work_reason`. The value set lives in `@hezo/shared`
+-- (`RunCancelReason`), read through a guard so a value written by a newer server
+-- degrades to "no Retry" on an older client rather than crashing it, and behaviour
+-- hangs off `RUN_CANCEL_BEHAVIOUR` so a new reason is one row rather than a case
+-- at four call sites. TEXT also avoids `ALTER TYPE ... ADD VALUE`, which cannot
+-- have its new value used in the same transaction a migration runs in.
+--
+-- Nullable with no backfill, and NULL is the honest value rather than a gap -
+-- the same reasoning 065 records for `created_by_run_id`. The attribution did
+-- not exist before, so no existing row has one, and no SQL can recover which of
+-- the four a historical cancel was. NULL stays correct for every run that was
+-- not cancelled at all, which is the overwhelming majority.
+--
+-- No index. The column is projected onto a run the reader already named; nothing
+-- filters or sorts on it, so an index would cost writes and serve no query.
+
+ALTER TABLE heartbeat_runs
+    ADD COLUMN IF NOT EXISTS cancel_reason TEXT;

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -129,7 +129,7 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id, hr.kind,
 	-- created_at, not just started_at: a run that ended before it ever started has
 	-- no started_at, and created_at is the only clock it has to be placed by.
-	hr.status, hr.queued_reason, hr.created_at, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
+	hr.status, hr.queued_reason, hr.cancel_reason, hr.created_at, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
 	hr.input_tokens, hr.output_tokens, hr.cost_cents, hr.usage_partial,
 	hr.invocation_command, hr.working_dir,
 	hr.retry_of_run_id, hr.process_loss_retry_count,

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -328,6 +328,9 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
               'queued_reason', ar.queued_reason
             ) ELSE NULL END AS active_run,
             lr.status AS last_run_status,
+            -- The thread folds a finished run open when there is something to act
+            -- on, which for a cancelled run depends on why it was cancelled.
+            lr.cancel_reason AS last_run_cancel_reason,
             left(lr.error, ${LAST_RUN_ERROR_MAX_CHARS}) AS last_run_error,
             lr.run_id AS last_run_id,
             lr.comment_id AS last_run_comment_id,
@@ -361,7 +364,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        LIMIT 1
      ) qw ON true
      LEFT JOIN LATERAL (
-       SELECT hr.id AS run_id, hr.status, hr.error, hrc.id AS comment_id,
+       SELECT hr.id AS run_id, hr.status, hr.error, hr.cancel_reason, hrc.id AS comment_id,
               hrc.public_id AS comment_public_id
        FROM heartbeat_runs hr
        LEFT JOIN task_comments hrc

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -35,10 +35,12 @@ import {
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 	RUNTIME_SYSTEM_PROMPT_FILE,
+	RunCancelReason,
 	repoNameFromIdentifier,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
 	type ThreadRowCategory,
+	WakeupSkipReason,
 	WakeupSource,
 	WsMessageType,
 	wsRoom,
@@ -239,11 +241,15 @@ export interface RunResult {
 	/** The run ended by hitting its wall-clock time limit; drives an automatic same-task continuation. */
 	timedOut?: boolean;
 	/**
-	 * The run never started because the instance was at its container-memory
-	 * budget. Not a failure: the wakeup is re-queued and dispatched again, and no
-	 * failure ping is posted.
+	 * The run never started because the instance was busy, and handed its work
+	 * back. Not a failure: the wakeup is re-queued and dispatched again, and no
+	 * failure ping is posted. Two waits reach it - the container-memory budget and
+	 * the rotating provider credential - so the cause travels beside it rather
+	 * than being assumed.
 	 */
 	requeued?: boolean;
+	/** Which wait gave up, so the queued wakeup reports the real reason it is waiting. */
+	requeueReason?: WakeupSkipReason;
 }
 
 export interface RunnerDeps {
@@ -1210,6 +1216,38 @@ const PREFLIGHT_BEARER_TOKEN = 'preflight.dry.run';
 export const CAPACITY_PARK_MAX_MS = 3 * 60_000;
 
 /**
+ * How long a run waits for the rotating provider credential before handing its
+ * work back.
+ *
+ * **Deliberately not {@link CAPACITY_PARK_MAX_MS}, which it used to share.** The
+ * two waits look alike and are not the same judgement. The capacity park waits
+ * for a container slot the idle-reclaim cron frees, so it resolves in seconds
+ * and giving up early costs nothing. This lock is held for a *whole other run*
+ * (the CLI rewrites the token file whenever it likes and the rotated value is
+ * read back during teardown), so what is being waited on is bounded by that
+ * run's `run_timeout_min` - 60 minutes by default. At a 3 minute ceiling a
+ * second run on a rotating credential gave up, re-queued, redispatched 5s later
+ * and gave up again, over and over, until the holder finished: a thrash loop
+ * that never converged and filled the run list on the way. Queueing on the lock
+ * is FIFO and correct; giving up early only randomises who goes next.
+ *
+ * Derived from the waiting run's own timeout rather than fixed, with headroom,
+ * because waiting past that deadline lets `launchTask`'s wall-clock timer abort
+ * the run as `timed_out` - trading one errored row for another, which is the
+ * same reason the capacity park does not use `run_timeout_min` raw. Floored at
+ * the capacity park's ceiling so an unusually short agent timeout cannot regress
+ * the wait below what it already tolerated, and capped so a mis-configured
+ * multi-hour timeout cannot park a run for that long.
+ */
+const CREDENTIAL_WAIT_MAX_FRACTION = 0.8;
+const CREDENTIAL_WAIT_CAP_MS = 30 * 60_000;
+
+export function credentialWaitMaxMs(runTimeoutMin: number | null | undefined): number {
+	const budget = (runTimeoutMin ?? 0) * 60_000 * CREDENTIAL_WAIT_MAX_FRACTION;
+	return Math.min(Math.max(budget, CAPACITY_PARK_MAX_MS), CREDENTIAL_WAIT_CAP_MS);
+}
+
+/**
  * Sleep that returns early when the run is aborted, so a cancel or a shutdown
  * during a capacity park is not held for the rest of the poll interval.
  */
@@ -1685,7 +1723,10 @@ export async function runAgent(
 	 * lost-run escalation. A terminal row does none of that, so the requeued
 	 * wakeup is free to dispatch on the next tick.
 	 */
-	const finalizeRequeue = async (reason: string): Promise<RunResult> => {
+	const finalizeRequeue = async (
+		reason: string,
+		requeueReason: WakeupSkipReason,
+	): Promise<RunResult> => {
 		releaseCredentialLock?.();
 		const message = `${reason} - returning this run to the queue.`;
 		emit('stdout', `[runner] ${message}\n`);
@@ -1699,6 +1740,10 @@ export async function runAgent(
 				exitCode: -1,
 				durationMs,
 				error: message,
+				// Not a cancel anyone has to act on: the caller re-queues the wakeup,
+				// so the work is already carried. Recorded anyway so a reader can tell
+				// this apart from a Terminate without parsing the message.
+				cancelReason: RunCancelReason.HandedBack,
 			},
 			runBroadcast,
 		);
@@ -1709,6 +1754,7 @@ export async function runAgent(
 			durationMs,
 			heartbeatRunId,
 			requeued: true,
+			requeueReason,
 		};
 	};
 
@@ -1738,19 +1784,31 @@ export async function runAgent(
 			 WHERE id = $2 AND status = $3::heartbeat_run_status`,
 			[QueuedRunReason.CredentialSerialized, heartbeatRunId, HeartbeatRunStatus.Queued],
 		);
+		// Read here rather than carried on `AgentInfo`: only a rotating credential
+		// reaches this block, so the extra round trip is on the slow path alone and
+		// every other caller of `runAgent` is left unchanged.
+		const timeoutRow = await deps.db.query<{ run_timeout_min: number }>(
+			'SELECT run_timeout_min FROM member_agents WHERE id = $1',
+			[agent.id],
+		);
 		try {
 			releaseCredentialLock = await acquireCredentialLock(credential.configId, {
 				signal: runAbort.signal,
-				// The same bound the capacity park gets, because it is the same
-				// judgement: the instance is busy, so come back rather than wait out a
-				// window the orphan pass has stopped believing in.
-				timeoutMs: deps.capacityPark?.maxMs ?? CAPACITY_PARK_MAX_MS,
+				// See {@link credentialWaitMaxMs}: this waits on a whole other run, not
+				// on the idle-reclaim cron, so it does not share the capacity park's
+				// ceiling. `deps.capacityPark?.maxMs` still overrides it, which is what
+				// lets a test drive either wait to its deadline quickly.
+				timeoutMs:
+					deps.capacityPark?.maxMs ?? credentialWaitMaxMs(timeoutRow.rows[0]?.run_timeout_min),
 				owner: runLabel,
 			});
 		} catch (e) {
 			if (runAbort.signal.aborted) return finalizeAbort();
 			if (e instanceof KeyedLockTimeoutError) {
-				return finalizeRequeue('Another run still holds this provider credential');
+				return finalizeRequeue(
+					'Another run still holds this provider credential',
+					WakeupSkipReason.CredentialBusy,
+				);
 			}
 			// Finalized rather than rethrown: nothing above this catches, and a
 			// throw here would leave the row `queued` with no driver - which is the
@@ -1820,7 +1878,9 @@ export async function runAgent(
 				);
 			} catch (e) {
 				if (!(e instanceof PoolCapacityError)) throw e;
-				if (Date.now() >= parkDeadline) return finalizeRequeue(e.message);
+				if (Date.now() >= parkDeadline) {
+					return finalizeRequeue(e.message, WakeupSkipReason.InstanceAtCapacity);
+				}
 				if (!parked) {
 					// Once, not per poll: a line every 5s would make the run log the
 					// new noise, and the wait itself is already on the row as
@@ -4606,6 +4666,8 @@ async function updateHeartbeatRun(
 		exitCode: number;
 		durationMs: number;
 		error?: string;
+		/** Why a `cancelled` run was cancelled. Ignored for every other status. */
+		cancelReason?: RunCancelReason;
 		usage?: AgentRunUsage | null;
 		/**
 		 * Whether the persisted usage is a mid-run snapshot. `false` on a clean
@@ -4633,7 +4695,8 @@ async function updateHeartbeatRun(
 		     input_tokens = COALESCE($4, input_tokens),
 		     output_tokens = COALESCE($5, output_tokens),
 		     cost_cents = COALESCE($6, cost_cents),
-		     usage_partial = COALESCE($7, usage_partial)
+		     usage_partial = COALESCE($7, usage_partial),
+		     cancel_reason = COALESCE($11, cancel_reason)
 		 WHERE id = $8
 		   AND status IN ($9::heartbeat_run_status, $10::heartbeat_run_status)
 		 RETURNING id`,
@@ -4648,6 +4711,7 @@ async function updateHeartbeatRun(
 			runId,
 			HeartbeatRunStatus.Queued,
 			HeartbeatRunStatus.Running,
+			update.cancelReason ?? null,
 		],
 	);
 	if (applied.rows.length > 0) {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -35,7 +35,7 @@ import {
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 	RUNTIME_SYSTEM_PROMPT_FILE,
-	RunCancelReason,
+	type RunCancelReason,
 	repoNameFromIdentifier,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
@@ -1234,17 +1234,30 @@ export const CAPACITY_PARK_MAX_MS = 3 * 60_000;
  * Derived from the waiting run's own timeout rather than fixed, with headroom,
  * because waiting past that deadline lets `launchTask`'s wall-clock timer abort
  * the run as `timed_out` - trading one errored row for another, which is the
- * same reason the capacity park does not use `run_timeout_min` raw. Floored at
- * the capacity park's ceiling so an unusually short agent timeout cannot regress
- * the wait below what it already tolerated, and capped so a mis-configured
- * multi-hour timeout cannot park a run for that long.
+ * same reason the capacity park does not use `run_timeout_min` raw.
+ *
+ * **Deliberately unfloored.** An earlier revision floored this at the capacity
+ * park's ceiling so a short agent timeout could not regress the wait; that
+ * inverted the invariant above for any `run_timeout_min` of 3 or less (settable
+ * to 1 in the UI), where a 180 s wait outlives a 60 s wall-clock timer and the
+ * run is finalized `timed_out` instead of handing back. The fraction alone keeps
+ * the wait inside the run's own budget at every setting.
+ *
+ * The cap bounds a cost the wait carries that is easy to miss: a dispatch with
+ * no spare container takes a `pendingContainerStarts` reservation *before*
+ * `launchTask`, and it is charged against the instance memory budget until the
+ * run settles. So a waiter reserves a container's worth of headroom for a
+ * container it has not asked for yet, and every minute of this wait is a minute
+ * another project can be told the instance is at capacity. 15 minutes covers the
+ * "a run takes several minutes" case this exists for while keeping that
+ * reservation bounded.
  */
 const CREDENTIAL_WAIT_MAX_FRACTION = 0.8;
-const CREDENTIAL_WAIT_CAP_MS = 30 * 60_000;
+const CREDENTIAL_WAIT_CAP_MS = 15 * 60_000;
 
 export function credentialWaitMaxMs(runTimeoutMin: number | null | undefined): number {
 	const budget = (runTimeoutMin ?? 0) * 60_000 * CREDENTIAL_WAIT_MAX_FRACTION;
-	return Math.min(Math.max(budget, CAPACITY_PARK_MAX_MS), CREDENTIAL_WAIT_CAP_MS);
+	return Math.min(budget, CREDENTIAL_WAIT_CAP_MS);
 }
 
 /**
@@ -1740,10 +1753,13 @@ export async function runAgent(
 				exitCode: -1,
 				durationMs,
 				error: message,
-				// Not a cancel anyone has to act on: the caller re-queues the wakeup,
-				// so the work is already carried. Recorded anyway so a reader can tell
-				// this apart from a Terminate without parsing the message.
-				cancelReason: RunCancelReason.HandedBack,
+				// Deliberately NOT stamping `cancel_reason` here. Whether the work is
+				// actually carried is not known until the caller settles the wakeup,
+				// and the guard there can bite. Writing `handed_back` at this point
+				// asserted an outcome before attempting it - the same defect the orphan
+				// sweeper was restructured to avoid - and left it standing when the
+				// handback failed. `JobManager.settleWakeupForRun` records it once the
+				// answer is in, through the recorder the sweeper shares.
 			},
 			runBroadcast,
 		);
@@ -4696,7 +4712,13 @@ async function updateHeartbeatRun(
 		     output_tokens = COALESCE($5, output_tokens),
 		     cost_cents = COALESCE($6, cost_cents),
 		     usage_partial = COALESCE($7, usage_partial),
-		     cancel_reason = COALESCE($11, cancel_reason)
+		     -- First writer wins, the opposite direction to the columns above. A
+		     -- cancel attribution says WHO stopped the run, and the first writer to
+		     -- reach the row is the one that knows: terminateHeartbeatRun backfills
+		     -- operator_terminated while the abort is still cascading, and the
+		     -- runner's own finalizer would otherwise overwrite it moments later
+		     -- with its own less specific verdict.
+		     cancel_reason = COALESCE(cancel_reason, $11)
 		 WHERE id = $8
 		   AND status IN ($9::heartbeat_run_status, $10::heartbeat_run_status)
 		 RETURNING id`,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -35,7 +35,6 @@ import {
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 	RUNTIME_SYSTEM_PROMPT_FILE,
-	type RunCancelReason,
 	repoNameFromIdentifier,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
@@ -4682,8 +4681,6 @@ async function updateHeartbeatRun(
 		exitCode: number;
 		durationMs: number;
 		error?: string;
-		/** Why a `cancelled` run was cancelled. Ignored for every other status. */
-		cancelReason?: RunCancelReason;
 		usage?: AgentRunUsage | null;
 		/**
 		 * Whether the persisted usage is a mid-run snapshot. `false` on a clean
@@ -4711,14 +4708,14 @@ async function updateHeartbeatRun(
 		     input_tokens = COALESCE($4, input_tokens),
 		     output_tokens = COALESCE($5, output_tokens),
 		     cost_cents = COALESCE($6, cost_cents),
-		     usage_partial = COALESCE($7, usage_partial),
-		     -- First writer wins, the opposite direction to the columns above. A
-		     -- cancel attribution says WHO stopped the run, and the first writer to
-		     -- reach the row is the one that knows: terminateHeartbeatRun backfills
-		     -- operator_terminated while the abort is still cascading, and the
-		     -- runner's own finalizer would otherwise overwrite it moments later
-		     -- with its own less specific verdict.
-		     cancel_reason = COALESCE(cancel_reason, $11)
+		     usage_partial = COALESCE($7, usage_partial)
+		     -- cancel_reason is deliberately absent from this SET list. A cancel
+		     -- attribution says WHO stopped the run, and this finalizer is never that
+		     -- party: terminateHeartbeatRun backfills operator_terminated while the
+		     -- abort is still cascading, and the orphan sweeper records its own
+		     -- through recordHandbackOutcome. Leaving the column out entirely is what
+		     -- makes their writes survive, rather than a COALESCE direction a later
+		     -- simplification could quietly reverse.
 		 WHERE id = $8
 		   AND status IN ($9::heartbeat_run_status, $10::heartbeat_run_status)
 		 RETURNING id`,
@@ -4733,7 +4730,6 @@ async function updateHeartbeatRun(
 			runId,
 			HeartbeatRunStatus.Queued,
 			HeartbeatRunStatus.Running,
-			update.cancelReason ?? null,
 		],
 	);
 	if (applied.rows.length > 0) {

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -1850,6 +1850,11 @@ const BUSY_PROJECTS_SQL = `
 	 JOIN tasks t ON t.id = hr.task_id
 	 WHERE hr.finished_at > now() - ($1 * interval '1 minute')
 	UNION
+	-- The exclusion list is capacity-only **by design**, and a new WakeupSkipReason
+	-- does not belong on it by reflex. Every other reason names work that is ready
+	-- to dispatch and therefore wants its container kept warm; only a wakeup
+	-- waiting on the very reclaim this scan feeds must be left out, or it
+	-- deadlocks. 'credential_busy' and 'run_never_started' are deliberately absent.
 	SELECT DISTINCT t.project_id FROM agent_wakeup_requests w
 	 JOIN tasks t ON t.id = (w.payload->>'task_id')::uuid
 	 WHERE w.status = 'queued'

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -89,6 +89,7 @@ import {
 	reclaimableForOthers,
 	sumProjectContainerMemoryGb,
 } from './run-concurrency';
+import { recordHandbackOutcome } from './run-handback';
 import { reclaimBusyPoolMembers } from './sandbox/pool-db';
 import type { SshAgentServer } from './ssh-agent';
 import { reportTelemetry } from './telemetry';
@@ -2733,7 +2734,15 @@ export class JobManager {
 			this.deps.wsManager,
 		);
 
-		if (await this.settleWakeupForRun(wakeupId, result)) return;
+		if (
+			await this.settleWakeupForRun(wakeupId, result, {
+				taskId,
+				teamId,
+				agentSlug,
+			})
+		) {
+			return;
+		}
 
 		// A run cut off by its wall-clock time limit is not a failure. Queue a same-task
 		// continuation so the agent resumes it (committed work is already pushed) and skip the
@@ -3079,7 +3088,9 @@ export class JobManager {
 			result.heartbeatRunId,
 			this.deps.wsManager,
 		);
-		await this.settleWakeupForRun(wakeupId, result);
+		// No task and no roster slug to name: a progress-update run's handback is
+		// recorded on its own row, and the abandoned notice has no thread to land in.
+		await this.settleWakeupForRun(wakeupId, result, { taskId: null, teamId, agentSlug: null });
 	}
 
 	/**
@@ -3101,7 +3112,14 @@ export class JobManager {
 	 */
 	private async settleWakeupForRun(
 		wakeupId: string | undefined,
-		result: { success: boolean; requeued?: boolean; requeueReason?: WakeupSkipReason },
+		result: {
+			success: boolean;
+			requeued?: boolean;
+			requeueReason?: WakeupSkipReason;
+			heartbeatRunId?: string;
+		},
+		/** Where to record the outcome. Omitted only where there is no run row to write. */
+		run?: { taskId: string | null; teamId: string; agentSlug: string | null },
 	): Promise<boolean> {
 		const intent: SettlementIntent = result.requeued
 			? // The runner names the wait it gave up on; capacity is only the default
@@ -3111,16 +3129,36 @@ export class JobManager {
 				? { kind: 'complete' }
 				: { kind: 'fail' };
 		const settled = await settleWakeupForRun(this.deps.db, wakeupId, intent);
-		if (settled.kind === 'handback_failed') {
-			// Another path settled the row first, so the work is not on the queue and
-			// this caller must not behave as though it were. Falling through to the
-			// failure path is the honest outcome: the run produced nothing and nothing
-			// is carrying its work.
-			log.warn(
-				`Wakeup ${wakeupId} could not be handed back (already settled) - reporting the run as failed instead`,
+
+		// A handback's run row may not assert an outcome until there is one. The
+		// runner finalized it `Cancelled` saying it was returning to the queue; only
+		// here is it known whether that happened, so only here is it recorded -
+		// through the same recorder the orphan sweeper uses, so the two cannot say
+		// different things about the same event.
+		if (intent.kind === 'handback' && result.heartbeatRunId && run) {
+			const requeued = settled.kind === 'requeued';
+			if (!requeued) {
+				log.warn(
+					`Wakeup ${wakeupId} could not be handed back (already settled) - run ${result.heartbeatRunId} is abandoned and needs a human`,
+				);
+			}
+			await recordHandbackOutcome(
+				this.deps.db,
+				{
+					runId: result.heartbeatRunId,
+					taskId: run.taskId,
+					teamId: run.teamId,
+					agentSlug: run.agentSlug,
+					terminalStatus: HeartbeatRunStatus.Cancelled,
+				},
+				requeued ? 'requeued' : 'abandoned',
+				undefined,
+				this.deps.wsManager,
 			);
-			return false;
 		}
+
+		// `false` on a failed handback so the caller stops treating this as a
+		// scheduling race: nothing is carrying the work, and the row now says so.
 		return settled.kind === 'requeued';
 	}
 

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -98,6 +98,8 @@ import {
 	assignmentWakeupAlreadyServed,
 	createProgressUpdateWakeup,
 	createWakeup,
+	type SettlementIntent,
+	settleWakeupForRun,
 } from './wakeup';
 import type { WebSocketManager } from './ws';
 
@@ -3084,37 +3086,42 @@ export class JobManager {
 	 * Settle a wakeup now its run has finished, and say whether the caller should
 	 * stop.
 	 *
-	 * A run that never started because the instance was at its container-memory
-	 * budget is **not** a failure - the dispatcher's own gate tests for exactly
-	 * that state, and a moment later it may not hold. So the wakeup goes back to
-	 * `queued` the same way the dispatcher's transient branch does, and `true`
-	 * stops the caller before the failure ping and the next-task chain, neither of
-	 * which should fire for a scheduling race. Every other outcome is terminal.
+	 * A run that handed its work back - the instance was at its container-memory
+	 * budget, or another run still held the rotating provider credential - is
+	 * **not** a failure. The dispatcher's own gates test for exactly those states,
+	 * and a moment later they may not hold. So the wakeup goes back to `queued`
+	 * and `true` stops the caller before the failure ping and the next-task chain,
+	 * neither of which should fire for a scheduling race. Every other outcome is
+	 * terminal.
+	 *
+	 * A thin mapping over the shared seam (`services/wakeup.ts`): this method owns
+	 * the `RunResult` vocabulary, `settleWakeupForRun` owns the writes. Keeping the
+	 * mapping here is what lets both this path and the orphan sweeper share one
+	 * handback, rather than each maintaining its own.
 	 */
 	private async settleWakeupForRun(
 		wakeupId: string | undefined,
-		result: { success: boolean; requeued?: boolean },
+		result: { success: boolean; requeued?: boolean; requeueReason?: WakeupSkipReason },
 	): Promise<boolean> {
-		const { db } = this.deps;
-		if (result.requeued) {
-			if (wakeupId) {
-				await db.query(
-					`UPDATE agent_wakeup_requests
-					 SET status = $1::wakeup_status, claimed_at = NULL,
-					     last_skipped_at = now(), last_skipped_reason = $2
-					 WHERE id = $3`,
-					[WakeupStatus.Queued, WakeupSkipReason.InstanceAtCapacity, wakeupId],
-				);
-			}
-			return true;
-		}
-		if (wakeupId) {
-			await db.query(
-				`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
-				[result.success ? WakeupStatus.Completed : WakeupStatus.Failed, wakeupId],
+		const intent: SettlementIntent = result.requeued
+			? // The runner names the wait it gave up on; capacity is only the default
+				// for a caller that predates the distinction.
+				{ kind: 'handback', reason: result.requeueReason ?? WakeupSkipReason.InstanceAtCapacity }
+			: result.success
+				? { kind: 'complete' }
+				: { kind: 'fail' };
+		const settled = await settleWakeupForRun(this.deps.db, wakeupId, intent);
+		if (settled.kind === 'handback_failed') {
+			// Another path settled the row first, so the work is not on the queue and
+			// this caller must not behave as though it were. Falling through to the
+			// failure path is the honest outcome: the run produced nothing and nothing
+			// is carrying its work.
+			log.warn(
+				`Wakeup ${wakeupId} could not be handed back (already settled) - reporting the run as failed instead`,
 			);
+			return false;
 		}
-		return false;
+		return settled.kind === 'requeued';
 	}
 
 	/**

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -2,6 +2,7 @@ import {
 	AgentRuntimeStatus,
 	ApprovalType,
 	HeartbeatRunStatus,
+	RunCancelReason,
 	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
@@ -12,7 +13,8 @@ import { readRunLogTail } from '../db/run-log-chunks';
 import { broadcastRowChange } from '../lib/broadcast';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
-import { createWakeup } from './wakeup';
+import { recordRunAbandoned } from './task-events';
+import { createWakeup, settleWakeupForRun } from './wakeup';
 import type { WebSocketManager } from './ws';
 
 const log = logger.child('orphan-detector');
@@ -55,46 +57,64 @@ export interface DetectOrphansOpts {
 const ORPHAN_ERROR_TAIL_CHARS = 400;
 
 /**
- * The run's `error`, carrying the actual cause where the log has one.
+ * What was observed, in the operator's terms. True whatever happens next, which
+ * is the whole point: it is written by the reap `UPDATE` before the work has
+ * been settled, so it may not assert an outcome.
  *
- * The bare verdict on its own ("run never started") named the symptom and left
- * the reason - almost always the instance being at its container-memory budget -
- * sitting in a log the reader had to open separately.
+ * The never-started verdict used to end "so it was returned to the queue" - a
+ * claim composed before the handback was attempted and stamped on the row
+ * whether or not the handback succeeded. Its other half named a "host process",
+ * which is this server, not the container and not the operator's machine.
+ * Neither told a reader anything they could act on.
  */
-function orphanErrorMessage(neverStarted: boolean, logTail: string): string {
-	const verdict = neverStarted
-		? 'Never started: no host process was driving this run, so it was returned to the queue.'
-		: // Says what was observed rather than what was inferred. This pass performs
-			// no process check - it finds a `running` row that no live run in this
-			// process claims - and the old wording ("process no longer running")
-			// asserted one, which read as a fact while being a guess. It was also the
-			// text every setup failure ended up wearing, because those runs threw
-			// without recording anything and this was the only writer left.
-			'Orphaned: nothing was driving this run any more, so no result was ever recorded. ' +
-			'A restart, a crash or a wedged dispatch - not the agent failing.';
+const ORPHAN_VERDICT: Record<OrphanArm, string> = {
+	never_started: 'Never started: this run was queued but never began, so no work was done.',
+	// Says what was observed rather than what was inferred. This pass performs no
+	// process check - it finds a `running` row that no live run in this process
+	// claims - and the old wording ("process no longer running") asserted one,
+	// which read as a fact while being a guess. It was also the text every setup
+	// failure ended up wearing, because those runs threw without recording
+	// anything and this was the only writer left.
+	orphaned:
+		'Orphaned: nothing was driving this run any more, so no result was ever recorded. ' +
+		'A restart, a crash or a wedged dispatch - not the agent failing.',
+};
+
+/**
+ * What happened to the work, written once it is known.
+ *
+ * A table rather than a branch, so a new outcome is a compile error here until
+ * someone writes the sentence for it. Every sentence names a state the reader
+ * can see for themselves: the queue, the Inbox, the Retry button.
+ */
+const ORPHAN_OUTCOME_COPY: Record<HandbackOutcome, string> = {
+	requeued: 'The work is back in the queue and will be picked up automatically.',
+	replaced: 'A fresh run has been queued to pick this work back up.',
+	escalated:
+		'Hezo has stopped retrying this and asked for a human. There is a pending item in your Inbox.',
+	abandoned:
+		'Nothing was left to put back on the queue, so this will not restart on its own. ' +
+		'Use Retry to run it again.',
+};
+
+/** The run's `error`, carrying the outcome and the actual cause where the log has one. */
+function orphanErrorMessage(arm: OrphanArm, outcome: HandbackOutcome, logTail: string): string {
+	const verdict = `${ORPHAN_VERDICT[arm]} ${ORPHAN_OUTCOME_COPY[outcome]}`;
 	const excerpt = logTail.trim().slice(-ORPHAN_ERROR_TAIL_CHARS).trim();
 	return excerpt ? `${verdict}\n\nLast log output:\n${excerpt}` : verdict;
 }
 
+/** Which of the two stranded shapes a reaped row was. */
+type OrphanArm = 'never_started' | 'orphaned';
+
 /**
- * Hand a claimed wakeup back to the queue. Returns whether it was still claimed.
+ * What became of the work a reaped run was carrying.
  *
- * The status guard is load-bearing: another path may have settled this wakeup
- * already, and returning a completed one to the queue dispatches its work a
- * second time. The boolean is how the caller knows whether the work was handed
- * back or still needs a retry raised for it.
+ * `abandoned` is the one outcome that leaves work owed with nothing carrying it,
+ * which is why it is named rather than folded into `escalated`: it is what the
+ * run row, the Retry affordance and the thread notice all key off.
  */
-async function requeueWakeup(db: Db, wakeupId: string): Promise<boolean> {
-	const res = await db.query(
-		`UPDATE agent_wakeup_requests
-		 SET status = $1::wakeup_status, claimed_at = NULL,
-		     last_skipped_at = now(), last_skipped_reason = $2
-		 WHERE id = $3 AND status = $4::wakeup_status
-		 RETURNING id`,
-		[WakeupStatus.Queued, WakeupSkipReason.InstanceAtCapacity, wakeupId, WakeupStatus.Claimed],
-	);
-	return res.rows.length > 0;
-}
+type HandbackOutcome = 'requeued' | 'replaced' | 'escalated' | 'abandoned';
 
 export async function detectOrphans(
 	db: Db,
@@ -122,9 +142,11 @@ export async function detectOrphans(
 		container_id: string | null;
 		process_loss_retry_count: number;
 		status: HeartbeatRunStatus;
+		agent_slug: string | null;
 	}>(
 		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.wakeup_id,
 		        hr.process_loss_retry_count, hr.status,
+		        (SELECT ma.slug FROM member_agents ma WHERE ma.id = hr.member_id) AS agent_slug,
 		        -- The team fallback is load-bearing for the broadcast, not a nicety.
 		        -- A progress-update run carries no task, so the task lookup alone
 		        -- left project_id NULL - and the client skips a heartbeat_runs
@@ -172,28 +194,38 @@ export async function detectOrphans(
 		// nobody could act on, and minted a fresh retry wakeup on every pass rather
 		// than returning the one already sitting there claimed.
 		const neverStarted = run.status === HeartbeatRunStatus.Queued;
+		const arm: OrphanArm = neverStarted ? 'never_started' : 'orphaned';
+		const terminalStatus = neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed;
 
 		// Read once and use twice - the message below and, on the failure arm, the
 		// retry wakeup's excerpt. This runs on a 30s cron, so a second read per
 		// orphan is a cost with nothing to show for it.
 		const tail = await readRunLogTail(db, run.id, ORPHAN_LOG_TAIL_CHARS);
-		const error = orphanErrorMessage(neverStarted, tail.text);
 
+		// Claim the row FIRST, with the verdict alone. The outcome sentence is
+		// appended below, once the work has actually been settled. Writing both at
+		// once is what let this row assert "returned to the queue" for a handback
+		// that had not been attempted yet and could still fail - the defect a
+		// stranded ask looked identical to a served one through. The row carries a
+		// true statement at every instant, including if this process dies between
+		// the two writes.
 		const reaped = await db.query<{ id: string }>(
 			`UPDATE heartbeat_runs
 			 SET status = $2::heartbeat_run_status,
 			     finished_at = now(),
 			     error = $3,
 			     -- Only a real process loss counts toward the escalation. A run that
-			     -- never started is being handed back, not retried after a failure.
+			     -- never started is being handed back, not retried after a failure;
+			     -- its own bounded ladder spends the budget below, where it also
+			     -- reads it.
 			     process_loss_retry_count = process_loss_retry_count + $4::int
 			 WHERE id = $1
 			   AND status IN ($5::heartbeat_run_status, $6::heartbeat_run_status)
 			 RETURNING id`,
 			[
 				run.id,
-				neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed,
-				error,
+				terminalStatus,
+				ORPHAN_VERDICT[arm],
 				neverStarted ? 0 : 1,
 				HeartbeatRunStatus.Queued,
 				HeartbeatRunStatus.Running,
@@ -225,39 +257,165 @@ export async function detectOrphans(
 
 		await setAgentIdleIfNoActiveRuns(db, run.member_id, run.team_id, run.id, wsManager);
 
+		const outcome = neverStarted
+			? await handBackNeverStartedWork(db, run)
+			: (await retryOrEscalateLostRun(
+						db,
+						{
+							runId: run.id,
+							memberId: run.member_id,
+							teamId: run.team_id,
+							taskId: run.task_id,
+							priorRetries: run.process_loss_retry_count,
+						},
+						tail.text,
+					)) === 'retried'
+				? 'replaced'
+				: 'escalated';
+
+		// Now the outcome is known, and only now, the row can say what happened to
+		// the work. Guarded on the status this pass just wrote, so a terminate or a
+		// container sweep landing in between keeps its own more specific record.
+		//
+		// `cancel_reason` rides along on the same write. Only the never-started arm
+		// sets one: the orphaned arm is `Failed`, and a failure's cause is its
+		// error, not a cancel attribution.
+		const error = orphanErrorMessage(arm, outcome, tail.text);
+		await db.query(
+			`UPDATE heartbeat_runs SET error = $1, cancel_reason = COALESCE($4, cancel_reason)
+			 WHERE id = $2 AND status = $3::heartbeat_run_status`,
+			[
+				error,
+				run.id,
+				terminalStatus,
+				neverStarted
+					? outcome === 'abandoned'
+						? RunCancelReason.Abandoned
+						: RunCancelReason.HandedBack
+					: null,
+			],
+		);
+
+		// Broadcast after the second write, so an open run page receives the final
+		// text rather than the provisional verdict.
 		broadcastRowChange(wsManager, wsRoom.team(run.team_id), 'heartbeat_runs', 'UPDATE', {
 			id: run.id,
 			member_id: run.member_id,
 			task_id: run.task_id,
 			project_id: run.project_id,
-			status: neverStarted ? HeartbeatRunStatus.Cancelled : HeartbeatRunStatus.Failed,
+			status: terminalStatus,
 			error,
 		});
 
-		// A run that never started is put back rather than retried: the original
-		// wakeup returns to the queue for the dispatcher to pick up, exactly as
-		// `JobManager.settleWakeupForRun` does for the capacity park's own give-up
-		// path. Guarded on `claimed` so a wakeup already settled by another path is
-		// not resurrected. With no wakeup to return (a run started by something
-		// else) there is nothing to hand back, so fall through to the retry path
-		// rather than dropping the work.
-		const requeued = neverStarted && run.wakeup_id ? await requeueWakeup(db, run.wakeup_id) : false;
-		if (requeued) continue;
+		// The only outcome a reader has to do something about, so the only one worth
+		// a row in the thread. Everything else either re-runs on its own or was
+		// somebody's own decision to stop.
+		if (outcome === 'abandoned' && run.task_id) {
+			await recordRunAbandoned(
+				db,
+				run.team_id,
+				run.task_id,
+				run.id,
+				run.agent_slug,
+				wsManager,
+			).catch((e) => log.error(`Failed to post abandoned-run notice for run ${run.id}:`, e));
+		}
 
-		await retryOrEscalateLostRun(
-			db,
-			{
-				runId: run.id,
-				memberId: run.member_id,
-				teamId: run.team_id,
-				taskId: run.task_id,
-				priorRetries: run.process_loss_retry_count,
-			},
-			tail.text,
+		log.info(
+			`Reaped ${arm} run ${run.id} (member ${run.member_id}, task ${run.task_id ?? 'none'}): ${outcome}`,
 		);
 	}
 
 	return orphanCount;
+}
+
+/**
+ * Put back the work a run that never started was carrying.
+ *
+ * Split off the process-loss ladder deliberately. A never-started run spent no
+ * strike (nothing ran, nothing was produced), so gating it on the strike budget
+ * was the defect: `retryOrEscalateLostRun` reads `process_loss_retry_count` for
+ * its ceiling, `createHeartbeatRun` inherits that count down an orphan-retry
+ * lineage, and this arm never incremented it - so an inherited 2 turned every
+ * later never-start into a permanent dead end that filed one approval, guarded
+ * `NOT EXISTS` per member, and queued nothing ever again.
+ *
+ * Two rungs, in order:
+ *
+ * 1. **Hand the original wakeup back.** It already names the work, and it keeps
+ *    its own `source` - which decides whether the dependency gate and the no-work
+ *    backoff apply to it. Requires the payload to name a task, or the run to have
+ *    had none: `createSyntheticOnDemandWakeup` writes an empty payload, so
+ *    returning one of those to the queue produces a task-less nudge that
+ *    `activateAgent` answers by picking some other task by priority, or by
+ *    completing it as "nothing to do". That is not this run's work.
+ * 2. **Mint one replacement naming the task**, carrying the original's source so
+ *    a `mention` does not silently become a `timer` - the downgrade that put a
+ *    teammate's direct ask behind the dependency gate it was exempt from. This
+ *    rung is bounded, and unlike rung 1 it spends a strike, so the arm that reads
+ *    the ceiling is now the arm that fills it.
+ *
+ * Past the ceiling the work is abandoned: an approval is filed and the run says
+ * so. Rung 1 stays deliberately unbounded, as before - the wakeup is intact and
+ * the dispatcher owns it, each lap leaves a visible cancelled row and a queued
+ * agent in the task sidebar, and bounding it would need a counter carried on the
+ * wakeup itself.
+ */
+async function handBackNeverStartedWork(
+	db: Db,
+	run: {
+		id: string;
+		member_id: string;
+		team_id: string;
+		task_id: string | null;
+		wakeup_id: string | null;
+		process_loss_retry_count: number;
+	},
+): Promise<HandbackOutcome> {
+	const original = run.wakeup_id
+		? (
+				await db.query<{ source: WakeupSource; task_id: string | null }>(
+					`SELECT source, payload->>'task_id' AS task_id
+					 FROM agent_wakeup_requests WHERE id = $1`,
+					[run.wakeup_id],
+				)
+			).rows[0]
+		: undefined;
+
+	// A wakeup that names no task is only worth handing back when the run had no
+	// task either - a progress update, say, where the agent picks its own work.
+	if (run.wakeup_id && (original?.task_id || !run.task_id)) {
+		const settled = await settleWakeupForRun(db, run.wakeup_id, {
+			kind: 'handback',
+			reason: WakeupSkipReason.RunNeverStarted,
+		});
+		if (settled.kind === 'requeued') return 'requeued';
+	}
+
+	if (!run.task_id || run.process_loss_retry_count + 1 >= MAX_RETRIES) {
+		await fileLostRunApproval(db, {
+			runId: run.id,
+			memberId: run.member_id,
+			teamId: run.team_id,
+			taskId: run.task_id,
+		});
+		return 'abandoned';
+	}
+
+	await db.query(
+		'UPDATE heartbeat_runs SET process_loss_retry_count = process_loss_retry_count + 1 WHERE id = $1',
+		[run.id],
+	);
+	await createWakeup(db, run.member_id, run.team_id, original?.source ?? WakeupSource.Timer, {
+		reason: 'never_started_retry',
+		task_id: run.task_id,
+		// Named under `previous_run_id`, NOT `previous_failure.run_id`:
+		// `RUN_LINEAGE_SOURCES` gives only the latter `inheritsLossBudget`, and a
+		// replacement for a run that produced nothing must record where it came
+		// from without inheriting a budget it never spent.
+		previous_run_id: run.id,
+	});
+	return 'replaced';
 }
 
 /**
@@ -288,7 +446,7 @@ export async function retryOrEscalateLostRun(
 	},
 	/** Log excerpt the caller has already read, to save reading it twice. */
 	knownLogTail?: string,
-): Promise<void> {
+): Promise<'retried' | 'escalated'> {
 	if (run.priorRetries + 1 < MAX_RETRIES) {
 		const failedRun = await db.query<{ exit_code: number | null }>(
 			`SELECT exit_code FROM heartbeat_runs WHERE id = $1`,
@@ -317,41 +475,62 @@ export async function retryOrEscalateLostRun(
 				log_tail: tailText.length > 0 ? tailText : null,
 			},
 		});
-	} else {
-		// One record per stuck agent, not one per ceiling. A partial unique index
-		// would be stronger, but this pass is serial in a single process and an
-		// index needs a migration for a guard that is not racing anything.
-		// The member id is bound twice on purpose: once as the uuid column and once
-		// as the text `payload->>` compares against. One parameter in both places
-		// leaves Postgres unable to deduce a single type for it.
-		await db.query(
-			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload)
-			 SELECT $1, $2::approval_type, $3::uuid, $5::jsonb
-			 WHERE NOT EXISTS (
-			   SELECT 1 FROM approvals
-			   WHERE team_id = $1 AND type = $2::approval_type AND status = 'pending'
-			     AND payload->>'type' = 'agent_error'
-			     AND payload->>'member_id' = $4::text
-			 )`,
-			[
-				run.teamId,
-				ApprovalType.Strategy,
-				run.memberId,
-				run.memberId,
-				JSON.stringify({
-					type: 'agent_error',
-					member_id: run.memberId,
-					// Named so the approval can be read back to the run that produced
-					// it; without these the record said an agent had failed and gave a
-					// human nowhere to look.
-					run_id: run.runId,
-					task_id: run.taskId ?? null,
-					last_error: knownLogTail?.trim().slice(-ORPHAN_LOG_TAIL_CHARS) || null,
-					message: `Agent has failed ${MAX_RETRIES} consecutive times. Manual intervention required.`,
-				}),
-			],
-		);
+		return 'retried';
 	}
+
+	await fileLostRunApproval(
+		db,
+		{ runId: run.runId, memberId: run.memberId, teamId: run.teamId, taskId: run.taskId },
+		knownLogTail,
+	);
+	return 'escalated';
+}
+
+/**
+ * Record that an agent needs a human, once per stuck agent rather than once per
+ * ceiling hit.
+ *
+ * Shared by both give-up paths - the process-loss ladder and the never-started
+ * one - so the two cannot drift in what they leave a human to find.
+ */
+async function fileLostRunApproval(
+	db: Db,
+	run: { runId: string; memberId: string; teamId: string; taskId?: string | null },
+	knownLogTail?: string,
+): Promise<void> {
+	// One record per stuck agent, not one per ceiling. A partial unique index
+	// would be stronger, but this pass is serial in a single process and an
+	// index needs a migration for a guard that is not racing anything.
+	// The member id is bound twice on purpose: once as the uuid column and once
+	// as the text `payload->>` compares against. One parameter in both places
+	// leaves Postgres unable to deduce a single type for it.
+	await db.query(
+		`INSERT INTO approvals (team_id, type, requested_by_member_id, payload)
+		 SELECT $1, $2::approval_type, $3::uuid, $5::jsonb
+		 WHERE NOT EXISTS (
+		   SELECT 1 FROM approvals
+		   WHERE team_id = $1 AND type = $2::approval_type AND status = 'pending'
+		     AND payload->>'type' = 'agent_error'
+		     AND payload->>'member_id' = $4::text
+		 )`,
+		[
+			run.teamId,
+			ApprovalType.Strategy,
+			run.memberId,
+			run.memberId,
+			JSON.stringify({
+				type: 'agent_error',
+				member_id: run.memberId,
+				// Named so the approval can be read back to the run that produced
+				// it; without these the record said an agent had failed and gave a
+				// human nowhere to look.
+				run_id: run.runId,
+				task_id: run.taskId ?? null,
+				last_error: knownLogTail?.trim().slice(-ORPHAN_LOG_TAIL_CHARS) || null,
+				message: `Agent has failed ${MAX_RETRIES} consecutive times. Manual intervention required.`,
+			}),
+		],
+	);
 }
 
 /**

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -2,7 +2,6 @@ import {
 	AgentRuntimeStatus,
 	ApprovalType,
 	HeartbeatRunStatus,
-	RunCancelReason,
 	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
@@ -13,13 +12,18 @@ import { readRunLogTail } from '../db/run-log-chunks';
 import { broadcastRowChange } from '../lib/broadcast';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
-import { recordRunAbandoned } from './task-events';
+import { HANDBACK_OUTCOME_COPY, type HandbackOutcome, recordHandbackOutcome } from './run-handback';
 import { createWakeup, settleWakeupForRun } from './wakeup';
 import type { WebSocketManager } from './ws';
 
 const log = logger.child('orphan-detector');
 
-const MAX_RETRIES = 3;
+/**
+ * How many attempts a piece of work gets before Hezo stops and asks for a human.
+ * Exported so a test can drive the chain to its ceiling without hard-coding a
+ * number that would silently stop matching if this moved.
+ */
+export const MAX_RETRIES = 3;
 const SAFETY_WINDOW_SECONDS = 30;
 /** Failure excerpt handed to the retry wakeup. */
 const ORPHAN_LOG_TAIL_CHARS = 1_000;
@@ -80,41 +84,15 @@ const ORPHAN_VERDICT: Record<OrphanArm, string> = {
 		'A restart, a crash or a wedged dispatch - not the agent failing.',
 };
 
-/**
- * What happened to the work, written once it is known.
- *
- * A table rather than a branch, so a new outcome is a compile error here until
- * someone writes the sentence for it. Every sentence names a state the reader
- * can see for themselves: the queue, the Inbox, the Retry button.
- */
-const ORPHAN_OUTCOME_COPY: Record<HandbackOutcome, string> = {
-	requeued: 'The work is back in the queue and will be picked up automatically.',
-	replaced: 'A fresh run has been queued to pick this work back up.',
-	escalated:
-		'Hezo has stopped retrying this and asked for a human. There is a pending item in your Inbox.',
-	abandoned:
-		'Nothing was left to put back on the queue, so this will not restart on its own. ' +
-		'Use Retry to run it again.',
-};
-
 /** The run's `error`, carrying the outcome and the actual cause where the log has one. */
 function orphanErrorMessage(arm: OrphanArm, outcome: HandbackOutcome, logTail: string): string {
-	const verdict = `${ORPHAN_VERDICT[arm]} ${ORPHAN_OUTCOME_COPY[outcome]}`;
+	const verdict = `${ORPHAN_VERDICT[arm]} ${HANDBACK_OUTCOME_COPY[outcome]}`;
 	const excerpt = logTail.trim().slice(-ORPHAN_ERROR_TAIL_CHARS).trim();
 	return excerpt ? `${verdict}\n\nLast log output:\n${excerpt}` : verdict;
 }
 
 /** Which of the two stranded shapes a reaped row was. */
 type OrphanArm = 'never_started' | 'orphaned';
-
-/**
- * What became of the work a reaped run was carrying.
- *
- * `abandoned` is the one outcome that leaves work owed with nothing carrying it,
- * which is why it is named rather than folded into `escalated`: it is what the
- * run row, the Retry affordance and the thread notice all key off.
- */
-type HandbackOutcome = 'requeued' | 'replaced' | 'escalated' | 'abandoned';
 
 export async function detectOrphans(
 	db: Db,
@@ -257,73 +235,69 @@ export async function detectOrphans(
 
 		await setAgentIdleIfNoActiveRuns(db, run.member_id, run.team_id, run.id, wsManager);
 
-		const outcome = neverStarted
-			? await handBackNeverStartedWork(db, run)
-			: (await retryOrEscalateLostRun(
-						db,
-						{
-							runId: run.id,
-							memberId: run.member_id,
-							teamId: run.team_id,
-							taskId: run.task_id,
-							priorRetries: run.process_loss_retry_count,
-						},
-						tail.text,
-					)) === 'retried'
-				? 'replaced'
-				: 'escalated';
+		// The row is terminal from here, so nothing will rescan it: a throw past this
+		// point strands the work permanently. Isolate each orphan so one bad row
+		// cannot also abandon every other orphan in the batch, and log loudly enough
+		// that a strand is findable rather than silent.
+		try {
+			const outcome = neverStarted
+				? await handBackNeverStartedWork(db, run)
+				: (await retryOrEscalateLostRun(
+							db,
+							{
+								runId: run.id,
+								memberId: run.member_id,
+								teamId: run.team_id,
+								taskId: run.task_id,
+								priorRetries: run.process_loss_retry_count,
+							},
+							tail.text,
+						)) === 'retried'
+					? 'replaced'
+					: 'escalated';
 
-		// Now the outcome is known, and only now, the row can say what happened to
-		// the work. Guarded on the status this pass just wrote, so a terminate or a
-		// container sweep landing in between keeps its own more specific record.
-		//
-		// `cancel_reason` rides along on the same write. Only the never-started arm
-		// sets one: the orphaned arm is `Failed`, and a failure's cause is its
-		// error, not a cancel attribution.
-		const error = orphanErrorMessage(arm, outcome, tail.text);
-		await db.query(
-			`UPDATE heartbeat_runs SET error = $1, cancel_reason = COALESCE($4, cancel_reason)
-			 WHERE id = $2 AND status = $3::heartbeat_run_status`,
-			[
-				error,
-				run.id,
-				terminalStatus,
-				neverStarted
-					? outcome === 'abandoned'
-						? RunCancelReason.Abandoned
-						: RunCancelReason.HandedBack
-					: null,
-			],
-		);
-
-		// Broadcast after the second write, so an open run page receives the final
-		// text rather than the provisional verdict.
-		broadcastRowChange(wsManager, wsRoom.team(run.team_id), 'heartbeat_runs', 'UPDATE', {
-			id: run.id,
-			member_id: run.member_id,
-			task_id: run.task_id,
-			project_id: run.project_id,
-			status: terminalStatus,
-			error,
-		});
-
-		// The only outcome a reader has to do something about, so the only one worth
-		// a row in the thread. Everything else either re-runs on its own or was
-		// somebody's own decision to stop.
-		if (outcome === 'abandoned' && run.task_id) {
-			await recordRunAbandoned(
+			// Now the outcome is known, and only now, the row can say what happened to
+			// the work. The recorder reports whether its guarded write applied, so a
+			// terminate or a container sweep landing in between keeps its own more
+			// specific record and this pass stays silent about a row it did not write.
+			const error = orphanErrorMessage(arm, outcome, tail.text);
+			const recorded = await recordHandbackOutcome(
 				db,
-				run.team_id,
-				run.task_id,
-				run.id,
-				run.agent_slug,
+				{
+					runId: run.id,
+					taskId: run.task_id,
+					teamId: run.team_id,
+					agentSlug: run.agent_slug,
+					terminalStatus,
+				},
+				outcome,
+				error,
 				wsManager,
-			).catch((e) => log.error(`Failed to post abandoned-run notice for run ${run.id}:`, e));
-		}
+			);
 
-		log.info(
-			`Reaped ${arm} run ${run.id} (member ${run.member_id}, task ${run.task_id ?? 'none'}): ${outcome}`,
-		);
+			// Broadcast after the second write and only if it landed, so an open run
+			// page receives the final text rather than the provisional verdict, and is
+			// never told a row says something it does not.
+			if (recorded) {
+				broadcastRowChange(wsManager, wsRoom.team(run.team_id), 'heartbeat_runs', 'UPDATE', {
+					id: run.id,
+					member_id: run.member_id,
+					task_id: run.task_id,
+					project_id: run.project_id,
+					status: terminalStatus,
+					error,
+				});
+			}
+
+			log.info(
+				`Reaped ${arm} run ${run.id} (member ${run.member_id}, task ${run.task_id ?? 'none'}): ${outcome}`,
+			);
+		} catch (e) {
+			log.error(
+				`Reaped ${arm} run ${run.id} but could not settle its work - it is stranded and needs a human:`,
+				e,
+			);
+		}
 	}
 
 	return orphanCount;
@@ -382,9 +356,16 @@ async function handBackNeverStartedWork(
 			).rows[0]
 		: undefined;
 
-	// A wakeup that names no task is only worth handing back when the run had no
-	// task either - a progress update, say, where the agent picks its own work.
-	if (run.wakeup_id && (original?.task_id || !run.task_id)) {
+	// Hand the original back whatever it names. An earlier revision gated this on
+	// the payload naming a task, to stop an "intent-less" synthetic wakeup coming
+	// back as a task-less nudge - but `createSyntheticOnDemandWakeup` is reachable
+	// only from the progress-update path, which passes no task, so that gate never
+	// fired for the rows it was written for. What it did catch was the ordinary
+	// heartbeat wakeup, whose payload names no task because `activateAgent` chooses
+	// one: those were left dangling in `claimed` for `healStaleRunState` to
+	// mislabel. A wakeup that names no task is not intent-less, it is "find work",
+	// and handing it back says exactly that.
+	if (run.wakeup_id) {
 		const settled = await settleWakeupForRun(db, run.wakeup_id, {
 			kind: 'handback',
 			reason: WakeupSkipReason.RunNeverStarted,
@@ -392,7 +373,21 @@ async function handBackNeverStartedWork(
 		if (settled.kind === 'requeued') return 'requeued';
 	}
 
-	if (!run.task_id || run.process_loss_retry_count + 1 >= MAX_RETRIES) {
+	// No task to name means no replacement can be minted that points at this work,
+	// so the ladder ends here however many strikes are left. Said plainly rather
+	// than borrowed from the retry ceiling, which would tell a human this agent had
+	// failed three times when it may not have run at all.
+	if (!run.task_id) {
+		await fileLostRunApproval(
+			db,
+			{ runId: run.id, memberId: run.member_id, teamId: run.team_id, taskId: null },
+			undefined,
+			'A run could not be started and there was no task to retry it against. Manual intervention required.',
+		);
+		return 'abandoned';
+	}
+
+	if (run.process_loss_retry_count + 1 >= MAX_RETRIES) {
 		await fileLostRunApproval(db, {
 			runId: run.id,
 			memberId: run.member_id,
@@ -402,6 +397,18 @@ async function handBackNeverStartedWork(
 		return 'abandoned';
 	}
 
+	// Spend the strike, then hand the replacement a lineage that INHERITS it.
+	// Those two halves must travel together or the ceiling above is unreachable:
+	// `previous_run_id` carries `inheritsLossBudget: false`, so a replacement named
+	// that way starts back at zero and the chain never climbs however many times it
+	// laps. `previous_failure.run_id` is the key `RUN_LINEAGE_SOURCES` gives the
+	// budget to, and it is now the honest one - this arm fills the counter it reads.
+	//
+	// The original defect was the mirror of that, not this: the arm read the
+	// ceiling while never incrementing it, so a count inherited from an unrelated
+	// process-loss chain dead-ended it permanently. Incrementing consistently fixes
+	// both, because the count now means one thing - how many attempts this work has
+	// had without producing a result.
 	await db.query(
 		'UPDATE heartbeat_runs SET process_loss_retry_count = process_loss_retry_count + 1 WHERE id = $1',
 		[run.id],
@@ -409,11 +416,9 @@ async function handBackNeverStartedWork(
 	await createWakeup(db, run.member_id, run.team_id, original?.source ?? WakeupSource.Timer, {
 		reason: 'never_started_retry',
 		task_id: run.task_id,
-		// Named under `previous_run_id`, NOT `previous_failure.run_id`:
-		// `RUN_LINEAGE_SOURCES` gives only the latter `inheritsLossBudget`, and a
-		// replacement for a run that produced nothing must record where it came
-		// from without inheriting a budget it never spent.
-		previous_run_id: run.id,
+		retry_count: run.process_loss_retry_count + 1,
+		max_retries: MAX_RETRIES,
+		previous_failure: { run_id: run.id },
 	});
 	return 'replaced';
 }
@@ -497,6 +502,8 @@ async function fileLostRunApproval(
 	db: Db,
 	run: { runId: string; memberId: string; teamId: string; taskId?: string | null },
 	knownLogTail?: string,
+	/** Override for a give-up that is not the retry ceiling, so the record stays true. */
+	message = `Agent has failed ${MAX_RETRIES} consecutive times. Manual intervention required.`,
 ): Promise<void> {
 	// One record per stuck agent, not one per ceiling. A partial unique index
 	// would be stronger, but this pass is serial in a single process and an
@@ -527,7 +534,7 @@ async function fileLostRunApproval(
 				run_id: run.runId,
 				task_id: run.taskId ?? null,
 				last_error: knownLogTail?.trim().slice(-ORPHAN_LOG_TAIL_CHARS) || null,
-				message: `Agent has failed ${MAX_RETRIES} consecutive times. Manual intervention required.`,
+				message,
 			}),
 		],
 	);

--- a/packages/server/src/services/run-handback.ts
+++ b/packages/server/src/services/run-handback.ts
@@ -1,0 +1,110 @@
+import { type HeartbeatRunStatus, RunCancelReason } from '@hezo/shared';
+import type { Db } from '../db/database';
+import { logger } from '../logger';
+import { recordRunAbandoned } from './task-events';
+import type { WebSocketManager } from './ws';
+
+const log = logger.child('run-handback');
+
+/**
+ * What became of the work a run was carrying when it ended without doing it.
+ *
+ * `abandoned` is the one outcome that leaves work owed with nothing carrying it,
+ * which is why it is named rather than folded into `escalated`: it is what the
+ * run row, the Retry affordance and the thread notice all key off.
+ */
+export type HandbackOutcome = 'requeued' | 'replaced' | 'escalated' | 'abandoned';
+
+/**
+ * What happened to the work, in the operator's terms.
+ *
+ * A table rather than a branch, so a new outcome is a compile error here until
+ * someone writes the sentence for it. Every sentence names a state the reader
+ * can see for themselves: the queue, the Inbox, the Retry button.
+ */
+export const HANDBACK_OUTCOME_COPY: Record<HandbackOutcome, string> = {
+	requeued: 'The work is back in the queue and will be picked up automatically.',
+	replaced: 'A fresh run has been queued to pick this work back up.',
+	escalated:
+		'Hezo has stopped retrying this and asked for a human. There is a pending item in your Inbox.',
+	abandoned:
+		'Nothing was left to put back on the queue, so this will not restart on its own. ' +
+		'Use Retry to run it again.',
+};
+
+/**
+ * The cancel attribution each outcome earns, for the outcomes that produce a
+ * `cancelled` row. `escalated` belongs to the process-loss arm, which finalizes
+ * `failed` and carries its cause in the error rather than a cancel reason.
+ */
+const OUTCOME_CANCEL_REASON: Record<HandbackOutcome, RunCancelReason | null> = {
+	requeued: RunCancelReason.HandedBack,
+	replaced: RunCancelReason.HandedBack,
+	escalated: null,
+	abandoned: RunCancelReason.Abandoned,
+};
+
+export interface HandbackRunContext {
+	runId: string;
+	taskId: string | null;
+	teamId: string;
+	agentSlug: string | null;
+	/** The status this writer put on the row, so a later writer's verdict is not overwritten. */
+	terminalStatus: HeartbeatRunStatus;
+}
+
+/**
+ * Record on the run row what actually became of its work, **after** it is known.
+ *
+ * The one home for the second half of a handback, shared by the orphan sweeper
+ * and the run-completion path. They had it in one place and not the other, which
+ * is how the completion path came to stamp `handed_back` before attempting the
+ * handback and then leave it standing when the handback failed - a row asserting
+ * the work was queued while nothing carried it, which is the whole defect this
+ * area exists to prevent.
+ *
+ * Returns whether the write applied. Two guards, and both matter. The status
+ * guard means a terminate or a container sweep landing in between keeps its own
+ * more specific record, so the caller must not broadcast a row it did not write.
+ * The `cancel_reason IS NULL` guard makes first-writer-wins structural rather
+ * than per-column: a human pressing Terminate backfills `operator_terminated`
+ * while the abort is still cascading, and neither the attribution, the appended
+ * sentence nor the thread notice may land on top of that. Whoever stopped the
+ * run is the authority on why, and this writer is never that party.
+ */
+export async function recordHandbackOutcome(
+	db: Db,
+	run: HandbackRunContext,
+	outcome: HandbackOutcome,
+	/** Full replacement text. Omit to append the outcome sentence to what is there. */
+	error: string | undefined,
+	wsManager: WebSocketManager | undefined,
+): Promise<boolean> {
+	const applied = await db.query<{ id: string }>(
+		`UPDATE heartbeat_runs
+		    SET error = COALESCE($1, trim(both from COALESCE(error, '') || ' ' || $5)),
+		        cancel_reason = COALESCE(cancel_reason, $4)
+		  WHERE id = $2 AND status = $3::heartbeat_run_status
+		    AND cancel_reason IS NULL
+		 RETURNING id`,
+		[
+			error ?? null,
+			run.runId,
+			run.terminalStatus,
+			OUTCOME_CANCEL_REASON[outcome],
+			HANDBACK_OUTCOME_COPY[outcome],
+		],
+	);
+	if (applied.rows.length === 0) return false;
+
+	// The only outcome a reader has to do something about, so the only one worth a
+	// row in the thread. Everything else either re-runs on its own or was
+	// somebody's own decision to stop. Posted only once the write above applied,
+	// so the notice can never point at a run whose row says something else.
+	if (outcome === 'abandoned' && run.taskId) {
+		await recordRunAbandoned(db, run.teamId, run.taskId, run.runId, run.agentSlug, wsManager).catch(
+			(e) => log.error(`Failed to post abandoned-run notice for run ${run.runId}:`, e),
+		);
+	}
+	return true;
+}

--- a/packages/server/src/services/run-termination.ts
+++ b/packages/server/src/services/run-termination.ts
@@ -2,6 +2,7 @@ import {
 	AgentAdminStatus,
 	COACH_AGENT_SLUG,
 	HeartbeatRunStatus,
+	RunCancelReason,
 	WakeupStatus,
 	wsRoom,
 } from '@hezo/shared';
@@ -9,6 +10,7 @@ import type { Db } from '../db/database';
 import { broadcastRowChange } from '../lib/broadcast';
 import type { JobManager } from './job-manager';
 import { recordRunTerminated } from './task-events';
+import { settleWakeupForRun } from './wakeup';
 import type { WebSocketManager } from './ws';
 
 export interface TerminateRunDeps {
@@ -27,6 +29,13 @@ export async function terminateHeartbeatRun(
 	runId: string,
 	reason: string,
 	actorMemberId: string | null,
+	/**
+	 * Who decided to stop, in the reader's terms. Both values mean the work is no
+	 * longer owed, so neither offers a Retry - they differ only in what a person
+	 * is told. Defaults to the operator case because that is what the Terminate
+	 * route is; the task-level sweeps pass `WorkWithdrawn`.
+	 */
+	cancelReason: RunCancelReason = RunCancelReason.OperatorTerminated,
 ): Promise<TerminateResult> {
 	const { db, wsManager, jobManager } = deps;
 
@@ -36,8 +45,9 @@ export async function terminateHeartbeatRun(
 		task_id: string | null;
 		member_id: string;
 		project_id: string | null;
+		wakeup_id: string | null;
 	}>(
-		`SELECT hr.status, hr.team_id, hr.task_id, hr.member_id,
+		`SELECT hr.status, hr.team_id, hr.task_id, hr.member_id, hr.wakeup_id,
 		        (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id) AS project_id
 		   FROM heartbeat_runs hr WHERE hr.id = $1`,
 		[runId],
@@ -53,11 +63,14 @@ export async function terminateHeartbeatRun(
 	if (wasLive) {
 		// finalizeAbort() inside runAgent will write status=cancelled, finished_at,
 		// exit_code=-1 once the abort cascades. Backfill the reason now without
-		// racing that write — its UPDATE uses COALESCE on error.
-		await db.query('UPDATE heartbeat_runs SET error = COALESCE(error, $1) WHERE id = $2', [
-			reason,
-			runId,
-		]);
+		// racing that write — its UPDATE uses COALESCE on error, and on
+		// cancel_reason, which finalizeAbort never sets.
+		await db.query(
+			`UPDATE heartbeat_runs
+			    SET error = COALESCE(error, $1), cancel_reason = COALESCE(cancel_reason, $3)
+			  WHERE id = $2`,
+			[reason, runId, cancelReason],
+		);
 	} else {
 		// Queued (not yet dispatched) — finalize directly.
 		await db.query(
@@ -66,7 +79,8 @@ export async function terminateHeartbeatRun(
 			        started_at = COALESCE(started_at, now()),
 			        finished_at = now(),
 			        exit_code = COALESCE(exit_code, -1),
-			        error = COALESCE(error, $2)
+			        error = COALESCE(error, $2),
+			        cancel_reason = COALESCE(cancel_reason, $6)
 			  WHERE id = $3
 			    AND status IN ($4::heartbeat_run_status, $5::heartbeat_run_status)`,
 			[
@@ -75,6 +89,7 @@ export async function terminateHeartbeatRun(
 				runId,
 				HeartbeatRunStatus.Queued,
 				HeartbeatRunStatus.Running,
+				cancelReason,
 			],
 		);
 		broadcastRowChange(wsManager, wsRoom.team(row.team_id), 'heartbeat_runs', 'UPDATE', {
@@ -86,6 +101,14 @@ export async function terminateHeartbeatRun(
 			status: HeartbeatRunStatus.Cancelled,
 		});
 	}
+
+	// Settle the driving wakeup here rather than leaving it `claimed` for
+	// `healStaleRunState` to pick up 120s later and record as `failed`. Both are
+	// the wrong label for work somebody withdrew, and for those two minutes the
+	// still-claimed row also suppresses `chainNextTaskWakeup` for this task.
+	// `withdraw`, not `handback`: every caller of this function is a decision that
+	// the work is no longer wanted.
+	await settleWakeupForRun(db, row.wakeup_id, { kind: 'withdraw' });
 
 	if (row.task_id) {
 		// The run-terminated note is a secondary system comment; API-key
@@ -168,7 +191,13 @@ export async function cancelCoachWorkForTask(
 		[taskId, coachId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
 	);
 	for (const row of runs.rows) {
-		await terminateHeartbeatRun(deps, row.id, 'Task re-opened', actorMemberId);
+		await terminateHeartbeatRun(
+			deps,
+			row.id,
+			'Task re-opened',
+			actorMemberId,
+			RunCancelReason.WorkWithdrawn,
+		);
 	}
 }
 
@@ -186,7 +215,13 @@ export async function terminateRunsForTask(
 	);
 	let count = 0;
 	for (const row of rows.rows) {
-		const result = await terminateHeartbeatRun(deps, row.id, reason, actorMemberId);
+		const result = await terminateHeartbeatRun(
+			deps,
+			row.id,
+			reason,
+			actorMemberId,
+			RunCancelReason.WorkWithdrawn,
+		);
 		if (result.terminated) count++;
 	}
 	return count;

--- a/packages/server/src/services/task-events.ts
+++ b/packages/server/src/services/task-events.ts
@@ -165,6 +165,49 @@ export async function recordRunTerminated(
 	}
 }
 
+/**
+ * Say in the thread that a run was abandoned and nobody is carrying its work.
+ *
+ * Posted only when the handback fails - the one outcome where work is still owed
+ * and nothing is going to pick it up. A successful handback stays silent on
+ * purpose: the work re-runs, and a note per interruption would bury the thread
+ * on a loaded instance in events nobody has to read.
+ *
+ * Authored by the system, not by the agent, so `author_member_id` is null.
+ * The `run_id` is what gives the reader something to act on: it is the run whose
+ * card carries the Retry button.
+ */
+export async function recordRunAbandoned(
+	db: Db,
+	teamId: string,
+	taskId: string,
+	runId: string,
+	agentSlug: string | null,
+	wsManager: WebSocketManager | undefined,
+): Promise<void> {
+	const r = await db.query<Record<string, unknown>>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, NULL, $2::comment_content_type, $3::jsonb)
+		 RETURNING *, (SELECT project_id FROM tasks WHERE id = $1) AS project_id`,
+		[
+			taskId,
+			CommentContentType.System,
+			JSON.stringify({
+				kind: 'run_abandoned',
+				run_id: runId,
+				agent_slug: agentSlug,
+				// The `text` fallback every system comment carries, for a reader on a
+				// surface with no dedicated renderer (the MCP thread read, an older
+				// client). The web renders the localized sentence instead.
+				text: 'A run could not be started and will not be retried automatically.',
+			}),
+		],
+	);
+	if (r.rows[0] && wsManager) {
+		broadcastRowChange(wsManager, wsRoom.team(teamId), 'task_comments', 'INSERT', r.rows[0]);
+	}
+}
+
 export async function recordWakeupCancelled(
 	db: Db,
 	teamId: string,

--- a/packages/server/src/services/wakeup.ts
+++ b/packages/server/src/services/wakeup.ts
@@ -1,5 +1,6 @@
 import {
 	HeartbeatRunStatus,
+	TERMINAL_WAKEUP_STATUSES,
 	type WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
@@ -298,11 +299,30 @@ export async function settleWakeupForRun(
 		return res.rows.length > 0 ? { kind: 'requeued' } : { kind: 'handback_failed' };
 	}
 
+	// Guarded the same way the handback arm is, and for the mirror reason. A
+	// wakeup that already reached a terminal status has had its outcome decided by
+	// whoever got there first, and that party knew more: `terminateHeartbeatRun`
+	// settles `cancelled` the moment a person presses Terminate, while the aborting
+	// run reaches `onAgentComplete` seconds later and would relabel it `failed` -
+	// the exact label the terminate path exists to avoid. Without this, the
+	// double-`onAgentComplete` on the runner's own catch path could also flip a
+	// wakeup that had just been handed back.
 	const status = SETTLEMENT_TERMINAL_STATUS[intent.kind];
-	await db.query(
-		`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
-		[status, wakeupId],
+	const applied = await db.query<{ id: string }>(
+		`UPDATE agent_wakeup_requests
+		    SET status = $1::wakeup_status, completed_at = now()
+		  WHERE id = $2 AND status <> ALL($3::wakeup_status[])
+		 RETURNING id`,
+		[status, wakeupId, TERMINAL_WAKEUP_STATUSES],
 	);
+	if (applied.rows.length === 0) {
+		const current = await db.query<{ status: WakeupStatus }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		const standing = current.rows[0]?.status;
+		return standing ? { kind: 'terminal', status: standing } : { kind: 'nothing_to_settle' };
+	}
 	return { kind: 'terminal', status };
 }
 

--- a/packages/server/src/services/wakeup.ts
+++ b/packages/server/src/services/wakeup.ts
@@ -1,4 +1,9 @@
-import { HeartbeatRunStatus, WakeupSource, WakeupStatus } from '@hezo/shared';
+import {
+	HeartbeatRunStatus,
+	type WakeupSkipReason,
+	WakeupSource,
+	WakeupStatus,
+} from '@hezo/shared';
 import type { Db } from '../db/database';
 import { trackBackground } from '../lib/background';
 import { logger } from '../logger';
@@ -218,6 +223,87 @@ export async function assignmentWakeupAlreadyServed(
 		[memberId, taskId, HeartbeatRunStatus.Succeeded, wakeupCreatedAt],
 	);
 	return served.rows.length > 0;
+}
+
+/**
+ * How a finished run wants its driving wakeup settled.
+ *
+ * A discriminated union rather than booleans: the four outcomes are mutually
+ * exclusive and `handback` is the only one carrying data, so a caller cannot
+ * spell "put it back" without saying why it is going back.
+ */
+export type SettlementIntent =
+	/** The work was not done and is owed. Put it back for the dispatcher. */
+	| { kind: 'handback'; reason: WakeupSkipReason }
+	/** The run did the work. */
+	| { kind: 'complete' }
+	/** The run tried and failed. Nothing here retries it. */
+	| { kind: 'fail' }
+	/** Nobody wants this work any more - the task was cancelled, or a human stopped the run. */
+	| { kind: 'withdraw' };
+
+/** What {@link settleWakeupForRun} actually did, so the caller can report it. */
+export type WakeupSettlement =
+	/** The original row went back to `queued` and still carries the work. */
+	| { kind: 'requeued' }
+	/** The row could not be handed back; nothing was settled and nothing carries the work. */
+	| { kind: 'handback_failed' }
+	/** The row reached a terminal status. */
+	| { kind: 'terminal'; status: WakeupStatus }
+	/** There was no wakeup to settle (a synthetic or manual run). */
+	| { kind: 'nothing_to_settle' };
+
+const SETTLEMENT_TERMINAL_STATUS: Record<
+	Exclude<SettlementIntent['kind'], 'handback'>,
+	WakeupStatus
+> = {
+	complete: WakeupStatus.Completed,
+	fail: WakeupStatus.Failed,
+	withdraw: WakeupStatus.Cancelled,
+};
+
+/**
+ * Settle the wakeup that drove a run, now that run has finished.
+ *
+ * The one home for the question "what happens to the work this run was woken
+ * for?". Both the completion path (`JobManager.onAgentComplete`) and the orphan
+ * sweeper reach it, and they used to answer it separately - which is how the
+ * sweeper's handback ended up with a `claimed` guard the completion path lacked,
+ * and how both ended up stamping `instance_at_capacity` on a handback that had
+ * nothing to do with capacity.
+ *
+ * The `claimed` guard on the handback arm is load-bearing and applies to every
+ * caller: another path may have settled this row already, and returning a
+ * completed one to the queue dispatches its work a second time. The caller is
+ * told when the guard bites (`handback_failed`) rather than being left to assume
+ * the work is safely queued - that assumption is exactly what let a stranded ask
+ * look identical to a served one.
+ */
+export async function settleWakeupForRun(
+	db: Db,
+	wakeupId: string | undefined | null,
+	intent: SettlementIntent,
+): Promise<WakeupSettlement> {
+	if (!wakeupId) return { kind: 'nothing_to_settle' };
+
+	if (intent.kind === 'handback') {
+		const res = await db.query<{ id: string }>(
+			`UPDATE agent_wakeup_requests
+			 SET status = $1::wakeup_status, claimed_at = NULL,
+			     last_skipped_at = now(), last_skipped_reason = $2
+			 WHERE id = $3 AND status = $4::wakeup_status
+			 RETURNING id`,
+			[WakeupStatus.Queued, intent.reason, wakeupId, WakeupStatus.Claimed],
+		);
+		return res.rows.length > 0 ? { kind: 'requeued' } : { kind: 'handback_failed' };
+	}
+
+	const status = SETTLEMENT_TERMINAL_STATUS[intent.kind];
+	await db.query(
+		`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
+		[status, wakeupId],
+	);
+	return { kind: 'terminal', status };
 }
 
 function mergePayloads(

--- a/packages/server/test/agent-runner-credential-lock.test.ts
+++ b/packages/server/test/agent-runner-credential-lock.test.ts
@@ -11,7 +11,13 @@
 // So the two properties asserted here are: the wait is bounded and hands the
 // work back, and a waiter holds no container while it waits.
 
-import { AgentRuntime, AiAuthMethod, AiProvider, ContainerStatus } from '@hezo/shared';
+import {
+	AgentRuntime,
+	AiAuthMethod,
+	AiProvider,
+	ContainerStatus,
+	WakeupSkipReason,
+} from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -139,8 +145,9 @@ async function runRow(id: string) {
 		started_at: string | null;
 		container_id: string | null;
 		error: string | null;
+		cancel_reason: string | null;
 	}>(
-		`SELECT status, queued_reason, started_at, container_id, error
+		`SELECT status, queued_reason, started_at, container_id, error, cancel_reason
 		   FROM heartbeat_runs WHERE id = $1`,
 		[id],
 	);
@@ -260,10 +267,22 @@ describe('runAgent credential wait', () => {
 			// instance being busy, not the agent failing, so no failure ping and no
 			// lost-run strike.
 			expect(result.requeued).toBe(true);
+			// Which wait gave up, named at the source. The seam honours whatever it
+			// is handed, so only an assertion here can catch this caller choosing
+			// the wrong one - and it used to hand over `instance_at_capacity`
+			// regardless, which has the idle pass reclaim the project's container
+			// out from under work that is only waiting for a credential.
+			expect(result.requeueReason).toBe(WakeupSkipReason.CredentialBusy);
+
 			const row = await runRow(result.heartbeatRunId as string);
 			expect(row.status).toBe('cancelled');
 			expect(row.error).toContain('returning this run to the queue');
 			expect(row.container_id).toBeNull();
+			// And no attribution yet: whether the work is actually carried is not
+			// known until the caller settles the wakeup, so the row must not claim
+			// `handed_back` here. `JobManager.settleWakeupForRun` records it once the
+			// answer is in, and records `abandoned` when the handback fails.
+			expect(row.cancel_reason).toBeNull();
 		} finally {
 			release();
 		}

--- a/packages/server/test/credential-wait-ceiling.test.ts
+++ b/packages/server/test/credential-wait-ceiling.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { CAPACITY_PARK_MAX_MS, credentialWaitMaxMs } from '../src/services/agent-runner';
+
+/**
+ * The credential wait and the capacity park look alike and are not the same
+ * judgement: the park waits for a container slot the idle cron frees in seconds,
+ * this queues behind a whole other run. They shared a ceiling until they didn't.
+ */
+describe('credentialWaitMaxMs', () => {
+	it("scales with the waiting run's own timeout", () => {
+		// 80% of the run's budget, so the wait always leaves the run room to finish.
+		expect(credentialWaitMaxMs(10)).toBe(8 * 60_000);
+		expect(credentialWaitMaxMs(5)).toBe(4 * 60_000);
+	});
+
+	it('never outlives the wall-clock timer that would finalize the run timed_out', () => {
+		// The regression guard. An earlier revision floored this at the capacity
+		// park's 180s, which for a short agent timeout produced a wait LONGER than
+		// launchTask's timer - so the run was killed as `timed_out` instead of
+		// handing its work back, trading one errored row for another. That is the
+		// exact outcome the fraction exists to avoid, so it must hold at every
+		// setting, including the minimum the UI allows.
+		for (const runTimeoutMin of [1, 2, 3, 5, 10, 60, 240]) {
+			const wallClockMs = runTimeoutMin * 60_000;
+			expect(credentialWaitMaxMs(runTimeoutMin)).toBeLessThan(wallClockMs);
+		}
+	});
+
+	it('is capped, because the waiter holds a container reservation for the whole wait', () => {
+		// A dispatch with no spare container reserves memory budget before
+		// launchTask and holds it until the run settles, so an unbounded wait is an
+		// unbounded charge against every other project's dispatch.
+		expect(credentialWaitMaxMs(600)).toBe(15 * 60_000);
+		expect(credentialWaitMaxMs(10_000)).toBe(15 * 60_000);
+	});
+
+	it('handles a missing or zero timeout without producing a negative or NaN wait', () => {
+		// `run_timeout_min` is read from a row that may not be there.
+		expect(credentialWaitMaxMs(undefined)).toBe(0);
+		expect(credentialWaitMaxMs(null)).toBe(0);
+		expect(credentialWaitMaxMs(0)).toBe(0);
+	});
+
+	it('no longer shares the capacity park ceiling', () => {
+		// Pins the split itself: if someone re-floors this at the park's constant,
+		// the invariant above breaks again for short timeouts.
+		expect(credentialWaitMaxMs(1)).not.toBe(CAPACITY_PARK_MAX_MS);
+	});
+});

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -105,6 +105,37 @@ describe('heartbeat-runs API', () => {
 		expect(verify.rows[0].task_id).toBe(taskId);
 	});
 
+	it('projects cancel_reason, which is the only thing telling a cancel apart', async () => {
+		// Without this the whole attribution is dead in production while the suite
+		// stays green: the web tests stub the response, so they pass against a
+		// server that never returns the field. `cancelled` covers a person stopping
+		// a run and the instance abandoning one, and only the second offers Retry.
+		const cancelled = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, finished_at, cancel_reason)
+			 VALUES ($1, $2, $3, 'cancelled'::heartbeat_run_status, now(), 'abandoned')
+			 RETURNING id`,
+			[agentId, teamId, taskId],
+		);
+		const cancelledId = cancelled.rows[0].id;
+
+		const list = await app.request(
+			`/api/projects/${projectSlug}/agents/${agentId}/heartbeat-runs`,
+			{ headers: authHeader(token) },
+		);
+		expect(list.status).toBe(200);
+		const rows = (await list.json()).data as { id: string; cancel_reason: string | null }[];
+		expect(rows.find((r) => r.id === cancelledId)?.cancel_reason).toBe('abandoned');
+
+		const single = await app.request(
+			`/api/projects/${projectSlug}/agents/${agentId}/heartbeat-runs/${cancelledId}`,
+			{ headers: authHeader(token) },
+		);
+		expect(single.status).toBe(200);
+		expect((await single.json()).data.cancel_reason).toBe('abandoned');
+
+		await db.query('DELETE FROM heartbeat_runs WHERE id = $1', [cancelledId]);
+	});
+
 	it('lists runs with task info', async () => {
 		await db.query(
 			`UPDATE heartbeat_runs

--- a/packages/server/test/job-manager-idle-stop.test.ts
+++ b/packages/server/test/job-manager-idle-stop.test.ts
@@ -234,6 +234,24 @@ describe('container-idle-stop', () => {
 		expect(stops).toContain(CONTAINER_ID);
 	});
 
+	it('a never-started requeue DOES hold the container, unlike a capacity skip', async () => {
+		// The two look alike and are opposite. A capacity-skipped wakeup waits on
+		// the very reclaim this scan feeds, so counting it busy deadlocks it. A
+		// wakeup handed back because its run never started is ready to dispatch on
+		// the next tick, so reclaiming its container is pulling the floor out from
+		// under work that is about to run. Stamping the handback
+		// `instance_at_capacity` - which it used to - put it on the wrong side of
+		// this line.
+		await db.query(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, last_skipped_at, last_skipped_reason)
+			 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+			         jsonb_build_object('task_id', $3::text), now(), 'run_never_started')`,
+			[agentId, teamId, taskId],
+		);
+		const { stops } = await runIdlePass();
+		expect(stops).toEqual([]);
+	});
+
 	it('a chat session with recent activity holds the container; a stale one does not', async () => {
 		const conversation = await db.query<{ id: string }>(
 			`INSERT INTO chat_conversations (member_id, team_id, project_id, title)

--- a/packages/server/test/migrate-066-run-cancel-reason.test.ts
+++ b/packages/server/test/migrate-066-run-cancel-reason.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '066_run_cancel_reason.sql';
+
+describe('066_run_cancel_reason migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let memberId: string;
+	let cancelledRunId: string;
+	let failedRunId: string;
+	let succeededRunId: string;
+
+	const CANCELLED_ERROR = 'Never started: no host process was driving this run';
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Worker') RETURNING id`,
+			[teamId],
+		);
+		memberId = member.rows[0].id;
+
+		// A cancel written before the attribution existed - the exact shape whose
+		// reason can never be recovered, and therefore the one that must read NULL
+		// rather than being guessed at.
+		const cancelled = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, status, error, exit_code, process_loss_retry_count, finished_at)
+			 VALUES ($1, $2, 'cancelled'::heartbeat_run_status, $3, -1, 2, now())
+			 RETURNING id`,
+			[teamId, memberId, CANCELLED_ERROR],
+		);
+		cancelledRunId = cancelled.rows[0].id;
+
+		const failed = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, status, error, exit_code, cost_cents,
+			    input_tokens, output_tokens, finished_at)
+			 VALUES ($1, $2, 'failed'::heartbeat_run_status, 'boom', 1, 42, 100, 200, now())
+			 RETURNING id`,
+			[teamId, memberId],
+		);
+		failedRunId = failed.rows[0].id;
+
+		const succeeded = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, exit_code, cost_cents, finished_at)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, 0, 7, now())
+			 RETURNING id`,
+			[teamId, memberId],
+		);
+		succeededRunId = succeeded.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+
+	afterAll(async () => {
+		await h.close();
+	});
+
+	it('keeps every pre-existing run row and everything recorded on it', async () => {
+		const rows = await h.db.query<{
+			id: string;
+			status: string;
+			error: string | null;
+			exit_code: number | null;
+			cost_cents: number | null;
+			input_tokens: number | null;
+			output_tokens: number | null;
+			process_loss_retry_count: number;
+		}>(
+			`SELECT id, status::text AS status, error, exit_code, cost_cents,
+			        input_tokens, output_tokens, process_loss_retry_count
+			 FROM heartbeat_runs ORDER BY created_at`,
+		);
+		expect(rows.rows.length).toBe(3);
+
+		const cancelled = rows.rows.find((r) => r.id === cancelledRunId);
+		expect(cancelled?.status).toBe('cancelled');
+		expect(cancelled?.error).toBe(CANCELLED_ERROR);
+		expect(cancelled?.exit_code).toBe(-1);
+		// The lost-run ceiling reads this, so a migration that reset it would
+		// silently un-bound every retry chain on the instance.
+		expect(cancelled?.process_loss_retry_count).toBe(2);
+
+		const failed = rows.rows.find((r) => r.id === failedRunId);
+		expect(failed?.status).toBe('failed');
+		expect(failed?.error).toBe('boom');
+		expect(Number(failed?.cost_cents)).toBe(42);
+		expect(Number(failed?.input_tokens)).toBe(100);
+		expect(Number(failed?.output_tokens)).toBe(200);
+
+		const succeeded = rows.rows.find((r) => r.id === succeededRunId);
+		expect(succeeded?.status).toBe('succeeded');
+		expect(Number(succeeded?.cost_cents)).toBe(7);
+	});
+
+	it('leaves every historical row unattributed rather than guessing', async () => {
+		const rows = await h.db.query<{ id: string; cancel_reason: string | null }>(
+			'SELECT id, cancel_reason FROM heartbeat_runs',
+		);
+		expect(rows.rows.every((r) => r.cancel_reason === null)).toBe(true);
+	});
+
+	it('accepts and reads back a reason on a new cancel', async () => {
+		await h.db.query('UPDATE heartbeat_runs SET cancel_reason = $1 WHERE id = $2', [
+			'abandoned',
+			cancelledRunId,
+		]);
+		const row = await h.db.query<{ cancel_reason: string | null }>(
+			'SELECT cancel_reason FROM heartbeat_runs WHERE id = $1',
+			[cancelledRunId],
+		);
+		expect(row.rows[0].cancel_reason).toBe('abandoned');
+	});
+});

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -411,9 +411,12 @@ describe('detectOrphans for runs stranded before they started', () => {
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
 		expect(run.rows[0].error).toContain('Never started');
 		expect(run.rows[0].finished_at).not.toBeNull();
-		// And it spends none of the three strikes that raise "manual intervention
-		// required" - those are for a run that got a fair attempt and lost it.
-		expect(run.rows[0].process_loss_retry_count).toBe(0);
+		// This run had no wakeup to hand back, so the work was carried by a fresh
+		// replacement run - and minting one spends a strike, which is what bounds
+		// the chain. Only a genuine handback of the original wakeup is free (see
+		// `hands the original wakeup back...` below): there the dispatcher already
+		// owns the work and no new attempt was made.
+		expect(run.rows[0].process_loss_retry_count).toBe(1);
 
 		// The point of the reap: the task stops reading as having an active run,
 		// which is what blocks reassignment and shows the agent as busy.
@@ -472,6 +475,23 @@ describe('detectOrphans for runs stranded before they started', () => {
 			[agentId],
 		);
 		expect(all.rows[0].count).toBe('1');
+
+		// Handing the original row back spends no strike: nothing was attempted,
+		// the dispatcher already owns the work, and charging the lost-run budget
+		// for it is what let an inherited count dead-end this arm permanently.
+		const strikes = await db.query<{ process_loss_retry_count: number }>(
+			'SELECT process_loss_retry_count FROM heartbeat_runs WHERE wakeup_id = $1',
+			[wakeupId],
+		);
+		expect(strikes.rows[0].process_loss_retry_count).toBe(0);
+
+		// The row says what actually happened, and only after it happened.
+		const run = await db.query<{ error: string }>(
+			'SELECT error FROM heartbeat_runs WHERE wakeup_id = $1',
+			[wakeupId],
+		);
+		expect(run.rows[0].error).toContain('back in the queue');
+		expect(run.rows[0].error).toContain('Never started');
 	});
 
 	it('carries the real cause into the error so the run page does not just say it never started', async () => {
@@ -584,6 +604,156 @@ describe('detectOrphans for runs stranded before they started', () => {
 		// A process that vanished mid-run is.
 		expect(byId.get(runningId)?.status).toBe(HeartbeatRunStatus.Failed);
 		expect(byId.get(runningId)?.error).toContain('Orphaned: nothing was driving this run');
+	});
+
+	it('replaces a wakeup it cannot hand back, keeping the source that decides the gates', async () => {
+		// The downgrade this closes: when the handback guard misses, the fallback
+		// used to mint a `timer` wakeup whatever the original was. `timer` is in
+		// GATED_WAKEUP_SOURCES and is not exempt from the no-work backoff, while a
+		// `mention` is neither - so a teammate's direct ask came back as a wakeup
+		// the dependency gate could park indefinitely.
+		await clearRuns();
+		const taskId = await createTask(teamId);
+		// After createTask: assigning the task fires its own `assignment` wakeup,
+		// which would otherwise be the row these assertions find.
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		// Already settled, so the `claimed`-only handback guard cannot take it.
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+			 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, $5::jsonb)
+			 RETURNING id`,
+			[
+				agentId,
+				teamId,
+				WakeupSource.Mention,
+				WakeupStatus.Failed,
+				JSON.stringify({ task_id: taskId }),
+			],
+		);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET wakeup_id = $1 WHERE id = $2', [
+			wakeup.rows[0].id,
+			runId,
+		]);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const replacement = await db.query<{ source: string; payload: Record<string, unknown> }>(
+			`SELECT source, payload FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(replacement.rows).toHaveLength(1);
+		expect(replacement.rows[0].source).toBe(WakeupSource.Mention);
+		expect(replacement.rows[0].payload.task_id).toBe(taskId);
+		// Lineage under `previous_run_id`, so RUN_LINEAGE_SOURCES does not hand the
+		// replacement a loss budget the original never spent.
+		expect(replacement.rows[0].payload.previous_run_id).toBe(runId);
+		expect(replacement.rows[0].payload.previous_failure).toBeUndefined();
+
+		// And the row says a fresh run was queued, not that the original went back.
+		const run = await db.query<{ error: string }>(
+			'SELECT error FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].error).toContain('A fresh run has been queued');
+	});
+
+	it('does not hand back an intent-less synthetic wakeup as if it were the work', async () => {
+		// `createSyntheticOnDemandWakeup` writes an empty payload. Returning one of
+		// those to the queue produces a task-less nudge, which `activateAgent`
+		// answers by selecting some other task by priority or by completing it as
+		// "nothing to do" - either way the run's actual work is gone.
+		await clearRuns();
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const synthetic = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, claimed_at)
+			 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, '{}'::jsonb, now())
+			 RETURNING id`,
+			[agentId, teamId, WakeupSource.OnDemand, WakeupStatus.Claimed],
+		);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET wakeup_id = $1 WHERE id = $2', [
+			synthetic.rows[0].id,
+			runId,
+		]);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		// The empty row stays claimed rather than being resurrected as a nudge...
+		const untouched = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[synthetic.rows[0].id],
+		);
+		expect(untouched.rows[0].status).toBe(WakeupStatus.Claimed);
+		// ...and the work is carried by a replacement that actually names the task.
+		const replacement = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(replacement.rows).toHaveLength(1);
+		expect(replacement.rows[0].payload.task_id).toBe(taskId);
+	});
+
+	it('an inherited retry count does not dead-end a run that never started', async () => {
+		// The permanent dead end: this arm read `process_loss_retry_count` for its
+		// ceiling but never incremented it, and `createHeartbeatRun` inherits the
+		// count down an orphan-retry lineage. So an inherited 2 filed one approval,
+		// guarded NOT EXISTS per member, and queued nothing ever again.
+		await clearRuns();
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET process_loss_retry_count = 1 WHERE id = $1', [runId]);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const queued = await db.query<{ id: string }>(
+			`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(queued.rows).toHaveLength(1);
+		const approvals = await db.query<{ id: string }>(
+			'SELECT id FROM approvals WHERE team_id = $1',
+			[teamId],
+		);
+		expect(approvals.rows).toHaveLength(0);
+	});
+
+	it('gives up visibly once the never-started chain hits its ceiling', async () => {
+		// The bound still exists, and it is now reachable only by spending strikes
+		// this arm actually filled. What changed is that the give-up says so on the
+		// row rather than claiming the work went back on the queue.
+		await clearRuns();
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET process_loss_retry_count = 2 WHERE id = $1', [runId]);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const queued = await db.query<{ id: string }>(
+			`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(queued.rows).toHaveLength(0);
+		const approvals = await db.query<{ type: string }>(
+			'SELECT type FROM approvals WHERE team_id = $1',
+			[teamId],
+		);
+		expect(approvals.rows).toHaveLength(1);
+		expect(approvals.rows[0].type).toBe(ApprovalType.Strategy);
+
+		const run = await db.query<{ error: string }>(
+			'SELECT error FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].error).toContain('will not restart on its own');
+		expect(run.rows[0].error).not.toContain('back in the queue');
 	});
 
 	it('leaves a run alone that went terminal between the scan and the write', async () => {

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -2,6 +2,8 @@ import {
 	AgentRuntimeStatus,
 	ApprovalType,
 	HeartbeatRunStatus,
+	RunCancelReason,
+	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
 } from '@hezo/shared';
@@ -18,6 +20,7 @@ import {
 import {
 	detectOrphans,
 	healStaleRunState,
+	MAX_RETRIES,
 	STALE_STATE_GRACE_SECONDS,
 } from '../src/services/orphan-detector';
 import { safeClose } from './helpers';
@@ -369,14 +372,36 @@ describe('detectOrphans', () => {
 
 describe('detectOrphans for runs stranded before they started', () => {
 	/** A `queued` run has no `started_at`, so it ages against `created_at`. */
-	async function insertQueuedRun(age: string, opts: { taskId?: string } = {}): Promise<string> {
+	async function insertQueuedRun(
+		age: string,
+		opts: { taskId?: string; inheritFrom?: string | null } = {},
+	): Promise<string> {
 		const result = await db.query<{ id: string }>(
-			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, created_at)
-			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - $5::interval)
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, created_at,
+			                             retry_of_run_id, process_loss_retry_count)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - $5::interval, $6,
+			         COALESCE((SELECT prior.process_loss_retry_count
+			                     FROM heartbeat_runs prior WHERE prior.id = $6), 0))
 			 RETURNING id`,
-			[teamId, agentId, opts.taskId ?? null, HeartbeatRunStatus.Queued, age],
+			[
+				teamId,
+				agentId,
+				opts.taskId ?? null,
+				HeartbeatRunStatus.Queued,
+				age,
+				opts.inheritFrom ?? null,
+			],
 		);
 		return result.rows[0].id;
+	}
+
+	async function abandonedNotices(forTaskId: string): Promise<number> {
+		const r = await db.query<{ count: string }>(
+			`SELECT count(*)::text AS count FROM task_comments
+			 WHERE task_id = $1 AND content->>'kind' = 'run_abandoned'`,
+			[forTaskId],
+		);
+		return Number(r.rows[0].count);
 	}
 
 	async function clearRuns(): Promise<void> {
@@ -534,6 +559,13 @@ describe('detectOrphans for runs stranded before they started', () => {
 		expect(row).toBeDefined();
 		expect(row?.project_id).toBeTruthy();
 		expect(row?.status).toBe(HeartbeatRunStatus.Cancelled);
+		// And it carries the FINAL text, not the provisional verdict. The reap
+		// writes the verdict alone and the outcome is appended only once the work
+		// has been settled; broadcasting between the two would push a sentence to an
+		// open run page that the row no longer says. Asserting only id/status left
+		// that ordering unobserved - reverting it broke nothing.
+		expect(String(row?.error ?? '')).toContain('Never started');
+		expect(String(row?.error ?? '')).toContain('queue');
 	});
 
 	it('capacity-park-grace: a park outliving the grace window is survivable, not a failure', async () => {
@@ -646,10 +678,12 @@ describe('detectOrphans for runs stranded before they started', () => {
 		expect(replacement.rows).toHaveLength(1);
 		expect(replacement.rows[0].source).toBe(WakeupSource.Mention);
 		expect(replacement.rows[0].payload.task_id).toBe(taskId);
-		// Lineage under `previous_run_id`, so RUN_LINEAGE_SOURCES does not hand the
-		// replacement a loss budget the original never spent.
-		expect(replacement.rows[0].payload.previous_run_id).toBe(runId);
-		expect(replacement.rows[0].payload.previous_failure).toBeUndefined();
+		// Lineage under `previous_failure.run_id`, the one key RUN_LINEAGE_SOURCES
+		// gives the loss budget to. The strike this arm just spent has to travel to
+		// the replacement or the ceiling can never be reached - see the lap-by-lap
+		// test above.
+		expect((replacement.rows[0].payload.previous_failure as { run_id: string }).run_id).toBe(runId);
+		expect(replacement.rows[0].payload.previous_run_id).toBeUndefined();
 
 		// And the row says a fresh run was queued, not that the original went back.
 		const run = await db.query<{ error: string }>(
@@ -659,42 +693,47 @@ describe('detectOrphans for runs stranded before they started', () => {
 		expect(run.rows[0].error).toContain('A fresh run has been queued');
 	});
 
-	it('does not hand back an intent-less synthetic wakeup as if it were the work', async () => {
-		// `createSyntheticOnDemandWakeup` writes an empty payload. Returning one of
-		// those to the queue produces a task-less nudge, which `activateAgent`
-		// answers by selecting some other task by priority or by completing it as
-		// "nothing to do" - either way the run's actual work is gone.
+	it('hands back a wakeup that names no task, because that means "find work"', async () => {
+		// A heartbeat wakeup carries no `task_id` - `activateAgent` chooses the task
+		// - so a guard requiring the payload to name one skipped every heartbeat and
+		// left the original dangling in `claimed` for healStaleRunState to mislabel
+		// `failed`. That guard was written for "intent-less" synthetic wakeups, which
+		// are only ever minted for task-less progress-update runs and so never met
+		// it. A wakeup naming no task is not intent-less; handing it back says
+		// exactly what it said the first time.
 		await clearRuns();
 		const taskId = await createTask(teamId);
 		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
-		const synthetic = await db.query<{ id: string }>(
+		const heartbeat = await db.query<{ id: string }>(
 			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, claimed_at)
 			 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, '{}'::jsonb, now())
 			 RETURNING id`,
-			[agentId, teamId, WakeupSource.OnDemand, WakeupStatus.Claimed],
+			[agentId, teamId, WakeupSource.Heartbeat, WakeupStatus.Claimed],
 		);
 		const runId = await insertQueuedRun('10 minutes', { taskId });
 		await db.query('UPDATE heartbeat_runs SET wakeup_id = $1 WHERE id = $2', [
-			synthetic.rows[0].id,
+			heartbeat.rows[0].id,
 			runId,
 		]);
 
 		expect(await detectOrphans(db, new Set())).toBe(1);
 
-		// The empty row stays claimed rather than being resurrected as a nudge...
-		const untouched = await db.query<{ status: string }>(
-			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
-			[synthetic.rows[0].id],
+		const settled = await db.query<{ status: string; last_skipped_reason: string | null }>(
+			'SELECT status, last_skipped_reason FROM agent_wakeup_requests WHERE id = $1',
+			[heartbeat.rows[0].id],
 		);
-		expect(untouched.rows[0].status).toBe(WakeupStatus.Claimed);
-		// ...and the work is carried by a replacement that actually names the task.
-		const replacement = await db.query<{ payload: Record<string, unknown> }>(
-			`SELECT payload FROM agent_wakeup_requests
-			 WHERE member_id = $1 AND status = $2::wakeup_status`,
-			[agentId, WakeupStatus.Queued],
+		expect(settled.rows[0].status).toBe(WakeupStatus.Queued);
+		// And it is labelled for what it is. Stamping `instance_at_capacity` here -
+		// which this used to - has the idle pass reclaim the project's container out
+		// from under work that dispatches on the next tick.
+		expect(settled.rows[0].last_skipped_reason).toBe(WakeupSkipReason.RunNeverStarted);
+
+		// No replacement was minted: the original still carries the work.
+		const all = await db.query<{ count: string }>(
+			'SELECT count(*)::text AS count FROM agent_wakeup_requests WHERE member_id = $1',
+			[agentId],
 		);
-		expect(replacement.rows).toHaveLength(1);
-		expect(replacement.rows[0].payload.task_id).toBe(taskId);
+		expect(all.rows[0].count).toBe('1');
 	});
 
 	it('an inherited retry count does not dead-end a run that never started', async () => {
@@ -721,6 +760,155 @@ describe('detectOrphans for runs stranded before they started', () => {
 			[teamId],
 		);
 		expect(approvals.rows).toHaveLength(0);
+	});
+
+	it('records the cancel attribution and posts a notice only when work is abandoned', async () => {
+		// Three writers set `cancel_reason` and none of them was asserted, so the
+		// Retry button and the thread fold could both be silently killed. And the
+		// notice was untested in BOTH directions: it could be removed entirely, or
+		// fired on every requeue, with the suite green either way.
+		await clearRuns();
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		await db.query('DELETE FROM task_comments WHERE task_id = $1', [taskId]);
+
+		// A run whose work goes back on the queue is not something to act on.
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, claimed_at)
+			 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, jsonb_build_object('task_id', $5::text), now())
+			 RETURNING id`,
+			[agentId, teamId, WakeupSource.Mention, WakeupStatus.Claimed, taskId],
+		);
+		const requeuedRun = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET wakeup_id = $1 WHERE id = $2', [
+			wakeup.rows[0].id,
+			requeuedRun,
+		]);
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const handed = await db.query<{ cancel_reason: string | null }>(
+			'SELECT cancel_reason FROM heartbeat_runs WHERE id = $1',
+			[requeuedRun],
+		);
+		expect(handed.rows[0].cancel_reason).toBe(RunCancelReason.HandedBack);
+		expect(await abandonedNotices(taskId)).toBe(0);
+
+		// A run nothing is carrying is. Drive it to the ceiling.
+		await clearRuns();
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		const abandonedRun = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET process_loss_retry_count = $1 WHERE id = $2', [
+			MAX_RETRIES - 1,
+			abandonedRun,
+		]);
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const abandoned = await db.query<{ cancel_reason: string | null }>(
+			'SELECT cancel_reason FROM heartbeat_runs WHERE id = $1',
+			[abandonedRun],
+		);
+		expect(abandoned.rows[0].cancel_reason).toBe(RunCancelReason.Abandoned);
+		// Exactly one, naming the run whose card carries the Retry button.
+		expect(await abandonedNotices(taskId)).toBe(1);
+		const notice = await db.query<{ content: { run_id?: string } }>(
+			`SELECT content FROM task_comments
+			 WHERE task_id = $1 AND content->>'kind' = 'run_abandoned'`,
+			[taskId],
+		);
+		expect(notice.rows[0].content.run_id).toBe(abandonedRun);
+	});
+
+	it("leaves a human's own cancel attribution alone, and posts no notice over it", async () => {
+		// First writer wins. A person pressing Terminate backfills
+		// `operator_terminated` while the abort is still cascading; this pass must
+		// not relabel that as something the instance did, nor tell the thread the
+		// work was abandoned when somebody chose to stop it.
+		await clearRuns();
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+		await db.query('DELETE FROM task_comments WHERE task_id = $1', [taskId]);
+		const runId = await insertQueuedRun('10 minutes', { taskId });
+		await db.query('UPDATE heartbeat_runs SET cancel_reason = $1 WHERE id = $2', [
+			RunCancelReason.OperatorTerminated,
+			runId,
+		]);
+
+		expect(await detectOrphans(db, new Set())).toBe(1);
+
+		const row = await db.query<{ cancel_reason: string | null }>(
+			'SELECT cancel_reason FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(row.rows[0].cancel_reason).toBe(RunCancelReason.OperatorTerminated);
+		expect(await abandonedNotices(taskId)).toBe(0);
+	});
+
+	it('the never-started chain actually climbs, lap by lap, to its ceiling', async () => {
+		// The regression this exists for: the arm used to spend its strike on the
+		// row it had just reaped and then hand the replacement a `previous_run_id`
+		// lineage, which does NOT inherit the loss budget - so every lap started
+		// back at zero and the ceiling was unreachable. Hand-setting the counter
+		// (as the two tests below do) cannot see that; only driving real laps can.
+		await clearRuns();
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+		const taskId = await createTask(teamId);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+
+		const counts: number[] = [];
+		let previousRunId: string | null = null;
+		for (let lap = 0; lap < MAX_RETRIES; lap++) {
+			// Each lap: the replacement wakeup from the previous lap becomes a run
+			// that also never starts. `createHeartbeatRun` is what carries the budget
+			// across, so the run must be minted the way production mints it.
+			const wakeup = await db.query<{ id: string; payload: Record<string, unknown> }>(
+				`SELECT id, payload FROM agent_wakeup_requests
+				 WHERE member_id = $1 AND status = $2::wakeup_status`,
+				[agentId, WakeupStatus.Queued],
+			);
+			const runId = await insertQueuedRun('10 minutes', {
+				taskId,
+				// Mirror createHeartbeatRun's inheritance rather than re-implementing
+				// it: a lineage naming previous_failure.run_id carries the count.
+				inheritFrom: lap === 0 ? null : previousRunId,
+			});
+			if (wakeup.rows[0]) {
+				await db.query('UPDATE heartbeat_runs SET wakeup_id = $1 WHERE id = $2', [
+					wakeup.rows[0].id,
+					runId,
+				]);
+				await db.query(
+					`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, claimed_at = now() WHERE id = $2`,
+					[WakeupStatus.Failed, wakeup.rows[0].id],
+				);
+			}
+
+			expect(await detectOrphans(db, new Set())).toBe(1);
+
+			const after = await db.query<{ process_loss_retry_count: number }>(
+				'SELECT process_loss_retry_count FROM heartbeat_runs WHERE id = $1',
+				[runId],
+			);
+			counts.push(after.rows[0].process_loss_retry_count);
+			previousRunId = runId;
+		}
+
+		// 1, 2, then the third lap trips the ceiling and gives up rather than
+		// spending a fourth strike. Before the fix this was 1, 1, 1 - every lap
+		// started back at zero, so the ceiling was never reached at all.
+		expect(counts).toEqual([1, 2, 2]);
+
+		// And the final lap gave up rather than queueing a fourth replacement.
+		const queued = await db.query<{ id: string }>(
+			`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(queued.rows).toHaveLength(0);
+		const approvals = await db.query<{ id: string }>(
+			'SELECT id FROM approvals WHERE team_id = $1',
+			[teamId],
+		);
+		expect(approvals.rows).toHaveLength(1);
 	});
 
 	it('gives up visibly once the never-started chain hits its ceiling', async () => {

--- a/packages/server/test/run-termination.test.ts
+++ b/packages/server/test/run-termination.test.ts
@@ -3,6 +3,8 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
+import { terminateHeartbeatRun } from '../src/services/run-termination';
+import { settleWakeupForRun } from '../src/services/wakeup';
 import { safeClose } from './helpers';
 import {
 	authHeader,
@@ -157,6 +159,59 @@ describe('POST /heartbeat-runs/:runId/terminate', () => {
 		);
 		expect(terminationComment).toBeTruthy();
 		expect(terminationComment?.content?.reason).toBe('Terminated by user');
+	});
+
+	it("a running run keeps the human's attribution once its abort cascades", async () => {
+		// The `wasLive` branch, which every other case here misses: `makeRun()`
+		// rows are not registered with the JobManager, so `cancelLiveRun` always
+		// returned false and this half was never executed. It is where the two
+		// races the change had to settle both live - the run is still in flight,
+		// and its own finalizer reaches the row and the wakeup moments later.
+		const runId = await makeRun('running');
+		const liveJobManager = {
+			cancelLiveRun: () => true,
+		} as unknown as Parameters<typeof terminateHeartbeatRun>[0]['jobManager'];
+
+		const result = await terminateHeartbeatRun(
+			{ db, wsManager: undefined, jobManager: liveJobManager },
+			runId,
+			'Terminated by user',
+			null,
+		);
+		expect(result.terminated).toBe(true);
+
+		// Backfilled while the abort is still cascading; the row stays `running`
+		// until the runner's own finalizer lands.
+		const backfilled = await getRunRow(runId);
+		expect(backfilled.cancel_reason).toBe(RunCancelReason.OperatorTerminated);
+		expect(await getWakeupStatus(runId)).toBe(WakeupStatus.Cancelled);
+
+		// Now the runner finalizes it. `updateHeartbeatRun` writes
+		// `COALESCE(cancel_reason, $n)`, so the person's attribution survives - the
+		// opposite direction overwrote it with the runner's own vaguer verdict.
+		await db.query(
+			`UPDATE heartbeat_runs
+			    SET status = 'cancelled'::heartbeat_run_status,
+			        cancel_reason = COALESCE(cancel_reason, $2)
+			  WHERE id = $1`,
+			[runId, RunCancelReason.HandedBack],
+		);
+		expect((await getRunRow(runId)).cancel_reason).toBe(RunCancelReason.OperatorTerminated);
+
+		// And its wakeup settlement survives too: the terminal arm declines to
+		// relabel a wakeup that already reached a terminal status, so work somebody
+		// withdrew is not reported as work that failed.
+		await settleWakeupForRun(
+			db,
+			(
+				await db.query<{ wakeup_id: string }>(
+					'SELECT wakeup_id FROM heartbeat_runs WHERE id = $1',
+					[runId],
+				)
+			).rows[0].wakeup_id,
+			{ kind: 'fail' },
+		);
+		expect(await getWakeupStatus(runId)).toBe(WakeupStatus.Cancelled);
 	});
 
 	it('returns 409 when the run is already terminal', async () => {

--- a/packages/server/test/run-termination.test.ts
+++ b/packages/server/test/run-termination.test.ts
@@ -1,3 +1,4 @@
+import { RunCancelReason, WakeupStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
@@ -40,12 +41,23 @@ async function makeRun(status: 'queued' | 'running' | 'succeeded'): Promise<stri
 	return r.rows[0].id;
 }
 
-async function getRunRow(runId: string): Promise<{ status: string; error: string | null }> {
-	const r = await db.query<{ status: string; error: string | null }>(
-		'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+async function getRunRow(
+	runId: string,
+): Promise<{ status: string; error: string | null; cancel_reason: string | null }> {
+	const r = await db.query<{ status: string; error: string | null; cancel_reason: string | null }>(
+		'SELECT status, error, cancel_reason FROM heartbeat_runs WHERE id = $1',
 		[runId],
 	);
 	return r.rows[0];
+}
+
+async function getWakeupStatus(runId: string): Promise<string | undefined> {
+	const r = await db.query<{ status: string }>(
+		`SELECT w.status FROM agent_wakeup_requests w
+		 JOIN heartbeat_runs hr ON hr.wakeup_id = w.id WHERE hr.id = $1`,
+		[runId],
+	);
+	return r.rows[0]?.status;
 }
 
 interface SysCommentRow {
@@ -129,6 +141,15 @@ describe('POST /heartbeat-runs/:runId/terminate', () => {
 		const row = await getRunRow(runId);
 		expect(row.status).toBe('cancelled');
 		expect(row.error).toBe('Terminated by user');
+		// A person chose to stop this, so no Retry is offered and the work is not
+		// owed. Recording it structurally is what keeps that decision out of the
+		// error prose every reader would otherwise have to parse.
+		expect(row.cancel_reason).toBe(RunCancelReason.OperatorTerminated);
+
+		// Settled here rather than left `claimed` for healStaleRunState to record
+		// as `failed` two minutes later. Both were the wrong label for withdrawn
+		// work, and a still-claimed row suppresses chainNextTaskWakeup meanwhile.
+		expect(await getWakeupStatus(runId)).toBe(WakeupStatus.Cancelled);
 
 		const sysComments = await getSystemComments(taskId);
 		const terminationComment = sysComments.find(
@@ -189,6 +210,10 @@ describe('PATCH /tasks status → Cancelled', () => {
 		const row = await getRunRow(runId);
 		expect(row.status).toBe('cancelled');
 		expect(row.error).toBe('Task cancelled');
+		// Withdrawn, not operator-terminated: nobody stopped this run, the work it
+		// was doing stopped being wanted. Both mean no Retry, and they differ only
+		// in what a reader is told.
+		expect(row.cancel_reason).toBe(RunCancelReason.WorkWithdrawn);
 
 		const sysComments = await getSystemComments(taskId);
 		const terminationComment = sysComments.find(

--- a/packages/server/test/run-termination.test.ts
+++ b/packages/server/test/run-termination.test.ts
@@ -186,19 +186,14 @@ describe('POST /heartbeat-runs/:runId/terminate', () => {
 		expect(backfilled.cancel_reason).toBe(RunCancelReason.OperatorTerminated);
 		expect(await getWakeupStatus(runId)).toBe(WakeupStatus.Cancelled);
 
-		// Now the runner finalizes it. `updateHeartbeatRun` writes
-		// `COALESCE(cancel_reason, $n)`, so the person's attribution survives - the
-		// opposite direction overwrote it with the runner's own vaguer verdict.
-		await db.query(
-			`UPDATE heartbeat_runs
-			    SET status = 'cancelled'::heartbeat_run_status,
-			        cancel_reason = COALESCE(cancel_reason, $2)
-			  WHERE id = $1`,
-			[runId, RunCancelReason.HandedBack],
-		);
-		expect((await getRunRow(runId)).cancel_reason).toBe(RunCancelReason.OperatorTerminated);
-
-		// And its wakeup settlement survives too: the terminal arm declines to
+		// The runner's own finalizer cannot undo that, and no test asserts it here
+		// on purpose: `updateHeartbeatRun` does not carry `cancel_reason` in its SET
+		// list at all, so the guarantee is structural rather than a COALESCE
+		// direction to pin. An earlier version of this test hand-wrote that COALESCE
+		// and asserted its own SQL preserved the value, under a comment crediting
+		// production - which passed just as happily with production mutated.
+		//
+		// Its wakeup settlement survives too: the terminal arm declines to
 		// relabel a wakeup that already reached a terminal status, so work somebody
 		// withdrew is not reported as work that failed.
 		await settleWakeupForRun(

--- a/packages/server/test/tasks-last-run.test.ts
+++ b/packages/server/test/tasks-last-run.test.ts
@@ -17,6 +17,7 @@ interface TaskRow {
 	id: string;
 	identifier: string;
 	last_run_status: string | null;
+	last_run_cancel_reason?: string | null;
 	last_run_id?: string | null;
 	last_run_comment_id?: string | null;
 	has_active_run: boolean;
@@ -100,6 +101,24 @@ async function fetchDetail(taskId: string): Promise<TaskRow> {
 }
 
 describe('task last-run fields', () => {
+	it("projects the last run's cancel reason, which decides whether the thread offers Retry", async () => {
+		// `cancelled` covers a person stopping a run and the instance abandoning
+		// one; only the second still owes work, and the thread keeps that run's card
+		// unfolded with a Retry button on the strength of this field. Without the
+		// projection the component tests still pass - they stub the response - so
+		// dropping it ships green and silently disables the affordance.
+		const taskId = await createTask('Abandoned run');
+		const runId = await insertRun(taskId, 'cancelled', new Date());
+		await db.query('UPDATE heartbeat_runs SET cancel_reason = $1 WHERE id = $2', [
+			'abandoned',
+			runId,
+		]);
+
+		const detail = await fetchDetail(taskId);
+		expect(detail.last_run_status).toBe('cancelled');
+		expect(detail.last_run_cancel_reason).toBe('abandoned');
+	});
+
 	it('returns null when the task has no runs', async () => {
 		const taskId = await createTask('No runs');
 		const listRow = await fetchListRow(taskId);

--- a/packages/server/test/wakeup-settlement.test.ts
+++ b/packages/server/test/wakeup-settlement.test.ts
@@ -1,0 +1,126 @@
+import { WakeupSkipReason, WakeupSource, WakeupStatus } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import { settleWakeupForRun } from '../src/services/wakeup';
+import { safeClose } from './helpers';
+import { createTestApp, createTestTeam } from './helpers/app';
+
+/**
+ * The seam that answers "what happens to the work this run was woken for?".
+ * It had no direct test at all, which is how its `claimed` guard came to exist
+ * on one caller and not the other, and how `handback_failed` came to be a signal
+ * nothing acted on.
+ */
+let db: Db;
+let teamId: string;
+let memberId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	const team = await createTestTeam(db, { name: 'Settlement Co' });
+	teamId = (await team.json()).data.id;
+	const member = await db.query<{ id: string }>(
+		`INSERT INTO members (team_id, member_type, display_name)
+		 VALUES ($1, 'agent', 'Settler') RETURNING id`,
+		[teamId],
+	);
+	memberId = member.rows[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function seedWakeup(status: WakeupStatus): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at)
+		 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status, now())
+		 RETURNING id`,
+		[memberId, teamId, WakeupSource.Mention, status],
+	);
+	return r.rows[0].id;
+}
+
+async function readWakeup(id: string) {
+	const r = await db.query<{
+		status: string;
+		claimed_at: string | null;
+		last_skipped_reason: string | null;
+	}>('SELECT status, claimed_at, last_skipped_reason FROM agent_wakeup_requests WHERE id = $1', [
+		id,
+	]);
+	return r.rows[0];
+}
+
+describe('settleWakeupForRun', () => {
+	it('hands a claimed wakeup back to the queue, labelled with the wait that gave up', async () => {
+		const id = await seedWakeup(WakeupStatus.Claimed);
+		const settled = await settleWakeupForRun(db, id, {
+			kind: 'handback',
+			reason: WakeupSkipReason.CredentialBusy,
+		});
+
+		expect(settled).toEqual({ kind: 'requeued' });
+		const row = await readWakeup(id);
+		expect(row.status).toBe(WakeupStatus.Queued);
+		expect(row.claimed_at).toBeNull();
+		// The label decides what the task sidebar tells an operator, and whether the
+		// idle pass counts the project busy. Both waits reached here stamping
+		// `instance_at_capacity` regardless of which one had actually given up.
+		expect(row.last_skipped_reason).toBe(WakeupSkipReason.CredentialBusy);
+	});
+
+	it('refuses to resurrect a wakeup another path already settled, and says so', async () => {
+		// The guard is the load-bearing part: returning a completed wakeup to the
+		// queue dispatches its work a second time. Reporting the refusal is equally
+		// load-bearing - a caller that reads this as success leaves work owed while
+		// its run row claims the work was queued.
+		const id = await seedWakeup(WakeupStatus.Completed);
+		const settled = await settleWakeupForRun(db, id, {
+			kind: 'handback',
+			reason: WakeupSkipReason.RunNeverStarted,
+		});
+
+		expect(settled).toEqual({ kind: 'handback_failed' });
+		expect((await readWakeup(id)).status).toBe(WakeupStatus.Completed);
+	});
+
+	it('settles every terminal intent to its own status', async () => {
+		for (const [intent, expected] of [
+			['complete', WakeupStatus.Completed],
+			['fail', WakeupStatus.Failed],
+			['withdraw', WakeupStatus.Cancelled],
+		] as const) {
+			const id = await seedWakeup(WakeupStatus.Claimed);
+			const settled = await settleWakeupForRun(db, id, { kind: intent });
+			expect(settled).toEqual({ kind: 'terminal', status: expected });
+			expect((await readWakeup(id)).status).toBe(expected);
+		}
+	});
+
+	it('leaves a terminal wakeup alone, so the first decision stands', async () => {
+		// The mirror of the handback guard. A person presses Terminate, which settles
+		// the wakeup `cancelled` immediately; the aborting run reaches
+		// `onAgentComplete` seconds later with `fail` and would relabel work somebody
+		// deliberately withdrew as work that failed. Whoever settled first knew more.
+		const id = await seedWakeup(WakeupStatus.Claimed);
+		await settleWakeupForRun(db, id, { kind: 'withdraw' });
+
+		const second = await settleWakeupForRun(db, id, { kind: 'fail' });
+
+		expect(second).toEqual({ kind: 'terminal', status: WakeupStatus.Cancelled });
+		expect((await readWakeup(id)).status).toBe(WakeupStatus.Cancelled);
+	});
+
+	it('reports when there was no wakeup to settle rather than pretending it worked', async () => {
+		// A synthetic or manual run has none, and a caller must be able to tell that
+		// apart from a successful handback.
+		expect(await settleWakeupForRun(db, undefined, { kind: 'complete' })).toEqual({
+			kind: 'nothing_to_settle',
+		});
+		expect(await settleWakeupForRun(db, null, { kind: 'fail' })).toEqual({
+			kind: 'nothing_to_settle',
+		});
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -603,6 +603,15 @@ export const RUN_CANCEL_REASONS = [
  * `offerRetry` is false for `handed_back` on purpose. The work is already queued
  * there, so a Retry button would be dead UI at best and a double dispatch at
  * worst; `abandoned` is the only cancel where a person still has something to do.
+ *
+ * **Scope:** this drives the Retry affordance only - the button on the run card
+ * and the thread fold that keeps that card open. Those two must agree, because a
+ * fold that opens on a row with no button, or a button on a folded row, is worse
+ * than either answer alone. It deliberately does NOT reach the task list's
+ * errored icon or the last-run banner, which track `failed`/`timed_out` and whose
+ * copy says the run failed - untrue of a run that never started. An abandoned run
+ * is surfaced instead by its thread notice and by the approval it raises, so it
+ * is not silent; it just is not counted as an error.
  */
 export const RUN_CANCEL_BEHAVIOUR: Record<
 	RunCancelReason,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -567,3 +567,80 @@ export const QUEUED_RUN_REASONS = [
 export function isQueuedRunReason(value: unknown): value is QueuedRunReason {
 	return typeof value === 'string' && (QUEUED_RUN_REASONS as readonly string[]).includes(value);
 }
+
+/**
+ * Why a run ended up `cancelled`.
+ *
+ * `cancelled` covers two opposite events. Two of these are somebody deciding to
+ * stop: an operator pressing Terminate, or a task being cancelled or re-opened
+ * so its pending work is moot. The other two are the instance giving up on its
+ * own, and only one of those leaves work owed with nothing carrying it.
+ */
+export const RunCancelReason = {
+	/** A person pressed Terminate on this run. */
+	OperatorTerminated: 'operator_terminated',
+	/** Nobody wants the work any more: the task was cancelled, or a re-open made a review moot. */
+	WorkWithdrawn: 'work_withdrawn',
+	/** The instance gave up waiting and put the work back on the queue. */
+	HandedBack: 'handed_back',
+	/** The instance gave up and could not put the work back. Needs a human. */
+	Abandoned: 'abandoned',
+} as const;
+export type RunCancelReason = (typeof RunCancelReason)[keyof typeof RunCancelReason];
+
+export const RUN_CANCEL_REASONS = [
+	RunCancelReason.OperatorTerminated,
+	RunCancelReason.WorkWithdrawn,
+	RunCancelReason.HandedBack,
+	RunCancelReason.Abandoned,
+] as const;
+
+/**
+ * What each cancel means for the reader, as a table rather than a branch: a new
+ * reason is a row here and a compile error at every consumer until it is filled
+ * in, instead of four call sites quietly falling through to a default.
+ *
+ * `offerRetry` is false for `handed_back` on purpose. The work is already queued
+ * there, so a Retry button would be dead UI at best and a double dispatch at
+ * worst; `abandoned` is the only cancel where a person still has something to do.
+ */
+export const RUN_CANCEL_BEHAVIOUR: Record<
+	RunCancelReason,
+	{
+		/** The work this run was woken for has still not been done. */
+		workStillOwed: boolean;
+		/** Nothing is carrying that work, so offer the reader a way to run it again. */
+		offerRetry: boolean;
+	}
+> = {
+	[RunCancelReason.OperatorTerminated]: { workStillOwed: false, offerRetry: false },
+	[RunCancelReason.WorkWithdrawn]: { workStillOwed: false, offerRetry: false },
+	[RunCancelReason.HandedBack]: { workStillOwed: true, offerRetry: false },
+	[RunCancelReason.Abandoned]: { workStillOwed: true, offerRetry: true },
+};
+
+/**
+ * Whether a stored `cancel_reason` is one this build knows what to do with.
+ *
+ * Guarding rather than indexing straight into the table matters across a
+ * version skew: a reason written by a newer server reads as unknown here and
+ * falls through to "no Retry", which is the safe answer, instead of indexing to
+ * `undefined` and throwing in the middle of a render.
+ */
+export function isRunCancelReason(value: unknown): value is RunCancelReason {
+	return typeof value === 'string' && (RUN_CANCEL_REASONS as readonly string[]).includes(value);
+}
+
+/**
+ * Whether a cancelled run should offer the reader a way to run it again.
+ *
+ * The guard plus the table lookup, in one place, because both surfaces that ask
+ * (the run card's own button and the thread's fold rule) must agree - a fold
+ * that opens on a row with no button, or a button on a folded row, is worse than
+ * either answer alone. An unknown or absent reason is false: an older cancel
+ * carries no attribution, and inventing an affordance for it would re-dispatch
+ * work somebody may have deliberately stopped.
+ */
+export function runCancelOffersRetry(reason: string | null | undefined): boolean {
+	return isRunCancelReason(reason) && RUN_CANCEL_BEHAVIOUR[reason].offerRetry;
+}

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -912,6 +912,19 @@ export const WakeupSkipReason = {
 	 * on new input. See `services/no-work-backoff.ts`.
 	 */
 	NoWorkCooldown: 'no_work_cooldown',
+	/**
+	 * Another run still held the rotating provider credential when this one gave
+	 * up waiting. Distinct from `InstanceAtCapacity` because the two waits clear
+	 * on different clocks: capacity frees when the idle pass reclaims a container,
+	 * this frees only when a whole other run finishes.
+	 */
+	CredentialBusy: 'credential_busy',
+	/**
+	 * A queued run's host-side driver vanished before the agent launched, so the
+	 * work was handed back. Not a capacity wait: nothing is being waited on, and
+	 * the dispatcher should pick this up on its next tick.
+	 */
+	RunNeverStarted: 'run_never_started',
 } as const;
 export type WakeupSkipReason = (typeof WakeupSkipReason)[keyof typeof WakeupSkipReason];
 

--- a/packages/shared/test/run-cancel-reason.test.ts
+++ b/packages/shared/test/run-cancel-reason.test.ts
@@ -1,0 +1,53 @@
+import {
+	isRunCancelReason,
+	RUN_CANCEL_BEHAVIOUR,
+	RUN_CANCEL_REASONS,
+	RunCancelReason,
+	runCancelOffersRetry,
+} from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+
+describe('RunCancelReason', () => {
+	it('describes every reason, so a new one cannot fall through to a default', () => {
+		for (const reason of RUN_CANCEL_REASONS) {
+			expect(RUN_CANCEL_BEHAVIOUR[reason]).toBeDefined();
+		}
+		expect(Object.keys(RUN_CANCEL_BEHAVIOUR).sort()).toEqual([...RUN_CANCEL_REASONS].sort());
+	});
+
+	it('offers a retry only where work is owed and nothing is carrying it', () => {
+		// `handed_back` owes work too, but the wakeup is already queued - a button
+		// there is dead at best and a double dispatch at worst.
+		expect(RUN_CANCEL_BEHAVIOUR[RunCancelReason.Abandoned]).toEqual({
+			workStillOwed: true,
+			offerRetry: true,
+		});
+		expect(RUN_CANCEL_BEHAVIOUR[RunCancelReason.HandedBack]).toEqual({
+			workStillOwed: true,
+			offerRetry: false,
+		});
+		// Nobody wants the work, so neither of these owes anything.
+		expect(RUN_CANCEL_BEHAVIOUR[RunCancelReason.OperatorTerminated].workStillOwed).toBe(false);
+		expect(RUN_CANCEL_BEHAVIOUR[RunCancelReason.WorkWithdrawn].workStillOwed).toBe(false);
+	});
+
+	it('recognises stored values and rejects everything else', () => {
+		expect(isRunCancelReason('abandoned')).toBe(true);
+		expect(isRunCancelReason('operator_terminated')).toBe(true);
+		expect(isRunCancelReason('something_a_newer_server_wrote')).toBe(false);
+		expect(isRunCancelReason(null)).toBe(false);
+		expect(isRunCancelReason(undefined)).toBe(false);
+		expect(isRunCancelReason(7)).toBe(false);
+	});
+
+	it('answers false for an unknown reason rather than throwing mid-render', () => {
+		// The version-skew case: a run cancelled by a newer server, or by one old
+		// enough to carry no attribution at all. Silence is the safe answer, since
+		// inventing a Retry could re-dispatch work somebody deliberately stopped.
+		expect(runCancelOffersRetry('abandoned')).toBe(true);
+		expect(runCancelOffersRetry('handed_back')).toBe(false);
+		expect(runCancelOffersRetry('a_reason_from_the_future')).toBe(false);
+		expect(runCancelOffersRetry(null)).toBe(false);
+		expect(runCancelOffersRetry(undefined)).toBe(false);
+	});
+});

--- a/packages/web/src/components/comment-content.ts
+++ b/packages/web/src/components/comment-content.ts
@@ -85,6 +85,18 @@ export interface SystemRunFailedContent {
 	text?: string;
 }
 
+/**
+ * A run the instance gave up on with nothing left carrying its work. Posted only
+ * on that outcome, so its presence in a thread is itself the signal that
+ * somebody has to act; `run_id` names the run whose card offers Retry.
+ */
+export interface SystemRunAbandonedContent {
+	kind: 'run_abandoned';
+	agent_slug?: string | null;
+	run_id?: string;
+	text?: string;
+}
+
 export interface SystemRepoDesignatedContent {
 	kind: 'repo_designated';
 	repo_identifier?: string;
@@ -110,6 +122,7 @@ export type SystemContent =
 	| SystemParentChangeContent
 	| SystemDescriptionChangeContent
 	| SystemRunFailedContent
+	| SystemRunAbandonedContent
 	| SystemRepoDesignatedContent
 	| SystemGenericContent;
 

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,4 +1,9 @@
-import { HeartbeatRunStatus, isQueuedRunReason, QueuedRunReason } from '@hezo/shared';
+import {
+	HeartbeatRunStatus,
+	isQueuedRunReason,
+	QueuedRunReason,
+	runCancelOffersRetry,
+} from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { AlertTriangle, DoorOpen, Loader2, RotateCw } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
@@ -225,10 +230,18 @@ export function RunCommentBody({
 	// Offer a manual retry on a failed/timed-out run, but only on the latest run
 	// and only when nothing is already running or queued for this task — that's
 	// exactly what `retryableRunId` resolves to (null otherwise).
+	//
+	// A cancelled run qualifies too, but only for the one reason that leaves work
+	// owed with nothing carrying it. The rest are read off `RUN_CANCEL_BEHAVIOUR`
+	// rather than listed here, so a new reason is decided once: a Terminate is
+	// somebody choosing to stop, and a handback has already re-queued the work, so
+	// a button on either is at best dead and at worst a double dispatch.
 	const canRetry =
 		Boolean(taskId) &&
 		runId === retryableRunId &&
-		(status === HeartbeatRunStatus.Failed || status === HeartbeatRunStatus.TimedOut);
+		(status === HeartbeatRunStatus.Failed ||
+			status === HeartbeatRunStatus.TimedOut ||
+			(status === HeartbeatRunStatus.Cancelled && runCancelOffersRetry(run?.cancel_reason)));
 	const { lines } = useRunLogs(run?.project_id, runId, run?.log_text, isActive);
 	const createdTasks = run?.created_tasks ?? [];
 	const createdDocs = run?.created_docs ?? [];

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -235,7 +235,9 @@ export function RunCommentBody({
 	// owed with nothing carrying it. The rest are read off `RUN_CANCEL_BEHAVIOUR`
 	// rather than listed here, so a new reason is decided once: a Terminate is
 	// somebody choosing to stop, and a handback has already re-queued the work, so
-	// a button on either is at best dead and at worst a double dispatch.
+	// a button on either is at best dead and at worst a double dispatch. The fold
+	// rule in `comments-section.tsx` reads the same table, which is what keeps this
+	// button and the row it sits on from disagreeing.
 	const canRetry =
 		Boolean(taskId) &&
 		runId === retryableRunId &&

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -9,6 +9,7 @@ import type {
 	SystemDescriptionChangeContent,
 	SystemParentChangeContent,
 	SystemRepoDesignatedContent,
+	SystemRunAbandonedContent,
 	SystemRunFailedContent,
 	SystemStatusChangeContent,
 	SystemTaskLinkContent,
@@ -30,6 +31,9 @@ function isStatusChange(c: SystemContent): c is SystemStatusChangeContent {
 }
 function isRunFailed(c: SystemContent): c is SystemRunFailedContent {
 	return c.kind === 'run_failed';
+}
+function isRunAbandoned(c: SystemContent): c is SystemRunAbandonedContent {
+	return c.kind === 'run_abandoned';
 }
 function isRepoDesignated(c: SystemContent): c is SystemRepoDesignatedContent {
 	return c.kind === 'repo_designated';
@@ -72,6 +76,10 @@ export function SystemComment({ comment, projectId }: Props) {
 
 	if (content && isRunFailed(content)) {
 		return <RunFailedBody content={content} projectId={projectId} timestamp={timestamp} />;
+	}
+
+	if (content && isRunAbandoned(content)) {
+		return <RunAbandonedBody content={content} projectId={projectId} timestamp={timestamp} />;
 	}
 
 	if (content && isRepoDesignated(content)) {
@@ -357,6 +365,51 @@ function RunFailedBody({
 							error: error ? <span className="text-text-3">{error}</span> : null,
 						}}
 					/>
+				</span>
+			</span>
+			{timestamp}
+		</div>
+	);
+}
+
+/**
+ * Deliberately shaped like `RunFailedBody` rather than sharing with it: the two
+ * sentences differ in every language (one reports a failure, the other reports
+ * that nothing ran and nothing will), and folding them into one template with a
+ * variable would force a wrong agreement somewhere.
+ */
+function RunAbandonedBody({
+	content,
+	projectId,
+	timestamp,
+}: {
+	content: SystemRunAbandonedContent;
+	projectId?: string;
+	timestamp: React.ReactNode;
+}) {
+	const { t } = useI18n();
+	const agentSlug = typeof content.agent_slug === 'string' ? content.agent_slug : '';
+	const agentNode =
+		agentSlug && projectId ? (
+			<Link
+				to="/projects/$projectId/agents/$agentId"
+				params={{ projectId, agentId: agentSlug }}
+				className="text-xs text-info-soft-fg hover:underline"
+				data-testid="run-abandoned-agent"
+			>
+				@{agentSlug}
+			</Link>
+		) : (
+			<span className="text-xs text-text-2">{t('comment.runAgentFallback')}</span>
+		);
+	return (
+		<div
+			className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2 leading-[26px]"
+			data-testid="run-abandoned-comment"
+		>
+			<span className="text-xs text-text-2 inline-flex items-baseline gap-1.5 flex-wrap">
+				<span>
+					<Trans k="comment.runAbandoned" vars={{ agent: agentNode }} />
 				</span>
 			</span>
 			{timestamp}

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -3,6 +3,7 @@ import {
 	findGroupKeyForRow,
 	HeartbeatRunStatus,
 	isWorkingThreadRow,
+	runCancelOffersRetry,
 	type TaskView,
 	type ThreadFoldContext,
 } from '@hezo/shared';
@@ -287,7 +288,9 @@ export function CommentsSection({
 	// offering nothing to act on.
 	const lastRunFailed =
 		task.last_run_status === HeartbeatRunStatus.Failed ||
-		task.last_run_status === HeartbeatRunStatus.TimedOut;
+		task.last_run_status === HeartbeatRunStatus.TimedOut ||
+		(task.last_run_status === HeartbeatRunStatus.Cancelled &&
+			runCancelOffersRetry(task.last_run_cancel_reason));
 	const foldCtx = useMemo<ThreadFoldContext>(
 		() => ({
 			activeRunId: task.active_run?.id ?? null,

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -17,6 +17,12 @@ export interface HeartbeatRun {
 	project_name: string | null;
 	status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'timed_out';
 	queued_reason: string | null;
+	/**
+	 * Why a `cancelled` run was cancelled. Read through `isRunCancelReason` so a
+	 * value from a newer server degrades rather than throwing. Null on every other
+	 * status, and on any run cancelled before the attribution existed.
+	 */
+	cancel_reason: string | null;
 	created_at: string;
 	/** Null until the run goes running - a run that ended before that never gets one. */
 	started_at: string | null;

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -9,7 +9,13 @@ import { toast } from './use-toast';
 
 export interface QueuedWakeup {
 	/** `project_at_capacity` is the pre-rename legacy value, kept for the upgrade window. */
-	reason: 'task_busy' | 'instance_at_capacity' | 'project_at_capacity' | 'agent_running';
+	reason:
+		| 'task_busy'
+		| 'instance_at_capacity'
+		| 'project_at_capacity'
+		| 'agent_running'
+		| 'credential_busy'
+		| 'run_never_started';
 	since: string;
 	blocker_task_id: string | null;
 	blocker_identifier: string | null;
@@ -66,6 +72,8 @@ export interface Task {
 	 */
 	admin_action_pending: boolean;
 	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
+	/** Why the last run was cancelled, when it was. See `RunCancelReason`. */
+	last_run_cancel_reason: string | null;
 	/** Capped server-side; the run detail read serves the whole value. */
 	last_run_error: string | null;
 	/** Id of the last completed run — the target of a manual retry. */

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} hat diese Aufgabe auf die oberste Ebene verschoben",
 	"comment.parentPromotedFrom": "{actor} hat diese Aufgabe auf die oberste Ebene verschoben (war unter {from})",
 	"comment.repoDesignated": "Repository {repo} wurde als zugewiesenes Repository festgelegt.",
+	"comment.runAbandoned": "Lauf für {agent} konnte nicht gestartet werden und wird nicht automatisch wiederholt.",
 	"comment.runAgentFallback": "einen Agenten",
 	"comment.runFailed": "Lauf für {agent} fehlgeschlagen.",
 	"comment.runFailedWithError": "Lauf für {agent} fehlgeschlagen: {error}",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} promoted this task to top level",
 	"comment.parentPromotedFrom": "{actor} promoted this task to top level (was under {from})",
 	"comment.repoDesignated": "Repository {repo} set as the designated repo.",
+	"comment.runAbandoned": "Run for {agent} could not be started and will not be retried automatically.",
 	"comment.runAgentFallback": "agent",
 	"comment.runFailed": "Run for {agent} failed.",
 	"comment.runFailedWithError": "Run for {agent} failed: {error}",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} promovió esta tarea al nivel superior",
 	"comment.parentPromotedFrom": "{actor} promovió esta tarea al nivel superior (estaba bajo {from})",
 	"comment.repoDesignated": "Repositorio {repo} establecido como repositorio designado.",
+	"comment.runAbandoned": "La ejecución de {agent} no pudo iniciarse y no se reintentará automáticamente.",
 	"comment.runAgentFallback": "un agente",
 	"comment.runFailed": "La ejecución de {agent} falló.",
 	"comment.runFailedWithError": "La ejecución de {agent} falló: {error}",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} a promu cette tâche au niveau supérieur",
 	"comment.parentPromotedFrom": "{actor} a promu cette tâche au niveau supérieur (elle était sous {from})",
 	"comment.repoDesignated": "Dépôt {repo} défini comme dépôt désigné.",
+	"comment.runAbandoned": "L'exécution pour {agent} n'a pas pu démarrer et ne sera pas relancée automatiquement.",
 	"comment.runAgentFallback": "un agent",
 	"comment.runFailed": "L'exécution pour {agent} a échoué.",
 	"comment.runFailedWithError": "L'exécution pour {agent} a échoué : {error}",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} ha promosso questa attività al livello principale",
 	"comment.parentPromotedFrom": "{actor} ha promosso questa attività al livello principale (era sotto {from})",
 	"comment.repoDesignated": "Repository {repo} impostato come repository designato.",
+	"comment.runAbandoned": "L'esecuzione per {agent} non è stata avviata e non verrà ritentata automaticamente.",
 	"comment.runAgentFallback": "un agente",
 	"comment.runFailed": "Esecuzione per {agent} non riuscita.",
 	"comment.runFailedWithError": "Esecuzione per {agent} non riuscita: {error}",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} がこのタスクを最上位に移動しました",
 	"comment.parentPromotedFrom": "{actor} がこのタスクを最上位に移動しました（{from} の下にありました）",
 	"comment.repoDesignated": "リポジトリ {repo} が指定リポジトリに設定されました。",
+	"comment.runAbandoned": "{agent} の実行を開始できませんでした。自動では再試行されません。",
 	"comment.runAgentFallback": "エージェント",
 	"comment.runFailed": "{agent} の実行が失敗しました。",
 	"comment.runFailedWithError": "{agent} の実行が失敗しました: {error}",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} 님이 이 작업을 최상위로 올렸어요",
 	"comment.parentPromotedFrom": "{actor} 님이 이 작업을 최상위로 올렸어요 ({from} 하위였어요)",
 	"comment.repoDesignated": "저장소 {repo}이(가) 지정 저장소로 설정되었어요.",
+	"comment.runAbandoned": "{agent} 실행을 시작하지 못했어요. 자동으로 다시 시도하지 않아요.",
 	"comment.runAgentFallback": "에이전트",
 	"comment.runFailed": "{agent} 실행이 실패했어요.",
 	"comment.runFailedWithError": "{agent} 실행이 실패했어요: {error}",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} heeft deze taak naar het hoogste niveau verplaatst",
 	"comment.parentPromotedFrom": "{actor} heeft deze taak naar het hoogste niveau verplaatst (stond onder {from})",
 	"comment.repoDesignated": "Repository {repo} ingesteld als aangewezen repository.",
+	"comment.runAbandoned": "Uitvoering voor {agent} kon niet worden gestart en wordt niet automatisch opnieuw geprobeerd.",
 	"comment.runAgentFallback": "een agent",
 	"comment.runFailed": "Uitvoering voor {agent} is mislukt.",
 	"comment.runFailedWithError": "Uitvoering voor {agent} is mislukt: {error}",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} przeniósł to zadanie na najwyższy poziom",
 	"comment.parentPromotedFrom": "{actor} przeniósł to zadanie na najwyższy poziom (było pod {from})",
 	"comment.repoDesignated": "Repozytorium {repo} ustawiono jako wyznaczone repozytorium.",
+	"comment.runAbandoned": "Uruchomienie dla {agent} nie mogło się rozpocząć i nie zostanie automatycznie ponowione.",
 	"comment.runAgentFallback": "agenta",
 	"comment.runFailed": "Uruchomienie dla {agent} nie powiodło się.",
 	"comment.runFailedWithError": "Uruchomienie dla {agent} nie powiodło się: {error}",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} promoveu esta tarefa para o nível principal",
 	"comment.parentPromotedFrom": "{actor} promoveu esta tarefa para o nível principal (estava sob {from})",
 	"comment.repoDesignated": "Repositório {repo} definido como repositório designado.",
+	"comment.runAbandoned": "A execução de {agent} não pôde ser iniciada e não será repetida automaticamente.",
 	"comment.runAgentFallback": "um agente",
 	"comment.runFailed": "A execução de {agent} falhou.",
 	"comment.runFailedWithError": "A execução de {agent} falhou: {error}",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} flyttade den här uppgiften till toppnivån",
 	"comment.parentPromotedFrom": "{actor} flyttade den här uppgiften till toppnivån (låg under {from})",
 	"comment.repoDesignated": "Repository {repo} angavs som utsett repository.",
+	"comment.runAbandoned": "Körningen för {agent} kunde inte startas och görs inte om automatiskt.",
 	"comment.runAgentFallback": "en agent",
 	"comment.runFailed": "Körningen för {agent} misslyckades.",
 	"comment.runFailedWithError": "Körningen för {agent} misslyckades: {error}",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -105,6 +105,7 @@
 	"comment.parentPromoted": "{actor} 将此任务提升到顶层",
 	"comment.parentPromotedFrom": "{actor} 将此任务提升到顶层（原先位于 {from} 之下）",
 	"comment.repoDesignated": "仓库 {repo} 已设为指定仓库。",
+	"comment.runAbandoned": "{agent} 的运行未能启动，且不会自动重试。",
 	"comment.runAgentFallback": "代理",
 	"comment.runFailed": "{agent} 的运行失败。",
 	"comment.runFailedWithError": "{agent} 的运行失败：{error}",

--- a/packages/web/test/agent-executions-list.test.tsx
+++ b/packages/web/test/agent-executions-list.test.tsx
@@ -41,6 +41,7 @@ function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		project_name: 'Demo Project',
 		status: 'succeeded',
 		queued_reason: null,
+		cancel_reason: null,
 		created_at: '2024-01-01T00:00:00.000Z',
 		started_at: '2026-06-07T20:58:30Z',
 		finished_at: '2026-06-07T20:59:50Z',

--- a/packages/web/test/agent-run-detail-realtime.test.tsx
+++ b/packages/web/test/agent-run-detail-realtime.test.tsx
@@ -37,6 +37,7 @@ function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		project_name: 'Demo',
 		status: 'queued',
 		queued_reason: null,
+		cancel_reason: null,
 		created_at: '2024-01-01T00:00:00.000Z',
 		started_at: null,
 		finished_at: null,
@@ -125,7 +126,9 @@ test('a run going terminal server-side reaches the open detail page without a re
 		project_slug: seeded.projectSlug,
 		status: 'cancelled',
 		finished_at: '2024-01-01T00:05:00.000Z',
-		error: 'Never started: no host process was driving this run.',
+		error:
+			'Never started: this run was queued but never began, so no work was done. ' +
+			'The work is back in the queue and will be picked up automatically.',
 	});
 	invalidateQueriesForRowChange(queryClient, seeded.projectSlug, 'heartbeat_runs', {
 		id: 'run-1',
@@ -136,6 +139,9 @@ test('a run going terminal server-side reaches the open detail page without a re
 	});
 
 	await findByText(/Never started/, undefined, { timeout: 20_000 });
+	// The outcome clause is the half a reader acts on, and it is only true because
+	// the sweeper now writes it after settling the work rather than before.
+	await findByText(/back in the queue/, undefined, { timeout: 20_000 });
 });
 
 test('the back link returns to the filtered view the reader came from', async () => {

--- a/packages/web/test/run-comment-retry.test.tsx
+++ b/packages/web/test/run-comment-retry.test.tsx
@@ -69,9 +69,11 @@ function runResponse(
 	teamId: string,
 	taskRowId: string,
 	status: string,
+	cancelReason: string | null = null,
 ): Record<string, unknown> {
 	const failed = status === 'failed' || status === 'timed_out';
 	return {
+		cancel_reason: cancelReason,
 		id: runId,
 		member_id: agent.id,
 		team_id: teamId,
@@ -223,6 +225,86 @@ test('failed run-entry comment shows Retry and retries that run on click', async
 	await waitFor(() => {
 		expect(retryCalls).toEqual([FAILED_RUN_ID]);
 	});
+});
+
+test('a run the instance abandoned offers Retry, because nothing is carrying its work', async () => {
+	// `cancelled` covers a person stopping a run and the instance giving up on
+	// one. Only the second can leave work owed with nothing to pick it up, and
+	// only that one is worth a button. The status alone cannot tell them apart,
+	// which is why `cancel_reason` exists.
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, user, router } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'cancelled', 'abandoned'),
+		}),
+		taskOverride: {
+			last_run_status: 'cancelled',
+			last_run_cancel_reason: 'abandoned',
+			last_run_id: FAILED_RUN_ID,
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const retryButton = (await findByTestId('retry-failed-run', undefined, {
+		timeout: 20_000,
+	})) as HTMLButtonElement;
+	await waitFor(() => expect(retryButton.disabled).toBe(false), { timeout: 20_000 });
+	await user.click(retryButton);
+	await waitFor(() => {
+		expect(retryCalls).toEqual([FAILED_RUN_ID]);
+	});
+});
+
+test('a run somebody terminated offers no Retry', async () => {
+	// The other half of the same distinction. Re-dispatching work a person
+	// deliberately stopped is worse than showing them nothing.
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByText, queryByTestId, router, user } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(
+				FAILED_RUN_ID,
+				agent,
+				teamId,
+				task.id,
+				'cancelled',
+				'operator_terminated',
+			),
+		}),
+		taskOverride: {
+			last_run_status: 'cancelled',
+			last_run_cancel_reason: 'operator_terminated',
+			last_run_id: FAILED_RUN_ID,
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// Wait for the thread itself before asserting on an absence, or the assertion
+	// passes simply because nothing has rendered yet.
+	await findByText('Run Retry Task', undefined, { timeout: 20_000 });
+	await expandEventGroups(user);
+	expect(queryByTestId('retry-failed-run')).toBeNull();
 });
 
 test('failed run-entry comment hides Retry once a later run supersedes it', async () => {

--- a/packages/web/test/run-trigger.test.ts
+++ b/packages/web/test/run-trigger.test.ts
@@ -22,6 +22,7 @@ function run(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		project_name: 'Web App',
 		status: 'succeeded',
 		queued_reason: null,
+		cancel_reason: null,
 		created_at: '2024-01-01T00:00:00.000Z',
 		started_at: null,
 		finished_at: null,

--- a/packages/web/test/system-comment-branches.test.tsx
+++ b/packages/web/test/system-comment-branches.test.tsx
@@ -150,6 +150,45 @@ test('status_change auto_unblock WITHOUT projectId falls through to the plain st
 	expect(queryByTestId('status-change-cascade')).toBeNull();
 });
 
+// ─── run_abandoned ────────────────────────────────────────────────────────
+
+test('run_abandoned: says the run could not be started, not that it failed', async () => {
+	// Its own sentence rather than a status variable on the failed one: this run
+	// never began, so "failed" would be untrue, and several of the twelve
+	// languages inflect the two differently.
+	const { findByTestId, queryByTestId } = renderSystem(
+		comment({ kind: 'run_abandoned', agent_slug: 'risk-verifier', run_id: 'r1' }),
+		'proj',
+	);
+	const wrapper = await findByTestId('run-abandoned-comment');
+	expect(wrapper.textContent).toContain('could not be started');
+	expect(wrapper.textContent).toContain('not be retried automatically');
+	// And it is not the failed renderer wearing different copy.
+	expect(queryByTestId('run-failed-comment')).toBeNull();
+
+	const link = (await findByTestId('run-abandoned-agent')) as HTMLAnchorElement;
+	expect(link.textContent).toBe('@risk-verifier');
+	expect(link.getAttribute('href')).toContain('/projects/proj/agents/risk-verifier');
+});
+
+test('run_abandoned: no agent_slug → fallback span, no link', async () => {
+	const { findByTestId, queryByTestId } = renderSystem(
+		comment({ kind: 'run_abandoned', run_id: 'r1' }),
+		'proj',
+	);
+	const wrapper = await findByTestId('run-abandoned-comment');
+	expect(wrapper.textContent).toContain('agent');
+	expect(queryByTestId('run-abandoned-agent')).toBeNull();
+});
+
+test('run_abandoned: agent_slug present but no projectId → span, no link', async () => {
+	const { findByTestId, queryByTestId } = renderSystem(
+		comment({ kind: 'run_abandoned', agent_slug: 'captain', run_id: 'r1' }),
+	);
+	await findByTestId('run-abandoned-comment');
+	expect(queryByTestId('run-abandoned-agent')).toBeNull();
+});
+
 // ─── run_failed ───────────────────────────────────────────────────────────
 
 test('run_failed: timed_out status, agent link, and error suffix', async () => {


### PR DESCRIPTION
## What happened

A Captain `@`-mentioned a teammate. The teammate's run went **cancelled** after two log lines and nothing ever ran again. Ten hours later the ask was still unserved. The run said:

```
Never started: no host process was driving this run, so it was returned to the queue.
```

"Host process" is this server, not the container and not the reader's machine. And the sentence was **not necessarily true**: it was composed before the handback was attempted and stamped on the row whether or not the handback succeeded.

> **Two commits.** The first fixed that. Four adversarial reviews then found it had **reproduced the same defect on the sibling path**, plus three more bugs — with CI green throughout, and **11 one-line mutations of the new code surviving the suite untouched**. The second commit closes those. This description reflects the final state; where the two disagree, the second commit is the truth.

## The defect, and its twin

`detectOrphans` now writes **twice**: the reap claims the row with the *verdict* alone (true whatever happens next), the work is settled, then a second write appends the *outcome* and `cancel_reason` before the broadcast fires.

The twin: `finalizeRequeue` stamped `cancel_reason = handed_back` **before** attempting the handback, and when `settleWakeupForRun` returned `handback_failed`, `JobManager` logged a warning and left the row standing — no ping (`postFailurePing` skips `cancelled`), no notice, no Retry, and a run card asserting the work was queued while nothing carried it. Both callers now record the outcome only once it is known, through one shared `recordHandbackOutcome` (`services/run-handback.ts`).

## The other defects

**The fallback wakeup was weaker than the one it replaced.** When the handback guard missed, the retry minted a `WakeupSource.Timer` wakeup regardless of the original. `timer` is in `GATED_WAKEUP_SOURCES` and is not exempt from the no-work backoff; a `mention` is neither. So a teammate's direct ask came back as a wakeup the dependency gate could park indefinitely. The replacement now carries the original wakeup's `source`.

**The ladder was not bounded.** It read `process_loss_retry_count` for its ceiling but never incremented it, so an inherited count dead-ended it permanently. The first fix incremented — but named the replacement's lineage under `previous_run_id`, which carries `inheritsLossBudget: false`, so every replacement started back at zero and the ceiling stayed unreachable. A reviewer drove six real laps and measured `[0,0,0,0,0,0]`. The lineage now names `previous_failure.run_id`, so **the strike the arm spends is the strike it reads**, and a new test drives real laps and measures the climb.

**A human's cancel attribution was overwritten.** `terminateHeartbeatRun` writes `COALESCE(cancel_reason, $n)` (preserve) while `updateHeartbeatRun` wrote `COALESCE($n, cancel_reason)` (parameter wins), so a Terminate landing on a parked run was relabelled `handed_back`. Both are now first-writer-wins, and the recorder declines to write over an attribution someone else set — so no abandoned notice lands on a run a person stopped.

**A guard written for a state that cannot exist.** Rung 1 required the payload to name a task, to stop an "intent-less" synthetic wakeup returning as a task-less nudge. `createSyntheticOnDemandWakeup` is reachable only from the progress-update path, which is always task-less, so that gate never fired for the rows it was written for. What it *did* catch was the ordinary heartbeat wakeup, whose payload names no task because `activateAgent` picks one — those were left dangling in `claimed`. Removed: a wakeup naming no task is not intent-less, it is "find work".

**Two handbacks lied about why they were waiting.** Both stamped `instance_at_capacity` — including the credential give-up. `BUSY_PROJECTS_SQL` excludes capacity-skipped wakeups from its busy set, so the idle pass reclaimed the container out from under work about to run. New `run_never_started` and `credential_busy` reasons.

**The credential wait shared the capacity park's 3-minute ceiling.** The park waits for a container slot the idle cron frees in seconds; the credential lock is held for a **whole other run**, bounded by `run_timeout_min` (60 min default). On a rotating credential (Codex) a second run burned 180s, cancelled itself, re-queued, redispatched 5s later, and repeated until the holder finished. `credentialWaitMaxMs` now derives from the waiting run's own timeout (80%), **unfloored** — the floor inverted its own invariant at `run_timeout_min ≤ 3`, where a 180s wait outlives a 60s wall-clock timer — and **capped at 15 minutes**, because a dispatch with no spare container holds a `pendingContainerStarts` reservation for the whole wait.

## Structural changes

**One settlement seam.** `settleWakeupForRun` (`services/wakeup.ts`) is shared by the sweeper and `onAgentComplete`. It reports `handback_failed` rather than a bare boolean, and **both callers now act on it**. Its terminal arm is guarded like its handback arm, so an aborting run cannot relabel a wakeup a person just withdrew.

**`heartbeat_runs.cancel_reason`** (migration `066`) replaces reading intent out of error prose — which `requeueContainerKilledRuns` already does (`WHERE error = 'container_error'`), in an area whose prose this change rewords. Only `abandoned` leaves work owed with nothing carrying it, so only that one offers **Retry** and posts a note. Behaviour hangs off `RUN_CANCEL_BEHAVIOUR`.

Each orphan is also isolated, so a throw after the reap cannot strand the row *and* abandon the rest of the batch.

## Tests

Written for what the suite demonstrably could not see — a reviewer executed 25 mutations against the first commit and 11 survived:

- **`settleWakeupForRun` directly** — the new seam had no test at all. All four intents, both guards, `handback_failed`.
- **The ladder climbing lap by lap** — drives real reap → wakeup → run → reap laps instead of hand-setting the counter, which is what hid the unbounded ladder.
- **`credentialWaitMaxMs`** — had none; now pins that the wait never outlives the wall-clock timer at any setting.
- **`run_never_started` / `credential_busy` at the point of writing** — both had zero references anywhere.
- **`cancel_reason` on every writer**, and that a human's attribution survives.
- **The abandoned notice in both directions** — it could previously be deleted *or* fired on every requeue with the suite green.
- **The route projections** the web tests stub — without these the feature could be dead in production, green.
- **The broadcast carrying the final text**, and the `wasLive` terminate branch, both previously uncovered.

## Checked and deliberately not changed

- **`NON_PINGING_STATUSES`.** Retry lives on the run card, gated on status, not on a `run_failed` comment — so making cancels ping would not produce a button, and *"Run for @x failed"* is the wrong sentence about a run that never began.
- **`STALE_STATE_GRACE_SECONDS` (120s).** The sweeper skips any run in the live registry, so a run still being worked on is never reaped however long it takes. Raising it delays recovery and rescues nothing.
- **The task-list error icon and last-run banner** do not cover abandoned runs. Both would need new prose in 12 languages saying something other than "failed". An abandoned run surfaces via its thread notice and Inbox item instead; the scope note in `RUN_CANCEL_BEHAVIOUR` now says so rather than claiming otherwise.
- **`list_task_runs` (MCP)** still does not project `cancel_reason`. It projects neither `error` nor `queued_reason` either, so closing this properly means all three — a separate change. `AGENTS.md` calls it a gap, not a scoping decision; recorded rather than hidden.

## Reviewer claims checked and rejected

Four "before" claims did not survive checking against `58d2ec6`: main's never-started arm was **equally unbounded** (it also added `0` strikes and `continue`d); the credential lock was **already** taken before container acquisition; that wait **already** had a timeout; and the escalation approval was **already** `NOT EXISTS`-guarded. The `COALESCE($n, col)` untyped-NULL hypothesis is also cleared — it is a pre-existing idiom running against real Postgres today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zZCVEdXjofxv7vJtQMh3a