### PR TITLE
fix(web): cut the boot and restart screens back to a spinner and a status line

### DIFF
--- a/packages/web/src/components/starting-screen.tsx
+++ b/packages/web/src/components/starting-screen.tsx
@@ -96,8 +96,7 @@ export function StartingScreen({ phase, message, detail, lastFailure }: Starting
 						{detail && <p className="max-w-md break-words text-[13px] text-text-2">{detail}</p>}
 						{elapsed >= SLOW_PHASE_SECONDS && (
 							<p className="max-w-md text-[13px] text-text-2">
-								Still working ({formatElapsed(elapsed)}). A large database can take several minutes
-								to migrate - it is safe to leave this page open.
+								Still working ({formatElapsed(elapsed)})
 							</p>
 						)}
 					</div>

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -69,13 +69,7 @@ export function UpdateBanner() {
 	const errored = data?.state === UpdateState.Error;
 
 	if (applying) {
-		return (
-			<UpdateRestartOverlay
-				targetVersion={data?.targetVersion ?? data?.latest ?? null}
-				fromVersion={data?.current ?? null}
-				autoUnlock={data?.autoUnlock ?? false}
-			/>
-		);
+		return <UpdateRestartOverlay fromVersion={data?.current ?? null} />;
 	}
 
 	const isDismissed =

--- a/packages/web/src/components/update-restart-overlay.tsx
+++ b/packages/web/src/components/update-restart-overlay.tsx
@@ -38,20 +38,12 @@ export function evaluateRestartPoll(
 /**
  * Full-screen overlay shown while the server restarts onto a new binary. Polls
  * `/api/status` (the same public endpoint the app shell gates on) and reloads the
- * page once the relaunched worker is up. A supervised update restart comes back
- * already unlocked (the supervisor hands the in-memory unlock key to the new
- * worker), so the copy only warns about re-entering the master key when the
- * instance will actually come back locked (`autoUnlock` is false).
+ * page once the relaunched worker is up. The copy is deliberately a spinner and
+ * one word: the confirm dialog the user just accepted carries the version, the
+ * in-flight-run consequence and the master-key warning, and repeating them here
+ * only crowds a screen nobody can act on.
  */
-export function UpdateRestartOverlay({
-	targetVersion,
-	fromVersion,
-	autoUnlock,
-}: {
-	targetVersion: string | null;
-	fromVersion: string | null;
-	autoUnlock: boolean;
-}) {
+export function UpdateRestartOverlay({ fromVersion }: { fromVersion: string | null }) {
 	const [reloading, setReloading] = useState(false);
 	const wentDown = useRef(false);
 
@@ -116,15 +108,8 @@ export function UpdateRestartOverlay({
 			<div className="flex w-full max-w-sm flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6 text-center shadow-lg sm:p-8">
 				<Loader2 className="w-8 h-8 animate-spin text-text-1" />
 				<div className="text-base font-semibold text-text-1">
-					{reloading ? 'Reloading…' : 'Updating Hezo…'}
+					{reloading ? 'Reloading…' : 'Restarting…'}
 				</div>
-				<p className="text-[13px] text-text-2 leading-relaxed">
-					{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
-					In-flight agent runs are paused and resume automatically.{' '}
-					{autoUnlock
-						? 'Hezo will come back unlocked - no master key needed.'
-						: "When Hezo comes back you'll need your 12-word master key to unlock it again."}
-				</p>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/version-display.tsx
+++ b/packages/web/src/components/version-display.tsx
@@ -41,13 +41,7 @@ export function VersionDisplay() {
 	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	if (applying) {
-		return (
-			<UpdateRestartOverlay
-				targetVersion={update?.targetVersion ?? update?.latest ?? null}
-				fromVersion={update?.current ?? null}
-				autoUnlock={update?.autoUnlock ?? false}
-			/>
-		);
+		return <UpdateRestartOverlay fromVersion={update?.current ?? null} />;
 	}
 
 	if (!update?.current) return null;

--- a/packages/web/test/update-restart-overlay.test.tsx
+++ b/packages/web/test/update-restart-overlay.test.tsx
@@ -59,22 +59,23 @@ describe('UpdateRestartOverlay copy', () => {
 
 	// The immediate poll would hit `/api/status`; reject it so the overlay just
 	// renders (never reaches `window.location.reload`).
-	function renderOverlay(props: { autoUnlock: boolean }) {
+	function renderOverlay() {
 		vi.spyOn(global, 'fetch').mockRejectedValue(new Error('down'));
-		return render(<UpdateRestartOverlay targetVersion="0.2.0" fromVersion="0.1.0" {...props} />);
+		return render(<UpdateRestartOverlay fromVersion="0.1.0" />);
 	}
 
-	test('warns about the master key when the instance comes back locked', () => {
-		const { getByTestId } = renderOverlay({ autoUnlock: false });
-		const text = getByTestId('update-restart-overlay').textContent ?? '';
-		expect(text).toContain("you'll need your 12-word master key");
-		expect(text).not.toContain('no master key needed');
+	test('says only that the server is restarting', () => {
+		const { getByTestId } = renderOverlay();
+		expect(getByTestId('update-restart-overlay').textContent).toBe('Restarting…');
 	});
 
-	test('reassures instead of warning when the instance auto-unlocks', () => {
-		const { getByTestId } = renderOverlay({ autoUnlock: true });
+	// Nothing here is actionable while the server is down, and the confirm dialog
+	// already carried the version, the run consequence and the master-key warning.
+	test('repeats none of the confirm dialog', () => {
+		const { getByTestId } = renderOverlay();
 		const text = getByTestId('update-restart-overlay').textContent ?? '';
-		expect(text).toContain('no master key needed');
-		expect(text).not.toContain("you'll need your 12-word master key");
+		expect(text).not.toContain('master key');
+		expect(text).not.toContain('0.');
+		expect(text).not.toContain('agent runs');
 	});
 });


### PR DESCRIPTION
Two waiting screens were carrying prose nobody can act on while the server is busy.

## Boot screen (`starting-screen.tsx`)

The slow-phase line was `Still working (52s). A large database can take several minutes to migrate - it is safe to leave this page open.` - three wrapped lines on a phone, under a phase detail that already says the same thing ("Writing a pre-migration backup - this can take a few minutes on a large instance"). It is now just `Still working (52s)`.

## Update restart overlay (`update-restart-overlay.tsx`)

The overlay repeated the target version, the in-flight-run consequence and the master-key warning - all of which the confirm dialog showed a moment earlier, and none of which can be acted on while the server is down. It is now the spinner plus `Restarting…` (`Reloading…` once the new worker answers).

`targetVersion` and `autoUnlock` are dropped from the component's props and from both call sites (`update-banner.tsx`, `version-display.tsx`). The confirm dialogs in those two files are untouched and still carry the version, the run consequence and the master-key warning. Polling is unchanged: `fromVersion` still drives `evaluateRestartPoll`.

## Tests

`update-restart-overlay.test.tsx`'s two copy tests are replaced by one asserting the overlay's whole text is `Restarting…` and one asserting it repeats no part of the confirm dialog. `evaluateRestartPoll`'s five tests are unchanged.

`bunx vitest run test/{starting-screen,update-restart-overlay,update-banner,settings-version}.test.tsx` - 44 passed. `bun run typecheck` and `bunx biome check` clean.

Neither screen reads the i18n catalog (the boot screen renders before the app shell; the overlay uses plain literals), so no catalog key was added, changed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DsrCAEkxsPfagYeC4mtm3

---
_Generated by [Claude Code](https://claude.ai/code/session_014DsrCAEkxsPfagYeC4mtm3)_