### PR TITLE
fix(runs): stop a container stop killing a run that only waits for its credential

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -399,7 +399,8 @@ assignment wakeup carries the target team). In-flight work is aborted first
 `converted_task_id` (FK to `tasks`, `ON DELETE SET NULL`) + `closed_at`. The system row
 carries `system_kind = 'converted_task'` (`chat_messages.system_kind`, migration 058; the
 CHECK list is widened by 067 for `connector_refused`, the chat's twin of a task run's connector
-refusal warning): which
+refusal warning, and by 068 for `credential_wait`, the twin of a waiting run's
+`[runner] Waiting for …` line): which
 marker a system row is has to be a property of the **message**, since the chatbox would otherwise
 choose by the thread's `converted_task_id` and render a handoff warning written before the
 conversion as the converted-task link. Converted
@@ -1927,13 +1928,24 @@ row) from *stopped* (suspend it) from *unanswerable* (change nothing).
 **A dead container ends the runs it was carrying, and no others.** `ContainerTransition` names
 the container, and both halves of the response are scoped to it: `failProjectRuns(…,
 containerId)` for the rows, and `JobManager.cancelLiveRunsForContainer` for the in-process
-execs. They must agree, or a run reads `failed` while its exec still streams; both therefore
-also take runs that have not yet claimed a container, which nothing can show to be executing
-elsewhere. Handling a container's death by *project* is the shared-fate blast radius the pool
-exists to remove, and it is not hypothetical - it is how an idle member being auto-stopped
-killed a run executing in a healthy sibling container. Two sources emit transitions in this
-one shape: `syncAllContainerStatuses` answers for the container `projects.container_id` names,
-and `reconcilePoolMembers` answers for every other member, which that sync cannot see at all.
+execs. They must agree, or a run reads `failed` while its exec still streams. **A live run
+that has claimed no container is not on the dead one**, so the in-memory half leaves it
+alone: it is parked - on the credential lock or on capacity - holding nothing, and its row is
+still `queued`, which the DB half never touches (a `running` row always carries its
+container, stamped by `markHeartbeatRunRunning`; the DB half's `container_id IS NULL` arm
+exists for rows recorded before 049 and nothing else). The in-memory half used to take
+unclaimed runs too, on the reasoning that nothing could show them executing elsewhere - which
+is how the surplus-idle pass suspending a project's *spare* container killed the run that was
+only waiting for a credential in that project: on a managed backend the stop takes seconds,
+the status sync saw the engine say stopped while the row still said running, and the
+resulting transition swept the waiter in on the null arm. That sync-versus-graceful-stop
+race still produces a transition (a stopped container is a fact whoever stopped it), and it
+is harmless now for the reason above: nothing live is on an idle container. Handling a
+container's death by *project* is the shared-fate blast radius the pool exists to remove,
+and it is not hypothetical - it is how an idle member being auto-stopped killed a run
+executing in a healthy sibling container. Two sources emit transitions in this one shape:
+`syncAllContainerStatuses` answers for the container `projects.container_id` names, and
+`reconcilePoolMembers` answers for every other member, which that sync cannot see at all.
 
 **The memory budget is instance-wide, so no project may sit on a share of it that it is not
 using.** Two mechanisms enforce that, and both exist because a container is pinned to its
@@ -2463,20 +2475,50 @@ or less (settable to 1), where a 180 s wait outlives a 60 s timer. And the cap i
 cosmetic - a dispatch with no spare container takes a `pendingContainerStarts` reservation
 *before* `launchTask` and holds it until the run settles, so every minute of this wait is a
 minute of instance memory budget charged for a container that has not been asked for. FIFO on the
-lock is the correct model; giving up early only randomises who goes next.
+lock is the correct model among runs; giving up early only randomises who goes next. The one
+exception is below, and it is not a run.
 
 And it is taken **before** the pool ladder is asked, because a waiter that already holds a
 container pins memory the pool counts as used and cannot reclaim, for the entire wait. That
 container then sits idle while its own run waits, long enough for a managed backend's idle
 timer to stop it underneath, so the run failed on the first call it made once it finally
-woke. A waiter now holds nothing.
+woke. A waiter now holds nothing - and, holding nothing, is on no container a death can be
+attributed to (§ *A dead container ends the runs it was carrying*).
+
+**The holder is a record, not a name.** The lock family's owner is a `CredentialLockHolder`
+- a label plus, for a task run, the `RunLink` to its page (project slug, agent slug, run id)
+- and `describeCredentialHolder` renders it once for every surface: a run's `[runner] Waiting
+for … to finish with this credential.` line and the CEO chat's notice both carry the holder
+as a markdown link (`formatRunLink`, `@hezo/shared`), which the log viewer and the chat
+widget turn into a link to that run through `splitRunLinks` / `RunLinkedText`. The raw log
+and the database row read as-is. The chat, holding it, is `the CEO chat` with no link.
+
+**A waiter re-reads the credential once it holds the lock.** Both a run and a chat exec
+snapshot the credential value before they wait, and the holder they queue behind rotates the
+single-use token and stores the new one on its way out - so by the time the wait ends the
+snapshot can be a rotation behind, and mounting it means the first refresh fails against a
+consumed token. The runner re-reads the value (`readAiProviderCredentialValue`) after
+`acquireCredentialLock` resolves and before `buildRunContext` writes the mount; the chat,
+whose mount was written at session start, rewrites the mounted file from the store when the
+value moved (`refreshSubscriptionMount`, beside `buildSubscriptionMount`) and moves its own
+snapshot along, so `persistRotatedSubscriptionAuth` afterwards compares against what the exec
+actually ran on and the file is rewritten only when the value really changed.
 
 **The CEO chat takes the same lock**, per exec rather than per session: a chat turn drives
 the same coding CLI, so on a rotating credential it consumes and rewrites the same
 single-use token, and each of the three CLI execs a session makes (turn, compaction,
 titling) can rotate it. Per-exec because a session is long-lived and holding it for the
-session would starve task runs. The bound is shorter than a run's and a timeout is
-reported to the operator rather than waited out, since someone is watching the chatbox.
+session would starve task runs. Its wait is the run's own cap (`CREDENTIAL_WAIT_CAP_MS`) and
+it is taken with **priority**: a person is behind the exec, so it queues ahead of runs merely
+parked on the lock - they hold nothing and re-queue on their own deadline - and waits on the
+holder alone, never preempting it. Two things follow that made the shorter, plain-FIFO wait it
+used to have wrong. The reply turn tells the thread what it is waiting on the moment it starts
+waiting - a `credential_wait` system row naming the holder in the same words a waiting run's
+log uses, linked the same way - and the operator can stop the turn rather than wait; priority
+is also what keeps that notice true for the whole wait. And a turn that does give up records
+the same holder-naming reason on its message, which the widget shows in place of a generic
+failure (`WsChatMessageComplete.error`); titling and compaction, which retry on their own from
+the next message, log a busy credential as a warning rather than an error.
 `persistRotatedSubscriptionAuth` (`services/runtime-home.ts`, beside the
 `buildSubscriptionMount` that put the file there) is the shared write-back both paths owe
 before releasing - the chat had neither lock nor write-back, so a turn overlapping a run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,8 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | "Is this cancelled run still owed, and can a human act on it?" | `heartbeat_runs.cancel_reason` read through `RUN_CANCEL_BEHAVIOUR` (`@hezo/shared`) - never the `error` prose |
 | "May this caller move this task's assignee?" | `assertNoBlockingRun` (`lib/reassign-guard.ts`) - not the one-run-per-task check, which is `isTaskBusyInDb` (`services/run-concurrency.ts`) |
 | Serialising async work per key, with or without a bound | `lib/keyed-lock.ts` - `withKeyedLock` for a scope, `acquireKeyedLock` when the wait needs a `signal`/`timeoutMs`. Each family owns its own `KeyedLockRegistry`; never a second mutex |
+| "Who holds this rotating credential, and how do I name them?" | `credentialLockHolder` / `describeCredentialHolder` / `credentialWaitNotice` (`services/agent-runner.ts`) - a `CredentialLockHolder` record, rendered as a run link (`formatRunLink`, `@hezo/shared`) that `RunLinkedText` (web) turns into the link; never a bare label |
+| Text the server writes that names a run (a log line, a chat notice) | `formatRunLink` / `splitRunLinks` (`@hezo/shared`) on the way out, `RunLinkedText` (`packages/web/src/components/`) on the way in |
 | "Did this release stop reading something an instance still sets?" | `REMOVED_ENV_VARS` / `detectRemovedEnvVars` (`config/removed-env.ts`) |
 | Fire-and-forget work | `trackBackground()` (`lib/background.ts`) |
 | Paging (lists and large content) | `mcp/paging.ts` |

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -148,10 +148,15 @@ pick one or the other, or the two will fall out of step.
 
 And **runs on a Codex subscription go one at a time.** The credential is rewritten
 mid-run, so a second run using it would invalidate the first; Hezo queues them instead,
-and a waiting run shows as queued with its reason rather than as an error. Nothing is
-lost, but the agents on that credential take turns. To run more at once, add a second
-Codex subscription, or use an OpenAI API key - a key is not rewritten by anything, so
-runs on it go in parallel. Subscriptions for other providers are unaffected.
+and a waiting run shows as queued with its reason rather than as an error. Its log names
+the run it is waiting on, linked to that run's page, and says when the credential came
+free. The CEO chat takes its turn on the same credential: when a run holds it, the thread
+shows which run the reply is waiting on (the chat goes ahead of runs that are only queued,
+so it waits for that one run alone), and the reply arrives once it finishes - or you can
+stop the turn. Nothing is lost, but the agents on that credential take turns. To run more
+at once, add a second Codex subscription, or use an OpenAI API key - a key is not
+rewritten by anything, so runs on it go in parallel. Subscriptions for other providers are
+unaffected.
 
 ## Where to get an API key
 

--- a/packages/server/migrations/068_chat_system_kind_credential_wait.sql
+++ b/packages/server/migrations/068_chat_system_kind_credential_wait.sql
@@ -1,0 +1,14 @@
+-- Admit a fourth kind of system message to a chat thread: the turn is parked
+-- until another execution finishes with the provider credential it needs, on a
+-- subscription that runs one agent at a time. The row names that execution and
+-- links to it when it is a task run - the chat twin of a waiting run's
+-- `[runner] Waiting for ...` line.
+--
+-- `system_kind` is TEXT under a CHECK list rather than an enum, so the change is
+-- a re-stated constraint: every existing row keeps its value, and an unknown
+-- kind still fails loudly at the write.
+
+ALTER TABLE chat_messages DROP CONSTRAINT chat_messages_system_kind_check;
+
+ALTER TABLE chat_messages ADD CONSTRAINT chat_messages_system_kind_check
+    CHECK (system_kind IS NULL OR system_kind IN ('converted_task', 'handoff_not_delivered', 'connector_refused', 'credential_wait'));

--- a/packages/server/src/lib/keyed-lock.ts
+++ b/packages/server/src/lib/keyed-lock.ts
@@ -11,46 +11,73 @@
  * removed from the queue and holds nothing.
  */
 
+/**
+ * What a lock family may label a holder with: a bare string, or a record with a
+ * label plus whatever else a waiter wants to know about who is ahead of it.
+ */
+export type LockOwner = string | { label: string };
+
+/** The human-readable half of an owner, for messages. */
+export function lockOwnerLabel(owner: LockOwner | null): string | null {
+	if (owner === null) return null;
+	return typeof owner === 'string' ? owner : owner.label;
+}
+
 /** Raised when an acquire gives up on its own deadline. */
 export class KeyedLockTimeoutError extends Error {
-	constructor(key: string, timeoutMs: number, owner: string | null) {
+	constructor(key: string, timeoutMs: number, owner: LockOwner | null) {
+		const label = lockOwnerLabel(owner);
 		super(
 			`timed out after ${timeoutMs}ms waiting for the '${key}' lock` +
-				`${owner ? `, held by ${owner}` : ''}`,
+				`${label ? `, held by ${label}` : ''}`,
 		);
 		this.name = 'KeyedLockTimeoutError';
 	}
 }
 
-interface Waiter {
+interface Waiter<Owner extends LockOwner> {
 	/** Hand the lock over. Null once this waiter has settled either way. */
-	grant: ((owner: string | null) => void) | null;
-	owner: string | null;
+	grant: ((owner: Owner | null) => void) | null;
+	owner: Owner | null;
+	priority: boolean;
 }
 
-interface LockState {
+interface LockState<Owner extends LockOwner> {
 	/** What is holding the lock, for diagnostics. Null when unlabelled. */
-	owner: string | null;
-	queue: Waiter[];
+	owner: Owner | null;
+	queue: Waiter<Owner>[];
 }
 
 /**
  * A lock family's key space. Held by the caller, never module-global, so the
- * scope of each family stays visible where it is declared.
+ * scope of each family stays visible where it is declared. The owner type is the
+ * family's: most label a holder with a string, one that wants a waiter to be able
+ * to point at the holder carries a record.
  */
-export type KeyedLockRegistry = Map<string, LockState>;
+export type KeyedLockRegistry<Owner extends LockOwner = string> = Map<string, LockState<Owner>>;
 
-export interface AcquireOptions {
+export interface AcquireOptions<Owner extends LockOwner = string> {
 	/** Gives up when this fires, rejecting with the signal's own reason. */
 	signal?: AbortSignal;
 	/** Gives up after this long, rejecting with {@link KeyedLockTimeoutError}. */
 	timeoutMs?: number;
 	/** Labels the holder so a waiter can say what it is waiting on. */
-	owner?: string;
+	owner?: Owner;
+	/**
+	 * Queue ahead of every waiter that did not ask for this, behind those that
+	 * did. Never preempts the holder. The one departure from arrival order, and
+	 * it is for a waiter a person is sitting behind: the plain waiters it passes
+	 * hold nothing and give up on their own deadline, so the cost of the jump is
+	 * a later start for work nobody is watching.
+	 */
+	priority?: boolean;
 }
 
 /** What currently holds the key, or null when the key is free or unlabelled. */
-export function currentOwner(registry: KeyedLockRegistry, key: string): string | null {
+export function currentOwner<Owner extends LockOwner>(
+	registry: KeyedLockRegistry<Owner>,
+	key: string,
+): Owner | null {
 	return registry.get(key)?.owner ?? null;
 }
 
@@ -59,15 +86,15 @@ export function currentOwner(registry: KeyedLockRegistry, key: string): string |
  *
  * Registration is synchronous - the state is created or the waiter enqueued
  * before this returns its promise - so acquires issued in one synchronous run
- * are served in that order.
+ * are served in that order, priority waiters ahead of the rest.
  *
  * The returned release is idempotent, since it is called from a `finally` that
  * may itself be reached more than one way.
  */
-export function acquireKeyedLock(
-	registry: KeyedLockRegistry,
+export function acquireKeyedLock<Owner extends LockOwner = string>(
+	registry: KeyedLockRegistry<Owner>,
 	key: string,
-	opts: AcquireOptions = {},
+	opts: AcquireOptions<Owner> = {},
 ): Promise<() => void> {
 	const owner = opts.owner ?? null;
 	const existing = registry.get(key);
@@ -79,8 +106,9 @@ export function acquireKeyedLock(
 
 	return new Promise<() => void>((resolve, reject) => {
 		let timer: ReturnType<typeof setTimeout> | undefined;
-		const waiter: Waiter = {
+		const waiter: Waiter<Owner> = {
 			owner,
+			priority: opts.priority === true,
 			grant: (nextOwner) => {
 				settle();
 				const state = registry.get(key);
@@ -126,7 +154,14 @@ export function acquireKeyedLock(
 			);
 		}
 
-		existing.queue.push(waiter);
+		if (waiter.priority) {
+			// Behind the priority waiters already queued, ahead of everyone else.
+			const at = existing.queue.findIndex((w) => !w.priority);
+			if (at < 0) existing.queue.push(waiter);
+			else existing.queue.splice(at, 0, waiter);
+		} else {
+			existing.queue.push(waiter);
+		}
 	});
 }
 
@@ -136,7 +171,10 @@ export function acquireKeyedLock(
  * Waiters that gave up are already out of the queue, so the head is always a
  * live one; the loop guards the case of a waiter settled between shift and call.
  */
-function makeRelease(registry: KeyedLockRegistry, key: string): () => void {
+function makeRelease<Owner extends LockOwner>(
+	registry: KeyedLockRegistry<Owner>,
+	key: string,
+): () => void {
 	let released = false;
 	return () => {
 		if (released) return;
@@ -164,8 +202,8 @@ function makeRelease(registry: KeyedLockRegistry, key: string): () => void {
  * A rejection propagates to this caller alone - the queue moves on regardless,
  * so one failure never poisons the key.
  */
-export async function withKeyedLock<T>(
-	registry: KeyedLockRegistry,
+export async function withKeyedLock<T, Owner extends LockOwner = string>(
+	registry: KeyedLockRegistry<Owner>,
 	key: string,
 	fn: () => Promise<T>,
 ): Promise<T> {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -13,6 +13,7 @@ import {
 	DEFAULT_THREAD_ROW_CATEGORIES,
 	effectiveRuntime,
 	formatContainerMetaLogLine,
+	formatRunLink,
 	HeartbeatRunKind,
 	HeartbeatRunStatus,
 	MAX_SINGLE_ARG_BYTES,
@@ -30,6 +31,7 @@ import {
 	RUNTIME_PROMPT_DELIVERY,
 	RUNTIME_STREAM_ARGS,
 	RUNTIME_SYSTEM_PROMPT_FILE,
+	type RunLink,
 	repoNameFromIdentifier,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
@@ -74,6 +76,7 @@ import {
 import {
 	type AiProviderCredential,
 	getProviderCredentialAndModel,
+	readAiProviderCredentialValue,
 	updateAiProviderCredential,
 } from './ai-provider-keys';
 import { BackgroundTerminationDetector } from './background-termination';
@@ -357,7 +360,17 @@ export const getHostSubscriptionRoot = getHostSubscriptionRootImpl;
  * run - which is why the wait is bounded, and why it is taken before a container
  * rather than after.
  */
-const credentialLocks: KeyedLockRegistry = new Map();
+const credentialLocks: KeyedLockRegistry<CredentialLockHolder> = new Map();
+
+/**
+ * Who holds a rotating credential: a name for the sentence a waiter writes, and
+ * the run behind it when there is one, so that sentence can point at it. The
+ * CEO chat holds it too and has no run page, so it carries a name alone.
+ */
+export interface CredentialLockHolder {
+	label: string;
+	link: RunLink | null;
+}
 
 /**
  * Take the credential lock, resolving to the function that gives it back.
@@ -368,14 +381,28 @@ const credentialLocks: KeyedLockRegistry = new Map();
  */
 export function acquireCredentialLock(
 	configId: string,
-	opts: AcquireOptions = {},
+	opts: AcquireOptions<CredentialLockHolder> = {},
 ): Promise<() => void> {
 	return acquireKeyedLock(credentialLocks, configId, opts);
 }
 
-/** What holds this credential right now, for a waiter's run log. */
-export function credentialLockHolder(configId: string): string | null {
+/** What holds this credential right now, for a waiter to name. */
+export function credentialLockHolder(configId: string): CredentialLockHolder | null {
 	return currentOwner(credentialLocks, configId);
+}
+
+/**
+ * The holder as a waiter writes it: the run as a link to its page where there is
+ * one, else the bare label. The one place the wording of "who" is decided, so a
+ * run log and a chat notice name the holder identically.
+ */
+export function describeCredentialHolder(holder: CredentialLockHolder): string {
+	return holder.link ? formatRunLink(holder.label, holder.link) : holder.label;
+}
+
+/** The sentence a waiter writes - to its run log, or into a chat thread - while it queues. */
+export function credentialWaitNotice(holder: CredentialLockHolder): string {
+	return `Waiting for ${describeCredentialHolder(holder)} to finish with this credential.`;
 }
 
 export interface RunContext {
@@ -1169,7 +1196,13 @@ export const CAPACITY_PARK_MAX_MS = 3 * 60_000;
  * reservation bounded.
  */
 const CREDENTIAL_WAIT_MAX_FRACTION = 0.8;
-const CREDENTIAL_WAIT_CAP_MS = 15 * 60_000;
+/**
+ * Also the CEO chat's ceiling on the same lock: a chat turn queues ahead of every
+ * parked run and so waits on the holder alone, and the operator sees what it is
+ * waiting for and can stop the turn at any moment, so the run's cap is the right
+ * one there too.
+ */
+export const CREDENTIAL_WAIT_CAP_MS = 15 * 60_000;
 
 export function credentialWaitMaxMs(runTimeoutMin: number | null | undefined): number {
 	const budget = (runTimeoutMin ?? 0) * 60_000 * CREDENTIAL_WAIT_MAX_FRACTION;
@@ -1534,7 +1567,7 @@ export async function runAgent(
 		requiredRuntime = resolved.runtime;
 	}
 
-	const credential = await getProviderCredentialAndModel(
+	let credential = await getProviderCredentialAndModel(
 		deps.db,
 		deps.masterKeyManager,
 		provider,
@@ -1705,10 +1738,12 @@ export async function runAgent(
 		// meant every waiter pinned a container's memory for that entire wait, which
 		// the pool counts as used and cannot reclaim. Worse, the container went idle
 		// while its run waited, so the backend stopped it underneath and the run then
-		// failed on the first call it made. A waiter now holds nothing.
+		// failed on the first call it made. A waiter now holds nothing - and, holding
+		// nothing, it is not on any container a death can be attributed to (see
+		// `JobManager.cancelLiveRunsForContainer`).
 		const holder = credentialLockHolder(credential.configId);
 		if (holder) {
-			emit('stdout', `[runner] Waiting for ${holder} to finish with this credential.\n`);
+			emit('stdout', `[runner] ${credentialWaitNotice(holder)}\n`);
 		}
 		// Records the true wait so the run comment reads honestly while blocked.
 		await deps.db.query(
@@ -1732,13 +1767,25 @@ export async function runAgent(
 				// lets a test drive either wait to its deadline quickly.
 				timeoutMs:
 					deps.capacityPark?.maxMs ?? credentialWaitMaxMs(timeoutRow.rows[0]?.run_timeout_min),
-				owner: runLabel,
+				owner: {
+					label: runLabel,
+					// The run page resolves its agent by slug or id alike.
+					link: {
+						projectSlug: project.slug,
+						agentSlug: agent.slug ?? agent.id,
+						runId: heartbeatRunId,
+					},
+				},
 			});
 		} catch (e) {
 			if (runAbort.signal.aborted) return finalizeAbort();
 			if (e instanceof KeyedLockTimeoutError) {
+				// The label alone: this lands in the row's `error`, which the thread shows
+				// as a one-line summary where a link has no home. The log line above
+				// carries the link.
+				const stillHeldBy = credentialLockHolder(credential.configId);
 				return finalizeRequeue(
-					'Another run still holds this provider credential',
+					`${stillHeldBy?.label ?? 'Another run'} still holds this provider credential`,
 					WakeupSkipReason.CredentialBusy,
 				);
 			}
@@ -1750,6 +1797,17 @@ export async function runAgent(
 			);
 		}
 		if (holder) emit('stdout', '[runner] Credential free, starting the run.\n');
+		// The value read before the wait can be a rotation behind by now: the holder
+		// this run queued behind rewrites the single-use token and stores the new
+		// one on its way out. Read it again while holding the lock, so the mount
+		// this run writes and the read-back it compares against are both current.
+		const stored = await readAiProviderCredentialValue(
+			deps.db,
+			deps.masterKeyManager,
+			credential.configId,
+		);
+		if (stored !== null && stored !== credential.value)
+			credential = { ...credential, value: stored };
 	}
 
 	// Containers run on demand, and this run claims one **for itself**: the pool
@@ -2085,8 +2143,8 @@ export async function runAgent(
 			: undefined;
 		const parser = createAgentStreamParser(runtimeType, priceFn, modelOverride);
 
-		const persistRotatedAuth = () =>
-			persistRotatedSubscriptionAuth({
+		const persistRotatedAuth = async (): Promise<void> => {
+			await persistRotatedSubscriptionAuth({
 				db: deps.db,
 				masterKeyManager: deps.masterKeyManager,
 				engine: deps.docker,
@@ -2096,6 +2154,7 @@ export async function runAgent(
 				mount: context.subscriptionMount,
 				onNotice: (text: string) => emit('stderr', `[runner] ${text}\n`),
 			});
+		};
 
 		// Best-effort teardown of run-scoped artifacts. Each step is isolated so a
 		// failed or slow release can never block the run result from reaching the

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -230,6 +230,27 @@ export async function updateAiProviderCredential(
 	return result.rows.length > 0;
 }
 
+/**
+ * The current decrypted value of one credential row, or null when the row is
+ * gone. For a caller that already chose its config and only needs to know
+ * whether the value moved since - a waiter that held a snapshot across a wait
+ * during which another execution may have rotated it.
+ */
+export async function readAiProviderCredentialValue(
+	db: Db,
+	masterKeyManager: MasterKeyManager,
+	configId: string,
+): Promise<string | null> {
+	const encryptionKey = masterKeyManager.getKey();
+	if (!encryptionKey) throw new Error('Master key not available');
+	const result = await db.query<{ encrypted_credential: string }>(
+		'SELECT encrypted_credential FROM ai_provider_configs WHERE id = $1',
+		[configId],
+	);
+	const row = result.rows[0];
+	return row ? decrypt(row.encrypted_credential, encryptionKey) : null;
+}
+
 export async function getProviderCredentialAndModel(
 	db: Db,
 	masterKeyManager: MasterKeyManager,

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -35,6 +35,11 @@ import {
 	acquireCredentialLock,
 	assertPromptDeliverable,
 	buildRuntimeInvocation,
+	CREDENTIAL_WAIT_CAP_MS,
+	type CredentialLockHolder,
+	credentialLockHolder,
+	credentialWaitNotice,
+	describeCredentialHolder,
 	type EgressEnvDescriptor,
 	getContainerPromptPath,
 	getPromptRelPath,
@@ -70,7 +75,7 @@ import { getAgentSystemPrompt } from './documents';
 import type { EffortRuntimeApplication } from './effort';
 import type { ConnectorRunRejection } from './egress';
 import { applyEffortToRuntime } from './runtime-adapters';
-import { persistRotatedSubscriptionAuth } from './runtime-home';
+import { persistRotatedSubscriptionAuth, refreshSubscriptionMount } from './runtime-home';
 import { resolveRuntimeForTask } from './runtime-resolver';
 import { dockerSandboxHandle } from './sandbox/handle';
 import { setPoolMemberChatReservation } from './sandbox/pool-db';
@@ -88,14 +93,24 @@ const log = logger.child('chat-session');
 const CHAT_WORKING_DIR = '/workspace';
 
 /**
- * How long a chat turn waits for a rotating provider credential before telling
- * the operator to try again.
- *
- * Shorter than a task run's ceiling on purpose: a run is re-queued and retried
- * for free, while a person is sitting in front of the chatbox watching nothing
- * happen. Failing fast with a message they can act on beats a longer silence.
+ * How the chat names itself as a credential holder. No link: a chat turn has no
+ * page of its own for a waiting run to point at.
  */
-const CHAT_CREDENTIAL_WAIT_MS = 60_000;
+const CHAT_CREDENTIAL_HOLDER: CredentialLockHolder = { label: 'the CEO chat', link: null };
+
+/**
+ * A chat exec gave up waiting for the provider credential. The message names
+ * the holder the way a run log does, so the operator can go and look at it.
+ */
+export class ChatCredentialBusyError extends Error {
+	constructor(holder: CredentialLockHolder | null) {
+		super(
+			`${holder ? describeCredentialHolder(holder) : 'Another execution'} is still using this provider credential; ` +
+				'this subscription runs one agent at a time.',
+		);
+		this.name = 'ChatCredentialBusyError';
+	}
+}
 
 const CHAT_GUIDE = `# Live Chat
 
@@ -1673,16 +1688,20 @@ export class ChatSessionManager {
 				}
 			};
 
-			await this.withCredentialLock(session, abort.signal, () =>
-				dockerSandboxHandle(this.deps.docker, session.containerId, session.runUser).exec({
-					cmd: execCmd,
-					env,
-					workingDir: CHAT_WORKING_DIR,
-					signal: abort.signal,
-					onChunk: (chunk) => {
-						if (chunk.stream === 'stdout') handle(parser.onStdout(chunk.text));
-					},
-				}),
+			await this.withCredentialLock(
+				session,
+				abort.signal,
+				() =>
+					dockerSandboxHandle(this.deps.docker, session.containerId, session.runUser).exec({
+						cmd: execCmd,
+						env,
+						workingDir: CHAT_WORKING_DIR,
+						signal: abort.signal,
+						onChunk: (chunk) => {
+							if (chunk.stream === 'stdout') handle(parser.onStdout(chunk.text));
+						},
+					}),
+				{ onWaiting: (holder) => this.postCredentialWait(ctx, holder) },
 			);
 			handle(parser.flush());
 			await finalize(ChatMessageStatus.Complete, parser.getUsage());
@@ -1695,7 +1714,11 @@ export class ChatSessionManager {
 				this.killAbandonedExec(session, execScopeId);
 				await finalize(ChatMessageStatus.Interrupted, null);
 			} else {
-				log.error('CEO chat turn failed', err);
+				// A credential still held elsewhere is the instance being busy, not
+				// the chat breaking; the operator reads the reason in the thread.
+				if (err instanceof ChatCredentialBusyError)
+					log.warn(`CEO chat turn gave up: ${err.message}`);
+				else log.error('CEO chat turn failed', err);
 				await finalize(ChatMessageStatus.Failed, null, (err as Error).message);
 			}
 		} finally {
@@ -1755,24 +1778,10 @@ export class ChatSessionManager {
 				comments: posted.rows,
 			});
 			for (const finding of findings) {
-				const content = formatNoWakeExitWarning(finding, 'This chat turn');
-				const messageId = await this.insertMessage({
-					conversationId: ctx.conversationId,
-					role: ChatMessageRole.System,
-					channel: ctx.channel,
-					status: ChatMessageStatus.Complete,
-					content,
-					systemKind: ChatSystemMessageKind.HandoffNotDelivered,
-					completed: true,
-				});
-				this.broadcastStart(
-					ctx.conversationId,
-					messageId,
-					ChatMessageRole.System,
-					ctx.channel,
-					content,
-					undefined,
+				await this.postSystemMessage(
+					ctx,
 					ChatSystemMessageKind.HandoffNotDelivered,
+					formatNoWakeExitWarning(finding, 'This chat turn'),
 				);
 			}
 		} catch (e) {
@@ -1838,25 +1847,51 @@ export class ChatSessionManager {
 			return;
 		}
 		for (const ctx of targets) {
-			const messageId = await this.insertMessage({
-				conversationId: ctx.conversationId,
-				role: ChatMessageRole.System,
-				channel: ctx.channel,
-				status: ChatMessageStatus.Complete,
-				content,
-				systemKind: ChatSystemMessageKind.ConnectorRefused,
-				completed: true,
-			});
-			this.broadcastStart(
-				ctx.conversationId,
-				messageId,
-				ChatMessageRole.System,
-				ctx.channel,
-				content,
-				undefined,
-				ChatSystemMessageKind.ConnectorRefused,
-			);
+			await this.postSystemMessage(ctx, ChatSystemMessageKind.ConnectorRefused, content);
 		}
+	}
+
+	/**
+	 * The turn is parked behind whoever holds the provider credential. Said in
+	 * the thread at once, in the words a waiting run's log uses, so the operator
+	 * knows what the silence is and where to look - and can stop the turn rather
+	 * than wait, if they would rather.
+	 */
+	private postCredentialWait(
+		ctx: ConversationContext,
+		holder: CredentialLockHolder,
+	): Promise<void> {
+		return this.postSystemMessage(
+			ctx,
+			ChatSystemMessageKind.CredentialWait,
+			credentialWaitNotice(holder),
+		);
+	}
+
+	/** A complete system row in one thread: stored, then announced to its open chatboxes. */
+	private async postSystemMessage(
+		ctx: ConversationContext,
+		kind: ChatSystemMessageKind,
+		content: string,
+	): Promise<void> {
+		const messageId = await this.insertMessage({
+			conversationId: ctx.conversationId,
+			role: ChatMessageRole.System,
+			channel: ctx.channel,
+			status: ChatMessageStatus.Complete,
+			content,
+			systemKind: kind,
+			completed: true,
+		});
+		this.broadcastStart(
+			ctx.conversationId,
+			messageId,
+			ChatMessageRole.System,
+			ctx.channel,
+			content,
+			undefined,
+			kind,
+		);
 	}
 
 	/**
@@ -1971,7 +2006,11 @@ export class ChatSessionManager {
 		try {
 			await run;
 		} catch (e) {
-			log.error('CEO chat compaction failed', e);
+			// Compaction retries on the next reply, so a credential held elsewhere is
+			// a delay to note, not a failure to alarm on.
+			if (e instanceof ChatCredentialBusyError)
+				log.warn(`CEO chat compaction deferred: ${e.message}`);
+			else log.error('CEO chat compaction failed', e);
 		} finally {
 			if (convo.compactionAbort === abort) convo.compactionAbort = null;
 			if (convo.compaction === run) convo.compaction = null;
@@ -2091,7 +2130,11 @@ export class ChatSessionManager {
 		const abort = new AbortController();
 		convo.titlingAbort = abort;
 		const run = this.runTitleGeneration(session, ctx.conversationId, abort).catch((e) => {
-			if (!abort.signal.aborted) log.error('CEO chat auto-title failed', e);
+			if (abort.signal.aborted) return;
+			// Titling is retried from the next message, so the same holds here.
+			if (e instanceof ChatCredentialBusyError)
+				log.warn(`CEO chat auto-title deferred: ${e.message}`);
+			else log.error('CEO chat auto-title failed', e);
 		});
 		convo.titling = run;
 		try {
@@ -2251,50 +2294,93 @@ export class ChatSessionManager {
 	 * was dropped, leaving the stored credential a rotation behind and the next
 	 * refresh failing. Silent credential corruption, on a live path.
 	 *
-	 * Bounded like every other wait on this lock, and reported rather than hung:
-	 * an operator sitting in front of the chatbox gets an error they can act on.
-	 * Non-rotating credentials skip all of it and run concurrently as before.
+	 * The wait is the run's own ceiling, taken with priority: a person is behind
+	 * this exec, so it queues ahead of runs merely parked on the lock (they hold
+	 * nothing and re-queue on their own deadline) and waits on the holder alone -
+	 * which is also what keeps `onWaiting`'s "waiting for X" true for the whole
+	 * wait. Non-rotating credentials skip all of it and run concurrently as before.
+	 *
+	 * Once the lock is held the mounted token is brought up to date with the
+	 * store, since the holder just waited on may have rotated it, and the value
+	 * this exec ran on is what the read-back afterwards is compared against.
 	 */
 	private async withCredentialLock<T>(
 		session: LiveSession,
 		signal: AbortSignal,
 		fn: () => Promise<T>,
+		opts: { onWaiting?: (holder: CredentialLockHolder) => Promise<void> } = {},
 	): Promise<T> {
-		const { provider, credential, runtimeType } = session.invocationInputs;
-		if (!credentialSerializesRuns(provider, runtimeType, credential.authMethod)) return fn();
+		const { provider, runtimeType } = session.invocationInputs;
+		const { configId, authMethod } = session.invocationInputs.credential;
+		if (!credentialSerializesRuns(provider, runtimeType, authMethod)) return fn();
 
+		const holder = credentialLockHolder(configId);
 		let release: (() => void) | null = null;
 		try {
-			release = await acquireCredentialLock(credential.configId, {
+			// Enqueued before the notice goes out, so "waiting" is already true when
+			// it is read - and a holder that finishes during the notice's own write
+			// hands the lock straight to this waiter rather than to whoever asked next.
+			const acquiring = acquireCredentialLock(configId, {
 				signal,
-				timeoutMs: CHAT_CREDENTIAL_WAIT_MS,
-				owner: `chat/${session.sessionId.slice(0, 8)}`,
+				// The same test-only override the runner honours for its waits.
+				timeoutMs: this.deps.capacityPark?.maxMs ?? CREDENTIAL_WAIT_CAP_MS,
+				owner: CHAT_CREDENTIAL_HOLDER,
+				priority: true,
 			});
+			if (holder && opts.onWaiting) {
+				// A courtesy, never a reason to abandon a wait that is already queued.
+				await opts.onWaiting(holder).catch((e: unknown) => {
+					log.warn('CEO chat could not post its credential-wait notice', e);
+				});
+			}
+			release = await acquiring;
 		} catch (e) {
 			if (e instanceof KeyedLockTimeoutError) {
-				throw new Error(
-					'Another agent run is still using this provider credential. ' +
-						'This subscription can only run one agent at a time - try again in a moment.',
-				);
+				throw new ChatCredentialBusyError(credentialLockHolder(configId) ?? holder);
 			}
 			throw e;
 		}
 		try {
+			const value = await refreshSubscriptionMount({
+				db: this.deps.db,
+				masterKeyManager: this.deps.masterKeyManager,
+				engine: this.deps.docker,
+				containerId: session.containerId,
+				runUser: session.runUser,
+				credential: session.invocationInputs.credential,
+				mount: session.subscriptionMount,
+			});
+			this.rememberCredentialValue(session, value);
 			return await fn();
 		} finally {
 			// Before the release, so the next holder reads what this exec left.
-			await persistRotatedSubscriptionAuth({
+			const rotated = await persistRotatedSubscriptionAuth({
 				db: this.deps.db,
 				masterKeyManager: this.deps.masterKeyManager,
 				engine: this.deps.docker,
 				containerId: session.containerId,
 				provider,
-				credential,
+				credential: session.invocationInputs.credential,
 				mount: session.subscriptionMount,
 				onNotice: (text: string) => log.warn(text, { session: session.sessionId }),
 			});
+			if (rotated !== null) this.rememberCredentialValue(session, rotated);
 			release();
 		}
+	}
+
+	/**
+	 * Keep the session's snapshot of the credential at the value the store holds,
+	 * so the next exec's comparison against the store starts from the truth and
+	 * rewrites the mounted file only when the value has really moved.
+	 */
+	private rememberCredentialValue(session: LiveSession, value: string): void {
+		const { credential } = session.invocationInputs;
+		if (credential.value === value) return;
+		session.invocationInputs = {
+			...session.invocationInputs,
+			credential: { ...credential, value },
+		};
 	}
 
 	/**
@@ -2519,6 +2605,7 @@ export class ChatSessionManager {
 			inputTokens: usage?.inputTokens ?? 0,
 			outputTokens: usage?.outputTokens ?? 0,
 			costCents: usage?.costCents ?? 0,
+			error: error ?? null,
 		});
 	}
 

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -473,22 +473,23 @@ export class JobManager {
 	}
 
 	/**
-	 * Abort the in-process runs one dead container was carrying.
+	 * Abort the in-process runs one dead container was carrying - and only those.
 	 *
-	 * The in-memory half of {@link failProjectRuns}, and scoped identically: the
-	 * named container's runs, plus runs that have not yet claimed one. Those
-	 * cannot be shown to be executing elsewhere, and the DB half fails them for
-	 * the same reason - the two have to agree or a run's row and its exec
-	 * disagree about whether it is alive.
+	 * The in-memory half of {@link failProjectRuns}. A live run whose container is
+	 * still null has not claimed one: it is parked on the credential lock or on
+	 * capacity, holding nothing, and its row is still `queued`. It cannot be on
+	 * the container that died, so it is left to finish its wait; the surplus-idle
+	 * pass retiring the project's spare container underneath such a waiter is the
+	 * intended memory behaviour, not a reason to end the run. The DB half only
+	 * touches `running` rows, which always carry their container by then, so the
+	 * two halves still describe the same set.
 	 */
 	cancelLiveRunsForContainer(
 		projectId: string,
 		containerId: string,
 		reason: ContainerExitReason,
 	): number {
-		const runs = this.getLiveRunsForProject(projectId).filter(
-			(r) => r.containerId === containerId || r.containerId === null,
-		);
+		const runs = this.getLiveRunsForProject(projectId).filter((r) => r.containerId === containerId);
 		for (const run of runs) {
 			this.cancelTask(run.taskKey, reason);
 			this.liveRuns.delete(run.runId);

--- a/packages/server/src/services/runtime-home.ts
+++ b/packages/server/src/services/runtime-home.ts
@@ -10,8 +10,10 @@ import type { Db } from '../db/database';
 import {
 	type AiProviderCredential,
 	type AiProviderCredentialAndModel,
+	readAiProviderCredentialValue,
 	updateAiProviderCredential,
 } from './ai-provider-keys';
+import { type ContainerRunUser, chownToRunUser } from './container-user';
 import type { SandboxFiles } from './sandbox/files';
 import type { ContainerEngine } from './sandbox/types';
 import { validateSubscriptionBlob } from './subscription-auth';
@@ -286,6 +288,47 @@ export async function buildSubscriptionMount(
 	};
 }
 
+/**
+ * Bring a mounted rotating credential up to date with the store before an
+ * execution uses it, and return the value the execution will run on.
+ *
+ * A waiter on the credential lock snapshots the credential before it waits, and
+ * the holder it waited on may have rotated the single-use token in the meantime
+ * - so by the time the waiter holds the lock, the file it mounted (or is about
+ * to mount) can be a rotation behind and the first refresh against it fails.
+ * Called only once the lock is held, so nothing can rotate it again between the
+ * read and the exec. Ownership is handed back to the run user because the write
+ * comes from the host side, exactly as the original mount write did.
+ *
+ * A mount that does not rotate has nothing to catch up on: its file is written
+ * from the store every run.
+ */
+export async function refreshSubscriptionMount(opts: {
+	db: Db;
+	masterKeyManager: MasterKeyManager;
+	engine: ContainerEngine;
+	containerId: string;
+	runUser: ContainerRunUser;
+	credential: AiProviderCredentialAndModel;
+	mount: SubscriptionMount | null | undefined;
+}): Promise<string> {
+	const { mount, credential } = opts;
+	if (!mount?.rotates) return credential.value;
+	const stored = await readAiProviderCredentialValue(
+		opts.db,
+		opts.masterKeyManager,
+		credential.configId,
+	);
+	if (stored === null || stored === credential.value) return credential.value;
+	await opts.engine
+		.files(opts.containerId, mount.containerDir)
+		.write(mount.authFileRelative, stored, { mode: 0o600, dirMode: SUBSCRIPTION_DIR_MODE });
+	await chownToRunUser(opts.engine, opts.containerId, opts.runUser, [
+		join(mount.containerDir, mount.authFileRelative),
+	]);
+	return stored;
+}
+
 export interface RuntimeHomeMount {
 	hostDir: string;
 	containerDir: string;
@@ -357,6 +400,9 @@ export async function ensureRuntimeHomeDir(
  *
  * Best-effort by design: a failed write-back must not fail the work that just
  * succeeded, so problems are reported through `onNotice` rather than thrown.
+ *
+ * Resolves to the value it stored, or null when nothing was written - so a
+ * caller holding its own snapshot of the credential can move it along.
  */
 export async function persistRotatedSubscriptionAuth(opts: {
 	db: Db;
@@ -367,17 +413,17 @@ export async function persistRotatedSubscriptionAuth(opts: {
 	credential: AiProviderCredentialAndModel;
 	mount: SubscriptionMount | null | undefined;
 	onNotice?: (text: string) => void;
-}): Promise<void> {
+}): Promise<string | null> {
 	const { mount } = opts;
-	if (!mount?.rotates) return;
+	if (!mount?.rotates) return null;
 	try {
 		// Through SandboxFiles: the *container* rewrote this file, so a backend
 		// whose container is not on this machine has to read it back through the
 		// provider's file API rather than off disk.
 		const mountFiles = opts.engine.files(opts.containerId, mount.containerDir);
-		if (!(await mountFiles.exists(mount.authFileRelative))) return;
+		if (!(await mountFiles.exists(mount.authFileRelative))) return null;
 		const rotated = await mountFiles.read(mount.authFileRelative);
-		if (!rotated || rotated === opts.credential.value) return;
+		if (!rotated || rotated === opts.credential.value) return null;
 		// The CLI rewrites this file on every run: a rotated credential on success,
 		// but an empty "tombstone" (blank tokens) when the refresh fails. Persisting
 		// a tombstone would wipe the stored credential, so only write back a value
@@ -385,7 +431,7 @@ export async function persistRotatedSubscriptionAuth(opts: {
 		const check = validateSubscriptionBlob(opts.provider, rotated);
 		if (!check.ok) {
 			opts.onNotice?.(`skipping rotated-auth write-back: ${check.error ?? 'invalid credential'}`);
-			return;
+			return null;
 		}
 		await updateAiProviderCredential(
 			opts.db,
@@ -393,7 +439,9 @@ export async function persistRotatedSubscriptionAuth(opts: {
 			opts.credential.configId,
 			rotated,
 		);
+		return rotated;
 	} catch (e) {
 		opts.onNotice?.(`failed to persist rotated subscription auth: ${(e as Error).message}`);
+		return null;
 	}
 }

--- a/packages/server/test/agent-runner-credential-lock.test.ts
+++ b/packages/server/test/agent-runner-credential-lock.test.ts
@@ -11,6 +11,7 @@
 // So the two properties asserted here are: the wait is bounded and hands the
 // work back, and a waiter holds no container while it waits.
 
+import { readFileSync } from 'node:fs';
 import {
 	AgentRuntime,
 	AiAuthMethod,
@@ -22,9 +23,18 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { runLogTextSql } from '../src/db/run-log-chunks';
 import type { Env } from '../src/lib/types';
-import { acquireCredentialLock, type RunnerDeps, runAgent } from '../src/services/agent-runner';
+import {
+	acquireCredentialLock,
+	type CredentialLockHolder,
+	credentialLockHolder,
+	type RunnerDeps,
+	runAgent,
+} from '../src/services/agent-runner';
+import { updateAiProviderCredential } from '../src/services/ai-provider-keys';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { getHostSubscriptionRoot } from '../src/services/runtime-home';
 import type { ContainerEngine } from '../src/services/sandbox/types';
 import { safeClose } from './helpers';
 import {
@@ -60,16 +70,21 @@ const AUTH_JSON = JSON.stringify({
 let seq = 0;
 let execCount = 0;
 
-function stubDocker(): ContainerEngine {
+/** A run that starts, execs once and produces output; `hooks` observe the exec. */
+function stubDocker(
+	hooks: { onExecCreate?: (opts: { Env?: string[] }) => void; onExecStart?: () => void } = {},
+): ContainerEngine {
 	const base = createStubDocker(
 		{
 			createContainer: vi.fn(async () => ({ Id: `cred-cid-${seq++}`, Warnings: [] })),
 			startContainer: vi.fn(async () => {}),
-			execCreate: vi.fn(async () => {
+			execCreate: vi.fn(async (_id: string, opts: { Env?: string[] }) => {
 				execCount++;
+				hooks.onExecCreate?.(opts);
 				return 'exec-cred';
 			}),
 			execStart: vi.fn(async () => {
+				hooks.onExecStart?.();
 				await db.query(
 					`UPDATE heartbeat_runs SET produced_output = true WHERE member_id = $1 AND status = 'running'`,
 					[agentId],
@@ -136,6 +151,14 @@ async function makeTask(title: string) {
 		progress_summary: null,
 		runtime_type: AgentRuntime.Codex,
 	};
+}
+
+async function runLog(id: string): Promise<string> {
+	const r = await db.query<{ log_text: string }>(
+		`SELECT ${runLogTextSql('heartbeat_runs.id')} AS log_text FROM heartbeat_runs WHERE id = $1`,
+		[id],
+	);
+	return r.rows[0].log_text;
 }
 
 async function runRow(id: string) {
@@ -224,7 +247,9 @@ afterAll(async () => {
 describe('runAgent credential wait', () => {
 	it('holds no container while it waits behind another run', async () => {
 		const task = await makeTask('Waits without a container');
-		const release = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 
 		const pending = runAgent(deps({ capacityPark: { pollMs: 10, maxMs: 20_000 } }), agent(), task, {
 			...project(),
@@ -254,7 +279,9 @@ describe('runAgent credential wait', () => {
 
 	it('gives the work back to the queue as cancelled once the wait ceiling passes', async () => {
 		const task = await makeTask('Waits then gives up');
-		const release = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 		try {
 			const result = await runAgent(
 				deps({ capacityPark: { pollMs: 10, maxMs: 60 } }),
@@ -276,7 +303,11 @@ describe('runAgent credential wait', () => {
 
 			const row = await runRow(result.heartbeatRunId as string);
 			expect(row.status).toBe('cancelled');
-			expect(row.error).toContain('returning this run to the queue');
+			// Names who it was waiting on, in the label alone - the row's `error` is
+			// shown as a one-line summary, and the log line already carries the link.
+			expect(row.error).toBe(
+				'prior-run still holds this provider credential - returning this run to the queue.',
+			);
 			expect(row.container_id).toBeNull();
 			// And no attribution yet: whether the work is actually carried is not
 			// known until the caller settles the wakeup, so the row must not claim
@@ -290,7 +321,9 @@ describe('runAgent credential wait', () => {
 
 	it('leaves nothing the orphan pass would reap after giving up', async () => {
 		const task = await makeTask('Leaves nothing stranded');
-		const release = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 		try {
 			await runAgent(deps({ capacityPark: { pollMs: 10, maxMs: 60 } }), agent(), task, project());
 		} finally {
@@ -306,7 +339,9 @@ describe('runAgent credential wait', () => {
 
 	it('finalizes as cancelled without executing when aborted during the wait', async () => {
 		const task = await makeTask('Aborted while waiting');
-		const release = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 		const ac = new AbortController();
 		const before = execCount;
 
@@ -336,7 +371,9 @@ describe('runAgent credential wait', () => {
 	// and the agent executed in full against a row the UI reported as cancelled.
 	it('does not execute when its row was ended while it waited', async () => {
 		const task = await makeTask('Reaped while waiting');
-		const release = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 		const before = execCount;
 
 		const pending = runAgent(
@@ -365,5 +402,114 @@ describe('runAgent credential wait', () => {
 		expect(row.status).toBe('cancelled');
 		expect(row.error).toContain('Orphaned');
 		expect(row.started_at).toBeNull();
+	});
+
+	it('names the run holding the credential in its log, as a link to that run', async () => {
+		const task = await makeTask('Names the holder');
+		const release = await acquireCredentialLock(configId, {
+			owner: {
+				label: 'growth-analyst/HM-336',
+				link: { projectSlug: 'hezo-marketing', agentSlug: 'growth-analyst', runId: 'run-hm-336' },
+			},
+		});
+		const pending = runAgent(deps({ capacityPark: { pollMs: 10, maxMs: 20_000 } }), agent(), task, {
+			...project(),
+		});
+		await waitForQueuedRow('waiting for prior run on this credential');
+		release();
+		const result = await pending;
+		expect(result.success).toBe(true);
+
+		const log = await runLog(result.heartbeatRunId as string);
+		// The label reads as the holder's name; the href is what the viewer turns
+		// into the link to the run's page in its own project.
+		expect(log).toContain(
+			'Waiting for [growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336) to finish with this credential.',
+		);
+		expect(log).toContain('Credential free, starting the run.');
+	});
+
+	it('names a holder that is not a run by its label alone', async () => {
+		const task = await makeTask('Names the chat');
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'the CEO chat', link: null },
+		});
+		const pending = runAgent(deps({ capacityPark: { pollMs: 10, maxMs: 20_000 } }), agent(), task, {
+			...project(),
+		});
+		await waitForQueuedRow('waiting for prior run on this credential');
+		release();
+		const result = await pending;
+		expect(await runLog(result.heartbeatRunId as string)).toContain(
+			'Waiting for the CEO chat to finish with this credential.',
+		);
+	});
+
+	it('holds the credential under its own name and run, for later waiters to point at', async () => {
+		const task = await makeTask('Is a holder itself');
+		let holderDuringExec: CredentialLockHolder | null = null;
+		const docker = stubDocker({
+			onExecStart: () => {
+				holderDuringExec = credentialLockHolder(configId);
+			},
+		});
+
+		const result = await runAgent(deps({ docker }), agent(), task, project());
+		expect(result.success).toBe(true);
+		expect(holderDuringExec).toEqual({
+			label: `${agentSlug}/${task.identifier}`,
+			link: { projectSlug, agentSlug, runId: result.heartbeatRunId },
+		});
+		expect(credentialLockHolder(configId)).toBeNull();
+	});
+
+	it('starts on the credential stored while it waited, not on its pre-wait snapshot', async () => {
+		const task = await makeTask('Starts on the current token');
+		const rotatedByHolder = JSON.stringify({
+			tokens: {
+				id_token: 'header.payload.sig2',
+				access_token: 'header.payload.sig2',
+				refresh_token: 'rt-rotated-by-holder',
+				account_id: 'acct-1',
+			},
+		});
+		let mounted: string | null = null;
+		const docker = stubDocker({
+			onExecCreate: (opts) => {
+				const home = (opts.Env ?? []).find((e) => e.startsWith('CODEX_HOME='));
+				const runId = home?.slice('CODEX_HOME='.length).split('/').pop() ?? '';
+				const root = getHostSubscriptionRoot(
+					AiProvider.OpenAI,
+					AgentRuntime.Codex,
+					dataDir,
+					teamId,
+					projectId,
+					runId,
+				);
+				mounted = readFileSync(`${root}/auth.json`, 'utf8');
+			},
+		});
+
+		const release = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
+		const pending = runAgent(
+			deps({ docker, capacityPark: { pollMs: 10, maxMs: 20_000 } }),
+			agent(),
+			task,
+			project(),
+		);
+		await waitForQueuedRow('waiting for prior run on this credential');
+		// What the holder does on its way out: the single-use token it consumed is
+		// replaced in the store. A waiter that mounted its pre-wait snapshot would
+		// start on the consumed one.
+		await updateAiProviderCredential(db, masterKeyManager, configId, rotatedByHolder);
+		release();
+
+		const result = await pending;
+		expect(result.success).toBe(true);
+		expect(mounted).toBe(rotatedByHolder);
+
+		await updateAiProviderCredential(db, masterKeyManager, configId, AUTH_JSON);
 	});
 });

--- a/packages/server/test/agent-runner-lifecycle-cov.test.ts
+++ b/packages/server/test/agent-runner-lifecycle-cov.test.ts
@@ -1099,7 +1099,9 @@ describe('runAgent lifecycle — subscription credential lock + rotation', () =>
 		});
 
 		// Hold the credential so the run has something real to wait behind.
-		const releaseCredential = await acquireCredentialLock(configId, { owner: 'prior-run' });
+		const releaseCredential = await acquireCredentialLock(configId, {
+			owner: { label: 'prior-run', link: null },
+		});
 
 		const runPromise = runAgent(
 			baseDeps(docker),

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -4,14 +4,16 @@ import {
 	AuthType,
 	ChatMessageStatus,
 	ChatSessionStatus,
+	ChatSystemMessageKind,
 	DEFAULT_TEAM_ID,
+	WsMessageType,
 	wsRoom,
 } from '@hezo/shared';
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import { decrypt, encrypt } from '../src/crypto/encryption';
 import { signChatSessionJwt, verifyToken } from '../src/middleware/auth';
 import { acquireCredentialLock } from '../src/services/agent-runner';
-import { ChatSessionManager } from '../src/services/chat-session-manager';
+import { type CeoSessionDeps, ChatSessionManager } from '../src/services/chat-session-manager';
 import type { ExecLogChunk } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { getWorkspacePath } from '../src/services/workspace';
@@ -183,7 +185,11 @@ async function seedProviderAndContainer(ctx: ServerTestContext): Promise<string>
 	return proj.rows[0].id;
 }
 
-function makeManager(ctx: ServerTestContext, docker: ReturnType<typeof createStubDocker>) {
+function makeManager(
+	ctx: ServerTestContext,
+	docker: ReturnType<typeof createStubDocker>,
+	extra: Partial<CeoSessionDeps> = {},
+) {
 	const wsManager = new WebSocketManager();
 	const logs = new LogStreamBroker();
 	logs.setWsManager(wsManager);
@@ -195,6 +201,7 @@ function makeManager(ctx: ServerTestContext, docker: ReturnType<typeof createStu
 		dataDir: ctx.dataDir,
 		wsManager,
 		logs,
+		...extra,
 	});
 	return { manager, wsManager };
 }
@@ -1058,6 +1065,244 @@ describe('ChatSessionManager', () => {
 			);
 			expect(decrypt(stored.rows[0].encrypted_credential, key)).toBe(ROTATED);
 
+			await manager.stop();
+		});
+
+		/** The docker every reply-shaped test uses: one exec that says hello. */
+		function replyingDocker() {
+			return createStubDocker(
+				{
+					execCreate: async () => 'exec-codex-chat',
+					execStart: async (
+						_execId: string,
+						opts: { onChunk?: (c: ExecLogChunk) => void | Promise<void> },
+					) => {
+						const onChunk = opts.onChunk ?? (() => undefined);
+						await onChunk({ stream: 'stdout', text: assistantText('Hello') });
+						await onChunk({ stream: 'stdout', text: resultEvent(10, 5, 0.01) });
+						return { stdout: '', stderr: '' };
+					},
+				},
+				{ db: ctx.db, dataDir: ctx.dataDir },
+			);
+		}
+
+		const HOLDER = {
+			label: 'growth-analyst/HM-336',
+			link: { projectSlug: 'hezo-marketing', agentSlug: 'growth-analyst', runId: 'run-hm-336' },
+		};
+		const HOLDER_TEXT =
+			'[growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336)';
+
+		test('tells the thread who holds the credential at once, then replies when it is free', async () => {
+			const configId = await seedCodexSubscription();
+			const release = await acquireCredentialLock(configId, { owner: HOLDER });
+			const { manager, wsManager } = makeManager(ctx, replyingDocker());
+			const { events } = captureCeoRoom(wsManager);
+
+			const { assistantMessageId, conversationId } = await manager.sendTurn({ text: 'Hello CEO' });
+			// The notice lands while the wait is still on - the same sentence a
+			// waiting run writes to its log, with the holder linked the same way.
+			await poll(async () => {
+				const r = await ctx.db.query<{ content: string }>(
+					`SELECT content FROM chat_messages WHERE conversation_id = $1 AND system_kind = $2`,
+					[conversationId, ChatSystemMessageKind.CredentialWait],
+				);
+				return r.rows.length === 1;
+			});
+			const notice = await ctx.db.query<{ content: string }>(
+				`SELECT content FROM chat_messages WHERE conversation_id = $1 AND system_kind = $2`,
+				[conversationId, ChatSystemMessageKind.CredentialWait],
+			);
+			expect(notice.rows[0].content).toBe(
+				`Waiting for ${HOLDER_TEXT} to finish with this credential.`,
+			);
+			expect(
+				events.some(
+					(e) =>
+						e.type === WsMessageType.ChatMessageStart &&
+						e.systemKind === ChatSystemMessageKind.CredentialWait,
+				),
+			).toBe(true);
+			const midWait = await ctx.db.query<{ status: string }>(
+				'SELECT status FROM chat_messages WHERE id = $1',
+				[assistantMessageId],
+			);
+			expect(midWait.rows[0].status).not.toBe(ChatMessageStatus.Complete);
+
+			release();
+			await poll(async () => {
+				const r = await ctx.db.query<{ status: string }>(
+					'SELECT status FROM chat_messages WHERE id = $1',
+					[assistantMessageId],
+				);
+				return r.rows[0]?.status === ChatMessageStatus.Complete;
+			});
+			await manager.stop();
+		});
+
+		test('goes ahead of runs merely parked on the credential', async () => {
+			const configId = await seedCodexSubscription();
+			const release = await acquireCredentialLock(configId, { owner: HOLDER });
+			// A task run parked behind the holder, exactly as the runner parks one.
+			const order: string[] = [];
+			const parkedRun = acquireCredentialLock(configId, {
+				owner: { label: 'ops/OP-1', link: null },
+				timeoutMs: 10_000,
+			}).then((rel) => {
+				order.push('run');
+				rel();
+			});
+			const docker = createStubDocker(
+				{
+					execCreate: async () => 'exec-codex-chat',
+					execStart: async (
+						_execId: string,
+						opts: { onChunk?: (c: ExecLogChunk) => void | Promise<void> },
+					) => {
+						order.push('chat');
+						const onChunk = opts.onChunk ?? (() => undefined);
+						await onChunk({ stream: 'stdout', text: assistantText('Hello') });
+						await onChunk({ stream: 'stdout', text: resultEvent(10, 5, 0.01) });
+						return { stdout: '', stderr: '' };
+					},
+				},
+				{ db: ctx.db, dataDir: ctx.dataDir },
+			);
+			const { manager } = makeManager(ctx, docker);
+			const { assistantMessageId, conversationId } = await manager.sendTurn({ text: 'Hello CEO' });
+			await poll(async () => {
+				const r = await ctx.db.query(
+					`SELECT 1 FROM chat_messages WHERE conversation_id = $1 AND system_kind = $2`,
+					[conversationId, ChatSystemMessageKind.CredentialWait],
+				);
+				return r.rows.length === 1;
+			});
+
+			release();
+			await poll(async () => {
+				const r = await ctx.db.query<{ status: string }>(
+					'SELECT status FROM chat_messages WHERE id = $1',
+					[assistantMessageId],
+				);
+				return r.rows[0]?.status === ChatMessageStatus.Complete;
+			});
+			await parkedRun;
+			// Every chat exec (the session's own probe, the reply, the title) lands
+			// before the run that was queued first.
+			expect(order.at(-1)).toBe('run');
+			expect(order.filter((o) => o === 'chat').length).toBeGreaterThan(0);
+			await manager.stop();
+		});
+
+		test('fails the turn naming the holder when the wait runs out, and tells the widget why', async () => {
+			const configId = await seedCodexSubscription();
+			const release = await acquireCredentialLock(configId, { owner: HOLDER });
+			try {
+				const { manager, wsManager } = makeManager(ctx, replyingDocker(), {
+					capacityPark: { pollMs: 10, maxMs: 40 },
+				});
+				const { events } = captureCeoRoom(wsManager);
+				const { assistantMessageId } = await manager.sendTurn({ text: 'Hello CEO' });
+				await poll(async () => {
+					const r = await ctx.db.query<{ status: string }>(
+						'SELECT status FROM chat_messages WHERE id = $1',
+						[assistantMessageId],
+					);
+					return r.rows[0]?.status === ChatMessageStatus.Failed;
+				});
+				const row = await ctx.db.query<{ error: string | null }>(
+					'SELECT error FROM chat_messages WHERE id = $1',
+					[assistantMessageId],
+				);
+				expect(row.rows[0].error).toBe(
+					`${HOLDER_TEXT} is still using this provider credential; this subscription runs one agent at a time.`,
+				);
+				// The reason travels with the completion frame, so an open chatbox shows
+				// it rather than a generic failure.
+				const complete = events.find(
+					(e) => e.type === WsMessageType.ChatMessageComplete && e.messageId === assistantMessageId,
+				);
+				expect(complete?.status).toBe(ChatMessageStatus.Failed);
+				expect(complete?.error).toBe(row.rows[0].error);
+				await manager.stop();
+			} finally {
+				release();
+			}
+		});
+
+		test('runs on the credential the store holds once the lock is taken, not the one it mounted at start', async () => {
+			const configId = await seedCodexSubscription();
+			const key = ctx.masterKeyManager.getKey();
+			if (!key) throw new Error('master key unavailable');
+			const rotatedByRun = JSON.stringify({
+				tokens: {
+					id_token: 'header.payload.sig3',
+					access_token: 'header.payload.sig3',
+					refresh_token: 'rt-rotated-by-run',
+					account_id: 'acct-1',
+				},
+			});
+
+			let codexHome: string | null = null;
+			const seen: string[] = [];
+			const docker = createStubDocker(
+				{
+					execCreate: async (_id: string, config: { Env?: string[] }) => {
+						const entry = (config.Env ?? []).find((e) => e.startsWith('CODEX_HOME='));
+						if (entry) codexHome = entry.slice('CODEX_HOME='.length);
+						return 'exec-codex-fresh';
+					},
+					execStart: async (
+						_execId: string,
+						opts: { onChunk?: (c: ExecLogChunk) => void | Promise<void> },
+					) => {
+						if (codexHome)
+							seen.push(await docker.files('hq-container', codexHome).read('auth.json'));
+						const onChunk = opts.onChunk ?? (() => undefined);
+						await onChunk({ stream: 'stdout', text: assistantText('Hello') });
+						await onChunk({ stream: 'stdout', text: resultEvent(10, 5, 0.01) });
+						return { stdout: '', stderr: '' };
+					},
+				},
+				{ db: ctx.db, dataDir: ctx.dataDir },
+			);
+			const { manager } = makeManager(ctx, docker);
+			const first = await manager.sendTurn({ text: 'First' });
+			// The reply and the auto-title both exec on this credential; wait for
+			// both, so nothing from this turn can read the file after the rotation.
+			await poll(async () => {
+				const r = await ctx.db.query<{ status: string }>(
+					'SELECT status FROM chat_messages WHERE id = $1',
+					[first.assistantMessageId],
+				);
+				return r.rows[0]?.status === ChatMessageStatus.Complete && seen.length >= 2;
+			});
+			expect(seen).toEqual([ORIGINAL, ORIGINAL]);
+			const execsBefore = seen.length;
+
+			// A task run took the credential between turns and rotated it.
+			await ctx.db.query('UPDATE ai_provider_configs SET encrypted_credential = $2 WHERE id = $1', [
+				configId,
+				encrypt(rotatedByRun, key),
+			]);
+			const second = await manager.sendTurn({ text: 'Second' });
+			await poll(async () => {
+				const r = await ctx.db.query<{ status: string }>(
+					'SELECT status FROM chat_messages WHERE id = $1',
+					[second.assistantMessageId],
+				);
+				return r.rows[0]?.status === ChatMessageStatus.Complete;
+			});
+			const after = seen.slice(execsBefore);
+			expect(after.length).toBeGreaterThan(0);
+			expect(after.every((v) => v === rotatedByRun)).toBe(true);
+			// And nothing was written back over it: the file and the store agree.
+			const stored = await ctx.db.query<{ encrypted_credential: string }>(
+				'SELECT encrypted_credential FROM ai_provider_configs WHERE id = $1',
+				[configId],
+			);
+			expect(decrypt(stored.rows[0].encrypted_credential, key)).toBe(rotatedByRun);
 			await manager.stop();
 		});
 	});

--- a/packages/server/test/job-manager-extended.test.ts
+++ b/packages/server/test/job-manager-extended.test.ts
@@ -284,10 +284,10 @@ describe('JobManager — extended coverage', () => {
 			manager.shutdown();
 		});
 
-		it('cancelLiveRunsForContainer also cancels a run that has not claimed a container', () => {
-			// Nothing can show such a run to be executing elsewhere, and the DB half
-			// fails it for the same reason - leaving it registered would disagree
-			// with its own row.
+		it('cancelLiveRunsForContainer leaves a run that has not claimed a container alone', () => {
+			// Such a run is parked - on the credential lock or on capacity - and holds
+			// nothing, so no container's death is its death. Its row is still queued,
+			// which the DB half never touches, so the two halves keep agreeing.
 			const manager = createJobManager();
 			const key = `${agentId}:${projectId}`;
 			let aborted = false;
@@ -313,11 +313,12 @@ describe('JobManager — extended coverage', () => {
 			});
 
 			expect(manager.cancelLiveRunsForContainer(projectId, 'ctr-dead', 'container_stopped')).toBe(
-				1,
+				0,
 			);
-			expect(aborted).toBe(true);
-			expect(manager.getLiveRunIds()).toEqual(new Set());
+			expect(aborted).toBe(false);
+			expect(manager.getLiveRunIds()).toEqual(new Set(['r-unplaced']));
 
+			manager.cancelLiveRun('r-unplaced');
 			manager.shutdown();
 		});
 	});
@@ -811,24 +812,41 @@ describe('JobManager — extended coverage', () => {
 	});
 
 	describe('container transition handling', () => {
-		it('handleContainerTransition fails project runs and cancels live runs on running→error', async () => {
-			const manager = createJobManager();
-			const key = `${agentId}:${projectId}`;
-			let aborted = false;
+		type TransitionHandler = {
+			handleContainerTransition(t: {
+				projectId: string;
+				projectSlug: string;
+				teamId: string;
+				containerId: string;
+				oldStatus: string;
+				newStatus: string;
+			}): Promise<void>;
+		};
+
+		/** A live run whose driver resolves when aborted, reporting that it was. */
+		const launchAbortable = (manager: ReturnType<typeof createJobManager>, key: string) => {
+			const state = { aborted: false };
 			manager.launchTask(
 				key,
 				(signal) =>
 					new Promise<void>((resolve) => {
 						signal.addEventListener('abort', () => {
-							aborted = true;
+							state.aborted = true;
 							resolve();
 						});
 					}),
 				60_000,
 			);
+			return state;
+		};
+
+		it('handleContainerTransition fails project runs and cancels live runs on running→error', async () => {
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+			const driver = launchAbortable(manager, key);
 			const run = await db.query<{ id: string }>(
-				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, container_id)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now(), 'ctr-dead')
 				 RETURNING id`,
 				[agentId, teamId, taskId, HeartbeatRunStatus.Running],
 			);
@@ -841,26 +859,18 @@ describe('JobManager — extended coverage', () => {
 				taskKey: key,
 				containerId: null,
 			});
+			manager.attachLiveRunContainer(run.rows[0].id, 'ctr-dead');
 
-			await (
-				manager as unknown as {
-					handleContainerTransition(t: {
-						projectId: string;
-						projectSlug: string;
-						teamId: string;
-						oldStatus: string;
-						newStatus: string;
-					}): Promise<void>;
-				}
-			).handleContainerTransition({
+			await (manager as unknown as TransitionHandler).handleContainerTransition({
 				projectId,
 				projectSlug,
 				teamId,
+				containerId: 'ctr-dead',
 				oldStatus: ContainerStatus.Running,
 				newStatus: ContainerStatus.Error,
 			});
 
-			expect(aborted).toBe(true);
+			expect(driver.aborted).toBe(true);
 			expect(manager.getLiveRunIds().has(run.rows[0].id)).toBe(false);
 			const r = await db.query<{ status: string }>(
 				'SELECT status FROM heartbeat_runs WHERE id = $1',
@@ -870,6 +880,54 @@ describe('JobManager — extended coverage', () => {
 
 			await waitForBackground();
 			manager.shutdown();
+		});
+
+		// The prod shape: a run parked on the credential lock holds no container,
+		// and the surplus-idle pass suspends the project's spare one underneath it.
+		// The stop is a transition on a container the run is not on, so the run
+		// keeps waiting.
+		it('leaves a live run that has claimed no container alone when a project container stops', async () => {
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+			const driver = launchAbortable(manager, key);
+			const run = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, queued_reason)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, 'waiting for prior run on this credential')
+				 RETURNING id`,
+				[agentId, teamId, taskId, HeartbeatRunStatus.Queued],
+			);
+			manager.registerLiveRun({
+				runId: run.rows[0].id,
+				memberId: agentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: key,
+				containerId: null,
+			});
+
+			await (manager as unknown as TransitionHandler).handleContainerTransition({
+				projectId,
+				projectSlug,
+				teamId,
+				containerId: 'ctr-idle-sibling',
+				oldStatus: ContainerStatus.Running,
+				newStatus: ContainerStatus.Stopped,
+			});
+
+			expect(driver.aborted).toBe(false);
+			expect(manager.getLiveRunIds().has(run.rows[0].id)).toBe(true);
+			const r = await db.query<{ status: string; queued_reason: string | null }>(
+				'SELECT status, queued_reason FROM heartbeat_runs WHERE id = $1',
+				[run.rows[0].id],
+			);
+			expect(r.rows[0].status).toBe(HeartbeatRunStatus.Queued);
+			expect(r.rows[0].queued_reason).toBe('waiting for prior run on this credential');
+
+			manager.cancelLiveRun(run.rows[0].id);
+			await waitForBackground();
+			manager.shutdown();
+			await db.query('DELETE FROM heartbeat_runs WHERE id = $1', [run.rows[0].id]);
 		});
 
 		it('handleContainerTransition is a no-op for an unrelated transition (creating→running)', async () => {

--- a/packages/server/test/job-manager-recovery.test.ts
+++ b/packages/server/test/job-manager-recovery.test.ts
@@ -738,8 +738,8 @@ describe('JobManager recovery & maintenance', () => {
 				[projectId],
 			);
 			const run = await db.query<{ id: string }>(
-				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, container_id)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now(), 'sync-box')
 				 RETURNING id`,
 				[teamId, agentId, taskId, HeartbeatRunStatus.Running],
 			);
@@ -775,6 +775,7 @@ describe('JobManager recovery & maintenance', () => {
 				taskKey: key,
 				containerId: null,
 			});
+			manager.attachLiveRunContainer(run.rows[0].id, 'sync-box');
 
 			await (manager as unknown as JmInternals).syncContainerStatuses();
 			await waitForBackground();
@@ -793,6 +794,93 @@ describe('JobManager recovery & maintenance', () => {
 			expect(project.rows[0].container_status).toBe(ContainerStatus.Stopped);
 
 			manager.shutdown();
+			await db.query(
+				'UPDATE projects SET container_status = NULL, container_id = NULL WHERE id = $1',
+				[projectId],
+			);
+		});
+
+		// The prod incident: a run parked on the credential lock (a live run with no
+		// container, row still queued) while the surplus-idle pass suspended the
+		// project's idle container. The sync tick that saw the stop must fail only
+		// what was on that container - which is nothing - and leave the waiter to
+		// finish its wait.
+		it('leaves a credential waiter queued when the project container it never claimed stops', async () => {
+			const { db } = ctx;
+			await db.query(
+				'UPDATE projects SET container_status = NULL, container_id = NULL WHERE id <> $1',
+				[projectId],
+			);
+			await db.query(
+				`UPDATE projects SET container_status = 'running'::container_status, container_id = 'idle-box'
+				 WHERE id = $1`,
+				[projectId],
+			);
+			const run = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, queued_reason)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, 'waiting for prior run on this credential')
+				 RETURNING id`,
+				[teamId, agentId, taskId, HeartbeatRunStatus.Queued],
+			);
+
+			const manager = createJobManager({
+				docker: createStubDocker({
+					inspectContainer: async (id: string) => ({
+						Id: id,
+						State: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+						Config: { Image: 'stub' },
+					}),
+				}),
+			});
+			const key = `${agentId}:${projectId}`;
+			let aborted = false;
+			manager.launchTask(
+				key,
+				(signal) =>
+					new Promise<void>((resolve) => {
+						signal.addEventListener('abort', () => {
+							aborted = true;
+							resolve();
+						});
+					}),
+				60_000,
+			);
+			manager.registerLiveRun({
+				runId: run.rows[0].id,
+				memberId: agentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: key,
+				containerId: null,
+			});
+
+			// No background drain before the assertions: the waiter is still live by
+			// design, and draining would wait on the thing under test not to have
+			// happened. The sync awaits its own DB writes.
+			await (manager as unknown as JmInternals).syncContainerStatuses();
+
+			expect(aborted).toBe(false);
+			expect(manager.getLiveRunIds().has(run.rows[0].id)).toBe(true);
+			const runRow = await db.query<{ status: string; queued_reason: string | null }>(
+				'SELECT status::text AS status, queued_reason FROM heartbeat_runs WHERE id = $1',
+				[run.rows[0].id],
+			);
+			expect(runRow.rows[0]).toEqual({
+				status: HeartbeatRunStatus.Queued,
+				queued_reason: 'waiting for prior run on this credential',
+			});
+			// The container itself is still recorded as having stopped.
+			const project = await db.query<{ container_status: string }>(
+				'SELECT container_status::text AS container_status FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(project.rows[0].container_status).toBe(ContainerStatus.Stopped);
+
+			manager.cancelLiveRun(run.rows[0].id);
+			await waitForBackground();
+			manager.shutdown();
+			await db.query('DELETE FROM heartbeat_runs WHERE id = $1', [run.rows[0].id]);
 			await db.query(
 				'UPDATE projects SET container_status = NULL, container_id = NULL WHERE id = $1',
 				[projectId],

--- a/packages/server/test/keyed-lock.test.ts
+++ b/packages/server/test/keyed-lock.test.ts
@@ -218,3 +218,68 @@ describe('lock bookkeeping', () => {
 		expect(reg.size).toBe(0);
 	});
 });
+
+describe('priority waiters', () => {
+	it('is granted before earlier plain waiters and after earlier priority waiters', async () => {
+		const reg = registry();
+		const release = await hold(reg, 'k', 'holder');
+		const order: string[] = [];
+		const wait = (owner: string, priority = false) =>
+			acquireKeyedLock(reg, 'k', { owner, priority, timeoutMs: 1_000 }).then((rel) => {
+				order.push(owner);
+				rel();
+			});
+		const all = [wait('plain-1'), wait('plain-2'), wait('prio-1', true), wait('prio-2', true)];
+
+		release();
+		await Promise.all(all);
+		expect(order).toEqual(['prio-1', 'prio-2', 'plain-1', 'plain-2']);
+	});
+
+	it('never preempts the holder', async () => {
+		const reg = registry();
+		const release = await hold(reg, 'k', 'holder');
+		let granted = false;
+		const waiting = acquireKeyedLock(reg, 'k', { priority: true, timeoutMs: 1_000 }).then((rel) => {
+			granted = true;
+			rel();
+		});
+		await new Promise((r) => setTimeout(r, 10));
+		expect(granted).toBe(false);
+		expect(currentOwner(reg, 'k')).toBe('holder');
+		release();
+		await waiting;
+		expect(granted).toBe(true);
+	});
+
+	it('leaves the queue cleanly when a priority waiter gives up', async () => {
+		const reg = registry();
+		const release = await hold(reg, 'k', 'holder');
+		const gaveUp = acquireKeyedLock(reg, 'k', { priority: true, timeoutMs: 5 }).catch((e) => e);
+		const plain = acquireKeyedLock(reg, 'k', { owner: 'plain', timeoutMs: 1_000 });
+		expect(await gaveUp).toBeInstanceOf(KeyedLockTimeoutError);
+		release();
+		(await plain)();
+		expect(reg.size).toBe(0);
+	});
+});
+
+describe('structured owners', () => {
+	interface Holder {
+		label: string;
+		runId: string;
+	}
+
+	it('reports the whole record to a waiter and its label in the timeout message', async () => {
+		const reg: KeyedLockRegistry<Holder> = new Map();
+		const holder = { label: 'growth-analyst/HM-336', runId: 'run-1' };
+		const release = await acquireKeyedLock(reg, 'k', { owner: holder });
+		expect(currentOwner(reg, 'k')).toEqual(holder);
+
+		const err = await acquireKeyedLock(reg, 'k', { timeoutMs: 5 }).catch((e) => e);
+		expect(err).toBeInstanceOf(KeyedLockTimeoutError);
+		expect((err as Error).message).toContain('held by growth-analyst/HM-336');
+		expect((err as Error).message).not.toContain('run-1');
+		release();
+	});
+});

--- a/packages/server/test/migrate-068-chat-system-kind-credential-wait.test.ts
+++ b/packages/server/test/migrate-068-chat-system-kind-credential-wait.test.ts
@@ -2,20 +2,17 @@ import { ChatSystemMessageKind } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
 
-const TARGET = '067_chat_system_kind_connector_refused.sql';
+const TARGET = '068_chat_system_kind_credential_wait.sql';
 
-// Seeds a chat thread at schema 066 carrying one row of each kind the CHECK
+// Seeds a chat thread at schema 067 carrying one row of each kind the CHECK
 // admitted before this migration, applies it, and asserts: every seeded row and
-// its kind survived, the new kind inserts, an unknown kind still fails, and
-// every kind this migration admits inserts. The enum-wide drift guard - every
-// value of the shared enum inserts - lives with the newest system-kind
-// migration's test, since a later migration widens the list again.
-describe('067_chat_system_kind_connector_refused migration', () => {
+// its kind survived, the new kind inserts, an unknown kind still fails, and -
+// the drift guard - every value of the shared enum inserts, so the enum and the
+// constraint cannot part ways without failing here.
+describe('068_chat_system_kind_credential_wait migration', () => {
 	let h: DataPreservationHarness;
 	let conversationId: string;
-	let convertedId: string;
-	let handoffId: string;
-	let plainId: string;
+	let seeded: string[];
 
 	beforeAll(async () => {
 		h = await createDataPreservationHarness();
@@ -49,13 +46,16 @@ describe('067_chat_system_kind_connector_refused migration', () => {
 			);
 			return r.rows[0].id;
 		};
-		plainId = await insert('assistant', 'here is the plan', null);
-		convertedId = await insert('system', 'Conversation converted to task HQ-4', 'converted_task');
-		handoffId = await insert(
-			'system',
-			'This chat turn named @dev without waking them',
-			'handoff_not_delivered',
-		);
+		seeded = [
+			await insert('assistant', 'here is the plan', null),
+			await insert('system', 'Conversation converted to task HQ-4', 'converted_task'),
+			await insert(
+				'system',
+				'This chat turn named @dev without waking them',
+				'handoff_not_delivered',
+			),
+			await insert('system', 'connector "ibkr" refused this run', 'connector_refused'),
+		];
 
 		await h.applyTarget(TARGET);
 	});
@@ -66,20 +66,21 @@ describe('067_chat_system_kind_connector_refused migration', () => {
 			`SELECT id, system_kind, content FROM chat_messages WHERE conversation_id = $1 ORDER BY created_at ASC`,
 			[conversationId],
 		);
-		expect(rows.rows.map((r) => r.id)).toEqual([plainId, convertedId, handoffId]);
+		expect(rows.rows.map((r) => r.id)).toEqual(seeded);
 		expect(rows.rows.map((r) => r.system_kind)).toEqual([
 			null,
 			'converted_task',
 			'handoff_not_delivered',
+			'connector_refused',
 		]);
-		expect(rows.rows[1].content).toBe('Conversation converted to task HQ-4');
+		expect(rows.rows[3].content).toBe('connector "ibkr" refused this run');
 	});
 
 	it('admits the new kind and still rejects an unknown one', async () => {
 		await expect(
 			h.db.query(
 				`INSERT INTO chat_messages (conversation_id, role, channel, status, content, system_kind)
-				 VALUES ($1, 'system', 'web', 'complete', 'connector "ibkr" refused this run', 'connector_refused')`,
+				 VALUES ($1, 'system', 'web', 'complete', 'Waiting for growth-analyst/HM-336 to finish with this credential.', 'credential_wait')`,
 				[conversationId],
 			),
 		).resolves.toBeDefined();
@@ -92,12 +93,8 @@ describe('067_chat_system_kind_connector_refused migration', () => {
 		).rejects.toThrow();
 	});
 
-	it('admits every kind it names', async () => {
-		for (const kind of [
-			ChatSystemMessageKind.ConvertedTask,
-			ChatSystemMessageKind.HandoffNotDelivered,
-			ChatSystemMessageKind.ConnectorRefused,
-		]) {
+	it('admits every kind the shared enum names', async () => {
+		for (const kind of Object.values(ChatSystemMessageKind)) {
 			await expect(
 				h.db.query(
 					`INSERT INTO chat_messages (conversation_id, role, channel, status, content, system_kind)

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,5 @@
+import { parseRunPath, type RunLink, runPath } from './mentions/paths.js';
+
 export const DEFAULT_PORT = 3100;
 export const DEFAULT_WEB_PORT = 5173;
 export const DEFAULT_DATA_DIR = '~/.hezo';
@@ -325,6 +327,44 @@ export function parseContainerMetaLogLine(
 		.split(CONTAINER_META_LOG_SEPARATOR);
 	if (!containerId || /\s/.test(containerId)) return null;
 	return { containerId, details: rest.join(CONTAINER_META_LOG_SEPARATOR) };
+}
+
+/**
+ * A run named inside a line of server-written text - a runner log line, a chat
+ * notice - as a markdown link to its page.
+ *
+ * Markdown rather than a private marker because it reads as-is wherever the
+ * text is shown raw (the raw log view, a copied line, the database row), and
+ * a viewer that wants a real link only has to recognise the one href shape
+ * {@link runPath} produces. The label is whatever the writer calls the run.
+ */
+export function formatRunLink(label: string, link: RunLink): string {
+	return `[${label}](${runPath(link)})`;
+}
+
+/** One piece of a line split by {@link splitRunLinks}: plain text, or a linked run. */
+export type RunLinkSegment = { text: string } | { label: string; link: RunLink };
+
+const MARKDOWN_LINK_RE = /\[([^\]\n]+)\]\(([^)\s]+)\)/g;
+
+/**
+ * Split text into plain segments and the run links {@link formatRunLink} wrote
+ * into it. A markdown link whose href is not a run path stays plain text, so
+ * an agent's own `[text](url)` in a log line is never turned into a run link.
+ */
+export function splitRunLinks(text: string): RunLinkSegment[] {
+	const segments: RunLinkSegment[] = [];
+	let cursor = 0;
+	for (const match of text.matchAll(MARKDOWN_LINK_RE)) {
+		const link = parseRunPath(match[2]);
+		if (!link) continue;
+		const at = match.index ?? 0;
+		if (at > cursor) segments.push({ text: text.slice(cursor, at) });
+		segments.push({ label: match[1], link });
+		cursor = at + match[0].length;
+	}
+	if (cursor < text.length) segments.push({ text: text.slice(cursor) });
+	return segments;
 }
 
 /**

--- a/packages/shared/src/mentions/paths.ts
+++ b/packages/shared/src/mentions/paths.ts
@@ -27,6 +27,29 @@ export function agentPath(projectSlug: string, agentSlug: string): string {
 	return `/projects/${projectSlug}/agents/${agentSlug}`;
 }
 
+/** Where one execution run of an agent is shown. */
+export interface RunLink {
+	projectSlug: string;
+	agentSlug: string;
+	runId: string;
+}
+
+export function runPath({ projectSlug, agentSlug, runId }: RunLink): string {
+	return `${agentPath(projectSlug, agentSlug)}/executions/${runId}`;
+}
+
+const RUN_PATH_RE = /^\/projects\/([^/\s]+)\/agents\/([^/\s]+)\/executions\/([^/\s?#]+)$/;
+
+/**
+ * The inverse of {@link runPath}: the run a path names, or null for any other
+ * path. Kept beside the builder so the two cannot drift.
+ */
+export function parseRunPath(path: string): RunLink | null {
+	const match = RUN_PATH_RE.exec(path);
+	if (!match) return null;
+	return { projectSlug: match[1], agentSlug: match[2], runId: match[3] };
+}
+
 export function projectInboxPath(projectSlug: string): string {
 	return `/projects/${projectSlug}/inbox`;
 }

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1250,6 +1250,12 @@ export const ChatSystemMessageKind = {
 	 * what Hezo's own re-check of the connector found.
 	 */
 	ConnectorRefused: 'connector_refused',
+	/**
+	 * The turn is parked until another execution finishes with the provider
+	 * credential it needs, on a subscription that runs one agent at a time. The
+	 * content names that execution and links to it when it is a task run.
+	 */
+	CredentialWait: 'credential_wait',
 } as const;
 export type ChatSystemMessageKind =
 	(typeof ChatSystemMessageKind)[keyof typeof ChatSystemMessageKind];

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -177,7 +177,7 @@ export interface WsChatMessageToolActivityMessage {
 	tool: string;
 }
 
-/** Terminal event for a CEO message: finalizes content, status, and usage. */
+/** Terminal event for a CEO message: finalizes content, status, usage, and why it failed if it did. */
 export interface WsChatMessageCompleteMessage {
 	type: WsMessageType.ChatMessageComplete;
 	conversationId: string;
@@ -187,6 +187,8 @@ export interface WsChatMessageCompleteMessage {
 	inputTokens: number;
 	outputTokens: number;
 	costCents: number;
+	/** Set on a failed message: the reason, in the words the server recorded. */
+	error: string | null;
 }
 
 /**

--- a/packages/shared/test/container-meta-log-line.test.ts
+++ b/packages/shared/test/container-meta-log-line.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	formatContainerMetaLogLine,
 	formatGib,
+	formatRunLink,
 	parseContainerMetaLogLine,
 	poolDiskCeilingBytes,
+	splitRunLinks,
 } from '../src/constants';
 
 const gib = (n: number) => n * 1024 ** 3;
@@ -63,6 +65,49 @@ describe('the container meta log line', () => {
 		expect(parseContainerMetaLogLine('Starting the project container…')).toBeNull();
 		expect(parseContainerMetaLogLine('Cloning acme/web · 4 GB RAM')).toBeNull();
 		expect(parseContainerMetaLogLine('')).toBeNull();
+	});
+});
+
+/**
+ * A runner line or a chat notice names another run as a markdown link; the
+ * viewer splits the text around it. Same contract as the container line: the
+ * writer and the reader share one vocabulary and the round trip is the test.
+ */
+describe('run links in server-written text', () => {
+	const link = { projectSlug: 'hezo-marketing', agentSlug: 'growth-analyst', runId: 'run-1' };
+
+	it('writes the run as a markdown link that reads as-is in raw text', () => {
+		expect(formatRunLink('growth-analyst/HM-336', link)).toBe(
+			'[growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-1)',
+		);
+	});
+
+	it('splits the surrounding text from the linked run', () => {
+		const line = `Waiting for ${formatRunLink('growth-analyst/HM-336', link)} to finish with this credential.`;
+		expect(splitRunLinks(line)).toEqual([
+			{ text: 'Waiting for ' },
+			{ label: 'growth-analyst/HM-336', link },
+			{ text: ' to finish with this credential.' },
+		]);
+	});
+
+	it('leaves text with no run link, or a link to anything else, as one plain segment', () => {
+		expect(splitRunLinks('Credential free, starting the run.')).toEqual([
+			{ text: 'Credential free, starting the run.' },
+		]);
+		const other = 'See [the docs](https://hezo.ai/docs) and [a task](/projects/ops/tasks/in-42).';
+		expect(splitRunLinks(other)).toEqual([{ text: other }]);
+		expect(splitRunLinks('')).toEqual([]);
+	});
+
+	it('handles a link at either edge and more than one link', () => {
+		const a = formatRunLink('a/T-1', link);
+		const b = formatRunLink('b/T-2', { ...link, runId: 'run-2' });
+		expect(splitRunLinks(`${a} then ${b}`)).toEqual([
+			{ label: 'a/T-1', link },
+			{ text: ' then ' },
+			{ label: 'b/T-2', link: { ...link, runId: 'run-2' } },
+		]);
 	});
 });
 

--- a/packages/shared/test/mentions-paths.test.ts
+++ b/packages/shared/test/mentions-paths.test.ts
@@ -4,8 +4,10 @@ import {
 	assetPath,
 	commentPath,
 	GLOBAL_INBOX_PATH,
+	parseRunPath,
 	projectDocPath,
 	projectInboxPath,
+	runPath,
 	SKILLS_SETTINGS_PATH,
 	taskPath,
 } from '../src/mentions/paths';
@@ -32,6 +34,20 @@ describe('mention paths', () => {
 	it('builds agent and inbox paths', () => {
 		expect(agentPath('ops', 'captain')).toBe('/projects/ops/agents/captain');
 		expect(projectInboxPath('ops')).toBe('/projects/ops/inbox');
+	});
+
+	it('builds a run path and parses it back', () => {
+		const link = { projectSlug: 'hezo-marketing', agentSlug: 'growth-analyst', runId: 'run-1' };
+		const path = runPath(link);
+		expect(path).toBe('/projects/hezo-marketing/agents/growth-analyst/executions/run-1');
+		expect(parseRunPath(path)).toEqual(link);
+	});
+
+	it('parses no other path as a run', () => {
+		expect(parseRunPath('/projects/ops/agents/captain')).toBeNull();
+		expect(parseRunPath('/projects/ops/agents/captain/executions')).toBeNull();
+		expect(parseRunPath('/projects/ops/tasks/in-42')).toBeNull();
+		expect(parseRunPath('https://example.com/projects/ops/agents/a/executions/r')).toBeNull();
 	});
 
 	it('exposes static instance paths', () => {

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -12,6 +12,7 @@ import {
 	Copy,
 	ExternalLink,
 	History,
+	Hourglass,
 	ListPlus,
 	Loader2,
 	Lock,
@@ -57,15 +58,32 @@ import {
 } from '../file-attachments';
 import { HqContainerNotice } from '../hq-container-notice';
 import { MarkdownProse } from '../markdown-prose';
+import { RunLinkedText } from '../run-linked-text';
 import { CountOverlayBadge } from '../ui/count-overlay-badge';
 import { Tooltip } from '../ui/tooltip';
 import { ConvertToTaskDialog } from './convert-to-task-dialog';
 
-/** System-message kinds rendered as an amber warning row rather than a marker. */
-const WARNING_SYSTEM_KINDS: ReadonlySet<ChatSystemMessageKind> = new Set<ChatSystemMessageKind>([
-	ChatSystemMessageKind.HandoffNotDelivered,
-	ChatSystemMessageKind.ConnectorRefused,
-]);
+/**
+ * System-message kinds rendered as a full-sentence row rather than a marker,
+ * and how each row looks: a warning is amber, a notice is quiet. Any kind not
+ * listed here is the converted-task marker.
+ */
+const SYSTEM_ROW_STYLE: Partial<
+	Record<ChatSystemMessageKind, { icon: typeof TriangleAlert; className: string }>
+> = {
+	[ChatSystemMessageKind.HandoffNotDelivered]: {
+		icon: TriangleAlert,
+		className: 'bg-warning-soft text-warning-soft-fg',
+	},
+	[ChatSystemMessageKind.ConnectorRefused]: {
+		icon: TriangleAlert,
+		className: 'bg-warning-soft text-warning-soft-fg',
+	},
+	[ChatSystemMessageKind.CredentialWait]: {
+		icon: Hourglass,
+		className: 'bg-surface-2 text-text-3',
+	},
+};
 
 /**
  * Floating chat with the CEO, pinned bottom-right (on portrait mobile screens
@@ -1053,24 +1071,28 @@ function MessageBubble({
 	// thread: reading it off the conversation would make every system row in a
 	// converted thread render as the converted-task link.
 	//
-	// A warning carries a full sentence rather than a label, so unlike the
-	// converted marker it wraps instead of truncating — its whole point is naming
-	// the task and the teammate who was not notified, or the connector that
-	// refused the turn and what Hezo found when it re-checked.
-	if (
-		message.role === 'system' &&
-		message.system_kind &&
-		WARNING_SYSTEM_KINDS.has(message.system_kind)
-	) {
+	// A warning or notice carries a full sentence rather than a label, so unlike
+	// the converted marker it wraps instead of truncating — its whole point is
+	// naming the task and the teammate who was not notified, the connector that
+	// refused the turn and what Hezo found when it re-checked, or the run this
+	// turn is waiting on for its credential (linked, so the operator can go look).
+	const rowStyle =
+		message.role === 'system' && message.system_kind
+			? SYSTEM_ROW_STYLE[message.system_kind]
+			: undefined;
+	if (rowStyle) {
+		const Icon = rowStyle.icon;
 		return (
 			<div
-				className="flex items-start gap-2 rounded-md bg-warning-soft px-3 py-2 text-[11.5px] leading-relaxed text-warning-soft-fg"
+				className={`flex items-start gap-2 rounded-md px-3 py-2 text-[11.5px] leading-relaxed ${rowStyle.className}`}
 				data-testid="chat-message"
 				data-role="system"
 				data-system-kind={message.system_kind}
 			>
-				<TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-				<span className="min-w-0">{message.content}</span>
+				<Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+				<span className="min-w-0">
+					<RunLinkedText text={message.content} />
+				</span>
 			</div>
 		);
 	}
@@ -1125,7 +1147,11 @@ function MessageBubble({
 							{message.content}
 						</MarkdownProse>
 					) : failed ? (
-						<span className="text-[13px] leading-relaxed">Something went wrong.</span>
+						// The server's own reason where it recorded one - it names the run
+						// holding a busy credential, for instance - else the bare fact.
+						<span className="text-[13px] leading-relaxed" data-testid="chat-failure">
+							{message.error ? <RunLinkedText text={message.error} /> : 'Something went wrong.'}
+						</span>
 					) : null}
 					{interrupted && <div className="mt-1 text-[11px] italic text-text-3">(interrupted)</div>}
 				</div>

--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -21,6 +21,7 @@ import { reflowEnumerations } from '../lib/reflow-thinking-lists';
 import { type CommentRefTask, remarkCommentRefs } from '../lib/remark-comment-refs';
 import { CommentRefLink } from './comment-ref-link';
 import { MarkdownProse } from './markdown-prose';
+import { RunLinkedText } from './run-linked-text';
 import { Badge } from './ui/badge';
 
 interface FormattedLogViewProps {
@@ -113,11 +114,12 @@ function SystemView({ block }: { block: SystemBlock }) {
 /**
  * Runner lines, styled like the system ones they sit beside.
  *
- * One element per line rather than a single joined `<pre>`, because the line
- * naming the run's container carries a link: its id goes to that container's
- * page, which is where the disk, memory, error and container log all are. Shown
- * truncated the same way the Containers list shows it, while the link and the
- * raw log both carry the full engine id.
+ * One element per line rather than a single joined `<pre>`, because some lines
+ * carry links: the one naming the run's container goes to that container's
+ * page, which is where the disk, memory, error and container log all are (its
+ * id shown truncated the same way the Containers list shows it, while the link
+ * and the raw log both carry the full engine id), and a line naming another run
+ * - the one this run queued behind for a credential - goes to that run's page.
  */
 function RunnerView({ block }: { block: RunnerBlock }) {
 	const color = block.stream === 'stderr' ? 'text-danger-soft-fg' : 'text-text-3';
@@ -139,7 +141,9 @@ function RunnerView({ block }: { block: RunnerBlock }) {
 							{line.container.details && CONTAINER_META_LOG_SEPARATOR + line.container.details}
 						</>
 					) : (
-						line.text
+						// A line naming another run - the credential wait names the run it
+						// queues behind - links it; every other line is verbatim.
+						<RunLinkedText text={line.text} />
 					)}
 				</div>
 			))}

--- a/packages/web/src/components/run-linked-text.tsx
+++ b/packages/web/src/components/run-linked-text.tsx
@@ -1,0 +1,37 @@
+import { splitRunLinks } from '@hezo/shared';
+import { Link } from '@tanstack/react-router';
+
+/**
+ * Server-written text that may name another run - a `[runner]` log line, a
+ * chat notice - with each named run rendered as a link to its page and
+ * everything else verbatim. The text is split by the same helper that wrote
+ * the reference, so the two cannot drift.
+ */
+export function RunLinkedText({ text, className }: { text: string; className?: string }) {
+	const segments = splitRunLinks(text);
+	return (
+		<>
+			{segments.map((segment, i) =>
+				'link' in segment ? (
+					<Link
+						// biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and never reorder
+						key={i}
+						to="/projects/$projectId/agents/$agentId/executions/$runId"
+						params={{
+							projectId: segment.link.projectSlug,
+							agentId: segment.link.agentSlug,
+							runId: segment.link.runId,
+						}}
+						className={className ?? 'underline underline-offset-2 hover:text-text-1'}
+						data-testid="run-link"
+					>
+						{segment.label}
+					</Link>
+				) : (
+					// biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and never reorder
+					<span key={i}>{segment.text}</span>
+				),
+			)}
+		</>
+	);
+}

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -30,6 +30,8 @@ export interface ChatMessage {
 	attachments?: CommentAttachment[];
 	/** Set on a `system` row: which marker it is. Drives how the row renders. */
 	system_kind?: ChatSystemMessageKind | null;
+	/** Why a failed reply failed, in the server's words. */
+	error?: string | null;
 }
 
 interface ConversationData {
@@ -345,7 +347,7 @@ export function useChat(active: boolean, conversationId?: string) {
 			if (!forThisThread(m.conversationId)) return;
 			patch((messages) =>
 				messages.map((x) =>
-					x.id === m.messageId ? { ...x, content: m.content, status: m.status } : x,
+					x.id === m.messageId ? { ...x, content: m.content, status: m.status, error: m.error } : x,
 				),
 			);
 			setToolActivity((prev) => (prev?.messageId === m.messageId ? null : prev));

--- a/packages/web/test/chat.test.tsx
+++ b/packages/web/test/chat.test.tsx
@@ -754,3 +754,88 @@ test('a connector refusal renders as the same warning row, keyed by its own kind
 	expect(row?.getAttribute('data-role')).toBe('system');
 	expect(queryByTestId('chat-converted-task-link')).toBeNull();
 });
+
+test('a credential wait renders as a quiet notice with the holding run linked', async () => {
+	const { findByTestId, queryByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('chat-launcher')).click();
+	await findByTestId('chat-panel');
+
+	seedConversation([
+		{
+			id: 's1',
+			role: 'system',
+			channel: 'web',
+			status: 'complete',
+			content:
+				'Waiting for [growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336) to finish with this credential.',
+			created_at: now(),
+			system_kind: 'credential_wait',
+		},
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: '',
+			created_at: now(),
+		},
+	]);
+
+	const row = await vi.waitFor(() => {
+		const el = document.querySelector('[data-system-kind="credential_wait"]');
+		if (!el) throw new Error('no row yet');
+		return el;
+	});
+	expect(row.getAttribute('data-role')).toBe('system');
+	// The sentence reads as written, with the holder's name as the link.
+	expect(row.textContent).toBe('Waiting for growth-analyst/HM-336 to finish with this credential.');
+	const link = row.querySelector('[data-testid="run-link"]') as HTMLAnchorElement | null;
+	expect(link?.getAttribute('href')).toBe(
+		'/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336',
+	);
+	expect(link?.textContent).toBe('growth-analyst/HM-336');
+	// A notice, not a warning: no amber.
+	expect(row.className).not.toContain('bg-warning-soft');
+	expect(queryByTestId('chat-converted-task-link')).toBeNull();
+});
+
+test('a failed reply shows the reason the server recorded, not a generic message', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('chat-launcher')).click();
+	await findByTestId('chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'failed',
+			content: '',
+			created_at: now(),
+			error:
+				'[growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336) is still using this provider credential; this subscription runs one agent at a time.',
+		},
+		{
+			id: 'a2',
+			role: 'assistant',
+			channel: 'web',
+			status: 'failed',
+			content: '',
+			created_at: now(),
+		},
+	]);
+
+	const failures = await vi.waitFor(() => {
+		const els = document.querySelectorAll('[data-testid="chat-failure"]');
+		if (els.length !== 2) throw new Error('not rendered yet');
+		return els;
+	});
+	expect(failures[0].textContent).toBe(
+		'growth-analyst/HM-336 is still using this provider credential; this subscription runs one agent at a time.',
+	);
+	expect(failures[0].querySelector('[data-testid="run-link"]')?.getAttribute('href')).toBe(
+		'/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336',
+	);
+	// With no recorded reason the bare fact still shows.
+	expect(failures[1].textContent).toBe('Something went wrong.');
+});

--- a/packages/web/test/formatted-log-view-branches.test.tsx
+++ b/packages/web/test/formatted-log-view-branches.test.tsx
@@ -261,3 +261,35 @@ test('renders nothing meaningful for an empty line set (no blocks)', async () =>
 	expect(root).not.toBeNull();
 	expect(root?.children.length).toBe(0);
 });
+
+test('runner block: a line naming another run links it to that run in its own project', async () => {
+	const { container } = await renderLog({
+		lines: lines(
+			'[runner] Waiting for [growth-analyst/HM-336](/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336) to finish with this credential.',
+			'[runner] Credential free, starting the run.',
+		),
+	});
+	const block = container.querySelector('[data-testid="log-runner-block"]');
+	expect(block).not.toBeNull();
+	const link = block?.querySelector('[data-testid="run-link"]');
+	expect(link?.getAttribute('href')).toBe(
+		'/projects/hezo-marketing/agents/growth-analyst/executions/run-hm-336',
+	);
+	expect(link?.textContent).toBe('growth-analyst/HM-336');
+	// The sentence reads exactly as written around the link, and the plain line
+	// stays plain.
+	expect(block?.textContent).toContain(
+		'Waiting for growth-analyst/HM-336 to finish with this credential.',
+	);
+	expect(block?.textContent).toContain('Credential free, starting the run.');
+	expect(block?.querySelectorAll('[data-testid="run-link"]')).toHaveLength(1);
+});
+
+test('runner block: a markdown link to anything but a run stays verbatim text', async () => {
+	const { container } = await renderLog({
+		lines: lines('[runner] See [the docs](https://hezo.ai/docs) for details.'),
+	});
+	const block = container.querySelector('[data-testid="log-runner-block"]');
+	expect(block?.textContent).toBe('See [the docs](https://hezo.ai/docs) for details.');
+	expect(block?.querySelector('[data-testid="run-link"]')).toBeNull();
+});


### PR DESCRIPTION
On prod (Daytona backend, Codex subscription) an Equity Analyst run failed `container_stopped` after 0s with a single log line: `Waiting for growth-analyst/HM-336 to finish with this credential.` The journal at that moment reads `surplus idle — suspending container investments` then `stopped`. The run was parked on the rotating-credential lock and held no container - the ordering that exists precisely so a waiter "holds nothing" - yet the surplus-idle pass suspending the project's *spare* container killed it: on Daytona the stop takes ~2.5s, the 1 Hz status sync saw the engine say stopped while the row still said running, and the resulting transition reached `JobManager.cancelLiveRunsForContainer`, whose filter took `containerId === null` as "on the dead container". The same session showed the CEO chat, which takes the same lock, dying with a bare "Something went wrong." 60s later, and the holder named in the log as plain text.

## What changed

- **A run that has claimed no container is never failed by a container stopping.** `cancelLiveRunsForContainer` drops its null arm: such a run is parked (credential lock or capacity), holds nothing, and its row is still `queued`, which the DB half never touches - `running` rows always carry their container. The surplus-idle pass retiring an idle container underneath a waiter is the intended memory behaviour; the fix is that the waiter survives it.
- **The credential holder is a record, and waiters link to it.** `KeyedLockRegistry` becomes generic on its owner and gains a bounded priority lane; the credential family's owner is `CredentialLockHolder { label, link }`. `describeCredentialHolder` / `credentialWaitNotice` write the holder once for every surface as a markdown run link (`formatRunLink`, `@hezo/shared`, beside the container-meta line); `splitRunLinks` + the new `RunLinkedText` turn it into a `<Link>` in the log viewer and the chat widget. Raw log and DB rows read as-is.
- **The CEO chat waits honestly.** It posts a `credential_wait` system row naming the holder (linked) the moment it starts waiting, waits on the run's own 15-min cap **with priority** over runs merely parked on the lock (they hold nothing and re-queue on their own deadline; it never preempts the holder - and priority is what keeps the notice true for the whole wait), and records the holder-naming reason on the message if the wait runs out. `WsChatMessageComplete` now carries `error`, and the widget shows it instead of the hardcoded fallback. Titling and compaction log a busy credential as `warn`, since they retry from the next message. Migration 068 admits the new kind (067 had shipped in #1003 by the time this landed).
- **Waiters re-read the credential once they hold the lock.** Both a run and a chat exec snapshotted the value *before* waiting, and the holder they queue behind rotates the single-use token and stores the new one on its way out. The runner re-reads (`readAiProviderCredentialValue`) before it writes its mount; the chat rewrites its mounted `auth.json` from the store when the value moved (`refreshSubscriptionMount`, beside `buildSubscriptionMount`) and moves its snapshot along, so the read-back after the exec compares against what actually ran and the file is rewritten only when the value really changed.

Deliberate calls: the requeue *error text* on a cancelled run names the holder by label alone (it renders in a truncated one-line summary where a link has no home; the log line carries the link). Chat priority is FIFO's only exception and is documented as such in `keyed-lock.ts` and `.dev/architecture.md`.

## Testing

- `keyed-lock.test.ts`: priority waiters go ahead of earlier plain ones and behind earlier priority ones, never preempt the holder, leave the queue clean on giving up; structured owners round-trip and label the timeout.
- `agent-runner-credential-lock.test.ts`: the waiter's log carries the holder as `[label](/projects/…/executions/<id>)`, a chat holder by label alone; a run holds the lock under its own name + run for later waiters; a value rotated in the store while it waited is what the mount receives; the requeue reason names the holder.
- `job-manager-extended.test.ts` / `job-manager-recovery.test.ts`: the prod shape - a null-container live run in a project whose container stops (both the direct transition and the sync-tick path) stays live and `queued`; the pinned old behaviour test is inverted; the sibling-container test attaches its container explicitly.
- `chat-session.test.ts`: notice row posted with the linked holder before the exec and broadcast; the chat goes ahead of a parked run; timeout records the holder-naming error and the completion frame carries it; a value rotated between turns is what the next exec runs on, with nothing written back over it.
- `migrate-068-…test.ts`: data preservation + enum-wide drift guard (067's test now guards its own kinds).
- Web: `chat.test.tsx` (quiet notice row with the run link; failed reply shows the server's reason, or the bare fact when none), `formatted-log-view-branches.test.tsx` (runner line links the run; a non-run markdown link stays verbatim). Shared: `runPath`/`parseRunPath`/`formatRunLink`/`splitRunLinks` round trips.
- `bun run typecheck`, biome, and the touched server/web/shared suites all pass locally.

Docs: `.dev/architecture.md` (container-death invariant, holder record, re-read after lock, CEO chat wait), `docs/ai-models.md` Codex paragraph, AGENTS.md seam rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArKPFJbwBGvmJQKxhqv7NJ
