### PR TITLE
fix(config): refuse to start when a removed env var still selects the data dir

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -5137,6 +5137,26 @@ than a generic "unrecognized key":
 - **`reset`** - it renames the embedded `pgdata` aside, which is a one-off action. In a
   persistent file it would wipe the database on **every** restart.
 
+**Refusing an upgrade that would look like a fresh install.** The env vars 0.50 stopped
+reading were removed with no shim and no warning, so an instance whose supervisor still
+exported them fell back to the built-in defaults. For `HEZO_DATA_DIR` that meant opening an
+empty database under `~/.hezo` and presenting the master-key setup page, with the real data
+untouched a directory away and nothing in the logs to say so. `config/removed-env.ts` closes
+that: `REMOVED_ENV_VARS` is an explicit table (never a `HEZO_*` prefix scan, which would
+catch the seams that survive) mapping each removed name to the key that replaced it.
+`detectRemovedEnvVars` splits them by severity. The three that select *where the data lives*
+- `HEZO_DATA_DIR`, `HEZO_DATABASE_URL`, `HEZO_ASSET_STORAGE_URL` - throw out of
+`resolveConfig`, which `index.ts` already renders as a one-line operator message and exit 1;
+the rest warn once at startup. A fatal one is raised only when its value **differs** from
+what the resolved config uses, compared after `resolveDataDir` normalisation, so an operator
+who migrated to `--config` but left `EnvironmentFile=` in place is not blocked by an export
+that agrees with them. The same check runs in `resolveSubcommandTargets`, so `hezo backup`
+cannot dump the wrong tree either. Values that can carry credentials are redacted through
+the same `redactDatabaseUrl` / `redactAssetStorageUrl` helpers the Storage settings page
+uses. `deploy/provision.sh` handles the other half: it reads a pre-0.50 `/etc/hezo/hezo.env`
+into the config file it generates and renames the old file to `hezo.env.migrated`, because
+the in-app updater swaps the binary and never touches a unit file.
+
 **Reaching the resolved config.** `index.ts` publishes it with `setRuntimeConfig()` right
 after resolving, and everything else reads it back through `runtimeConfig()`
 (`config/runtime.ts`). The accessor exists because `index.ts` imports `./app` - and through

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,5 +2,6 @@ bunx commitlint --edit $1
 bun scripts/check-docs-ack.ts $1
 bun scripts/check-translations-ack.ts $1
 bun scripts/check-prompts-ack.ts $1
+bun scripts/check-upgrade-ack.ts $1
 bun scripts/check-docs-links.ts
 bun scripts/check-prompt-style.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@
 | Container backend behaviour | `SANDBOX_AGENT_ENVIRONMENTS`, that provider's `docs/containers/remote/` page, the Containers settings UI | compile error, **new backend only** |
 | A `ContainerEngine` method added or its contract changed | every adapter, the conformance suite, `.dev/adding-a-container-backend.md` | compile error for the method, **nothing for the contract** |
 | Architecture (data model, run pipeline, providers, egress, SSH/git, OAuth, auth, build) | `.dev/architecture.md` | the `Docs-Checked:` trailer |
+| A config mechanism, data location or startup path an existing instance carries across a restart | a check that fails loudly on the old form, plus every deployment artifact in `deploy/` still writing it | the `Upgrade-Checked:` trailer |
 | A `.dev/` guide added, renamed or removed | the link from its section here, the `.dev/` bullet under **Layout**, this table | **nothing - on you** |
 | A Bun workaround added or removed, or `BUN_VERSION` moved | its entry in `.dev/bun-issues.md` | **nothing - on you** |
 | A rule this file states | its guide in `.dev/`, if one covers that area - they must not disagree | **nothing - on you** |
@@ -106,7 +107,7 @@
 
 **Verify, don't assume.** Generated surfaces have drift tests (`{mcp-reference,llms-txt,docs-bundle}.test.ts`); hand-written prose has one guard, `docs-terminology.test.ts`, checking punctuation only. Nothing checks whether prose is *true* — re-read the pages describing what you changed and confirm every concrete claim still matches the code.
 
-**Two husky hooks run on every commit.** `.husky/pre-commit`: `bunx biome check --diagnostic-level=error .`, `bun run typecheck`, `bun run build`. `.husky/commit-msg`: `bunx commitlint --edit`, `scripts/check-docs-ack.ts`, `scripts/check-translations-ack.ts`, `scripts/check-prompts-ack.ts`, `scripts/check-docs-links.ts`, `scripts/check-prompt-style.ts`.
+**Two husky hooks run on every commit.** `.husky/pre-commit`: `bunx biome check --diagnostic-level=error .`, `bun run typecheck`, `bun run build`. `.husky/commit-msg`: `bunx commitlint --edit`, `scripts/check-docs-ack.ts`, `scripts/check-translations-ack.ts`, `scripts/check-prompts-ack.ts`, `scripts/check-upgrade-ack.ts`, `scripts/check-docs-links.ts`, `scripts/check-prompt-style.ts`.
 
 **`check-docs-links.ts` fails a commit staging any `docs/**/*.md` on a broken link.** Internal links (docs-to-docs incl. `#anchors`, relative paths, `github.com/hezo-ai/hezo/{blob,raw,tree}/main/<path>`) are checked across the whole tree - a rename or delete breaks *other* files' links. External URLs are probed for staged files only (7-day success cache in `.git/`); a definitive 404/410 blocks, network-shaped failures (403 bot walls, timeouts, DNS) only warn, so an offline commit passes. Fix the link, never bypass; `docs-links.test.ts` re-runs the internal check in CI.
 
@@ -145,6 +146,25 @@ There is no per-team internal project. The only `is_internal` project is **HQ**,
 Project-teams get a Captain plus the roster's worker roles; rosters never include CEO/Coach. `POST /api/projects` (superuser) creates the team, project, planning task and initial CEO coherence task. The roster comes from the seeded Blank `team_templates` row or, with a `marketplace_slug`, straight from the marketplace catalog.
 
 **Cross-team execution:** CEO/Coach are HQ members acting inside other teams' projects. A run is scoped to the **task's project team** (JWT, `HEZO_TEAM_ID`, MCP, skills, git, container) while the agent's system prompt loads from its **home** team (HQ). Auth validates the `heartbeat_runs` row, not team membership.
+
+## Production upgrades
+
+Real instances upgrade in place: they keep their data directory, their config file, their service definition and their database, and only the binary changes. **A change to how Hezo is configured, where it keeps its data, or how it starts is a change to those instances, not just to this repo.** No test can see it - every suite builds a fresh instance from the code under test, so a self-consistent change passes green while breaking every instance that upgrades onto it. Migrations are one instance of this rule; the section below is the rest of it.
+
+- **A mechanism you remove or rename must fail loudly on its old form, never fall back to a default.** An instance that silently reverts to a built-in default comes up healthy and empty, which reads as a fresh install rather than a fault. Detect the old form and refuse to start, naming what was ignored and what replaces it - `REMOVED_ENV_VARS` / `detectRemovedEnvVars` (`config/removed-env.ts`) is the worked example.
+- **Ship the migration, do not document it.** Where a deployment artifact this repo owns still writes the old form - `deploy/provision.sh`, the systemd unit, an on-disk layout - the change that breaks it also translates it, in the same commit.
+- **The in-app updater replaces the binary and nothing else.** It never edits a unit file, a config file or an argv, and the supervisor relaunches with the argv it already had. A change needing any of those changed cannot assume the operator did it.
+- **A `BREAKING CHANGE:` note is not a migration.** It reaches whoever reads the changelog; it does nothing for the instance that auto-updated overnight.
+
+**`Upgrade-Checked:` is enforced at commit time.** Any commit staging a surface an existing instance carries across a restart (`packages/server/src/config/`, `packages/server/src/db/`, `packages/*/migrations/`, `cli.ts`, `index.ts`, `startup.ts`, `supervisor.ts`, `services/updater.ts`, `deploy/`, `docker/`) is rejected without an `Upgrade-Checked:` trailer recording what an instance running the previous release does when it restarts onto this one. Bare values under 10 characters are rejected:
+
+```
+Upgrade-Checked: the old key is still read and warns; an instance that never writes a config file is unaffected
+Upgrade-Checked: migration 072 backfills the column for existing rows; provision.sh rewrites the unit for hosts installed before it
+Upgrade-Checked: reads nothing written by a previous release; an upgrading instance starts identically to a fresh one
+```
+
+The trailer must be true. **Never bypass the hook with `--no-verify`.** Same exemptions as `Docs-Checked:`. The bearing list is deliberately narrower than the doc-bearing one - a trailer demanded of every commit is a trailer nobody reads. Classification is tested in `upgrade-ack-hook.test.ts`; a new upgrade-bearing path goes into `UPGRADE_BEARING_PATTERNS` in the same change.
 
 ## Database migrations
 
@@ -303,6 +323,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | "Is this cancelled run still owed, and can a human act on it?" | `heartbeat_runs.cancel_reason` read through `RUN_CANCEL_BEHAVIOUR` (`@hezo/shared`) - never the `error` prose |
 | "May this caller move this task's assignee?" | `assertNoBlockingRun` (`lib/reassign-guard.ts`) - not the one-run-per-task check, which is `isTaskBusyInDb` (`services/run-concurrency.ts`) |
 | Serialising async work per key, with or without a bound | `lib/keyed-lock.ts` - `withKeyedLock` for a scope, `acquireKeyedLock` when the wait needs a `signal`/`timeoutMs`. Each family owns its own `KeyedLockRegistry`; never a second mutex |
+| "Did this release stop reading something an instance still sets?" | `REMOVED_ENV_VARS` / `detectRemovedEnvVars` (`config/removed-env.ts`) |
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |
 | Paging (lists and large content) | `mcp/paging.ts` |
 | Shared enums, constants, validation run on both sides | `@hezo/shared` (`types/common.ts`) |

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -31,10 +31,13 @@
 #                          verifying the certificate; for verified TLS use
 #                          sslmode=verify-full, adding &sslrootcert=/etc/hezo/db-ca.crt
 #                          when the provider signs with its own CA (most do).
-#                          Persisted into /etc/hezo/hezo.config.cjs on first provision; omit to
-#                          use the embedded database on the VM's disk (the default).
+#                          A provisioning-shell input, not a runtime variable: it is
+#                          persisted into /etc/hezo/hezo.config.cjs on first provision, and
+#                          the server reads it from there. Omit to use the embedded
+#                          database on the VM's disk (the default).
 #   HEZO_ASSET_STORAGE_URL S3-compatible object storage for asset files
-#                          (s3://KEY:SECRET@endpoint/bucket[/prefix]). Persisted into
+#                          (s3://KEY:SECRET@endpoint/bucket[/prefix]). A provisioning-shell
+#                          input, not a runtime variable: persisted into
 #                          /etc/hezo/hezo.config.cjs on first provision; omit for local disk.
 #   HEZO_DATABASE_POOL_SIZE  connection-pool size for the external database (2-100).
 #   HEZO_SWAP_SIZE         size of the swap file this script creates so low-RAM hosts
@@ -74,6 +77,36 @@ if [[ -f "${DEPLOY_ENV}" ]]; then
 fi
 
 log() { echo "[hezo-provision] $*"; }
+
+# ---------------------------------------------------------------------------
+# 1a. Migrate a pre-0.50 /etc/hezo/hezo.env
+#     Before 0.50 this script wrote an env file and wired it in with
+#     EnvironmentFile=. 0.50 reads a config file instead and ignores those
+#     variables entirely, so a host upgraded in place would fall back to the
+#     built-in defaults - an empty database that looks like a fresh install.
+#     Read the old file into this shell so the config file written below carries
+#     its settings; the shell environment still wins. The file itself is only
+#     renamed aside once the config file exists, so an interrupted run loses
+#     nothing.
+# ---------------------------------------------------------------------------
+LEGACY_ENV="/etc/hezo/hezo.env"
+LEGACY_ENV_CARRIED=""
+if [[ -f "${LEGACY_ENV}" && ! -f "${CONFIG_FILE}" ]]; then
+	while IFS='=' read -r key value; do
+		[[ "${key}" =~ ^(HEZO_DATA_DIR|HEZO_DATABASE_URL|HEZO_DATABASE_POOL_SIZE|HEZO_ASSET_STORAGE_URL)$ ]] || continue
+		if [[ -z "${!key:-}" ]]; then
+			export "${key}=${value}"
+			LEGACY_ENV_CARRIED+=" ${key}"
+		fi
+	done <"${LEGACY_ENV}"
+	log "Found ${LEGACY_ENV} from a pre-0.50 install."
+	if [[ -n "${LEGACY_ENV_CARRIED}" ]]; then
+		log "Carrying into ${CONFIG_FILE}:${LEGACY_ENV_CARRIED}"
+	fi
+fi
+
+# An operator who moved the data dir keeps it. Everything below writes to this path.
+DATA_DIR="${HEZO_DATA_DIR:-${DATA_DIR}}"
 
 # ---------------------------------------------------------------------------
 # 1. Swap file — give low-RAM hosts a memory cushion so the install itself and
@@ -265,6 +298,13 @@ EOF
 		echo "	assetStorage: { url: '${HEZO_ASSET_STORAGE_URL}' }," >>"${CONFIG_FILE}"
 	fi
 	echo "};" >>"${CONFIG_FILE}"
+fi
+
+# Now that the settings live in the config file, take the old one out of the way:
+# nothing reads it any more, and leaving it invites a hand-edit that does nothing.
+if [[ -n "${LEGACY_ENV_CARRIED}" && -f "${CONFIG_FILE}" && -f "${LEGACY_ENV}" ]]; then
+	mv "${LEGACY_ENV}" "${LEGACY_ENV}.migrated"
+	log "Renamed ${LEGACY_ENV} to ${LEGACY_ENV}.migrated (no longer read)."
 fi
 
 # Persist optional settings the first-boot unit reads (domain override, swap size).

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -93,7 +93,7 @@ LEGACY_ENV="/etc/hezo/hezo.env"
 LEGACY_ENV_CARRIED=""
 if [[ -f "${LEGACY_ENV}" && ! -f "${CONFIG_FILE}" ]]; then
 	while IFS='=' read -r key value; do
-		[[ "${key}" =~ ^(HEZO_DATA_DIR|HEZO_DATABASE_URL|HEZO_DATABASE_POOL_SIZE|HEZO_ASSET_STORAGE_URL)$ ]] || continue
+		[[ "${key}" =~ ^(HEZO_DATA_DIR|HEZO_WEB_URL|HEZO_DATABASE_URL|HEZO_DATABASE_POOL_SIZE|HEZO_ASSET_STORAGE_URL)$ ]] || continue
 		if [[ -z "${!key:-}" ]]; then
 			export "${key}=${value}"
 			LEGACY_ENV_CARRIED+=" ${key}"
@@ -102,6 +102,14 @@ if [[ -f "${LEGACY_ENV}" && ! -f "${CONFIG_FILE}" ]]; then
 	log "Found ${LEGACY_ENV} from a pre-0.50 install."
 	if [[ -n "${LEGACY_ENV_CARRIED}" ]]; then
 		log "Carrying into ${CONFIG_FILE}:${LEGACY_ENV_CARRIED}"
+	fi
+	# The generated config reads its webUrl from the side file hezo-firstboot
+	# writes, and firstboot will not re-run here - its sentinel was set the day
+	# this host was provisioned. Seed the file from the old variable instead of
+	# special-casing the generator, so both paths keep one mechanism.
+	if [[ -n "${HEZO_WEB_URL:-}" && ! -s "${WEB_URL_FILE}" ]]; then
+		echo "${HEZO_WEB_URL}" >"${WEB_URL_FILE}"
+		log "Seeded ${WEB_URL_FILE} with ${HEZO_WEB_URL}"
 	fi
 fi
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -162,7 +162,7 @@ storage](/docs/deployment/configuration#storing-assets-in-s3-compatible-object-s
 
 **At provision time** - uncomment the `/etc/hezo/deploy.env` lines in the
 [snippet above](#deploy-it) and fill in your URLs before you paste it. The installer
-persists them into the service's environment file and Hezo uses the managed backends
+persists them into `/etc/hezo/hezo.config.cjs` and Hezo uses the managed backends
 from its very first boot. One caveat: on most providers, anything in the user-data
 field stays readable later via the instance's metadata service - if you'd rather keep
 the credentials out of user data entirely, deploy without them and use the post-boot

--- a/packages/server/src/assets/open.ts
+++ b/packages/server/src/assets/open.ts
@@ -70,7 +70,7 @@ export async function openAssetStorage(
 			throw new AssetStorageError(
 				`Cannot reach the configured asset storage at ${redacted}: ${detail}\n` +
 					'Check the endpoint, credentials, bucket name, and pathStyle/tls parameters in ' +
-					'--asset-storage-url / HEZO_ASSET_STORAGE_URL, and that the bucket exists. ' +
+					'--asset-storage-url or the `assetStorage.url` config-file key, and that the bucket exists. ' +
 					'Omit the option to store assets on the local filesystem.',
 				{ cause: err },
 			);

--- a/packages/server/src/assets/url.ts
+++ b/packages/server/src/assets/url.ts
@@ -1,7 +1,7 @@
 import { AssetStorageError } from './errors';
 
 /**
- * Parsed form of `--asset-storage-url` / `HEZO_ASSET_STORAGE_URL`:
+ * Parsed form of `--asset-storage-url` / the `assetStorage.url` config-file key:
  *
  *   s3://ACCESS_KEY_ID:SECRET_ACCESS_KEY@endpoint[:port]/bucket[/prefix]?region=…&pathStyle=…&tls=…
  *

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -7,6 +7,11 @@ import {
 } from '@hezo/shared';
 import { Command } from 'commander';
 import { loadConfigFile } from './config/load';
+import {
+	detectRemovedEnvVars,
+	formatRemovedEnvFatal,
+	type ResolvedDataLocation,
+} from './config/removed-env';
 import type { ConfigFile } from './config/schema';
 import { DEFAULT_CONFIG, type HezoConfig, resolveDataDir } from './config/types';
 import { createStreamProgressReporter, formatBytes } from './lib/progress';
@@ -38,15 +43,24 @@ interface SubcommandTargets {
 	assetStorageUrl?: string;
 }
 
-function resolveSubcommandTargets(opts: Record<string, unknown>): SubcommandTargets {
+function resolveSubcommandTargets(
+	opts: Record<string, unknown>,
+	env: NodeJS.ProcessEnv = process.env,
+): SubcommandTargets {
 	const file = readConfigFile(opts);
 	const flag = (value: unknown): string | undefined =>
 		typeof value === 'string' && value.length > 0 ? value : undefined;
-	return {
+	const targets: SubcommandTargets = {
 		dataDir: resolveDataDir(flag(opts.dataDir) ?? file.dataDir ?? DEFAULT_DATA_DIR),
 		databaseUrl: flag(opts.databaseUrl) ?? file.database?.url,
 		assetStorageUrl: flag(opts.assetStorageUrl) ?? file.assetStorage?.url,
 	};
+	assertNoRemovedDataLocationEnv(env, {
+		dataDir: targets.dataDir,
+		database: { url: targets.databaseUrl },
+		assetStorage: { url: targets.assetStorageUrl },
+	});
+	return targets;
 }
 
 /** The `--config` option text, identical on every command that accepts one. */
@@ -226,18 +240,18 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 		// `_migrations` bookkeeping. For embedded storage `openPersistentDb` happily
 		// creates an empty database on open, so without this guard the dump would
 		// crash with a bare `relation "_migrations" does not exist`. Fail with an
-		// actionable message instead — the usual cause is a `--data-dir` /
-		// `HEZO_DATA_DIR` that doesn't point at the running instance's data.
+		// actionable message instead - the usual cause is a `--data-dir` (or a
+		// config file's `dataDir`) that doesn't point at the running instance's data.
 		const probe = await db.query<{ reg: string | null }>(
 			`SELECT to_regclass('public._migrations')::text AS reg`,
 		);
 		if (probe.rows[0]?.reg == null) {
 			throw new Error(
 				`No Hezo database found at ${sourceLabel}: its migration bookkeeping (the _migrations ` +
-					`table) is missing, so there is nothing to back up. Check that --data-dir / ` +
-					`HEZO_DATA_DIR points at your instance's data directory (an external database is ` +
-					`selected with --database-url / HEZO_DATABASE_URL). A brand-new instance has no ` +
-					`database until the server has started at least once.`,
+					`table) is missing, so there is nothing to back up. Check that --data-dir (or the ` +
+					`\`dataDir\` key in the file you pass to --config) points at your instance's data ` +
+					`directory; an external database is selected with --database-url or \`database.url\`. ` +
+					`A brand-new instance has no database until the server has started at least once.`,
 			);
 		}
 		const { loadAllMigrations } = await import('./db/load-migrations.js');
@@ -807,7 +821,7 @@ export function resolveConfig(
 		return str('masterKey');
 	})();
 
-	return {
+	const config: HezoConfig = {
 		port,
 		dataDir: resolveDataDir(str('dataDir') ?? file.dataDir ?? DEFAULT_DATA_DIR),
 		webUrl: str('webUrl') ?? file.webUrl ?? d.webUrl,
@@ -867,4 +881,23 @@ export function resolveConfig(
 		masterKey: masterKeyRaw ? parseMasterKey(masterKeyRaw) : undefined,
 		configPath,
 	};
+
+	// Configuration env vars are no longer read. Refuse to start when an ignored
+	// one would have put the data somewhere other than where we are about to look:
+	// coming up on an empty database looks like a fresh install, not a fault.
+	assertNoRemovedDataLocationEnv(env, config);
+	return config;
+}
+
+/**
+ * Throw when a removed env var still selects where the data lives. Shared by the
+ * server and the backup/restore/uninstall subcommands, each of which would
+ * otherwise silently target a different tree than the operator configured.
+ */
+function assertNoRemovedDataLocationEnv(
+	env: NodeJS.ProcessEnv,
+	location: ResolvedDataLocation,
+): void {
+	const { fatal } = detectRemovedEnvVars(env, location);
+	if (fatal.length > 0) throw new Error(formatRemovedEnvFatal(fatal));
 }

--- a/packages/server/src/config/removed-env.ts
+++ b/packages/server/src/config/removed-env.ts
@@ -1,0 +1,271 @@
+/**
+ * The configuration environment variables 0.50 stopped reading, and the check
+ * that refuses to let one be ignored in silence.
+ *
+ * Before 0.50 every setting here was an env var. They are now config-file keys
+ * and flags, resolved by `resolveConfig`. An instance whose supervisor still
+ * exports the old names got no error and no warning: it fell back to the
+ * built-in defaults, which for `HEZO_DATA_DIR` means opening an empty database
+ * under `~/.hezo` and presenting the master-key setup page as if the instance
+ * were brand new.
+ *
+ * So the three variables that select *where the data lives* are fatal, and
+ * everything else warns. A fatal one is only raised when the value it carried
+ * differs from what the resolved config actually uses, so an operator who has
+ * migrated but left `EnvironmentFile=` in place is not blocked.
+ *
+ * This table names only variables that are genuinely no longer read. The env
+ * vars that survive - `HEZO_MASTER_KEY`, `HEZO_WORKER`, `HEZO_SKIP_DOCKER`, the
+ * `HEZO_TEST_*` seams, the run plumbing injected into agent containers - must
+ * never appear here, which is why it is an explicit list and not a `HEZO_*`
+ * prefix scan.
+ */
+
+import { redactAssetStorageUrl } from '../lib/asset-storage-info';
+import { redactDatabaseUrl } from '../lib/db-info';
+import { resolveDataDir } from './types';
+
+/**
+ * The part of the resolved configuration this check reads. Narrower than
+ * `HezoConfig` (which satisfies it structurally) so the backup, restore and
+ * uninstall subcommands, which resolve only these three, can run the same check.
+ */
+export interface ResolvedDataLocation {
+	dataDir: string;
+	database: { url?: string };
+	assetStorage: { url?: string };
+}
+
+/** Where to read about the migration when a variable is reported. */
+export const CONFIG_DOCS_URL = 'https://hezo.ai/docs/deployment/configuration';
+
+export interface RemovedEnvVar {
+	/** How this setting is configured now: the config-file key, and the flag if it has one. */
+	replacement: string;
+	/**
+	 * `fatal` for the variables that select where data lives - ignoring one of
+	 * those silently points the instance at a different (usually empty) database.
+	 * Everything else is `warn`: the setting reverts to its default, which is
+	 * visible in behaviour rather than catastrophic.
+	 */
+	severity: 'fatal' | 'warn';
+	/**
+	 * `fatal` only: what the resolved config uses for this setting, so the check
+	 * can stay quiet when the ignored variable agrees with it.
+	 */
+	inEffect?: (config: ResolvedDataLocation) => string | undefined;
+	/** Canonicalise both sides before comparing them. */
+	normalise?: (value: string) => string;
+	/**
+	 * Redact the value before it reaches a log line. Set for anything that can
+	 * carry credentials; `undefined` means the raw value is safe to print, which
+	 * is what makes the `HEZO_DATA_DIR` message useful.
+	 */
+	redact?: (value: string) => string;
+}
+
+const JOB_CRONS: Record<string, string> = {
+	HEZO_WAKEUP_CRON: 'jobs.wakeupCron',
+	HEZO_HEARTBEAT_CRON: 'jobs.heartbeatCron',
+	HEZO_INBOX_ARCHIVE_CRON: 'jobs.inboxArchiveCron',
+	HEZO_PRICING_REFRESH_CRON: 'jobs.pricingRefreshCron',
+	HEZO_MODEL_PIN_REFRESH_CRON: 'jobs.modelPinRefreshCron',
+	HEZO_UPDATE_CHECK_CRON: 'jobs.updateCheckCron',
+	HEZO_AUTO_INSTALL_CRON: 'jobs.autoInstallCron',
+	HEZO_TELEMETRY_CRON: 'jobs.telemetryCron',
+	HEZO_BUDGET_RESUME_CRON: 'jobs.budgetResumeCron',
+	HEZO_CONNECTOR_HEALTH_CRON: 'jobs.connectorHealthCron',
+	HEZO_CONTAINER_SYNC_CRON: 'jobs.containerSyncCron',
+	HEZO_CONTAINER_IDLE_STOP_CRON: 'jobs.containerIdleStopCron',
+	HEZO_ORPHAN_DETECTION_CRON: 'jobs.orphanDetectionCron',
+	HEZO_ORPHAN_CONTAINER_SWEEP_CRON: 'jobs.orphanContainerSweepCron',
+	HEZO_DB_MAINTENANCE_CRON: 'jobs.dbMaintenanceCron',
+	HEZO_WAKEUP_COALESCING_MS: 'jobs.wakeupCoalescingMs',
+	HEZO_HEARTBEAT_COOLDOWN_SEC: 'jobs.heartbeatCooldownSec',
+	HEZO_HEARTBEAT_FLOOR_MIN: 'jobs.heartbeatFloorMin',
+	HEZO_INBOX_RETENTION_DAYS: 'jobs.inboxRetentionDays',
+	HEZO_LOG_COMPACTION_CRON: 'logCompaction.cron',
+	HEZO_LOG_COMPACTION_BATCH: 'logCompaction.batch',
+	HEZO_LOG_COMPACTION_MAX_PER_TICK: 'logCompaction.maxPerTick',
+	HEZO_LOG_COMPACTION_PRESERVED_BYTES: 'logCompaction.preservedBytes',
+	HEZO_CHAT_HEALTH_INTERVAL_MS: 'chat.healthIntervalMs',
+};
+
+const warnOnly = (replacement: string, redact?: (value: string) => string): RemovedEnvVar => ({
+	replacement,
+	severity: 'warn',
+	redact,
+});
+
+export const REMOVED_ENV_VARS: Record<string, RemovedEnvVar> = {
+	// Fatal: each one moves where the instance's data lives.
+	HEZO_DATA_DIR: {
+		replacement: 'the `dataDir` config-file key, or --data-dir',
+		severity: 'fatal',
+		inEffect: (c) => c.dataDir,
+		normalise: resolveDataDir,
+	},
+	HEZO_DATABASE_URL: {
+		replacement: 'the `database.url` config-file key, or --database-url',
+		severity: 'fatal',
+		inEffect: (c) => c.database.url,
+		normalise: (v) => v.trim(),
+		redact: redactDatabaseUrl,
+	},
+	HEZO_ASSET_STORAGE_URL: {
+		replacement: 'the `assetStorage.url` config-file key, or --asset-storage-url',
+		severity: 'fatal',
+		inEffect: (c) => c.assetStorage.url,
+		normalise: (v) => v.trim(),
+		redact: redactAssetStorageUrl,
+	},
+
+	HEZO_PORT: warnOnly('the `port` config-file key, or --port'),
+	HEZO_WEB_URL: warnOnly('the `webUrl` config-file key, or --web-url'),
+	HEZO_LOG_LEVEL: warnOnly('the `logLevel` config-file key, or --log-level'),
+	HEZO_OPEN: warnOnly('the `open` config-file key, or --no-open'),
+	HEZO_RESET: warnOnly('--reset (never a config-file key: it would wipe the database on restart)'),
+	HEZO_DATABASE_POOL_SIZE: warnOnly('the `database.poolSize` config-file key'),
+
+	HEZO_SANDBOX_BACKEND: warnOnly('the `containers.backend` config-file key, or --sandbox-backend'),
+	HEZO_DOCKER_SOCKET: warnOnly('the `containers.dockerSocket` config-file key, or --docker-socket'),
+	DOCKER_REQUEST_TIMEOUT_MS: warnOnly('the `containers.dockerRequestTimeoutMs` config-file key'),
+	HEZO_KEEP_OLD_CONTAINERS: warnOnly(
+		'the `containers.keepOld` config-file key, or --keep-old-containers',
+	),
+	HEZO_SKIP_MOUNT_CHECK: warnOnly('the `containers.skipMountCheck` config-file key'),
+	HEZO_AGENT_BASE_IMAGE: warnOnly('the `containers.agentBaseImage` config-file key'),
+	HEZO_DAYTONA_API_KEY: warnOnly(
+		'the `containers.daytona.apiKey` config-file key, or --daytona-api-key',
+		() => '(redacted)',
+	),
+	HEZO_DAYTONA_API_URL: warnOnly(
+		'the `containers.daytona.apiUrl` config-file key, or --daytona-api-url',
+	),
+
+	HEZO_EGRESS_PROXY_AUTH: warnOnly(
+		'the `egress.proxyAuth` config-file key, or --no-egress-proxy-auth',
+	),
+	HEZO_EGRESS_ALLOW_PRIVATE_TARGETS: warnOnly(
+		'the `egress.allowPrivateTargets` config-file key, or --egress-allow-private-targets',
+	),
+	HEZO_EGRESS_DEBUG: warnOnly('the `egress.debug` config-file key'),
+
+	HEZO_TELEMETRY_ENABLED: warnOnly(
+		'the `telemetry.enabled` config-file key, or --disable-telemetry',
+	),
+	HEZO_TELEMETRY_ENDPOINT: warnOnly(
+		'the `telemetry.endpoint` config-file key, or --telemetry-endpoint',
+	),
+	HEZO_DISABLE_AUTO_UPDATE: warnOnly('the `updates.disabled` config-file key'),
+	HEZO_AUTO_INSTALL_UPDATES: warnOnly(
+		'the `updates.autoInstall` config-file key, or --auto-install-updates',
+	),
+
+	HEZO_MARKETPLACE_REF: warnOnly('the `marketplace.ref` config-file key'),
+	HEZO_MARKETPLACE_BASE_URL: warnOnly('the `marketplace.baseUrl` config-file key'),
+	GITHUB_OAUTH_CLIENT_ID: warnOnly('the `github.oauthClientId` config-file key'),
+
+	...Object.fromEntries(
+		Object.entries(JOB_CRONS).map(([name, key]) => [
+			name,
+			warnOnly(`the \`${key}\` config-file key`),
+		]),
+	),
+};
+
+export interface RemovedEnvFinding {
+	/** The variable name, always safe to print. */
+	name: string;
+	/** Its value, already redacted where the variable can carry credentials. */
+	value: string;
+	replacement: string;
+	/** `fatal` only: what the resolved config uses instead, redacted the same way. */
+	inEffect?: string;
+}
+
+export interface RemovedEnvReport {
+	fatal: RemovedEnvFinding[];
+	warnings: RemovedEnvFinding[];
+}
+
+/**
+ * Which removed variables this process was started with. `config` is the fully
+ * resolved configuration, so a fatal variable that agrees with the value
+ * actually in effect is not reported at all.
+ */
+export function detectRemovedEnvVars(
+	env: Record<string, string | undefined>,
+	config: ResolvedDataLocation,
+): RemovedEnvReport {
+	const report: RemovedEnvReport = { fatal: [], warnings: [] };
+	// Sorted so a multi-variable message reads the same on every host.
+	for (const name of Object.keys(REMOVED_ENV_VARS).sort()) {
+		const raw = env[name];
+		if (raw === undefined || raw === '') continue;
+		const spec = REMOVED_ENV_VARS[name];
+		const show = (value: string): string => spec.redact?.(value) ?? value;
+
+		if (spec.severity === 'warn' || !spec.inEffect) {
+			report.warnings.push({ name, value: show(raw), replacement: spec.replacement });
+			continue;
+		}
+
+		const canonical = spec.normalise ?? ((v: string) => v);
+		const resolved = spec.inEffect(config);
+		// Agreeing values mean the operator has migrated and merely left the old
+		// export in place. Nothing is being ignored in a way that matters.
+		if (resolved !== undefined && canonical(resolved) === canonical(raw)) continue;
+
+		report.fatal.push({
+			name,
+			value: show(raw),
+			replacement: spec.replacement,
+			inEffect: resolved === undefined ? undefined : show(resolved),
+		});
+	}
+	return report;
+}
+
+/**
+ * The message `resolveConfig` throws with. `index.ts` prints it verbatim and
+ * exits 1, so it has to be the whole diagnosis: what was ignored, what is in
+ * effect instead, and the two ways to fix it.
+ */
+export function formatRemovedEnvFatal(findings: RemovedEnvFinding[]): string {
+	const lines = [
+		findings.length === 1
+			? `${findings[0].name} is set, but Hezo no longer reads it.`
+			: `${findings.length} environment variables are set that Hezo no longer reads.`,
+		'',
+		'Each one selected where this instance keeps its data, so starting anyway would',
+		'open a different (most likely empty) database and show the master-key setup page',
+		'as if this were a brand-new instance. Nothing has been changed or deleted.',
+		'',
+	];
+	for (const f of findings) {
+		lines.push(`  ${f.name}=${f.value}`);
+		lines.push(`    in effect instead: ${f.inEffect ?? '(the built-in default)'}`);
+		lines.push(`    configure it with: ${f.replacement}`);
+	}
+	lines.push(
+		'',
+		'Move each one into a config file and pass --config, or pass the matching flag.',
+		'A systemd unit upgraded from 0.49 or earlier needs both: the config file, and',
+		'--config on its ExecStart line in place of EnvironmentFile=.',
+		'',
+		`Configuration reference: ${CONFIG_DOCS_URL}`,
+	);
+	return lines.join('\n');
+}
+
+/** The one-line-per-variable warning for the settings that merely reverted to their default. */
+export function formatRemovedEnvWarning(findings: RemovedEnvFinding[]): string {
+	const lines = [
+		`Ignoring ${findings.length} environment variable${findings.length === 1 ? '' : 's'} Hezo no longer reads. ` +
+			`${findings.length === 1 ? 'This setting is' : 'These settings are'} on the built-in default until moved into a config file:`,
+	];
+	for (const f of findings) lines.push(`  ${f.name} -> ${f.replacement}`);
+	lines.push(`See ${CONFIG_DOCS_URL}`);
+	return lines.join('\n');
+}

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -2,7 +2,7 @@
  * The storage abstraction every part of the server talks to. Two drivers
  * implement it: `PgliteDb` (embedded PGlite under `<dataDir>/pgdata`, the
  * default) and `PostgresDb` (an external Postgres reached via
- * `--database-url` / `HEZO_DATABASE_URL`). Application code must only ever
+ * `--database-url` / the `database.url` config-file key). Application code must only ever
  * depend on this interface — the concrete driver types appear solely in the
  * open/backup/migration plumbing under `src/db/`.
  */

--- a/packages/server/src/db/migrate-errors.ts
+++ b/packages/server/src/db/migrate-errors.ts
@@ -45,7 +45,7 @@ export class MigrationFailedError extends Error {
 }
 
 /**
- * The external database (`--database-url` / `HEZO_DATABASE_URL`) could not be
+ * The external database (`--database-url` / the `database.url` config-file key) could not be
  * used: unreachable, incompatible version, failed preflight, or an invalid
  * connection string. Messages must carry operator guidance and NEVER the raw
  * connection string (credentials) — pass pre-redacted text only.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import { AuthType, WsClientAction } from '@hezo/shared';
 import { app } from './app';
 import { AssetStorageError } from './assets/errors';
 import { resolveConfig, runBackup, runRestore, runUninstall, runVersion } from './cli';
+import { detectRemovedEnvVars, formatRemovedEnvWarning } from './config/removed-env';
 import { setRuntimeConfig } from './config/runtime';
 import type { HezoConfig } from './config/types';
 import type { MasterKeyManager } from './crypto/master-key';
@@ -134,6 +135,14 @@ const config = ((): HezoConfig => {
 setRuntimeConfig(config);
 setLogLevel(config.logLevel);
 
+// The removed env vars that only revert a setting to its default: not worth
+// refusing to start over, but the operator has to be told they did nothing. The
+// fatal ones (the data-location trio) already threw inside `resolveConfig`.
+{
+	const { warnings } = detectRemovedEnvVars(process.env, config);
+	if (warnings.length > 0) log.warn(formatRemovedEnvWarning(warnings));
+}
+
 // Self-update supervisor. A compiled binary with auto-update enabled runs as a
 // thin supervisor that spawns the real server as a worker (HEZO_WORKER=1),
 // applies staged updates between restarts, and otherwise propagates the worker's
@@ -168,7 +177,7 @@ for (const sig of ['SIGTERM', 'SIGINT'] as const) {
 
 // Port preflight: Bun binds the port itself from the default export below, so an
 // already-taken port would otherwise surface as a bare `EADDRINUSE` crash. Probe
-// it first and exit with guidance pointing at `--port`/`HEZO_PORT`. Guarded so it
+// it first and exit with guidance pointing at `--port` / the `port` key. Guarded so it
 // runs only on a cold start, never on a `bun --hot` reload (where the dev server
 // keeps the port bound across reloads and a re-probe would falsely see a conflict).
 if (!globalThis.__hezoPortProbed) {

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -54,7 +54,8 @@ async function fetchLatest(): Promise<UpdateInfo> {
 		updateAvailable: false,
 		url: null,
 	};
-	// Test/CI-only, alongside HEZO_SKIP_PRICING_REFRESH and HEZO_TELEMETRY_ENABLED=0:
+	// Test/CI-only, alongside HEZO_SKIP_PRICING_REFRESH and the e2e config's
+	// `telemetry: { enabled: false }`:
 	// the e2e server makes no outbound feed fetches. This one is not just about the
 	// network - whether a release newer than this working tree's version happens to
 	// exist decides whether the UpdateBanner renders, which moves every element in

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -140,7 +140,7 @@ export interface EgressProxyDeps {
 	 * relies on the runtime's system CA bundle. */
 	extraUpstreamTrustedCAs?: string | string[];
 	/** Require a per-run bearer token on every proxied request/CONNECT.
-	 * Defaults to `true`. Set `false` (via `HEZO_EGRESS_PROXY_AUTH=0`) only to
+	 * Defaults to `true`. Set `false` (via `--no-egress-proxy-auth`) only to
 	 * unblock a runtime whose HTTP client can't carry proxy credentials — the
 	 * secret-substitution red line still holds either way, since an
 	 * unauthenticated caller only ever ships unsubstituted placeholders. */
@@ -149,7 +149,7 @@ export interface EgressProxyDeps {
 	 * Defaults to `false`: the proxy runs in the host's network namespace, so
 	 * without this an agent could reach Hezo's own API, its database, or any
 	 * host-bound daemon through the tunnel (see `net-guard.ts`). Set `true` (via
-	 * `--egress-allow-private-targets` / `HEZO_EGRESS_ALLOW_PRIVATE_TARGETS=1`)
+	 * `--egress-allow-private-targets` / the `egress.allowPrivateTargets` config key)
 	 * for an operator whose MCP server or git remote genuinely lives on the LAN. */
 	allowPrivateTargets?: boolean;
 	/** Hezo's own endpoint as a container reaches it, exempted from the

--- a/packages/server/src/services/port-preflight.ts
+++ b/packages/server/src/services/port-preflight.ts
@@ -41,9 +41,9 @@ export function probePort(port: number, host = '0.0.0.0'): Promise<PortProbeResu
 /**
  * Operator-actionable guidance when the configured port is already taken,
  * printed to the log right before the server exits. Mirrors the Docker
- * preflight: a one-line diagnosis, then the exact remedy — pick another port via
- * the `--port` flag or the `HEZO_PORT` env var (the two paths `parseConfig`
- * already supports).
+ * preflight: a one-line diagnosis, then the exact remedy - pick another port via
+ * the `--port` flag or the `port` config-file key (the two paths `resolveConfig`
+ * supports; the env var stopped being read in 0.50).
  */
 export function formatPortInUseMessage(port: number): string {
 	return [
@@ -52,6 +52,6 @@ export function formatPortInUseMessage(port: number): string {
 		'Free that port, or start Hezo on a different one:',
 		'',
 		`  hezo --port <port>        e.g. hezo --port ${port + 1}`,
-		'  HEZO_PORT=<port> hezo',
+		'  port: <port>              in the file you pass to hezo --config',
 	].join('\n');
 }

--- a/packages/server/src/services/sandbox/open.ts
+++ b/packages/server/src/services/sandbox/open.ts
@@ -38,7 +38,7 @@ export interface OpenSandboxBackendOptions {
 	backend?: string;
 	daytonaApiKey?: string;
 	daytonaApiUrl?: string;
-	/** `--docker-socket` / `HEZO_DOCKER_SOCKET`, when the operator pinned one. */
+	/** `--docker-socket` / the `containers.dockerSocket` config key, when the operator pinned one. */
 	dockerSocket?: string;
 	/** Test hook: overrides the preflight retry backoff. */
 	retryDelaysMs?: number[];

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -176,7 +176,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 
 	if (config.telemetry?.enabled) {
 		log.info(
-			'Anonymous usage telemetry is enabled — aggregate counts only (no names, content, or costs). Disable with --disable-telemetry or HEZO_TELEMETRY_ENABLED=0.',
+			'Anonymous usage telemetry is enabled - aggregate counts only (no names, content, or costs). Disable with --disable-telemetry, or `telemetry: { enabled: false }` in your config file.',
 		);
 	}
 

--- a/packages/server/test/port-preflight.test.ts
+++ b/packages/server/test/port-preflight.test.ts
@@ -55,11 +55,14 @@ describe('probePort', () => {
 });
 
 describe('formatPortInUseMessage', () => {
-	it('names the taken port and points at both --port and HEZO_PORT', () => {
+	it('names the taken port and points at both --port and the config key', () => {
 		const msg = formatPortInUseMessage(3100);
 		expect(msg).toContain('3100');
 		expect(msg).toContain('--port');
-		expect(msg).toContain('HEZO_PORT');
+		expect(msg).toContain('--config');
+		// The env var stopped being read in 0.50; suggesting it would send the
+		// operator somewhere that does nothing.
+		expect(msg).not.toContain('HEZO_PORT');
 	});
 
 	it('suggests a concrete alternative port', () => {

--- a/packages/server/test/removed-env.test.ts
+++ b/packages/server/test/removed-env.test.ts
@@ -170,6 +170,29 @@ describe('the operator-facing messages', () => {
 		expect(message).toContain('master-key setup page');
 	});
 
+	it('counts them when more than one is ignored, which is the managed-hosting case', () => {
+		// An instance on external Postgres plus object storage loses both at once,
+		// so the plural branch is the one those operators actually read.
+		const { fatal } = detectRemovedEnvVars(
+			{
+				HEZO_DATA_DIR: '/var/lib/hezo',
+				HEZO_DATABASE_URL: 'postgres://hezo:pw@db.example.com:5432/hezo',
+				HEZO_ASSET_STORAGE_URL: 's3://k:s@account.r2.cloudflarestorage.com/bucket',
+			},
+			at('/root/.hezo'),
+		);
+		const message = formatRemovedEnvFatal(fatal);
+		expect(message).toContain('3 environment variables are set');
+		for (const name of ['HEZO_DATA_DIR', 'HEZO_DATABASE_URL', 'HEZO_ASSET_STORAGE_URL']) {
+			expect(message, name).toContain(name);
+		}
+		// Neither credential survives into the message.
+		expect(message).not.toContain('pw@');
+		expect(message).not.toContain('k:s@');
+		// Both fall back to a built-in default rather than to another configured value.
+		expect(message).toContain('(the built-in default)');
+	});
+
 	it('lists each ignored setting once in the warning', () => {
 		const { warnings } = detectRemovedEnvVars(
 			{ HEZO_PORT: '8080', HEZO_TELEMETRY_ENABLED: '0' },

--- a/packages/server/test/removed-env.test.ts
+++ b/packages/server/test/removed-env.test.ts
@@ -1,0 +1,222 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveConfig } from '../src/cli';
+import {
+	detectRemovedEnvVars,
+	formatRemovedEnvFatal,
+	formatRemovedEnvWarning,
+	REMOVED_ENV_VARS,
+	type ResolvedDataLocation,
+} from '../src/config/removed-env';
+
+const at = (dataDir: string, extra: Partial<ResolvedDataLocation> = {}): ResolvedDataLocation => ({
+	dataDir,
+	database: {},
+	assetStorage: {},
+	...extra,
+});
+
+describe('detectRemovedEnvVars', () => {
+	it('is fatal when HEZO_DATA_DIR would have pointed somewhere else', () => {
+		// The 0.50 upgrade regression: systemd still exports the old variable, the
+		// binary ignores it and opens an empty database under the default path.
+		const { fatal, warnings } = detectRemovedEnvVars(
+			{ HEZO_DATA_DIR: '/var/lib/hezo' },
+			at('/root/.hezo'),
+		);
+		expect(warnings).toEqual([]);
+		expect(fatal).toHaveLength(1);
+		expect(fatal[0].name).toBe('HEZO_DATA_DIR');
+		expect(fatal[0].value).toBe('/var/lib/hezo');
+		expect(fatal[0].inEffect).toBe('/root/.hezo');
+	});
+
+	it('stays quiet when the ignored variable agrees with the resolved data dir', () => {
+		// An operator who migrated to --config but left EnvironmentFile= in place is
+		// not being surprised by anything, so blocking them would be noise.
+		const { fatal } = detectRemovedEnvVars({ HEZO_DATA_DIR: '/var/lib/hezo' }, at('/var/lib/hezo'));
+		expect(fatal).toEqual([]);
+	});
+
+	it('compares data dirs after normalisation, not as raw strings', () => {
+		const { fatal } = detectRemovedEnvVars(
+			{ HEZO_DATA_DIR: '/var/lib/hezo/' },
+			at('/var/lib/hezo'),
+		);
+		expect(fatal).toEqual([]);
+	});
+
+	it('is fatal for an ignored external database, and never prints its credentials', () => {
+		const { fatal } = detectRemovedEnvVars(
+			{ HEZO_DATABASE_URL: 'postgres://hezo:hunter2@db.internal:5432/hezo' },
+			at('/var/lib/hezo'),
+		);
+		expect(fatal).toHaveLength(1);
+		expect(fatal[0].name).toBe('HEZO_DATABASE_URL');
+		expect(fatal[0].value).not.toContain('hunter2');
+		// The embedded database is what it would silently fall back to.
+		expect(fatal[0].inEffect).toBeUndefined();
+	});
+
+	it('is fatal for an ignored asset store, redacted the same way', () => {
+		const { fatal } = detectRemovedEnvVars(
+			{ HEZO_ASSET_STORAGE_URL: 's3://AKIAKEY:supersecret@s3.example.com/bucket' },
+			at('/var/lib/hezo'),
+		);
+		expect(fatal).toHaveLength(1);
+		expect(fatal[0].name).toBe('HEZO_ASSET_STORAGE_URL');
+		expect(fatal[0].value).not.toContain('supersecret');
+	});
+
+	it('reports every ignored data-location variable at once', () => {
+		const { fatal } = detectRemovedEnvVars(
+			{ HEZO_DATA_DIR: '/var/lib/hezo', HEZO_DATABASE_URL: 'postgres://h/db' },
+			at('/root/.hezo'),
+		);
+		expect(fatal.map((f) => f.name)).toEqual(['HEZO_DATABASE_URL', 'HEZO_DATA_DIR']);
+	});
+
+	it('only warns for a setting that merely reverted to its default', () => {
+		const { fatal, warnings } = detectRemovedEnvVars(
+			{ HEZO_LOG_LEVEL: 'debug', HEZO_PORT: '8080', HEZO_WAKEUP_CRON: '* * * * * *' },
+			at('/var/lib/hezo'),
+		);
+		expect(fatal).toEqual([]);
+		expect(warnings.map((w) => w.name)).toEqual([
+			'HEZO_LOG_LEVEL',
+			'HEZO_PORT',
+			'HEZO_WAKEUP_CRON',
+		]);
+		expect(warnings[0].replacement).toContain('logLevel');
+	});
+
+	it('redacts the Daytona API key even though it only warns', () => {
+		const { warnings } = detectRemovedEnvVars({ HEZO_DAYTONA_API_KEY: 'dtn_live_abc' }, at('/d'));
+		expect(warnings[0].value).not.toContain('dtn_live_abc');
+	});
+
+	it('ignores an empty value, which sets nothing', () => {
+		expect(detectRemovedEnvVars({ HEZO_DATA_DIR: '' }, at('/root/.hezo')).fatal).toEqual([]);
+	});
+
+	it('never reports an env var that is still read', () => {
+		// A prefix scan over HEZO_* would break every one of these.
+		const live = {
+			HEZO_MASTER_KEY: 'abandon abandon abandon',
+			HEZO_WORKER: '1',
+			HEZO_SKIP_DOCKER: '1',
+			HEZO_TEST_SCRYPT_LOG_N: '1',
+			HEZO_TEAM_ID: 'team-uuid',
+			HEZO_MARKETPLACE_DIR: '/repo/marketplace',
+		};
+		const report = detectRemovedEnvVars(live, at('/var/lib/hezo'));
+		expect(report).toEqual({ fatal: [], warnings: [] });
+	});
+});
+
+describe('the removed-variable table', () => {
+	it('names no variable the server still reads', () => {
+		// A variable listed here but still read would make the check lie: the
+		// operator is told it does nothing while it quietly keeps working.
+		const src = join(import.meta.dirname, '../src');
+		const files: string[] = [];
+		const walk = (dir: string): void => {
+			for (const entry of readdirSync(dir, { withFileTypes: true })) {
+				const path = join(dir, entry.name);
+				if (entry.isDirectory()) walk(path);
+				else if (entry.name.endsWith('.ts') && entry.name !== 'removed-env.ts') files.push(path);
+			}
+		};
+		walk(src);
+
+		const stillRead: string[] = [];
+		for (const name of Object.keys(REMOVED_ENV_VARS)) {
+			const read = new RegExp(`env(\\.${name}\\b|\\[['"\`]${name}['"\`]\\])`);
+			for (const file of files) {
+				if (read.test(readFileSync(file, 'utf8'))) {
+					stillRead.push(`${name} in ${file.slice(src.length + 1)}`);
+					break;
+				}
+			}
+		}
+		expect(stillRead).toEqual([]);
+	});
+
+	it('gives every entry a replacement naming a config key or a flag', () => {
+		for (const [name, spec] of Object.entries(REMOVED_ENV_VARS)) {
+			expect(spec.replacement, name).toMatch(/config-file key|--/);
+		}
+	});
+
+	it('marks exactly the three data-location variables fatal', () => {
+		const fatal = Object.entries(REMOVED_ENV_VARS)
+			.filter(([, spec]) => spec.severity === 'fatal')
+			.map(([name]) => name)
+			.sort();
+		expect(fatal).toEqual(['HEZO_ASSET_STORAGE_URL', 'HEZO_DATABASE_URL', 'HEZO_DATA_DIR']);
+	});
+});
+
+describe('the operator-facing messages', () => {
+	it('says what was ignored, what is in effect, and how to fix it', () => {
+		const { fatal } = detectRemovedEnvVars({ HEZO_DATA_DIR: '/var/lib/hezo' }, at('/root/.hezo'));
+		const message = formatRemovedEnvFatal(fatal);
+		expect(message).toContain('HEZO_DATA_DIR=/var/lib/hezo');
+		expect(message).toContain('/root/.hezo');
+		expect(message).toContain('--data-dir');
+		expect(message).toContain('hezo.ai/docs/deployment/configuration');
+		// The symptom the operator actually saw, so they can match the two up.
+		expect(message).toContain('master-key setup page');
+	});
+
+	it('lists each ignored setting once in the warning', () => {
+		const { warnings } = detectRemovedEnvVars(
+			{ HEZO_PORT: '8080', HEZO_TELEMETRY_ENABLED: '0' },
+			at('/d'),
+		);
+		const message = formatRemovedEnvWarning(warnings);
+		expect(message).toContain('HEZO_PORT -> ');
+		expect(message).toContain('HEZO_TELEMETRY_ENABLED -> ');
+	});
+
+	it('uses no em or en dash, which operator-facing prose bans', () => {
+		const { fatal } = detectRemovedEnvVars({ HEZO_DATA_DIR: '/a' }, at('/b'));
+		const { warnings } = detectRemovedEnvVars({ HEZO_PORT: '1' }, at('/b'));
+		expect(formatRemovedEnvFatal(fatal)).not.toMatch(/[–—]/);
+		expect(formatRemovedEnvWarning(warnings)).not.toMatch(/[–—]/);
+		for (const spec of Object.values(REMOVED_ENV_VARS)) {
+			expect(spec.replacement).not.toMatch(/[–—]/);
+		}
+	});
+});
+
+describe('resolveConfig', () => {
+	const argv = (...rest: string[]): string[] => ['bun', 'hezo', ...rest];
+
+	it('refuses to start when a removed variable moves the data dir', () => {
+		expect(() => resolveConfig(argv(), { HEZO_DATA_DIR: '/var/lib/hezo' })).toThrow(
+			/HEZO_DATA_DIR/,
+		);
+	});
+
+	it('starts when the flag matches the variable that is no longer read', () => {
+		const config = resolveConfig(argv('--data-dir', '/var/lib/hezo'), {
+			HEZO_DATA_DIR: '/var/lib/hezo',
+		});
+		expect(config.dataDir).toBe('/var/lib/hezo');
+	});
+
+	it('starts, but does not honour, a removed variable that only warns', () => {
+		const config = resolveConfig(argv(), { HEZO_PORT: '8080' });
+		expect(config.port).not.toBe(8080);
+	});
+
+	it('still accepts HEZO_MASTER_KEY, the one env var that survived', () => {
+		const config = resolveConfig(argv(), {
+			HEZO_MASTER_KEY:
+				'legal winner thank year wave sausage worth useful legal winner thank yellow',
+		});
+		expect(config.masterKey?.unlockKeyHex).toBeTruthy();
+	});
+});

--- a/packages/server/test/upgrade-ack-hook.test.ts
+++ b/packages/server/test/upgrade-ack-hook.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+	checkCommitMessage,
+	findUpgradeAckValue,
+	UPGRADE_BEARING_PATTERNS,
+	upgradeBearingFiles,
+} from '../../../scripts/check-upgrade-ack';
+
+/**
+ * Guard for the `Upgrade-Checked:` commit hook. Mirrors docs-ack-hook.test.ts -
+ * same shared machinery, different bearing paths and a different obligation.
+ */
+describe('upgrade-bearing classification', () => {
+	it('covers the surfaces an already-running instance carries across a restart', () => {
+		expect(
+			upgradeBearingFiles([
+				'packages/server/src/config/removed-env.ts',
+				'packages/server/src/db/client.ts',
+				'packages/server/migrations/072_add_column.sql',
+				'packages/server/src/cli.ts',
+				'packages/server/src/index.ts',
+				'packages/server/src/startup.ts',
+				'packages/server/src/supervisor.ts',
+				'packages/server/src/services/updater.ts',
+				'deploy/provision.sh',
+				'docker/Dockerfile.agent-base',
+			]),
+		).toHaveLength(10);
+	});
+
+	it('leaves ordinary feature work alone, which ships whole with the binary', () => {
+		// A trailer demanded of every commit is a trailer nobody reads.
+		expect(
+			upgradeBearingFiles([
+				'packages/server/src/routes/tasks.ts',
+				'packages/server/src/services/agent-runner.ts',
+				'packages/web/src/routes/index.tsx',
+				'packages/shared/src/types/common.ts',
+				'agents/software-development/engineer.md',
+				'docs/deployment/configuration.md',
+				'packages/server/test/cli.test.ts',
+			]),
+		).toEqual([]);
+	});
+
+	it('matches the named single files exactly, not by prefix', () => {
+		const hit = (f: string) => UPGRADE_BEARING_PATTERNS.some((p) => p.test(f));
+		expect(hit('packages/server/src/cli.ts')).toBe(true);
+		expect(hit('packages/server/src/services/updater.ts')).toBe(true);
+		expect(hit('packages/server/test/cli.test.ts')).toBe(false);
+		expect(hit('packages/server/test/updater-branches-cov.test.ts')).toBe(false);
+	});
+});
+
+describe('the Upgrade-Checked trailer', () => {
+	const staged = ['packages/server/src/config/schema.ts'];
+
+	it('rejects a config commit with no trailer', () => {
+		const r = checkCommitMessage('feat(config): rename the data directory key', staged);
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('Upgrade-Checked');
+	});
+
+	it('rejects a rubber stamp', () => {
+		const r = checkCommitMessage('feat(config): x\n\nUpgrade-Checked: yes', staged);
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('not a meaningful acknowledgment');
+	});
+
+	it('accepts a real acknowledgment', () => {
+		const r = checkCommitMessage(
+			'feat(config): x\n\nUpgrade-Checked: the old key is still read and warns; an instance that never rewrites its config is unaffected',
+			staged,
+		);
+		expect(r.ok).toBe(true);
+	});
+
+	it('leaves a commit touching nothing upgrade-bearing alone', () => {
+		expect(checkCommitMessage('fix: unrelated', ['packages/web/src/main.tsx']).ok).toBe(true);
+	});
+
+	it('exempts merges, reverts and fixups', () => {
+		for (const msg of ['Merge branch main', 'Revert "x"', 'fixup! earlier']) {
+			expect(checkCommitMessage(msg, staged).ok, msg).toBe(true);
+		}
+	});
+
+	it('reads the trailer case-insensitively, anywhere in the body', () => {
+		expect(
+			findUpgradeAckValue('title\n\nupgrade-checked: existing instances keep their data'),
+		).toBe('existing instances keep their data');
+	});
+});

--- a/scripts/check-upgrade-ack.ts
+++ b/scripts/check-upgrade-ack.ts
@@ -1,0 +1,81 @@
+// Commit-msg guard: every commit that touches a surface an existing instance
+// depends on must carry an `Upgrade-Checked:` trailer acknowledging the pass
+// over in-place upgrades (AGENTS.md § Production upgrades).
+//
+// Nothing else in the repo can see this. Every test runs against a fresh
+// instance built by the code under test, so a change that is self-consistent
+// passes the whole suite while breaking every instance that upgrades onto it -
+// a renamed config mechanism the old deployment still uses, a data path that
+// moved, a supervisor that relaunches without the argument it now needs. The
+// symptom is silence: the server starts, finds nothing where it looked, and
+// presents itself as a brand-new install.
+//
+// The classification/parsing machinery is shared with the Docs-Checked,
+// Translations-Checked and Prompts-Checked hooks — see scripts/commit-ack.ts.
+// Pure functions here are unit-tested in
+// packages/server/test/upgrade-ack-hook.test.ts.
+import { type AckRule, bearingFiles, checkAck, runAckHook, summarizeBearing } from './commit-ack';
+
+export { effectiveMessage, isExemptCommit } from './commit-ack';
+
+/**
+ * Path prefixes whose changes an already-running instance can be broken by:
+ * how settings are resolved, where data lives and how it is read, how the
+ * process starts and replaces itself, and what a deployment installs.
+ *
+ * Deliberately narrower than the doc-bearing list. A trailer demanded of every
+ * commit is a trailer nobody reads, so ordinary feature work under
+ * `services/`, `routes/` and the web package is absent: those ship with the
+ * binary and carry nothing forward from the previous install.
+ */
+export const UPGRADE_BEARING_PATTERNS: RegExp[] = [
+	/^packages\/server\/src\/config\//,
+	/^packages\/server\/src\/db\//,
+	/^packages\/[^/]+\/migrations\//,
+	/^packages\/server\/src\/cli\.ts$/,
+	/^packages\/server\/src\/index\.ts$/,
+	/^packages\/server\/src\/startup\.ts$/,
+	/^packages\/server\/src\/supervisor\.ts$/,
+	/^packages\/server\/src\/services\/updater\.ts$/,
+	/^deploy\//,
+	/^docker\//,
+];
+
+export const UPGRADE_ACK_RULE: AckRule = {
+	trailer: 'Upgrade-Checked',
+	patterns: UPGRADE_BEARING_PATTERNS,
+	missingMessage: (bearing) =>
+		`This commit touches a surface existing instances depend on (${summarizeBearing(bearing)}) ` +
+		'but has no Upgrade-Checked: trailer. State what happens to an instance running the ' +
+		'previous release when it restarts onto this one.',
+	emptyMessage: (value) =>
+		`Upgrade-Checked value "${value}" is not a meaningful acknowledgment — say what an existing instance does on restart, or why nothing it holds is affected.`,
+	guidance: [
+		'Every commit here must acknowledge the in-place-upgrade pass (AGENTS.md § Production upgrades).',
+		'Walk one running instance through the restart: it keeps its data directory, its config,',
+		'its service definition and its database, and only the binary changes. Then add a trailer, e.g.:\n',
+		'  Upgrade-Checked: the new key falls back to the old one when absent, so an instance that never writes a config file is unaffected',
+		'  Upgrade-Checked: migration 072 backfills the column for existing rows; provision.sh rewrites the unit for hosts installed before it',
+		'  Upgrade-Checked: reads nothing written by a previous release; an upgrading instance starts identically to a fresh one',
+	],
+};
+
+export function upgradeBearingFiles(stagedFiles: string[]): string[] {
+	return bearingFiles(stagedFiles, UPGRADE_BEARING_PATTERNS);
+}
+
+export function findUpgradeAckValue(message: string): string | null {
+	// Kept as a named export because the trailer is part of the repo's contract,
+	// not an implementation detail of the generic checker.
+	const match = message.match(/^Upgrade-Checked:[ \t]*(.*)$/im);
+	return match ? match[1].trim() : null;
+}
+
+export function checkCommitMessage(
+	rawMessage: string,
+	stagedFiles: string[],
+): { ok: boolean; error?: string } {
+	return checkAck(rawMessage, stagedFiles, UPGRADE_ACK_RULE);
+}
+
+if (import.meta.main) runAckHook(UPGRADE_ACK_RULE, 'check-upgrade-ack.ts');


### PR DESCRIPTION
## The bug

A production instance upgraded to 0.50.0 came back showing the **"Create your master key"** setup page, as if it were a brand-new install.

`a41eb6e` (#995) removed every `HEZO_*` configuration env var with no shim, no warning, and no startup check that notices an ignored one. On a `provision.sh` host the chain is:

1. The in-app updater swaps only the binary (`services/updater.ts`); the supervisor relaunches with the same argv. Neither touches `/etc/systemd/system/hezo.service`, so no `--config` appears.
2. systemd still exports `HEZO_DATA_DIR=/var/lib/hezo` from `EnvironmentFile=`. 0.50 ignores it.
3. `dataDir` falls back to `~/.hezo`. The unit sets no `User=`, so that is `/root/.hezo`.
4. PGlite creates an empty database there.
5. `system_meta` has no `master_key_auth_public_key` row, so `MasterKeyManager` lands on `'unset'` and the web gate renders the setup screen.

**No data is lost** - the original tree is untouched and a second, empty one was created beside it.

**Managed-hosting instances lose more, and lose it more quietly.** With `HEZO_DATABASE_URL` and `HEZO_ASSET_STORAGE_URL` also ignored, an instance on external Postgres plus object storage falls back to embedded PGlite *and* local-disk assets. The remote backends are never connected to, so nothing there is touched, but no amount of fixing `dataDir` alone recovers such a host.

Second, independent path: re-running `provision.sh` writes the config file only when absent and populates `database.url` / `assetStorage.url` from the *provisioning shell* only. It never read the existing `/etc/hezo/hezo.env`, so a re-provision silently dropped an external database configuration.

## The fix

**`packages/server/src/config/removed-env.ts`** - one table plus one pure function.

- `REMOVED_ENV_VARS` maps each removed name to the config key or flag that replaced it. Explicit list, never a `HEZO_*` prefix scan: `HEZO_MASTER_KEY`, `HEZO_WORKER`, `HEZO_SKIP_DOCKER` and the `HEZO_TEST_*` seams all survive and must not be caught.
- The three that select where data lives (`HEZO_DATA_DIR`, `HEZO_DATABASE_URL`, `HEZO_ASSET_STORAGE_URL`) throw out of `resolveConfig`, which `index.ts` already renders as a one-line operator message and exit 1. Everything else warns once at startup.
- A fatal one is raised **only when its value differs** from what the resolved config uses, compared after `resolveDataDir` normalisation - so leaving `EnvironmentFile=` in place after a correct migration does not block anyone.
- The same check runs in `resolveSubcommandTargets`, so `hezo backup` cannot dump the wrong tree either.
- Credential-bearing values go through the existing `redactDatabaseUrl` / `redactAssetStorageUrl` helpers.

**`deploy/provision.sh`** now reads a pre-0.50 `/etc/hezo/hezo.env` into the config file it generates - `dataDir`, `database.url`, `poolSize`, `assetStorage.url`, and the web URL - then renames the old file to `hezo.env.migrated`. The shell environment still wins, and the rename happens only once the config file exists, so an interrupted run loses nothing.

The web URL needs its own handling: the generated config reads `webUrl` from `/etc/hezo/web-url`, and `hezo-firstboot` will not recreate that file on an already-provisioned host because its `ConditionPathExists=!/var/lib/hezo/.firstboot-done` sentinel was set on the original provision. Rather than special-case the generator with a `webUrl:` literal, the migration seeds the side file from the old variable - one mechanism, written from two places instead of read from two.

**Seven stale operator-facing messages** still named variables that no longer do anything - `HEZO_PORT` offered as the remedy for a taken port, `HEZO_DATA_DIR` in the backup guidance, `HEZO_TELEMETRY_ENABLED=0` in the startup line. They now name the flag or the config key.

## The rule this broke

Nothing in the suite can see this class of bug: every test builds a fresh instance from the code under test, so a self-consistent change passes green while breaking every instance that upgrades onto it.

- **AGENTS.md § Production upgrades** - fail loudly on a removed mechanism rather than falling back to a default; ship the migration rather than documenting it; the updater replaces the binary and nothing else; a `BREAKING CHANGE:` note is not a migration.
- **`Upgrade-Checked:` commit trailer**, enforced by `scripts/check-upgrade-ack.ts` alongside the three existing ack hooks, over the surfaces an instance carries across a restart: `config/`, `db/`, `migrations/`, `cli.ts`, `index.ts`, `startup.ts`, `supervisor.ts`, `services/updater.ts`, `deploy/`, `docker/`. Deliberately narrower than the doc-bearing list - a trailer demanded of every commit is one nobody reads.

## Verification

- `packages/server/test/removed-env.test.ts` (21 tests): the fatal trio, the agreeing-value case, path normalisation, redaction, the surviving seams, table integrity (no listed name is still read anywhere in `src/`), both singular and plural message forms, and `resolveConfig` throwing / not throwing.
- `packages/server/test/upgrade-ack-hook.test.ts` (9 tests): bearing classification, exact-file matching, trailer parsing and exemptions.
- Reproduced end to end: `HEZO_DATA_DIR=/tmp/hezo-old bun run --cwd packages/server src/index.ts --no-open` now exits 1 naming the variable and the path in effect, instead of booting on `~/.hezo`. With a matching `--config`, it starts normally.
- `provision.sh` migration dry-run against a fixture `hezo.env` carrying an external database, an S3 store and a web URL: all land in the generated `.cjs`, which then loads clean through the real `loadConfigFile` validator and resolves `webUrl` back out of the seeded side file.

## Note on docs

The version transition itself is deliberately not documented in `docs/` - the code refuses to start with the fix inline, and `provision.sh` migrates the host. The only `docs/` change is correcting a stale "the service's environment file" in `one-click.md`; the rationale lives in `.dev/architecture.md § Configuration resolution`.

## Recovering an instance already in this state

Stop the service, then re-run `provision.sh` - it now writes the config file from the old `hezo.env` and rewrites the unit with `--config`.

By hand, write `/etc/hezo/hezo.config.cjs` with `dataDir`, `webUrl`, and **every** `database.url` / `assetStorage.url` the old `hezo.env` carried, then add `--config` to `ExecStart`. On an instance using managed Postgres or object storage, those two are the load-bearing settings: `--data-dir` alone just selects a different empty embedded database. Remove the stray `/root/.hezo` only after confirming the real instance is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aXJHf6ZUzugjSuev5AtwB