### PR TITLE
fix(web): make settings group headings read as labels, not menu links

### DIFF
--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -74,16 +74,18 @@ function isActive(itemTo: string, pathname: string): boolean {
 }
 
 /**
- * Group heading: a label for what follows, not a target. Two things keep it from
- * reading as another link in the same column - it is set as an eyebrow (smaller,
- * lighter and letter-spaced against the 13px items) and a hairline runs off it to
- * the menu's edge, which no link ever does. Spacing binds it to its own items:
- * open above the group, tight below the label.
+ * Group heading: a label for what follows, not a target. Three things keep it
+ * from reading as another link in the same column - it is set as an eyebrow
+ * (small, uppercase and letter-spaced against the 13px items), it is bolder and
+ * darker than anything it labels, and a hairline runs off it to the menu's edge,
+ * which no link ever does. `font-bold` overrides the eyebrow's own 500: the
+ * utility is declared earlier in the sheet, so the later class wins. Spacing
+ * binds the label to its own items: open above the group, tight below.
  */
 function GroupHeading({ label }: { label: string }) {
 	return (
 		<div className="flex items-center gap-2 px-3 pb-1.5">
-			<span className="text-eyebrow text-text-3">{label}</span>
+			<span className="text-eyebrow font-bold text-text-1">{label}</span>
 			<span className="h-px flex-1 bg-border" />
 		</div>
 	);

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from '@tanstack/react-router';
 import { ChevronDown, LogOut } from 'lucide-react';
-import { Fragment, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useCloseOnRouteChange } from '../hooks/use-close-on-route-change';
 import { useMe } from '../hooks/use-me';
 import { logout } from '../lib/auth';
@@ -73,9 +73,24 @@ function isActive(itemTo: string, pathname: string): boolean {
 	return (pathname.replace(/\/$/, '') || '/settings') === itemTo;
 }
 
-/** Group heading: a label, not a target - quieter and smaller than its items. */
-const groupClass =
-	'px-3 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-text-3 first:pt-0';
+/**
+ * Group heading: a label for what follows, not a target. Two things keep it from
+ * reading as another link in the same column - it is set as an eyebrow (smaller,
+ * lighter and letter-spaced against the 13px items) and a hairline runs off it to
+ * the menu's edge, which no link ever does. Spacing binds it to its own items:
+ * open above the group, tight below the label.
+ */
+function GroupHeading({ label }: { label: string }) {
+	return (
+		<div className="flex items-center gap-2 px-3 pb-1.5">
+			<span className="text-eyebrow text-text-3">{label}</span>
+			<span className="h-px flex-1 bg-border" />
+		</div>
+	);
+}
+
+/** Groups after the first are pushed apart; the rule alone is too quiet to separate them. */
+const groupClass = 'flex flex-col gap-0.5 mt-4 first:mt-0';
 
 function itemClass(active: boolean): string {
 	return `text-left text-[13px] px-3 py-1.5 rounded-md transition-colors cursor-pointer ${
@@ -176,8 +191,8 @@ export function SettingsSidebar() {
 						/>
 						<nav className="absolute left-4 right-4 z-30 mt-1 flex flex-col gap-0.5 rounded-md border border-border bg-surface p-1 shadow-lg">
 							{groups.map((group) => (
-								<Fragment key={group.titleKey}>
-									<span className={groupClass}>{t(group.titleKey)}</span>
+								<div key={group.titleKey} className={groupClass}>
+									<GroupHeading label={t(group.titleKey)} />
 									{group.items.map((item) => (
 										<Link
 											key={item.to}
@@ -188,7 +203,7 @@ export function SettingsSidebar() {
 											{t(item.labelKey)}
 										</Link>
 									))}
-								</Fragment>
+								</div>
 							))}
 							<LogoutButton onClick={handleLogout} className="mt-3" />
 						</nav>
@@ -202,14 +217,14 @@ export function SettingsSidebar() {
 				data-testid="settings-nav-desktop"
 			>
 				{groups.map((group) => (
-					<Fragment key={group.titleKey}>
-						<span className={groupClass}>{t(group.titleKey)}</span>
+					<div key={group.titleKey} className={groupClass}>
+						<GroupHeading label={t(group.titleKey)} />
 						{group.items.map((item) => (
 							<Link key={item.to} to={item.to} className={itemClass(isActive(item.to, pathname))}>
 								{t(item.labelKey)}
 							</Link>
 						))}
-					</Fragment>
+					</div>
 				))}
 				<LogoutButton onClick={handleLogout} className="mt-4" />
 			</nav>

--- a/packages/web/test/settings-ia.test.tsx
+++ b/packages/web/test/settings-ia.test.tsx
@@ -25,6 +25,21 @@ test('the settings menu is grouped, and each group heading precedes its items', 
 	expect(text.indexOf('Maintenance')).toBeLessThan(text.indexOf('Storage'));
 });
 
+test('a group heading is a label, not another link in the menu', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+	const nav = await findByTestId('settings-nav-desktop');
+
+	// The headings read as links only if they *are* reachable as one. Every
+	// interactive node in the menu is a nav item or the log-out button; a group
+	// title is neither, so it must not turn up among them.
+	const interactive = within(nav)
+		.getAllByRole('link')
+		.map((el) => el.textContent?.trim());
+	for (const heading of ['General', 'Agents', 'Integrations', 'Access', 'Maintenance']) {
+		expect(interactive, `${heading} is reachable as a link`).not.toContain(heading);
+	}
+});
+
 test('the retired pages are gone from the menu and their subjects live on', async () => {
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 	const nav = await findByTestId('settings-nav-desktop');


### PR DESCRIPTION
The five Settings group titles (General, Agents, Integrations, Access, Maintenance) sat in the same column, at the same left edge and in the same vertical rhythm as the nav items, so they scanned as another row of links rather than as labels for what follows.

## What changed

- Each group title is now an **eyebrow** (`text-eyebrow`, the existing 11px / +0.08em uppercase utility from `index.css`) taken to **bold in `text-1`**, so a heading clearly outranks the items it labels. `font-bold` overrides the utility's own 500 weight because the utility is declared earlier in the sheet.
- A **hairline runs off the label to the menu's edge** - a shape no link in the menu has, which is what stops the title reading as a target.
- Groups are wrapped and **pushed apart** (`mt-4`, first group flush), and the label sits tight above its own items, so each heading binds downward to what it labels.
- Applies to both nav variants: the desktop rail and the mobile dropdown panel.

No routes, labels or behaviour changed - the same items in the same order, restyled.

## Testing

- New component test in `settings-ia.test.tsx`: a group heading must not be reachable as a link in the menu, which is the complaint made testable.
- `packages/web` component tests for the settings nav pass (`settings-ia`, `settings-logout`), plus `bun run typecheck` and biome.
- Weight and colour were chosen by rendering four candidates side by side in real Chromium, in both themes; the shipped treatment is verified at 1280px and 390px, light and dark.