### PR TITLE
fix(inbox): strip markdown from inbox and search preview text

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -5149,7 +5149,11 @@ is the single home for how each kind is labelled across the three surfaces that 
 them. Read state is per user (`read_at`), and acting on the request clears it for everyone -
 `fulfill-credential` and `resolve-asset-deletion` both mark the comment's rows read, the
 same way resolving an approval retires it. Migration `057` backfilled rows for the
-credential requests that predate the fan-out.
+credential requests that predate the fan-out. Each row's `snippet` is the comment body run
+through `markdownToPreviewText` (`@hezo/shared`) and truncated - a preview line renders as
+plain text on all three surfaces, so a stripped body is the only form that reads as prose
+rather than source. `buildHighlightedSnippet` (search results) normalises through the same
+function, so one strip serves every preview line in the product.
 
 **Task list ordering: two tiers, then the chosen sort.** `buildTaskListOrderBy`
 (`lib/task-sort.ts`) prefixes every sort mode of `GET /api/projects/:projectId/tasks` with

--- a/packages/server/src/lib/snippet.ts
+++ b/packages/server/src/lib/snippet.ts
@@ -1,4 +1,4 @@
-import { HIGHLIGHT_SENTINEL } from '@hezo/shared';
+import { HIGHLIGHT_SENTINEL, markdownToPreviewText } from '@hezo/shared';
 
 /**
  * Builds the gray preview line for a search result. Full-text search matches by
@@ -9,7 +9,8 @@ import { HIGHLIGHT_SENTINEL } from '@hezo/shared';
  * text with no markers.
  *
  * Pure (no DB) so it runs identically under Node (vitest) and Bun (prod), and is
- * unit-testable in isolation. Generalises `buildSnippet` in `routes/inbox.ts`.
+ * unit-testable in isolation. Generalises `buildSnippet` in `routes/inbox.ts`,
+ * which shares this module's markdown strip.
  */
 
 const SNIPPET_MAX_LEN = 200;
@@ -28,18 +29,15 @@ export interface HighlightedSnippet {
 
 /**
  * Collapse whitespace and strip the markdown syntax that would otherwise land
- * inside a highlight (`##`, list/quote markers, link/image wrappers, code
- * backticks). Conservative — keeps the visible text, only drops markup. Runs
- * before any windowing so offsets stay stable.
+ * inside a highlight (`##`, `**`, list/quote markers, link/image wrappers, code
+ * backticks). Runs before any windowing so offsets stay stable. Shares the strip
+ * with every other preview line via `markdownToPreviewText`, so a search result
+ * and an inbox row read the same body the same way.
  */
 function normalize(raw: string | null | undefined): string {
 	if (!raw) return '';
-	let text = raw.split(HIGHLIGHT_SENTINEL).join(''); // defensive; NUL can't occur in corpus
-	text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1'); // image → alt
-	text = text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1'); // link → text
-	text = text.replace(/`+/g, ''); // code fences/backticks → inner text
-	text = text.replace(/^[ \t]*(?:#{1,6}|[-*+>]|\d+\.)\s+/gm, ''); // leading block markers
-	return text.replace(/\s+/g, ' ').trim();
+	// Defensive; NUL can't occur in the corpus.
+	return markdownToPreviewText(raw.split(HIGHLIGHT_SENTINEL).join(''));
 }
 
 /** Lowercased query tokens; drop sub-2-char tokens unless that empties the set. */

--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -1,4 +1,11 @@
-import { ApprovalStatus, ApprovalType, AuthType, CommentContentType, wsRoom } from '@hezo/shared';
+import {
+	ApprovalStatus,
+	ApprovalType,
+	AuthType,
+	CommentContentType,
+	markdownToPreviewText,
+	wsRoom,
+} from '@hezo/shared';
 import { Hono } from 'hono';
 import { agentDisplayNameSql } from '../lib/agent-identity';
 import { broadcastChange } from '../lib/broadcast';
@@ -9,10 +16,18 @@ import type { Env } from '../lib/types';
 export const inboxRoutes = new Hono<Env>();
 
 const SNIPPET_MAX_LEN = 180;
+/**
+ * Chars of the body the Markdown strip runs over. A listing renders up to 200
+ * rows and a comment body has no ceiling, so the scan is bounded - far above
+ * `SNIPPET_MAX_LEN`, so a cut can never strand syntax inside the kept window.
+ */
+const SNIPPET_SCAN_LIMIT = 4000;
 
 /**
- * The one line of prose an inbox row shows. A comment kind that carries no
- * `text` still has to read as something: a credential request's human-facing
+ * The one line of prose an inbox row shows. Comment bodies are Markdown, so the
+ * syntax is stripped: a row is a preview, not a source view, and `**bold**` read
+ * literally is what the reader would otherwise see. A comment kind that carries
+ * no `text` still has to read as something: a credential request's human-facing
  * `instructions` is that comment's whole point, so it stands in.
  */
 function buildSnippet(content: unknown): string {
@@ -20,7 +35,7 @@ function buildSnippet(content: unknown): string {
 	const fields = content as Record<string, unknown>;
 	const body = typeof fields.text === 'string' ? fields.text : fields.instructions;
 	if (typeof body !== 'string') return '';
-	const stripped = body.replace(/\s+/g, ' ').trim();
+	const stripped = markdownToPreviewText(body.slice(0, SNIPPET_SCAN_LIMIT));
 	if (stripped.length <= SNIPPET_MAX_LEN) return stripped;
 	return `${stripped.slice(0, SNIPPET_MAX_LEN - 1).trimEnd()}…`;
 }

--- a/packages/server/test/inbox-routes-coverage.test.ts
+++ b/packages/server/test/inbox-routes-coverage.test.ts
@@ -147,6 +147,22 @@ describe('GET /inbox/mentions', () => {
 		expect(empty).toBeDefined();
 	});
 
+	it('strips markdown so the snippet reads as prose, not source', async () => {
+		const markdownComment = await insertComment(
+			'**Captain review: PASS.**\n\nThe submission satisfies:\n\n- ZNTL uses the [Aug 17 offering](/x)\n- `verify_totals` passes',
+		);
+		await insertMention(markdownComment);
+
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/inbox/mentions`, {
+			headers: authHeader(ctx.token),
+		});
+		const mentions = (await res.json()).data as Array<Record<string, unknown>>;
+		const row = mentions.find((m) => (m.snippet as string).startsWith('Captain review'));
+		expect(row?.snippet).toBe(
+			'Captain review: PASS. The submission satisfies: • ZNTL uses the Aug 17 offering • verify_totals passes',
+		);
+	});
+
 	it('archived=true returns only archived mentions', async () => {
 		const archivedComment = await insertComment('archived mention');
 		await insertMention(archivedComment, { archived: true });

--- a/packages/shared/src/documents/text.ts
+++ b/packages/shared/src/documents/text.ts
@@ -1,9 +1,11 @@
 /**
- * Document download helpers. Project documents are stored as Markdown text, so
- * the two download formats are the Markdown source itself and a plain-text
- * rendering with the Markdown syntax stripped. These are pure functions (no DOM,
- * no browser APIs) so they live in the shared package and are unit-tested there;
- * the browser-side blob/anchor plumbing lives in the web package.
+ * Markdown-to-text helpers, and the document download shapes built on them.
+ * Project documents are stored as Markdown, so the two download formats are the
+ * Markdown source itself and a plain-text rendering with the syntax stripped;
+ * that same strip is what every preview line renders, so no surface shows a
+ * reader raw `**` or `##`. These are pure functions (no DOM, no browser APIs) so
+ * they live in the shared package and are unit-tested there; the browser-side
+ * blob/anchor plumbing lives in the web package.
  */
 
 export type DocDownloadFormat = 'markdown' | 'text';
@@ -41,9 +43,13 @@ function stripInlineMarkdown(line: string): string {
 	// `!` doesn't strand once the brackets are gone).
 	s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
 	s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
-	// Emphasis: bold/italic (** __ * _) and strikethrough (~~).
-	s = s.replace(/(\*\*|__)(.+?)\1/g, '$2');
-	s = s.replace(/(\*|_)(.+?)\1/g, '$2');
+	// Emphasis: bold/italic (** __ * _) and strikethrough (~~). A delimiter must
+	// hug its content, and an underscore one must not sit inside a word, so
+	// `snake_case_name` and `2 * 3 * 4` survive as written.
+	s = s.replace(/\*\*(\S(?:.*?\S)?)\*\*/g, '$1');
+	s = s.replace(/(?<!\w)__(\S(?:.*?\S)?)__(?!\w)/g, '$1');
+	s = s.replace(/\*([^*\s](?:[^*]*[^*\s])?)\*/g, '$1');
+	s = s.replace(/(?<!\w)_([^_\s](?:[^_]*[^_\s])?)_(?!\w)/g, '$1');
 	s = s.replace(/~~(.+?)~~/g, '$1');
 	// Inline code.
 	s = s.replace(/`([^`]+)`/g, '$1');
@@ -76,4 +82,14 @@ export function markdownToPlainText(markdown: string): string {
 		.join('\n')
 		.replace(/\n{3,}/g, '\n\n')
 		.trim();
+}
+
+/**
+ * Collapse a Markdown body to the one line of prose a preview row shows - an
+ * inbox snippet, a search result's lead. Strips the syntax, then folds every run
+ * of whitespace so a multi-line source reads as a single line. Truncation is the
+ * caller's, since each surface carries its own budget.
+ */
+export function markdownToPreviewText(markdown: string): string {
+	return markdownToPlainText(markdown).replace(/\s+/g, ' ').trim();
 }

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -804,6 +804,7 @@ export interface AdminMentionItem {
 	content_type: CommentContentType;
 	/** Secret name on a `credential_request` row, null on every other kind. */
 	credential_name: string | null;
+	/** One line of the comment body, Markdown stripped - render it as plain text. */
 	snippet: string;
 	author_member_id: string | null;
 	author_display_name: string;

--- a/packages/shared/src/types/project-dashboard.ts
+++ b/packages/shared/src/types/project-dashboard.ts
@@ -75,6 +75,7 @@ export interface ProjectDashboardMention {
 	comment_public_id: string;
 	content_type: CommentContentType;
 	credential_name: string | null;
+	/** One line of the comment body, Markdown stripped - render it as plain text. */
 	snippet: string;
 	author_display_name: string;
 	created_at: string;

--- a/packages/shared/test/documents-text.test.ts
+++ b/packages/shared/test/documents-text.test.ts
@@ -3,6 +3,7 @@ import {
 	DOC_DOWNLOAD_MIME,
 	docDownloadFilename,
 	markdownToPlainText,
+	markdownToPreviewText,
 } from '../src/documents/text.js';
 
 describe('docDownloadFilename', () => {
@@ -73,5 +74,37 @@ describe('markdownToPlainText', () => {
 
 	it('drops horizontal rules', () => {
 		expect(markdownToPlainText('above\n\n---\n\nbelow')).toBe('above\n\nbelow');
+	});
+
+	it('leaves intraword underscores alone so identifiers survive', () => {
+		expect(markdownToPlainText('call create_comment then update_comment')).toBe(
+			'call create_comment then update_comment',
+		);
+		expect(markdownToPlainText('the column is agent__run__id')).toBe(
+			'the column is agent__run__id',
+		);
+	});
+
+	it('leaves an asterisk that hugs no content alone', () => {
+		expect(markdownToPlainText('2 * 3 * 4 = 24')).toBe('2 * 3 * 4 = 24');
+	});
+});
+
+describe('markdownToPreviewText', () => {
+	it('folds a multi-line body into one stripped line', () => {
+		const md = '**Captain review: PASS.**\n\nThe submission satisfies:\n\n- ZNTL uses the offering';
+		expect(markdownToPreviewText(md)).toBe(
+			'Captain review: PASS. The submission satisfies: • ZNTL uses the offering',
+		);
+	});
+
+	it('strips headings, links and inline code', () => {
+		expect(markdownToPreviewText('## Deploy\n\nSee [the doc](/x) and run `deploy`')).toBe(
+			'Deploy See the doc and run deploy',
+		);
+	});
+
+	it('returns an empty string for a body that is only markup', () => {
+		expect(markdownToPreviewText('\n\n---\n\n')).toBe('');
 	});
 });


### PR DESCRIPTION
## The bug

An inbox row rendered the comment body verbatim, so an agent's `**bold**` lead and `- ` list markers showed as source rather than prose:

> `**Captain review: PASS. INV-139 clears the triage gate.**` The corrected submission satisfies every revision requirement: `- ` ZNTL now uses the completed August 17 offering…

A row is a preview, not a source view, so `buildSnippet` (`routes/inbox.ts`) now strips the Markdown before collapsing and truncating.

## What changed

- **`markdownToPreviewText` in `@hezo/shared`** (`documents/text.ts`) - the existing `markdownToPlainText` strip plus a whitespace fold, so a multi-line body reads as one line. Truncation stays with the caller, since each surface has its own budget.
- **`buildSnippet`** routes through it. That one snippet feeds all three surfaces the inbox row renders on: the inbox cards, the project dashboard's action items, and the home "Needs you" list. It also feeds the client-side inbox search string, so searching now matches what is displayed.
- **`buildHighlightedSnippet`** (`lib/snippet.ts`, search results) routes through it too, replacing a hand-rolled partial strip that handled `##`, links and backticks but left `**` and `_` behind. One strip now serves every preview line in the product.
- **Emphasis regexes hardened** while they gain these callers: a delimiter must hug its content, and an underscore one must not sit inside a word. `create_comment`, `agent__run__id` and `2 * 3 * 4` now survive as written - matching how CommonMark renders them in the comment view, which the previous `(\*|_)(.+?)\1` did not. This also improves the plain-text document download that already used the helper.
- **Bounded scan**: the strip runs over at most 4000 chars of a body, far above the 180-char snippet, so a 200-row listing cannot be made expensive by one long comment.

## Testing

- `packages/shared/test/documents-text.test.ts` - new `markdownToPreviewText` block (multi-line fold, headings/links/inline code, markup-only body) plus intraword-underscore and bare-asterisk cases on `markdownToPlainText`.
- `packages/server/test/inbox-routes-coverage.test.ts` - a mention whose body carries bold, a list, a link and inline code asserts the exact prose snippet the route returns.
- Green locally: `documents-text`, `snippet`, `inbox-routes-coverage`, `inbox-parity`, `admin-mentions`, `credential-requests`, `approvals*`, `search-*`, `global-search`, `inbox-mentions`, `inbox-approvals`, `dashboard-inbox-parity`, `home-needs-you`, `document-download`; plus `bun run typecheck`, `biome check` and `bun run build`.

## Docs

`.dev/architecture.md` (dashboard/inbox section) records that the snippet is the body run through `markdownToPreviewText`, and that search normalises through the same function. No `docs/` page describes the preview line, and no user-facing strings changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtRXVTAeqRkQ3cm7Zd2wmU)_