### PR TITLE
ci: clean up two things #1012 left behind in test-browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,11 +398,14 @@ jobs:
       - name: Install bun
         timeout-minutes: 5
         run: npm install -g bun@${{ env.BUN_VERSION }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
+      # Deliberately no bun cache here, unlike every other job. This image has
+      # no zstd, and the compression method is part of the cache *version*
+      # hash, so a gzip-compressing container can never match the zstd entries
+      # the host jobs write - it just maintains a second 136 MB copy of the
+      # same content under the same key. It does not even pay for itself:
+      # measured on run 32239850690, the save cost 18-22s per shard while a
+      # cold `bun install` here takes 3-4s. Restore this step only alongside a
+      # measurement showing install got slow enough to be worth caching.
       - run: bun install --frozen-lockfile
         timeout-minutes: 5
       - run: bun run test --browser --shard ${{ matrix.shard }}/3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,14 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v${{ needs.playwright-version.outputs.version }}-noble
       options: --ipc=host
+    # A `run:` step defaults to bash on a runner but to `sh` in this container,
+    # which silently turned the failure-context step below into `sh -e` and made
+    # it die on `shopt: not found` - exit 127 on top of the browser failure it
+    # existed to explain. Pin the job back to the host default so every step
+    # here, present and future, gets the shell it was written against.
+    defaults:
+      run:
+        shell: bash
     # Sharded across runners the same way the vitest tiers are: Playwright splits
     # its suite into thirds (`--shard <i>/3`), so wall time drops to roughly a
     # third versus the single-runner run. fail-fast off so one shard failing


### PR DESCRIPTION
Follow-up to #1012. Two pieces of fallout from moving the browser shards into the Playwright image.

## 1. The bun cache stopped working and started costing time

The image has no `zstd`, and `actions/cache` folds the compression method into the cache **version** hash. So the container compresses with gzip and can never match the zstd entries the eight host-side jobs write under the same key. The evidence is in [run 32239850690](https://github.com/hezo-ai/hezo/actions/runs/32239850690) - same workflow, two compression methods:

```
container:  tar --posix -cf cache.tgz  ... -z
host:       tar -xf         cache.tzst ... --use-compress-program unzstd
```

Not a miss that self-heals on the next run - a permanent second copy, 136 MB of the same content, re-saved into every new branch scope.

**It also never paid for itself.** All three shards missed on that run, which makes their `bun install` timings the *uncached* cost:

| Shard | restore | `bun install` (uncached) | save |
|---|---|---|---|
| 1 | 0s (miss) | 4s | 18s |
| 2 | 0s (miss) | 3s | 19s |
| 3 | 0s (miss) | 4s | 22s |

Even a warm cache loses: the restore alone ran ~5s when this job was host-side, on top of the install. No configuration of this step beats not having it.

So it comes out, **only here**. The other eight jobs are untouched - still zstd, still sharing one entry.

## 2. Every step in the job had silently switched to `sh`

A `run:` step defaults to bash on a runner but to `sh` inside a container. Only one step cared, and only when it ran: "Print Playwright failure context" is `if: failure()`, so three green container runs never executed it. The first browser failure since the move hit it and it died on `shopt: not found`, exit 127 - **the step that exists to explain a browser failure instead added a second red step and printed nothing.**

Reproduced locally from the step's own script: `sh -e` reproduces CI's error exactly, `bash -e` prints the context and exits 0. Fixed job-wide via `defaults.run.shell` rather than on the one step, since the container changed the default for all of them and the next step added here would hit the same trap.

## Still open, and not fixed here

[Run 32242094099](https://github.com/hezo-ai/hezo/actions/runs/32242094099) failed on `test/browser/task-doc-preview-sticky.spec.ts:119` - "the preview panel still fits the scroller when the shell renders a banner". It is a geometry assertion with 1px and 2px tolerances:

```js
expect(pinned.y).toBeGreaterThanOrEqual(mainBox.y - 1);
expect(pinned.y + pinned.height).toBeLessThanOrEqual(mainBox.y + mainBox.height + 2);
```

It has now passed two container runs and failed one (all three retries), so it is marginal rather than systematically broken. Neither change in this PR can affect page layout, so this is not caused by the diff - but it may well be caused by #1012, so I am not writing it off. **I have deliberately not pushed a speculative fix for it**, because the mechanism that would tell me the actual pixel delta is the failure-context step fixed above. If it recurs on this PR's run, the log will now carry the numbers.

## Verification

- Numbers above are read from run 32239850690's step timings and its logs, not inferred.
- The `sh` vs `bash` behaviour was reproduced locally against the step's own extracted script.
- **This PR's own CI:** on the previous run, shards 1 and 3 passed at 3.0-3.1 min with `bun install` at 4-5s and no cache step present - which is the cache half's premise confirmed. I said I would report it plainly if install came back materially slower; it did not.