### PR TITLE
ci: run browser tests in Playwright's image instead of installing deps per run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   BUN_VERSION: "1.3.11"
-  PLAYWRIGHT_VERSION: "1.59.0"
 
 jobs:
   lint:
@@ -332,9 +331,56 @@ jobs:
       - name: Bun-native S3 client test
         run: cd packages/server && bun test ./test/bun/asset-s3-client.bun.test.ts
 
+  # test-browser runs inside Playwright's own container image, and that tag must
+  # match the Playwright the lockfile resolves to: browsers live in a
+  # per-revision directory, so a mismatched image means "Executable doesn't
+  # exist". `container.image` cannot read the `env` context - only github,
+  # needs, strategy, matrix, vars and inputs - so the tag can't come from an
+  # env var. Derive it from bun.lock, the actual source of truth, and hand it
+  # over via `needs`. That leaves nothing hand-synced: bumping Playwright in
+  # the lockfile moves the image with it, with no second place to remember.
+  playwright-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: resolve
+        run: |
+          version="$(grep -o '"@playwright/test@[0-9][^"]*"' bun.lock | head -1 | sed 's/.*@//; s/"$//')"
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::Could not read @playwright/test's version out of bun.lock (got '$version'). test-browser picks its container image from this."
+              exit 1
+              ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "bun.lock resolves @playwright/test to $version"
+
   test-browser:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Runs inside Playwright's own image, which ships the browsers AND their
+    # system libraries pre-installed. That is the whole point: the previous
+    # setup installed them per run with `playwright install-deps`, which shells
+    # out to `apt-get update`, and the runner's azure mirror routinely goes Ign
+    # and leaves the archive.ubuntu.com fallback dangling with no output. apt
+    # has no default fetch timeout, so that hung for the full job cap - four
+    # separate runs, sometimes all three shards at once. It is a known, still
+    # open runner-image bug (actions/runner-images#11347), so the fix is to
+    # take apt out of this job entirely rather than keep tuning it. Doing that
+    # also drops the browser download and its 253 MB cache: nothing here now
+    # touches apt, cdn.playwright.dev or the cache service.
+    #
+    # Running as root is fine - Playwright always passes --no-sandbox and
+    # --disable-dev-shm-usage. --ipc=host is its documented flag for stopping
+    # Chromium running out of memory in a container.
+    needs: playwright-version
+    container:
+      image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
+      options: --ipc=host
     # Sharded across runners the same way the vitest tiers are: Playwright splits
     # its suite into thirds (`--shard <i>/3`), so wall time drops to roughly a
     # third versus the single-runner run. fail-fast off so one shard failing
@@ -345,57 +391,20 @@ jobs:
         shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
+      # Not oven-sh/setup-bun: it unpacks a zip via `unzip`, which this image
+      # does not carry. npm is present (the image installs yarn with it), and
+      # `npm install -g bun` is already how docker/Dockerfile.agent-base gets
+      # bun, so this reuses a path the repo already relies on.
+      - name: Install bun
+        timeout-minutes: 5
+        run: npm install -g bun@${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
-      - uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
-      # Both Playwright install paths below run `apt-get update`, which has two
-      # distinct ways to take the whole browser shard down.
-      #
-      # It fails hard (exit 100) if any pre-configured apt source 403s. The
-      # runner image ships Microsoft's azure-cli/prod repos, which Playwright
-      # doesn't need and which intermittently return 403, so drop those sources.
-      #
-      # It also *hangs*. apt has no default fetch timeout, so when the runner's
-      # azure mirror goes Ign and apt falls back to archive.ubuntu.com, a
-      # fallback connection that stops sending simply dangles - observed at 24
-      # minutes on main, and again on the first run of the PR that added the
-      # step timeouts below. It is per-runner, not a global outage: sibling
-      # shards on the same commit installed fine. So bound the fetch, and apt
-      # abandons a dead mirror in 20s and moves to the next mirrorlist entry
-      # instead of burning the step's whole budget on one dangling socket.
-      - name: De-flake apt before Playwright installs deps
-        run: |
-          sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null \
-            | sudo xargs -0 -r rm -f || true
-          sudo tee /etc/apt/apt.conf.d/99-hezo-ci-fetch-timeouts >/dev/null <<'APTCONF'
-          Acquire::http::Timeout "20";
-          Acquire::https::Timeout "20";
-          APTCONF
-      # apt-get update inside both steps below has hung for the full job cap on
-      # three separate runs: the runner's azure mirror went Ign, apt failed over
-      # to archive.ubuntu.com, and that fetch then dangled with no output and no
-      # timeout of its own. A healthy install-deps takes ~70s, so bound each step
-      # far below the job cap - a stalled mirror should cost 5 minutes and a
-      # named step timeout, not 25 minutes and an opaque job cancellation.
-      - name: Install Playwright browsers and system deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 10
-        run: bunx playwright install --with-deps chromium
-      - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
         timeout-minutes: 5
-        run: bunx playwright install-deps chromium
       - run: bun run test --browser --shard ${{ matrix.shard }}/3
       # Everything needed to diagnose a failure is in the artifact below, but
       # reading it means downloading a zip — a slow loop for a browser failure


### PR DESCRIPTION
## Why

#1008 bounded `bunx playwright install-deps chromium` so a stall cost 5 minutes instead of 25. That worked, but it treated the symptom - the step still **fails**, and it has kept failing:

| Run | Result |
|---|---|
| [32226604416](https://github.com/hezo-ai/hezo/actions/runs/32226604416) (main) | red |
| [32232292833](https://github.com/hezo-ai/hezo/actions/runs/32232292833) (main) | all 3 shards, 313s each - the 5-min cap exactly |
| [32233640047](https://github.com/hezo-ai/hezo/actions/runs/32233640047) | red |
| [32234543188](https://github.com/hezo-ai/hezo/actions/runs/32234543188) | red |

**Tuning apt did not work.** #1008's second commit set `Acquire::http::Timeout` / `Acquire::https::Timeout` to 20s. The logs show it never fired - the hang lands immediately after the `Get:` lines with no timeout message and no retry:

```
Get:3 https://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 https://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Error: The action 'Install Playwright system deps' has timed out after 5 minutes.
```

apt's timeout is for an *idle* socket. This connection is not idle - it is alive and sending nothing, so the timeout has nothing to trip on.

The underlying fault is [actions/runner-images#11347](https://github.com/actions/runner-images/issues/11347): the runner's `azure.archive.ubuntu.com` mirror goes `Ign:` and the `archive.ubuntu.com` fallback dangles. Open since January 2025, no fix coming. Since we cannot make apt reliable, this stops trying and takes apt out of the job.

## What changed

`test-browser` now runs inside `mcr.microsoft.com/playwright:v<version>-noble`, which ships the browsers **and** their system libraries. That removes the whole class of failure and deletes four steps:

- the apt de-flake step (`sudo` source removal + `Acquire::*::Timeout`)
- `bunx playwright install --with-deps chromium`
- `bunx playwright install-deps chromium`
- the 253 MB `~/.cache/ms-playwright` cache step

Nothing in the job now touches apt, `cdn.playwright.dev`, or the cache service for browsers.

Two details worth review:

**bun no longer comes from `oven-sh/setup-bun`.** That action extracts a zip with `unzip`, which the image does not carry. It uses `npm install -g bun@$BUN_VERSION` instead - npm *is* present (the image installs yarn with it), and this is already how `docker/Dockerfile.agent-base:77` gets bun.

**The image tag is derived from `bun.lock`, not hand-written.** `container.image` cannot read the `env` context (only `github`, `needs`, `strategy`, `matrix`, `vars`, `inputs`), so a small `playwright-version` job reads the resolved `@playwright/test` out of the lockfile and passes it through `needs`. `PLAYWRIGHT_VERSION` is deleted: it was a hand-maintained mirror of the lockfile, and the cache key that was its only other consumer is gone. Bumping Playwright in the lockfile now moves the image on its own, with no second place to remember - which also closes the pre-existing silent-drift hazard, since `package.json` asks for `"^1"`.

## Verification

Checked before pushing, rather than assumed:

- `mcr.microsoft.com/playwright:v1.59.0-noble` exists (queried the MCR tag list).
- The image's Dockerfile confirms `git` and `npm` are present and `unzip` is **not**, that `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` is baked in, and that there is no `USER` directive.
- **No Docker daemon needed:** `playwright.config.ts:171` sets `HEZO_SKIP_DOCKER: '1'`, so the e2e server uses the in-process fake.
- **Root is safe:** `playwright-core` always passes `--no-sandbox` and `--disable-dev-shm-usage`, so no `--shm-size` tuning is needed. `--ipc=host` is set per Playwright's docs to stop Chromium OOMing.
- **The post-run `docker` cleanup in `scripts/test.ts:298` is a no-op without a docker binary** - I confirmed on the real Bun runtime that `Bun.spawn` on a missing binary throws `ENOENT` synchronously, inside the existing `try/catch`. This was the one thing that could have failed at the very end of an otherwise-green run.
- The version resolver and **its failure path** were both executed under `bash -e`: valid lockfile → `version=1.59.0` written to `$GITHUB_OUTPUT`, exit 0; empty lockfile → named `::error::` and exit 1.
- Workflow parses; every job in the file still has a `timeout-minutes`.

**What this PR's own CI proves:** the browser shards going green with **no apt output anywhere in the log** is the proof - there is no longer a mirror stall to reproduce, because apt is no longer in the path.

**What it does not prove:** the cost profile. An image pull replaces a cache restore plus ~60s of `install-deps`; I expect roughly time-neutral but will report the actual shard timings from this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018U7pzyKyE3evyPFMzRVGx9)_