### PR TITLE
fix(web): pin blocked tasks to the In progress section

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -135,6 +135,19 @@ If a run is stranded (its process vanished, or it never managed to start), Hezo 
 within a couple of minutes and marks it failed, which releases the task and returns the
 assignee to **Idle**. You do not need to restart Hezo to clear a stuck task.
 
+## How the task list is grouped
+
+A project's task list is split into three sections:
+
+- **In progress** - the work in flight: everything in progress, in review, or blocked. A
+  blocked task sits here rather than in the backlog, because it is work already started
+  that has hit something and needs the same visibility as the rest of the active work.
+- **Backlog** - the open work nobody has picked up yet, paged as you scroll.
+- **Done** - finished tasks, at the bottom.
+
+The status filter narrows the Backlog and Done sections. In progress is pinned above them
+and stays put whichever statuses you filter for, so the work in flight is always in view.
+
 ## How the task list is ordered
 
 Every task list puts the tasks you are most likely to care about first, in three bands,

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -40,11 +40,20 @@ import { Tooltip } from './ui/tooltip';
 const ALL_STATUSES = Object.values(TaskStatus) as string[];
 const TERMINAL_STATUS_SET = new Set<string>(TERMINAL_TASK_STATUSES);
 const DEFAULT_OPEN_STATUSES: string[] = ALL_STATUSES.filter((s) => !TERMINAL_STATUS_SET.has(s));
-/** Task statuses pinned in the top "In progress" section (also excluded from the main list). */
-const PINNED_TASK_STATUSES = [TaskStatus.InProgress, TaskStatus.Review] as const;
+/**
+ * Task statuses pinned in the top "In progress" section (also excluded from the
+ * main list). `blocked` belongs here rather than in the backlog: it is work
+ * already started that has hit something, so it needs the same visibility as the
+ * rest of the work in flight.
+ */
+const PINNED_TASK_STATUSES = [
+	TaskStatus.InProgress,
+	TaskStatus.Review,
+	TaskStatus.Blocked,
+] as const;
 const PINNED_STATUS_SET = new Set<string>(PINNED_TASK_STATUSES);
 const PINNED_STATUS_PARAM = PINNED_TASK_STATUSES.join(',');
-// The default selection shows open work (backlog/blocked; in_progress/review are
+// The default selection shows open work (backlog; in_progress/review/blocked are
 // pinned in their own section) plus completed (`done`) tasks, which land in the
 // bottom "Done" section. `cancelled` stays hidden unless explicitly filtered in.
 const DEFAULT_TODO_STATUSES: string[] = [
@@ -67,6 +76,20 @@ const sortLabels: Record<`${SortField}:${SortDir}`, string> = {
 	'updated_at:desc': 'Recently updated',
 	'updated_at:asc': 'Oldest updates',
 };
+
+/**
+ * Drop now-pinned statuses from a persisted selection - the main-list query must
+ * not fetch rows the pinned section renders, and the filter dropdown no longer
+ * offers them. A selection emptied by that filtering falls back to the defaults
+ * rather than reading as a deliberate "no statuses" choice; an already-empty one
+ * is that deliberate choice and is kept.
+ */
+function sanitizeTodoStatuses(values: string[] | undefined): string[] {
+	if (!values) return [...DEFAULT_TODO_STATUSES];
+	const kept = values.filter((s) => !PINNED_STATUS_SET.has(s));
+	if (kept.length === 0 && values.length > 0) return [...DEFAULT_TODO_STATUSES];
+	return kept;
+}
 
 function isDefaultTodoSelection(values: string[]): boolean {
 	if (values.length !== DEFAULT_TODO_STATUSES.length) return false;
@@ -192,8 +215,8 @@ export function TaskList({ projectId }: TaskListProps) {
 	const [stored] = useState(() => readStoredTaskFilters(projectId));
 	const [search, setSearch] = useState(stored?.search ?? '');
 	const [debouncedSearch, setDebouncedSearch] = useState((stored?.search ?? '').trim());
-	const [statusValues, setStatusValues] = useState<string[]>(
-		stored?.statusValues ?? [...DEFAULT_TODO_STATUSES],
+	const [statusValues, setStatusValues] = useState<string[]>(() =>
+		sanitizeTodoStatuses(stored?.statusValues),
 	);
 	const [ownerValues, setOwnerValues] = useState<string[]>(stored?.ownerValues ?? []);
 	const [sortField, setSortField] = useState<SortField>(stored?.sortField ?? 'work_order');
@@ -227,7 +250,7 @@ export function TaskList({ projectId }: TaskListProps) {
 		const next = readStoredTaskFilters(projectId);
 		setSearch(next?.search ?? '');
 		setDebouncedSearch((next?.search ?? '').trim());
-		setStatusValues(next?.statusValues ?? [...DEFAULT_TODO_STATUSES]);
+		setStatusValues(sanitizeTodoStatuses(next?.statusValues));
 		setOwnerValues(next?.ownerValues ?? []);
 		setSortField(next?.sortField ?? 'work_order');
 		setSortDir(next?.sortDir ?? 'asc');

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -13,6 +13,26 @@ async function patchStatus(ws: SeededWorkspace, taskId: string, status: string) 
 	if (!res.ok) throw new Error(`patchStatus failed: ${res.status} ${await res.text()}`);
 }
 
+/**
+ * Block a task the only way the server allows: `blocked` is derived from open
+ * blockers (`coerceTargetStatusForBlockers`), so a direct status PATCH to
+ * `blocked` collapses straight back to `backlog`.
+ */
+async function addDependency(
+	ws: SeededWorkspace,
+	project: { slug: string },
+	taskId: string,
+	blockedByTaskId: string,
+) {
+	const { apiBase } = getTestContext();
+	const res = await apiBase(`/api/projects/${project.slug}/tasks/${taskId}/dependencies`, {
+		method: 'POST',
+		headers: ws.headers,
+		body: JSON.stringify({ blocked_by_task_id: blockedByTaskId }),
+	});
+	if (!res.ok) throw new Error(`addDependency failed: ${res.status} ${await res.text()}`);
+}
+
 async function insertActiveRun(memberId: string, teamId: string, taskId: string) {
 	const { db } = getTestContext();
 	await db.query(
@@ -589,6 +609,71 @@ test('in progress tasks render in a pinned section without duplicating in the ma
 	expect(mainSection.textContent).toContain('Backlog Task');
 	expect(mainSection.textContent).not.toContain('Active Task');
 	expect(mainSection.textContent).not.toContain('Review Task');
+});
+
+test('blocked tasks pin to the in progress section, not the backlog', async () => {
+	let projectSlug = '';
+
+	const { findByTestId, findByText, findByRole, queryAllByRole, queryByText, router, user } =
+		await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Blocked Split Project' });
+				projectSlug = project.slug;
+				const agentId = ws.agents[0].id;
+				const blocked = await seedTask(ws, project, {
+					title: 'Blocked Task',
+					assignee_id: agentId,
+				});
+				const blocker = await seedTask(ws, project, {
+					title: 'Blocker Task',
+					assignee_id: agentId,
+				});
+				// `blocked` is derived from open blockers, never set directly.
+				await addDependency(ws, project, blocked.id, blocker.id);
+				await seedTask(ws, project, { title: 'Backlog Task', assignee_id: agentId });
+			},
+		});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	await findByText('Blocked Task', undefined, { timeout: 10_000 });
+	await findByText('Backlog Task');
+
+	const inProgressSection = await findByTestId('task-list-in-progress');
+	const mainSection = await findByTestId('task-list-main');
+	expect(inProgressSection.textContent).toContain('Blocked Task');
+	expect(inProgressSection.textContent).not.toContain('Backlog Task');
+	expect(mainSection.textContent).toContain('Backlog Task');
+	expect(mainSection.textContent).not.toContain('Blocked Task');
+
+	// Pinned statuses are dropped from the to-do filter, and narrowing the to-do
+	// list to Backlog leaves the pinned blocked task in place.
+	const toggle = await findByTestId('task-filter-toggle');
+	await user.click(toggle);
+	const statusBtn = await findByTestId('task-filter-status');
+	await user.click(statusBtn);
+	// The pinned statuses are not offered as to-do filters (the row's own status
+	// badge still reads "Blocked", so match the option button, not any text).
+	expect(queryAllByRole('button', { name: 'Blocked' })).toHaveLength(0);
+	const clear = await findByRole('button', { name: 'Clear selection' });
+	await user.click(clear);
+	const backlogOption = await findByRole('button', { name: 'Backlog' });
+	await user.click(backlogOption);
+	await user.click(statusBtn);
+
+	await waitFor(
+		() => {
+			expect(queryByText('Backlog Task')).not.toBeNull();
+			expect(queryByText('Blocked Task')).not.toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+	expect((await findByTestId('task-list-main')).textContent).not.toContain('Blocked Task');
 });
 
 test('to-do search does not filter the in progress section', async () => {


### PR DESCRIPTION
A blocked task was rendering in the **Backlog** section, below the pinned **In progress** section. Blocked is work already started that has hit something, so it belongs beside the rest of the work in flight, not with work nobody has picked up.

## What changed

- `PINNED_TASK_STATUSES` (`packages/web/src/components/task-list.tsx`) gains `TaskStatus.Blocked`. That one constant drives all four consumers at once: the pinned section's query (`status=in_progress,review,blocked`), the exclusion of pinned rows from the main list, the default to-do status selection, and the status filter's option list — so `blocked` moves up, leaves the filter dropdown, and stops being fetched into a list that no longer renders it.
- `sanitizeTodoStatuses` strips now-pinned statuses from a **persisted** filter selection on both hydration paths (initial mount and project switch). Without it, a `blocked` left in `localStorage` from before this change would keep asking the main-list query for rows the component then drops, skewing the "Showing X of Y" count. A selection emptied by that filtering falls back to the defaults; an already-empty one is a deliberate "no statuses" choice and is kept.
- `docs/concepts/tasks.md` gains a short "How the task list is grouped" section naming the three sections and where a blocked task lands.

## Testing

- New component test `blocked tasks pin to the in progress section, not the backlog`: asserts the blocked task renders in `task-list-in-progress` and not in `task-list-main`, that `Blocked` is no longer offered as a to-do filter option, and that narrowing the to-do list to Backlog leaves the pinned blocked task in place. It seeds the blocked state through `POST .../dependencies` rather than a status PATCH, because `blocked` is derived from open blockers (`coerceTargetStatusForBlockers` collapses a direct PATCH straight back to `backlog`).
- `bunx vitest run test/task-list.test.tsx` — 15 passed.
- Related task-page specs green: `task-crud`, `task-create`, `task-list-failed-warning`, `task-list-filter-persistence`, `task-blocked-by`, `header-new-task`, `overlay-close-on-navigate`, `admin-approvals-banner`, `internal-project`, `project-sidebar` (54 passed).
- `docs-terminology`, `docs-bundle`, `docs-links` green; `bun run typecheck`, `bun run build` and `biome check` clean.

## Not changed

The dashboard's "In progress" widget (`components/dashboard/in-progress-tasks.tsx`, and the matching `dashboard-metrics` query) still covers in-progress + review only. It is a separate capped "work in flight" card whose slot count is balanced against the goals card, and `docs/concepts/projects-and-teams.md` describes it as such — worth a follow-up decision, but outside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBTF171Mto2YahAt9D6qaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBTF171Mto2YahAt9D6qaG)_