### PR TITLE
feat(tasks): carry the task name in the pinned breadcrumb, on one line

### DIFF
--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -54,9 +54,10 @@ function useScrolledPast(ref: RefObject<HTMLElement | null>): boolean {
 
 /**
  * Top-of-page header for a task: a breadcrumb of ancestor tasks ending in the
- * current identifier - pinned to the top of the shell scroller at `lg`+, so a
- * long thread never leaves the reader without the task's identity or a way back
- * to the list - then the title, an inline mono metadata row (status ·
+ * current identifier and the task's own name - pinned to the top of the shell
+ * scroller at every breakpoint, so a long thread never leaves the reader without
+ * the task's identity or a way back to the list - then the title, an inline mono
+ * metadata row (status ·
  * priority · assignee) with a runs · duration · cost summary, the queued-wakeup
  * chip, and the description card. The title renames in place and the description
  * edits in place; both are recorded on the task thread as meta comments by the
@@ -91,21 +92,29 @@ export function TaskHeader({
 		<>
 			{/* Marks where the breadcrumb rests. `-mb-px` keeps it out of the layout. */}
 			<div ref={restingSentinelRef} aria-hidden="true" className="h-px w-full -mb-px" />
-			{/* Desktop pins the crumb to the top of the scrolling <main>; below `lg` it
-			    scrolls away with the rest, where vertical space is the scarce thing.
-			    `top` clears the project banners stickied above it in the same scroller,
-			    reading the height ContainerStatusBanner publishes - the idiom the task
-			    meta rail already uses. z-10 stays under those banners (z-20 and up) and
-			    over the content column, which carries no z-index of its own. */}
+			{/* Pinned to the top of the scrolling <main> at every breakpoint - the phone
+			    is where the title leaves the screen soonest, so it is the last place to
+			    drop the crumb. `top` clears the project banners stickied above it in the
+			    same scroller, reading the height ContainerStatusBanner publishes - the
+			    idiom the task meta rail already uses. z-10 stays under those banners
+			    (z-20 and up) and over the content column, which carries no z-index of
+			    its own. `-mt-3` cancels the `pt-3` that gives the pinned band its top
+			    breathing room, so the resting position is unmoved; the route wrapper
+			    always leaves at least that much above (py-4 at its narrowest).
+
+			    NO `flex-wrap`: the crumb is one line at every width, and only the task
+			    name gives way. Everything ahead of it is `shrink-0`, the name alone is
+			    `min-w-0 truncate`, so the browser cuts it to whatever the column is
+			    rather than pushing the row to two lines. */}
 			<nav
 				aria-label="Breadcrumb"
 				data-pinned={pinned ? 'true' : 'false'}
-				className={`mb-1 flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-2 lg:sticky lg:top-[var(--container-banner-h,0px)] lg:z-10 lg:-mt-3 lg:mb-0 lg:border-b lg:border-transparent lg:bg-bg lg:pt-3 lg:pb-2 lg:transition-[border-color,box-shadow] lg:duration-150 ${
-					pinned ? 'lg:border-border lg:shadow-xs' : ''
+				className={`sticky top-[var(--container-banner-h,0px)] z-10 -mt-3 flex items-center gap-x-1 border-b border-transparent bg-bg pt-3 pb-2 text-[13px] font-mono text-text-2 transition-[border-color,box-shadow] duration-150 ${
+					pinned ? 'border-border shadow-xs' : ''
 				}`}
 				data-testid="task-breadcrumb"
 			>
-				<span className="flex items-center gap-x-1">
+				<span className="flex shrink-0 items-center gap-x-1">
 					<Link
 						to="/projects/$projectId/tasks"
 						params={{ projectId: taskProjectSlug }}
@@ -116,8 +125,25 @@ export function TaskHeader({
 					</Link>
 					<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
 				</span>
+				{/* Below `sm` the ancestor identifiers would spend the whole line, so they
+				    collapse to one ellipsis and the name keeps the room. The links stay in
+				    the accessibility tree (`sr-only`, not `hidden`), so a screen reader on
+				    a phone still gets the full path this stands in for. */}
+				{!!ancestors?.length && (
+					<span
+						aria-hidden="true"
+						className="flex shrink-0 items-center gap-x-1 sm:hidden"
+						data-testid="task-breadcrumb-ancestors-collapsed"
+					>
+						<span className="text-text-3">…</span>
+						<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
+					</span>
+				)}
 				{ancestors?.map((ancestor) => (
-					<span key={ancestor.id} className="flex items-center gap-x-1">
+					<span
+						key={ancestor.id}
+						className="sr-only items-center gap-x-1 sm:not-sr-only sm:flex sm:shrink-0"
+					>
 						<Link
 							to="/projects/$projectId/tasks/$taskId"
 							params={{ projectId: taskProjectSlug, taskId: ancestor.identifier.toLowerCase() }}
@@ -130,7 +156,24 @@ export function TaskHeader({
 						<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
 					</span>
 				))}
-				<span aria-current="page">{task.identifier}</span>
+				{/* Identifier and name are one crumb, so they sit inside a single
+				    `aria-current` - a reader hears "HM-246, Fix the flaky test", not two
+				    separate items. The name is sans against the mono identifiers because
+				    it is prose, not something you quote, and `title` keeps the full text
+				    reachable once it truncates. */}
+				<span aria-current="page" className="flex min-w-0 items-center gap-x-1">
+					<span className="shrink-0">{task.identifier}</span>
+					<span aria-hidden="true" className="shrink-0 text-text-3">
+						·
+					</span>
+					<span
+						className="min-w-0 truncate font-sans text-text-3"
+						title={task.title}
+						data-testid="task-breadcrumb-title"
+					>
+						{task.title}
+					</span>
+				</span>
 			</nav>
 			<TaskTitle task={task} updateTask={updateTask} />
 

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -343,3 +343,16 @@ async function interactUntil(
 		{ timeout: options.timeout ?? 15_000 },
 	);
 }
+
+/**
+ * Scopes a text query to the task page's `<h1>`.
+ *
+ * A task's title renders twice on its own page: the heading, and the breadcrumb
+ * that carries the name beside the identifier. So a bare `findByText(title)`
+ * matches two elements and throws. Pass this as the query's options argument
+ * when the intent is "wait until the page for this task is up", which is what
+ * the heading means:
+ *
+ *     await findByText('Target task', taskHeadingQuery, { timeout: 10_000 });
+ */
+export const taskHeadingQuery = { selector: 'h1' } as const;

--- a/packages/web/test/run-comment-retry.test.tsx
+++ b/packages/web/test/run-comment-retry.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { getTestContext, renderApp } from './helpers/render';
+import { getTestContext, renderApp, taskHeadingQuery } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 import { expandEventGroups } from './helpers/thread';
 
@@ -302,7 +302,7 @@ test('a run somebody terminated offers no Retry', async () => {
 
 	// Wait for the thread itself before asserting on an absence, or the assertion
 	// passes simply because nothing has rendered yet.
-	await findByText('Run Retry Task', undefined, { timeout: 20_000 });
+	await findByText('Run Retry Task', taskHeadingQuery, { timeout: 20_000 });
 	await expandEventGroups(user);
 	expect(queryByTestId('retry-failed-run')).toBeNull();
 });

--- a/packages/web/test/task-breadcrumb.test.tsx
+++ b/packages/web/test/task-breadcrumb.test.tsx
@@ -53,6 +53,17 @@ test('sub-task header shows a breadcrumb link to its parent and navigates there'
 	expect(parentLink.textContent).toBe(seeded.parentIdentifier);
 	expect(parentLink.getAttribute('href')).toContain(seeded.parentIdentifier.toLowerCase());
 
+	// The task's own name rides in the crumb beside its identifier, and carries
+	// the untruncated text in `title` for the widths where it is cut short.
+	const crumbTitle = await findByTestId('task-breadcrumb-title');
+	expect(crumbTitle.textContent).toBe('Child Task');
+	expect(crumbTitle.getAttribute('title')).toBe('Child Task');
+
+	// A sub-task also renders the below-`sm` stand-in for the ancestor chain. The
+	// links themselves stay in the tree at every width (sr-only, never `hidden`),
+	// which is why both are present here - happy-dom runs no media queries.
+	expect(await findByTestId('task-breadcrumb-ancestors-collapsed')).toBeTruthy();
+
 	// Clicking it navigates to the parent task.
 	await user.click(parentLink);
 	await waitFor(() =>
@@ -81,8 +92,14 @@ test('top-level task header shows a Tasks crumb and its identifier with no ances
 
 	const breadcrumb = await findByTestId('task-breadcrumb');
 	expect(breadcrumb.textContent).toContain(seeded.identifier);
-	// No parent → no ancestor crumb, but the Tasks list crumb is always there.
+	// No parent → neither an ancestor crumb nor the ellipsis standing in for one,
+	// but the Tasks list crumb is always there.
 	expect(queryByTestId('task-breadcrumb-ancestor')).toBeNull();
+	expect(queryByTestId('task-breadcrumb-ancestors-collapsed')).toBeNull();
+
+	// The name is carried at rest too, not only once the crumb pins.
+	const crumbTitle = await findByTestId('task-breadcrumb-title');
+	expect(crumbTitle.textContent).toBe('Solo Task');
 	const tasksLink = await findByTestId('task-breadcrumb-tasks');
 	expect(tasksLink.getAttribute('href')).toContain(`/projects/${seeded.projectSlug}/tasks`);
 

--- a/packages/web/test/task-detail-state-per-task.test.tsx
+++ b/packages/web/test/task-detail-state-per-task.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { clickUntil, renderApp } from './helpers/render';
+import { clickUntil, renderApp, taskHeadingQuery } from './helpers/render';
 import { seedComment, seedDocument, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 // The task-detail route serves every task on `/projects/$projectId/tasks/$taskId`
@@ -49,7 +49,7 @@ test('the doc preview panel does not follow the reader into another task', async
 		params: { projectId: ref.projectSlug, taskId: ref.secondTask },
 	});
 
-	await findByText('Remove non-portfolio stocks');
+	await findByText('Remove non-portfolio stocks', taskHeadingQuery);
 	expect(document.querySelector('[data-testid="preview-panel"]')).toBeNull();
 });
 
@@ -89,6 +89,6 @@ test('a reply target does not follow the reader into another task', async () => 
 
 	// A surviving target would post the next comment with a `parent_comment_id`
 	// pointing at a comment on the task the reader just left.
-	await findByText('Remove non-portfolio stocks');
+	await findByText('Remove non-portfolio stocks', taskHeadingQuery);
 	expect(document.querySelector('[data-testid="reply-indicator"]')).toBeNull();
 });

--- a/packages/web/test/task-history-timeline.test.tsx
+++ b/packages/web/test/task-history-timeline.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { getTestContext, renderApp } from './helpers/render';
+import { getTestContext, renderApp, taskHeadingQuery } from './helpers/render';
 import {
 	type SeededWorkspace,
 	seedComment,
@@ -84,7 +84,7 @@ test('status changes and cross-task mentions appear as system entries on the tim
 	// view; this file is about the entries themselves.
 	await expandEventGroups(user);
 
-	await findByText('Target task', undefined, { timeout: 10_000 });
+	await findByText('Target task', taskHeadingQuery, { timeout: 10_000 });
 
 	// The status-change system comment should be present.
 	await waitFor(
@@ -148,7 +148,7 @@ test('status changes and cross-task mentions appear as system entries on the tim
 	// view; this file is about the entries themselves.
 	await expandEventGroups(user);
 
-	await findByText('Target task', undefined, { timeout: 10_000 });
+	await findByText('Target task', taskHeadingQuery, { timeout: 10_000 });
 	await waitFor(
 		async () => {
 			const items = await findAllByTestId('comment-item');
@@ -194,7 +194,7 @@ test('title renames appear as system entries on the timeline', async () => {
 	// view; this file is about the entries themselves.
 	await expandEventGroups(user);
 
-	await findByText('Renamed task', undefined, { timeout: 10_000 });
+	await findByText('Renamed task', taskHeadingQuery, { timeout: 10_000 });
 
 	await waitFor(
 		async () => {

--- a/test/browser/task-breadcrumb-sticky.spec.ts
+++ b/test/browser/task-breadcrumb-sticky.spec.ts
@@ -1,9 +1,10 @@
 // Real CSS layout plus a viewport-conditional rule (testing decision tree,
 // points 1 & 2): the breadcrumb's pinning is `position: sticky` resolving
 // against the shell <main> scroller, asserted through `boundingBox()` before and
-// after a real scroll, and it is deliberately desktop-only, which happy-dom
-// cannot decide because it runs no media queries against a layout pass. The
-// crumb's links and ancestor rendering stay covered by the component tests in
+// after a real scroll; and the one-line guarantee is a layout fact - whether the
+// segments share a line box, and whether the name truncated - which happy-dom
+// cannot answer because it runs no layout pass and no media queries. The crumb's
+// links, name and ancestor rendering stay covered by the component tests in
 // packages/web/test/task-breadcrumb.test.tsx.
 
 import { expect, test } from './fixtures';
@@ -103,10 +104,7 @@ test('desktop: the breadcrumb stays pinned to the top while the thread scrolls',
 	await expect(crumb).toHaveAttribute('data-pinned', 'false');
 });
 
-test('mobile: the breadcrumb scrolls away with the page', async ({
-	sharedPage: page,
-	sharedWorkspace,
-}) => {
+test('mobile: the breadcrumb stays pinned too', async ({ sharedPage: page, sharedWorkspace }) => {
 	test.setTimeout(60_000);
 	await page.setViewportSize({ width: 375, height: 800 });
 	const { project, task } = await seedTaskWithLongThread(page, sharedWorkspace.token);
@@ -119,13 +117,93 @@ test('mobile: the breadcrumb scrolls away with the page', async ({
 
 	const before = await crumb.boundingBox();
 	expect(before).not.toBeNull();
+	await expect(crumb).toHaveAttribute('data-pinned', 'false');
 
 	const scrolled = await scrollMain(page, 600);
 	expect(scrolled).toBeGreaterThan(300);
 
-	// Vertical space is the scarce thing on a phone, so the crumb goes with the
-	// rest of the page rather than holding a band at the top.
-	await expect(crumb).not.toBeInViewport();
+	// The phone is where the title leaves the screen soonest, so the crumb holds
+	// its band here as well - carrying the name, not just the identifier.
+	await expect(crumb).toBeInViewport();
 	const after = await crumb.boundingBox();
-	if (before && after) expect(after.y).toBeLessThan(before.y - 300);
+	expect(after).not.toBeNull();
+	if (before && after) expect(Math.abs(after.y - before.y)).toBeLessThan(30);
+	await expect(crumb).toContainText(task.identifier);
+	await expect(crumb).toHaveAttribute('data-pinned', 'true');
+});
+
+test('the crumb stays one line when a deep sub-task has a long name on a narrow phone', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	test.setTimeout(60_000);
+	// 320px is the narrowest viewport the UX rules cover, so it is the width at
+	// which a wrapping crumb would first show itself.
+	await page.setViewportSize({ width: 320, height: 800 });
+	const headers = {
+		Authorization: `Bearer ${sharedWorkspace.token}`,
+		'Content-Type': 'application/json',
+	};
+	const projRes = await createProjectAndClearPlanning(page, '', sharedWorkspace.token, {
+		name: uniqueName('Breadcrumb One Line'),
+		description: 'One-line breadcrumb test.',
+	});
+	const project = ((await projRes.json()) as { data: { id: string; slug: string } }).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const parentRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Parent task', assignee_id: assigneeId },
+	});
+	const parent = ((await parentRes.json()) as { data: { id: string } }).data;
+	const longTitle =
+		'Refuse to start when a removed env var still selects the data directory, and name what replaced it';
+	const childRes = await page.request.post(
+		`/api/projects/${project.slug}/tasks/${parent.id}/sub-tasks`,
+		{ headers, data: { title: longTitle, assignee_id: assigneeId } },
+	);
+	const child = ((await childRes.json()) as { data: { identifier: string } }).data;
+
+	await page.goto(`/projects/${project.slug}/tasks/${child.identifier.toLowerCase()}`);
+	await waitForPageLoad(page);
+
+	const crumb = page.getByTestId('task-breadcrumb');
+	await expect(crumb).toBeVisible({ timeout: 20000 });
+
+	// One line, stated structurally rather than as a pixel budget: every segment
+	// that occupies flow shares a line box. Two lines would spread these tops by
+	// a whole line-height.
+	const topSpread = await crumb.evaluate((el) => {
+		const tops = Array.from(el.children)
+			.filter((kid) => {
+				const cs = getComputedStyle(kid);
+				return cs.position !== 'absolute' && cs.display !== 'none';
+			})
+			.map((kid) => kid.getBoundingClientRect().top);
+		return Math.max(...tops) - Math.min(...tops);
+	});
+	expect(topSpread).toBeLessThan(2);
+
+	// ...and it holds because the name gave way, not because this title happened
+	// to fit: the browser really did cut it.
+	const nameOverflow = await page
+		.getByTestId('task-breadcrumb-title')
+		.evaluate((el) => el.scrollWidth - el.clientWidth);
+	expect(nameOverflow).toBeGreaterThan(0);
+
+	// Below `sm` the ancestor identifiers give up their room to the name, leaving
+	// the ellipsis in their place. The links stay in the accessibility tree.
+	await expect(page.getByTestId('task-breadcrumb-ancestors-collapsed')).toBeVisible();
+	await expect(page.getByTestId('task-breadcrumb-ancestor')).toBeAttached();
+	await expect(page.getByTestId('task-breadcrumb-ancestor')).not.toBeInViewport();
+
+	// Widen past `sm` and the chain comes back in place of the ellipsis - the
+	// other half of the same rule, and the half no other test would catch if
+	// `sm:not-sr-only` stopped resolving.
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await expect(page.getByTestId('task-breadcrumb-ancestor')).toBeVisible();
+	await expect(page.getByTestId('task-breadcrumb-ancestors-collapsed')).toBeHidden();
 });


### PR DESCRIPTION
The task breadcrumb read `Tasks > HM-246`, so once the title scrolled out of view the header kept a route but lost the answer to "which task am I in". It now carries the task's own name beside the identifier, at rest and pinned alike.

## What changes

**The name is carried in both states.** Sans against the mono identifiers and one step back in the text ramp, so it reads as prose rather than another thing you quote. Identifier and name sit inside a single `aria-current` span, so a screen reader hears one crumb item rather than two, and `title` keeps the full text reachable once it truncates.

**The row is one line at every width.** `flex-wrap` is gone from the nav, everything ahead of the name is `shrink-0`, and the name alone carries `min-w-0 truncate`. The browser cuts it to whatever the column happens to be instead of pushing the crumb to a second line. No character cap, no measuring. Below `sm` the ancestor identifiers give their room to the name and leave an ellipsis in their place, keeping their links in the accessibility tree via `sr-only` rather than `hidden`, so a phone reader still gets the full path.

**It pins at every breakpoint, not just `lg`+.** The phone is where the title leaves the screen soonest, which makes it the last place to drop the crumb rather than the first. Pinning adds no page height (the crumb already occupies that space in the flow); it does keep about 35px of a small scrollport covered while you scroll, which is the cost this accepts.

## Tests

`packages/web/test/task-breadcrumb.test.tsx` covers the markup: the name, its `title` attribute, and the ellipsis stand-in appearing only when there are ancestors.

`test/browser/task-breadcrumb-sticky.spec.ts` covers what only a layout pass can answer. Its mobile test asserted the crumb scrolls away and now asserts the opposite. A third test pins the one-line rule down at 320px with the deepest nesting and a name long enough to overflow: every flow segment shares one line box, the name really did overflow, the ancestors are collapsed, and widening past `sm` brings the chain back.

Verified locally: `bun run typecheck`, biome, the two component tests, and the full `task-breadcrumb-sticky.spec.ts` against real Chromium (15 passed).

## Notes

No catalog work: the name is task data and the separator is punctuation, so the twelve translation catalogs are untouched. No `docs/` page describes this breadcrumb (the one in `docs/concepts/assets.md` is the asset-folder trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbHZjGkU23rHZ5qJLiyYzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbHZjGkU23rHZ5qJLiyYzF)_