### PR TITLE
ci: bound package-install time so a stalled apt can't burn the job cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
@@ -27,6 +28,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
@@ -366,9 +368,19 @@ jobs:
         run: |
           sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null \
             | sudo xargs -0 -r rm -f || true
-      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+      # apt-get update inside both steps below has hung for the full job cap on
+      # three separate runs: the runner's azure mirror went Ign, apt failed over
+      # to archive.ubuntu.com, and that fetch then dangled with no output and no
+      # timeout of its own. A healthy install-deps takes ~70s, so bound each step
+      # far below the job cap - a stalled mirror should cost 5 minutes and a
+      # named step timeout, not 25 minutes and an opaque job cancellation.
+      - name: Install Playwright browsers and system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: bunx playwright install --with-deps chromium
-      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 5
         run: bunx playwright install-deps chromium
       - run: bun run test --browser --shard ${{ matrix.shard }}/3
       # Everything needed to diagnose a failure is in the artifact below, but
@@ -414,6 +426,7 @@ jobs:
     if: always()
     needs: test-backend
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: '[ "${{ needs.test-backend.result }}" = "success" ]'
 
@@ -421,6 +434,7 @@ jobs:
     if: always()
     needs: test-integration
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: '[ "${{ needs.test-integration.result }}" = "success" ]'
 
@@ -428,6 +442,7 @@ jobs:
     if: always()
     needs: test-shared
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: '[ "${{ needs.test-shared.result }}" = "success" ]'
 
@@ -435,6 +450,7 @@ jobs:
     if: always()
     needs: test-browser
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: '[ "${{ needs.test-browser.result }}" = "success" ]'
 
@@ -453,6 +469,7 @@ jobs:
     if: always()
     needs: [test-backend, test-integration, test-shared]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,15 +359,29 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
-      # Both Playwright install paths below run `apt-get update`, which fails
-      # hard (exit 100) if any pre-configured apt source 403s. The runner image
-      # ships Microsoft's azure-cli/prod repos, which Playwright doesn't need and
-      # which intermittently return 403 — taking the whole browser shard down.
-      # Drop those sources first so an unrelated repo outage can't fail the job.
-      - name: Remove unneeded Microsoft apt sources (avoid 403 flakes)
+      # Both Playwright install paths below run `apt-get update`, which has two
+      # distinct ways to take the whole browser shard down.
+      #
+      # It fails hard (exit 100) if any pre-configured apt source 403s. The
+      # runner image ships Microsoft's azure-cli/prod repos, which Playwright
+      # doesn't need and which intermittently return 403, so drop those sources.
+      #
+      # It also *hangs*. apt has no default fetch timeout, so when the runner's
+      # azure mirror goes Ign and apt falls back to archive.ubuntu.com, a
+      # fallback connection that stops sending simply dangles - observed at 24
+      # minutes on main, and again on the first run of the PR that added the
+      # step timeouts below. It is per-runner, not a global outage: sibling
+      # shards on the same commit installed fine. So bound the fetch, and apt
+      # abandons a dead mirror in 20s and moves to the next mirrorlist entry
+      # instead of burning the step's whole budget on one dangling socket.
+      - name: De-flake apt before Playwright installs deps
         run: |
           sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null \
             | sudo xargs -0 -r rm -f || true
+          sudo tee /etc/apt/apt.conf.d/99-hezo-ci-fetch-timeouts >/dev/null <<'APTCONF'
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          APTCONF
       # apt-get update inside both steps below has hung for the full job cap on
       # three separate runs: the runner's azure mirror went Ign, apt failed over
       # to archive.ubuntu.com, and that fetch then dangled with no output and no

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -89,6 +89,7 @@ jobs:
   # never point users at binaries whose provisioning pull would 404.
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: publish-agent-image
     if: >-
       github.event.pull_request.merged == true &&
@@ -145,6 +146,7 @@ jobs:
   # bucket.
   publish-cfn-template:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: publish
     if: >-
       github.event.pull_request.merged == true &&
@@ -187,6 +189,7 @@ jobs:
   # update-hezo-submodule.yml; this job only announces the tag.
   notify-website:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: publish
     if: >-
       github.event.pull_request.merged == true &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    # Must stay above the 3600s CI-wait deadline in "Verify CI passed for HEAD"
+    # below - that step deliberately blocks for up to an hour, so a tighter cap
+    # here would abort every release that waits on a normal CI run.
+    timeout-minutes: 75
     # Releases are only ever prepared from main.
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
## The problem

Recent CI runs sat for ~25 minutes and were killed by the job cap. They died on the **same step** — `bunx playwright install-deps chromium` in `test-browser`:

| Run | Job | Duration |
|---|---|---|
| [32218989910](https://github.com/hezo-ai/hezo/actions/runs/32218989910) | `test-browser (3)` | 24.9 min → cancelled |
| [32216643824](https://github.com/hezo-ai/hezo/actions/runs/32216643824) | `test-browser (1)`, `(2)`, `(3)` — all three | 24.8-24.9 min → cancelled |
| [32159840572](https://github.com/hezo-ai/hezo/actions/runs/32159840572) | `test-browser (1)` | 24.9 min → cancelled |

`playwright install-deps` shells out to `apt-get update`. The runner's `http://azure.archive.ubuntu.com/ubuntu` mirror returned `Ign:` on every source, apt failed over to `https://archive.ubuntu.com`, fetched `noble-security InRelease`, and then emitted **nothing for 24 minutes** until the job cap killed it.

Two things make this worse than it looks:

- The stall is on the **cache-hit** path. `install-deps` runs `apt-get update` on every run, even when the 253 MB Playwright browser cache hits — so it is not a cold-cache-only exposure.
- One outage took out all three shards at once, so `test-browser-complete` (a required check) went red having tested nothing, after burning 75 runner-minutes.

There were two independent causes of the *duration*. The workflows had **zero step-level `timeout-minutes`**, so a job cap was the only bound — and seven jobs had no cap either, inheriting GitHub's 360-minute default. And **apt ships no default fetch timeout**, so a mirror that stops sending mid-transfer simply dangles forever.

## The change

**1. Bound the two Playwright install steps** (`ci.yml`):

- `install-deps chromium` (cache hit) → **5 min**. A healthy run takes **68s**, so ~4.4x normal.
- `install --with-deps chromium` (cache miss) → **10 min**. Cold path also pulls ~250 MB of browser binaries.

Both steps are now `name:`d, so a timeout reads as the install in the checks UI rather than as an opaque job cancellation. `test-browser`'s existing `timeout-minutes: 25` stays as the backstop.

**2. Give apt a fetch timeout** — folded into the step that already existed to de-flake apt for these same two install paths, and renamed accordingly:

```
Acquire::http::Timeout "20";
Acquire::https::Timeout "20";
```

apt now abandons a dangling mirror after 20s and moves to the next mirrorlist entry, instead of consuming the step's whole budget on one dead socket. This is **not a retry** — it makes the fail-fast bound above fire fast, and with a real apt error rather than a bare step timeout.

**3. Fill in the seven missing job caps** (`ci.yml`): `lint` 10, `build` 15, the four `*-complete` rollups 5 each, `coverage-merge` 15.

**4. Cap the four uncapped release jobs:** `prepare` 75, `publish` 45, `publish-cfn-template` 10, `notify-website` 10.

⚠️ `prepare`'s 75 is load-bearing: its `Verify CI passed for HEAD` step polls on a `deadline=$(( $(date +%s) + 3600 ))`, so it blocks for up to an hour by design. A tighter cap would abort every release that waits on a normal CI run. There's a comment on the line saying so.

## This PR's first CI run validated the fix, then justified the second half of it

The first push carried only the step timeouts. The same apt stall hit `test-browser (2)` on that very run:

```
06:50:04  Ign:8..17  http://azure.archive.ubuntu.com/ubuntu ...
06:50:04  Get:5      https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
06:54:38  ##[error]The action 'Install Playwright system deps' has timed out after 5 minutes.
```

The bound worked — **5.2 min instead of 24.9**. But the shard was still red, and shards 1 and 3 installed deps fine *on the same commit*, which shows the bad mirror is a per-runner draw rather than a global outage: apt had healthy mirrorlist entries left and simply sat on a dangling socket. That is what the `Acquire::*::Timeout` commit addresses.

## Sizing

Every cap is sized off observed durations, with large headroom. From this PR's own run 32225027512 and release-publish 32119046459:

| Job | Cap | Observed |
|---|---|---|
| `lint` | 10 | 0.3 min |
| `build` | 15 | 0.5 min |
| `*-complete` (×4) | 5 | 0.1 min |
| `coverage-merge` | 15 | 0.5 min |
| `test-backend` (5 shards) | 30 | 5.2-8.0 min |
| `test-integration` (5 shards) | 20 | 4.5-6.7 min |
| `publish` | 45 | 1.0 min |
| `publish-cfn-template` / `notify-website` | 10 | 0.2 / 0.1 min |

The tightest ratio anywhere is `install-deps` at ~4.4x its normal 70 seconds. A job's timer starts when the job begins executing, not while it waits on `needs:`, so a 5-minute cap on a rollup that waits 20 minutes for its matrix is safe.

## Deliberately not included

- **Retry loops** around the install steps, and `Acquire::Retries`. A stall that outlives the 20s fetch timeout on every mirror still goes red and needs a re-run.
- **Step-level timeouts on `bun install` (9 sites), `docker pull`, `actions/cache` restores** — none has ever been observed to stall; all are now covered by a job cap at minimum.

## Verification

- All three workflows parse; every job in all three now has a cap, audited programmatically.
- The apt heredoc sits at the YAML block scalar's base indentation, so de-indentation leaves the `APTCONF` delimiter at column 0. The resolved script was extracted from the parsed YAML and **executed under `bash -e`** (exit 0, correct file contents), and the resulting config was validated with **apt's own parser** (`apt-config dump` reads back both directives as `"20"`).
- Commit hooks pass (biome, typecheck, `bun run build`, commitlint, all four ack hooks — `.github/` matches no bearing pattern, so no trailers are required).
- **Already proven in production:** the 5-minute bound fired correctly on a real mirror stall, in this PR's own first run.
- **What remains unproven:** that the 20s apt timeout converts that stall into a pass — it needs a run that draws a bad mirror to demonstrate. And the release workflows, which no PR run exercises; their caps are verified by inspection only, notably that `prepare`'s 75 exceeds its own 3600s poll deadline.