### PR TITLE
feat(web): autolink URLs in CSV cells and plain-text assets

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -635,7 +635,14 @@ the asset viewer reuses for text assets (markdown through the same rehype plugin
 text through `PlainTextWithHighlights`, a CSV through `CsvTable`). The three highlight
 painters share one resolver, `claimQuoteRanges`, and the two non-markdown ones share
 `ReviewTextSegments`; a CSV's stream is its cells concatenated in document order, which the
-table keeps byte-identical to the DOM by emitting no text of its own. Those same three surfaces each carry
+table keeps byte-identical to the DOM by emitting no text of its own. Those two surfaces also
+**autolink**: `findLinkRanges` (`packages/web/src/lib/autolink.ts`) finds `http(s)://`, `www.`,
+`mailto:` and bare-email runs - and only those four, so no other scheme can be emitted from
+file content - and `segmentsForSlice` splits the stream on link and review boundaries together,
+so a quote overlapping a URL still resolves. Links are found **per CSV cell** and shifted into
+the stream afterwards, because the stream concatenates cells with no separator; the anchors
+carry only the segment's own text, so the DOM stream is unchanged and anchoring is unaffected.
+Markdown reaches the same reading through remark-gfm's autolink literals. Those same three surfaces each carry
 `DocumentDownloadMenu` (`packages/web/src/components/document-download-menu.tsx`) — a
 client-side save of the already-loaded content as Markdown (verbatim) or plain text
 (`markdownToPlainText`), no server round-trip; the two preview surfaces render it in the

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -142,7 +142,9 @@ agent's **HTML** deliverable (a mockup, a dashboard, a report) renders live and 
 in a **sandbox**, isolated from your instance and your data, so viewing an agent's output is
 safe by default; **markdown** renders as formatted prose with a **view-source** toggle; a
 **CSV** renders as a table, quoted cells resolved, with the raw file behind the same toggle;
-images and SVGs display scaled to fit; other types show a summary card. **Open raw** in the
+images and SVGs display scaled to fit; other types show a summary card. In a **CSV** cell or a
+**plain-text** file, any web address, `www.` host or email address you can read is a link you
+can click - it opens in a new tab, so a column of URLs needs no copy-and-paste. **Open raw** in the
 viewer's toolbar still opens the underlying file in its own tab whenever you want the
 unwrapped thing. A **dropdown** next to the breadcrumb opens a name search for jumping
 straight to another asset without returning to the library.

--- a/packages/web/src/components/asset-review/csv-table.tsx
+++ b/packages/web/src/components/asset-review/csv-table.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { findLinkRanges, type LinkRange, shiftLinkRanges } from '../../lib/autolink';
 import { csvColumnCount } from '../../lib/csv';
 import { claimQuoteRanges, type ReviewAnnotation } from '../../lib/rehype-review-highlights';
 import { ReviewTextSegments, segmentsForSlice } from './review-text-segments';
@@ -8,6 +9,8 @@ interface CellSlice {
 	/** Offset of this cell's text in the table's flat text stream. */
 	start: number;
 	end: number;
+	/** Links found in this cell, in the flat stream's coordinates. */
+	links: LinkRange[];
 }
 
 interface CsvTableProps {
@@ -44,8 +47,12 @@ export function CsvTable({ rows, annotations, activeId, onHighlightClick }: CsvT
 		const cells: CellSlice[][] = rows.map((row) =>
 			row.map((text) => {
 				const start = stream.length;
+				// Links are found per cell and only then shifted into the stream: the
+				// stream concatenates cells with no separator, so a URL ending one cell
+				// would otherwise swallow the start of the next.
+				const links = shiftLinkRanges(findLinkRanges(text), start);
 				stream += text;
-				return { text, start, end: stream.length };
+				return { text, start, end: stream.length, links };
 			}),
 		);
 		return { stream, cells };
@@ -63,7 +70,7 @@ export function CsvTable({ rows, annotations, activeId, onHighlightClick }: CsvT
 	const renderCell = (cell: CellSlice | undefined) =>
 		cell ? (
 			<ReviewTextSegments
-				segments={segmentsForSlice(stream, cell.start, cell.end, claimed)}
+				segments={segmentsForSlice(stream, cell.start, cell.end, claimed, cell.links)}
 				activeId={activeId}
 				onHighlightClick={onHighlightClick}
 			/>

--- a/packages/web/src/components/asset-review/plain-text-highlights.tsx
+++ b/packages/web/src/components/asset-review/plain-text-highlights.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { findLinkRanges } from '../../lib/autolink';
 import { claimQuoteRanges, type ReviewAnnotation } from '../../lib/rehype-review-highlights';
 import { ReviewTextSegments, segmentsForSlice } from './review-text-segments';
 
@@ -11,9 +12,10 @@ interface PlainTextWithHighlightsProps {
 
 /**
  * A plain-text asset body with review highlights: the string renders inside a
- * `<pre>`, quote anchors wrapped in clickable marks. The pre's DOM text stream
- * is byte-identical to the source string, so `computeSelectionAnchor` resolves
- * selections against it exactly as it does for rendered markdown.
+ * `<pre>`, quote anchors wrapped in clickable marks and URLs in anchors. The
+ * pre's DOM text stream is byte-identical to the source string, so
+ * `computeSelectionAnchor` resolves selections against it exactly as it does
+ * for rendered markdown.
  */
 export function PlainTextWithHighlights({
 	content,
@@ -21,9 +23,11 @@ export function PlainTextWithHighlights({
 	activeId,
 	onHighlightClick,
 }: PlainTextWithHighlightsProps) {
+	const links = useMemo(() => findLinkRanges(content), [content]);
 	const segments = useMemo(
-		() => segmentsForSlice(content, 0, content.length, claimQuoteRanges(content, annotations)),
-		[content, annotations],
+		() =>
+			segmentsForSlice(content, 0, content.length, claimQuoteRanges(content, annotations), links),
+		[content, annotations, links],
 	);
 	return (
 		<pre

--- a/packages/web/src/components/asset-review/review-text-segments.tsx
+++ b/packages/web/src/components/asset-review/review-text-segments.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+import type { LinkRange } from '../../lib/autolink';
 import type { MatchRange } from '../../lib/rehype-review-highlights';
 import { REVIEW_MARK_ACTIVE_CLASSES, REVIEW_MARK_CLASSES } from '../markdown-prose';
 
@@ -5,31 +7,60 @@ export interface HighlightSegment {
 	text: string;
 	/** The annotation this segment is highlighted for; undefined = plain text. */
 	reviewId?: string;
+	/** The link this segment falls inside; undefined = not part of one. */
+	href?: string;
 }
 
+const NO_LINKS: LinkRange[] = [];
+
+// The markdown surface's link colour, so a URL reads the same whichever pane it
+// is in. Wrapping is left to the container (`break-words` on the cell and the
+// plain-text `pre`), which already breaks an over-long URL.
+const LINK_CLASSES = 'text-info-soft-fg underline underline-offset-2 hover:opacity-80';
+
 /**
- * Split `stream[from, to)` around the claimed ranges it intersects. A range
- * spanning the slice boundary yields a segment in each slice it covers, both
- * carrying the same review id - the same behaviour the markdown surface has
- * for a quote spanning several text nodes.
+ * Split `stream[from, to)` around the claimed review ranges and link ranges it
+ * intersects. A range spanning the slice boundary yields a segment in each
+ * slice it covers, both carrying the same id/href - the same behaviour the
+ * markdown surface has for a quote spanning several text nodes.
+ *
+ * Both range lists must be sorted by `start` and internally non-overlapping;
+ * `claimQuoteRanges` and `findLinkRanges` each guarantee that. The two lists
+ * may overlap each other, in which case a segment carries both.
  */
 export function segmentsForSlice(
 	stream: string,
 	from: number,
 	to: number,
 	claimed: MatchRange[],
+	links: LinkRange[] = NO_LINKS,
 ): HighlightSegment[] {
-	const segments: HighlightSegment[] = [];
-	let cursor = from;
+	const cuts = new Set<number>();
 	for (const range of claimed) {
-		const start = Math.max(range.start, from);
-		const end = Math.min(range.end, to);
-		if (end <= start) continue;
-		if (start > cursor) segments.push({ text: stream.slice(cursor, start) });
-		segments.push({ text: stream.slice(start, end), reviewId: range.id });
-		cursor = end;
+		if (range.start > from && range.start < to) cuts.add(range.start);
+		if (range.end > from && range.end < to) cuts.add(range.end);
 	}
-	if (cursor < to) segments.push({ text: stream.slice(cursor, to) });
+	for (const range of links) {
+		if (range.start > from && range.start < to) cuts.add(range.start);
+		if (range.end > from && range.end < to) cuts.add(range.end);
+	}
+	const points = [from, ...Array.from(cuts).sort((a, b) => a - b), to];
+
+	const segments: HighlightSegment[] = [];
+	// Both lists are sorted, and the cut points ascend, so one cursor each walks
+	// them in step with the segments rather than rescanning per segment.
+	let ci = 0;
+	let li = 0;
+	for (let i = 0; i + 1 < points.length; i++) {
+		const start = points[i];
+		const end = points[i + 1];
+		if (end <= start) continue;
+		while (ci < claimed.length && claimed[ci].end <= start) ci++;
+		while (li < links.length && links[li].end <= start) li++;
+		const review = ci < claimed.length && claimed[ci].start <= start ? claimed[ci] : undefined;
+		const link = li < links.length && links[li].start <= start ? links[li] : undefined;
+		segments.push({ text: stream.slice(start, end), reviewId: review?.id, href: link?.href });
+	}
 	return segments;
 }
 
@@ -40,11 +71,12 @@ interface ReviewTextSegmentsProps {
 }
 
 /**
- * Render pre-sliced segments, highlighted ones wrapped in the same clickable
- * `mark[data-review-id]` the markdown surface produces. Emits nothing but the
- * segment text, so the container's DOM text stream stays byte-identical to the
- * string the segments were sliced from - which is what lets a selection made
- * here resolve back to a `{ quote, occurrence }` anchor.
+ * Render pre-sliced segments: highlighted ones wrapped in the same clickable
+ * `mark[data-review-id]` the markdown surface produces, linked ones in an
+ * anchor. Both wrappers emit nothing but the segment text, so the container's
+ * DOM text stream stays byte-identical to the string the segments were sliced
+ * from - which is what lets a selection made here resolve back to a
+ * `{ quote, occurrence }` anchor.
  */
 export function ReviewTextSegments({
 	segments,
@@ -53,32 +85,54 @@ export function ReviewTextSegments({
 }: ReviewTextSegmentsProps) {
 	return (
 		<>
-			{segments.map((seg, i) =>
-				seg.reviewId ? (
+			{segments.map((seg, i) => {
+				// A linked segment renders as an anchor, a highlighted one as the same
+				// clickable mark the markdown surface produces, and one that is both
+				// nests the anchor inside the mark. Plain text stays a bare string so
+				// the common case adds no element at all.
+				const link = seg.href ? (
+					<a
+						href={seg.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={LINK_CLASSES}
+						data-testid="autolink"
+						// A click on a link inside a highlight follows the link and does
+						// nothing else; the highlight stays clickable across the rest of
+						// its quote, and its comment is listed in the review panel too.
+						onClick={(e) => e.stopPropagation()}
+					>
+						{seg.text}
+					</a>
+				) : null;
+				if (!seg.reviewId) {
+					// biome-ignore lint/suspicious/noArrayIndexKey: segments are a pure slicing of the stream — stable for a given (stream, annotations, links)
+					return link ? <Fragment key={i}>{link}</Fragment> : seg.text;
+				}
+				const reviewId = seg.reviewId;
+				return (
 					// biome-ignore lint/a11y/useSemanticElements: a <button> cannot wrap arbitrary inline pre text; the mark carries role/tabIndex/keydown instead (same pattern as markdown-prose)
 					<mark
-						// biome-ignore lint/suspicious/noArrayIndexKey: segments are a pure slicing of the stream — stable for a given (stream, annotations)
+						// biome-ignore lint/suspicious/noArrayIndexKey: segments are a pure slicing of the stream — stable for a given (stream, annotations, links)
 						key={i}
-						data-review-id={seg.reviewId}
+						data-review-id={reviewId}
 						data-testid="review-highlight"
-						className={seg.reviewId === activeId ? REVIEW_MARK_ACTIVE_CLASSES : REVIEW_MARK_CLASSES}
-						onClick={() => onHighlightClick(seg.reviewId as string)}
+						className={reviewId === activeId ? REVIEW_MARK_ACTIVE_CLASSES : REVIEW_MARK_CLASSES}
+						onClick={() => onHighlightClick(reviewId)}
 						onKeyDown={(e) => {
 							if (e.key === 'Enter' || e.key === ' ') {
 								e.preventDefault();
-								onHighlightClick(seg.reviewId as string);
+								onHighlightClick(reviewId);
 							}
 						}}
 						// biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: the highlight is genuinely interactive (opens its comment editor); full keyboard support is provided
 						role="button"
 						tabIndex={0}
 					>
-						{seg.text}
+						{link ?? seg.text}
 					</mark>
-				) : (
-					seg.text
-				),
-			)}
+				);
+			})}
 		</>
 	);
 }

--- a/packages/web/src/components/asset-review/reviewable-asset-text.tsx
+++ b/packages/web/src/components/asset-review/reviewable-asset-text.tsx
@@ -48,7 +48,7 @@ interface ReviewableAssetTextProps {
  * Types with a richer reading than their raw bytes - markdown as prose, a CSV
  * as a table - render that as the Preview tab and keep the raw file behind
  * Source. Anchors are computed over the Preview stream, so the Source tab
- * renders without review affordances.
+ * renders without review affordances, and without autolinking (see below).
  */
 export function ReviewableAssetText({
 	projectId,
@@ -202,6 +202,12 @@ export function ReviewableAssetText({
 					)}
 				</>
 			) : (
+				// Source stays raw, deliberately: it is the only surface here showing
+				// bytes that were never parsed. Autolinking a delimited file would run
+				// a URL straight into the delimiter after it - a raw CSV row linked
+				// `https://x.com/a,high` rather than `https://x.com/a`, because a
+				// comma is a legal URL character and only the parser knows this one
+				// separates fields. Preview links instead, per parsed cell.
 				<pre
 					className="whitespace-pre-wrap break-words font-mono text-[12px] text-text-1"
 					data-testid="asset-viewer-source"

--- a/packages/web/src/lib/autolink.ts
+++ b/packages/web/src/lib/autolink.ts
@@ -1,0 +1,132 @@
+/**
+ * Autolinking for the text surfaces whose bytes carry no markup - a CSV cell, a
+ * plain-text asset body. Markdown reaches the same reading through remark-gfm's
+ * autolink literals; this is the equivalent for files that have no syntax, so a
+ * URL sitting in a column is a link rather than a string to copy out by hand.
+ *
+ * The rules follow GFM's autolink literals closely enough that the two surfaces
+ * agree on what counts as a link: `http(s)://`, a bare `www.` host, an explicit
+ * `mailto:`, and a bare email address. Trailing sentence punctuation and an
+ * unbalanced closing bracket stay outside the link.
+ *
+ * Only those four forms ever produce an href, so no other scheme (`javascript:`,
+ * `data:`) can be emitted from file content the instance did not author.
+ */
+
+export interface LinkRange {
+	/** Offset of the link's first character in the string it was found in. */
+	start: number;
+	/** Offset one past its last character. */
+	end: number;
+	/** Absolute URL for the anchor's `href` (a `www.` host gains `https://`). */
+	href: string;
+}
+
+// A scheme-led or `www.`-led run of non-space characters, or a bare email
+// address. Quotes, angle brackets and backticks end a run: in a delimited file
+// they are far more likely to be the text around a URL than part of one.
+const CANDIDATE_RE =
+	/(?:https?:\/\/|mailto:|www\.)[^\s<>"'`\\]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/gi;
+
+// What a link may follow. Anything else means the match continues a word
+// (`xhttps://…`, a path segment) and is not a link of its own.
+const BOUNDARY_BEFORE_RE = /[\s(\[{<"'`,;:*_~|]/;
+
+/** Sentence punctuation a link never ends on, trimmed back off the match. */
+const TRAILING_PUNCTUATION = new Set(['?', '!', '.', ',', ':', ';', '*', '_', '~', "'", '"']);
+
+/** Closing brackets, trimmed only when the match holds no opener for them. */
+const CLOSERS = new Map([
+	[')', '('],
+	[']', '['],
+	['}', '{'],
+]);
+
+const HOST_RE = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$/;
+const EMAIL_RE = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+
+/** Occurrences of `ch` in `text[0, end)`. */
+function countBefore(text: string, ch: string, end: number): number {
+	let count = 0;
+	for (let i = 0; i < end; i++) if (text[i] === ch) count++;
+	return count;
+}
+
+/** Drop trailing punctuation and unbalanced closers ("(see https://x.com/a)."). */
+function trimTrailing(text: string): string {
+	let end = text.length;
+	while (end > 0) {
+		const ch = text[end - 1];
+		if (TRAILING_PUNCTUATION.has(ch)) {
+			end--;
+			continue;
+		}
+		const opener = CLOSERS.get(ch);
+		if (opener !== undefined && countBefore(text, opener, end) < countBefore(text, ch, end)) {
+			end--;
+			continue;
+		}
+		break;
+	}
+	return text.slice(0, end);
+}
+
+/** The authority of an absolute URL: everything between `://` and `/?#`. */
+function hostOf(url: string): string {
+	const afterScheme = url.slice(url.indexOf('://') + 3);
+	const end = afterScheme.search(/[/?#]/);
+	const authority = end === -1 ? afterScheme : afterScheme.slice(0, end);
+	// Userinfo and port are not part of the name being validated.
+	const host = authority.slice(authority.lastIndexOf('@') + 1);
+	return host.replace(/:\d*$/, '');
+}
+
+/** A named host with a dot in it, or `localhost`. Bare IPv6 is not linked. */
+function isValidHost(host: string): boolean {
+	if (!HOST_RE.test(host)) return false;
+	return host.includes('.') || host.toLowerCase() === 'localhost';
+}
+
+/** The href a candidate resolves to, or null when it is not a link after all. */
+function hrefFor(candidate: string): string | null {
+	const lower = candidate.toLowerCase();
+	if (lower.startsWith('mailto:')) {
+		return EMAIL_RE.test(candidate.slice('mailto:'.length)) ? candidate : null;
+	}
+	if (lower.startsWith('http://') || lower.startsWith('https://')) {
+		return isValidHost(hostOf(candidate)) ? candidate : null;
+	}
+	if (lower.startsWith('www.')) {
+		const url = `https://${candidate}`;
+		const host = hostOf(url);
+		// A `www.` host needs a real domain under it - `www.example.com`, not `www.x`.
+		return isValidHost(host) && host.split('.').length >= 3 ? url : null;
+	}
+	return EMAIL_RE.test(candidate) ? `mailto:${candidate}` : null;
+}
+
+/**
+ * Every link in `text`, in ascending order and never overlapping - the shape
+ * `segmentsForSlice` splits a text stream on.
+ */
+export function findLinkRanges(text: string): LinkRange[] {
+	const ranges: LinkRange[] = [];
+	CANDIDATE_RE.lastIndex = 0;
+	for (let match = CANDIDATE_RE.exec(text); match; match = CANDIDATE_RE.exec(text)) {
+		const start = match.index;
+		const before = start === 0 ? undefined : text[start - 1];
+		if (before !== undefined && !BOUNDARY_BEFORE_RE.test(before)) continue;
+		const candidate = trimTrailing(match[0]);
+		if (candidate === '') continue;
+		const href = hrefFor(candidate);
+		if (href === null) continue;
+		ranges.push({ start, end: start + candidate.length, href });
+	}
+	return ranges;
+}
+
+/** The same ranges, shifted into a wider stream that `text` starts at `offset` in. */
+export function shiftLinkRanges(ranges: LinkRange[], offset: number): LinkRange[] {
+	if (offset === 0) return ranges;
+	return ranges.map((r) => ({ start: r.start + offset, end: r.end + offset, href: r.href }));
+}

--- a/packages/web/test/asset-viewer.test.tsx
+++ b/packages/web/test/asset-viewer.test.tsx
@@ -465,3 +465,85 @@ test('a .csv with nothing to split into columns stays plain text', async () => {
 	expect(queryByTestId('asset-csv-table')).toBeNull();
 	expect(queryByTestId('asset-viewer-preview-tab')).toBeNull();
 });
+
+test('URLs in a CSV cell render as links, bounded by the cell they sit in', async () => {
+	const content = [
+		'original_tweet_url,reply_text,contact',
+		'https://x.com/PenguinWeb3/status/2087206311586918767,"Ask about it (see www.hezo.ai/docs).",ops@hezo.ai',
+	].join('\n');
+	const { container, findByTestId } = await setupViewer({
+		filename: 'links.csv',
+		contentType: 'text/plain',
+		bytes: new TextEncoder().encode(content),
+	});
+
+	const table = await findByTestId('asset-csv-table');
+	const links = Array.from(table.querySelectorAll('a'));
+	expect(links.map((a) => [a.textContent, a.getAttribute('href')])).toEqual([
+		[
+			'https://x.com/PenguinWeb3/status/2087206311586918767',
+			'https://x.com/PenguinWeb3/status/2087206311586918767',
+		],
+		// A bare www host gains a scheme; the trailing `).` stays outside the link.
+		['www.hezo.ai/docs', 'https://www.hezo.ai/docs'],
+		['ops@hezo.ai', 'mailto:ops@hezo.ai'],
+	]);
+	for (const a of links) {
+		expect(a.getAttribute('target')).toBe('_blank');
+		expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+	}
+
+	// The cells still read exactly as parsed - linking adds elements, never text.
+	const firstRow = table.querySelectorAll('tbody tr')[0];
+	expect(Array.from(firstRow.querySelectorAll('td')).map((td) => td.textContent)).toEqual([
+		'https://x.com/PenguinWeb3/status/2087206311586918767',
+		'Ask about it (see www.hezo.ai/docs).',
+		'ops@hezo.ai',
+	]);
+	// A header cell holds no URL, so the header row gains no links.
+	expect(container.querySelectorAll('th a').length).toBe(0);
+});
+
+test('a URL ending one CSV cell never runs into the next cell', async () => {
+	// The table anchors review quotes over a flat stream that concatenates cells
+	// with no separator ("…/a" + "high"), so links have to be found per cell.
+	const content = ['url,priority', 'https://x.com/a,high'].join('\n');
+	const { findByTestId } = await setupViewer({
+		filename: 'adjacent.csv',
+		contentType: 'text/plain',
+		bytes: new TextEncoder().encode(content),
+	});
+
+	const table = await findByTestId('asset-csv-table');
+	const links = Array.from(table.querySelectorAll('a'));
+	expect(links.length).toBe(1);
+	expect(links[0].textContent).toBe('https://x.com/a');
+	expect(links[0].getAttribute('href')).toBe('https://x.com/a');
+});
+
+test('a plain-text asset links its URLs and still anchors review quotes across them', async () => {
+	const txt = 'run failed, see https://ci.example.com/job/42 for the log\nsecond line';
+	const { container, findByTestId } = await setupViewer({
+		filename: 'run.txt',
+		contentType: 'text/plain',
+		bytes: new TextEncoder().encode(txt),
+		comments: [{ quote: 'see https://ci.example.com/job/42 for', comment: 'Link the run instead' }],
+	});
+
+	const pre = await findByTestId('asset-plain-text');
+	// The rendered text stream is byte-identical to the file, which is what keeps
+	// selection anchors resolvable.
+	expect(pre.textContent).toBe(txt);
+
+	const link = pre.querySelector('a') as HTMLAnchorElement;
+	expect(link.textContent).toBe('https://ci.example.com/job/42');
+	expect(link.getAttribute('href')).toBe('https://ci.example.com/job/42');
+
+	// The seeded quote spans the link, so the highlight wraps it rather than
+	// being displaced by it.
+	await waitFor(() => {
+		const marks = Array.from(container.querySelectorAll('mark[data-review-id]'));
+		expect(marks.map((m) => m.textContent).join('')).toBe('see https://ci.example.com/job/42 for');
+		expect(marks.some((m) => m.querySelector('a'))).toBe(true);
+	});
+});

--- a/packages/web/test/asset-viewer.test.tsx
+++ b/packages/web/test/asset-viewer.test.tsx
@@ -547,3 +547,47 @@ test('a plain-text asset links its URLs and still anchors review quotes across t
 		expect(marks.some((m) => m.querySelector('a'))).toBe(true);
 	});
 });
+
+test('the Source tab leaves the raw file unlinked', async () => {
+	// Preview links per parsed cell; Source shows bytes nothing parsed. Linking
+	// there would run a URL into the delimiter after it - `https://x.com/a,high`
+	// rather than `https://x.com/a` - because a comma is a legal URL character
+	// and only the CSV parser knows this one separates fields.
+	const content = ['url,priority', 'https://x.com/a,high'].join('\n');
+	const { findByTestId, user } = await setupViewer({
+		filename: 'source-raw.csv',
+		contentType: 'text/plain',
+		bytes: new TextEncoder().encode(content),
+	});
+
+	expect((await findByTestId('asset-csv-table')).querySelectorAll('a').length).toBe(1);
+
+	await user.click(await findByTestId('asset-viewer-source-tab'));
+	const source = await findByTestId('asset-viewer-source');
+	expect(source.textContent).toBe(content);
+	expect(source.querySelectorAll('a').length).toBe(0);
+});
+
+test('a review highlight activates from the keyboard as well as the mouse', async () => {
+	const txt = 'first line of output\nsecond line with the flaky assertion\nthird line';
+	const { container, findByTestId, user } = await setupViewer({
+		filename: 'keyboard.txt',
+		contentType: 'text/plain',
+		bytes: new TextEncoder().encode(txt),
+		comments: [{ quote: 'flaky assertion', comment: 'This is the real bug' }],
+	});
+
+	let mark!: HTMLElement;
+	await waitFor(() => {
+		mark = container.querySelector('mark[data-review-id]') as HTMLElement;
+		expect(mark).not.toBeNull();
+	});
+
+	// The mark carries role="button" + tabIndex, so Enter and Space have to open
+	// its comment the same way a click does.
+	const row = await findByTestId('asset-review-row');
+	expect(row.getAttribute('data-active')).not.toBe('true');
+	mark.focus();
+	await user.keyboard('{Enter}');
+	await waitFor(() => expect(row.getAttribute('data-active')).toBe('true'));
+});

--- a/packages/web/test/autolink.test.ts
+++ b/packages/web/test/autolink.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from 'vitest';
+import { findLinkRanges, shiftLinkRanges } from '../src/lib/autolink';
+
+// Link detection for the text surfaces that carry no markup (CSV cells, plain
+// text assets). The rules mirror GFM's autolink literals so the same string
+// links the same way whether it arrives as markdown or as raw file bytes.
+
+function linked(text: string): Array<{ text: string; href: string }> {
+	return findLinkRanges(text).map((r) => ({ text: text.slice(r.start, r.end), href: r.href }));
+}
+
+test('links http and https URLs, keeping the whole path and query', () => {
+	expect(linked('https://x.com/PenguinWeb3/status/2087206311586918767')).toEqual([
+		{
+			text: 'https://x.com/PenguinWeb3/status/2087206311586918767',
+			href: 'https://x.com/PenguinWeb3/status/2087206311586918767',
+		},
+	]);
+	expect(linked('see http://example.com/a?b=1&c=2#frag now')).toEqual([
+		{ text: 'http://example.com/a?b=1&c=2#frag', href: 'http://example.com/a?b=1&c=2#frag' },
+	]);
+});
+
+test('a bare www host gains a scheme; a bare email becomes mailto', () => {
+	expect(linked('www.example.com/docs')).toEqual([
+		{ text: 'www.example.com/docs', href: 'https://www.example.com/docs' },
+	]);
+	expect(linked('ping ops@hezo.ai please')).toEqual([
+		{ text: 'ops@hezo.ai', href: 'mailto:ops@hezo.ai' },
+	]);
+	expect(linked('mailto:ops@hezo.ai')).toEqual([
+		{ text: 'mailto:ops@hezo.ai', href: 'mailto:ops@hezo.ai' },
+	]);
+});
+
+test('trailing sentence punctuation and an unbalanced bracket stay outside the link', () => {
+	expect(linked('Read https://example.com/a.')[0].text).toBe('https://example.com/a');
+	expect(linked('Read https://example.com/a, then stop')[0].text).toBe('https://example.com/a');
+	expect(linked('(see https://example.com/a)')[0].text).toBe('https://example.com/a');
+	// A balanced pair inside the URL is part of it.
+	expect(linked('https://en.wikipedia.org/wiki/Foo_(bar)')[0].text).toBe(
+		'https://en.wikipedia.org/wiki/Foo_(bar)',
+	);
+});
+
+test('finds several links in one string, in ascending non-overlapping order', () => {
+	const text = 'a https://one.example/x b www.two.example c ops@three.example d';
+	const ranges = findLinkRanges(text);
+	expect(ranges.map((r) => r.href)).toEqual([
+		'https://one.example/x',
+		'https://www.two.example',
+		'mailto:ops@three.example',
+	]);
+	for (let i = 1; i < ranges.length; i++) {
+		expect(ranges[i].start).toBeGreaterThanOrEqual(ranges[i - 1].end);
+	}
+});
+
+test('only http, https, mailto and www forms produce an href', () => {
+	// A dangerous scheme is never emitted - it is not one of the four forms.
+	expect(findLinkRanges('javascript:alert(1)')).toEqual([]);
+	expect(findLinkRanges('data:text/html;base64,PHNjcmlwdD4=')).toEqual([]);
+	expect(findLinkRanges('ftp://files.example.com/pub')).toEqual([]);
+	expect(findLinkRanges('file:///etc/passwd')).toEqual([]);
+});
+
+test('rejects candidates that are not a real host or continue a word', () => {
+	// No domain to speak of.
+	expect(findLinkRanges('http://')).toEqual([]);
+	expect(findLinkRanges('https://nodot/path')).toEqual([]);
+	// `www.` needs a domain under it.
+	expect(findLinkRanges('www.local')).toEqual([]);
+	// Mid-word matches are text, not links.
+	expect(findLinkRanges('xhttps://example.com')).toEqual([]);
+	// A localhost URL is a link - it is the one dotless host that resolves.
+	expect(linked('http://localhost:3101/api')).toEqual([
+		{ text: 'http://localhost:3101/api', href: 'http://localhost:3101/api' },
+	]);
+});
+
+test('a URL is bounded by whitespace, quotes and angle brackets', () => {
+	expect(linked('"https://example.com/a" and <https://example.com/b>')).toEqual([
+		{ text: 'https://example.com/a', href: 'https://example.com/a' },
+		{ text: 'https://example.com/b', href: 'https://example.com/b' },
+	]);
+	// A newline inside a quoted CSV cell ends the URL.
+	expect(linked('https://example.com/a\nnext line')[0].text).toBe('https://example.com/a');
+});
+
+test('shiftLinkRanges moves ranges into a wider stream', () => {
+	const ranges = findLinkRanges('https://example.com/a');
+	expect(shiftLinkRanges(ranges, 10)).toEqual([
+		{ start: 10, end: 31, href: 'https://example.com/a' },
+	]);
+	// A zero offset is the identity.
+	expect(shiftLinkRanges(ranges, 0)).toBe(ranges);
+});


### PR DESCRIPTION
A URL sitting in a CSV column, or in a `.txt` asset, rendered as inert text - reading a column of links meant copying each one out by hand. Markdown assets already autolink through remark-gfm; the two non-markdown text surfaces in the asset viewer now reach the same reading.

## What changed

**`packages/web/src/lib/autolink.ts` (new).** `findLinkRanges(text)` returns the sorted, non-overlapping link ranges in a string, following GFM's autolink literals so the same string links the same way whether it arrives as markdown or as raw file bytes:

- `http://` / `https://`, a bare `www.` host (gains `https://`), `mailto:`, and a bare email address (gains `mailto:`).
- Trailing sentence punctuation (`.`, `,`, `:`, `;`, `?`, `!`, `*`, `_`, `~`, quotes) and unbalanced closing brackets stay outside the link, so `(see https://example.com/a).` links just the URL.
- A host has to be a real name with a dot in it, or `localhost`; a match that continues a word (`xhttps://…`) is text, not a link.
- Those four forms are the **only** ones that produce an href, so no other scheme (`javascript:`, `data:`, `file:`) can be emitted from file content. Anchors carry `target="_blank"` + `rel="noopener noreferrer"`, matching the markdown surface.

**`segmentsForSlice`** now splits its text stream on link ranges and review-quote ranges together, walking both sorted lists with a cursor rather than rescanning per segment. A review quote overlapping a URL still resolves and renders - the anchor nests inside the `<mark>`, and a click on the link follows the link only.

**`CsvTable`** finds links **per cell** and shifts them into the flat stream afterwards. The stream that review anchoring is measured over concatenates cells with no separator, so detecting over the stream would let a URL ending one cell swallow the start of the next (`…/a` + `high` → `…/ahigh`).

Anchoring is unaffected throughout: the new elements emit only their segment's own text, so the container's DOM text stream stays byte-identical to the string the segments were sliced from.

## Testing

- `packages/web/test/autolink.test.ts` (new, 8 cases): each linked form, punctuation and bracket trimming, multiple links in one string, rejection of other schemes and of non-hosts / mid-word matches, and range shifting.
- `packages/web/test/asset-viewer.test.tsx` (3 new component tests): links render in CSV cells with the right hrefs and cell text unchanged; a URL ending one cell never runs into the next; a plain-text asset links its URLs while a seeded review quote spanning the link still highlights.
- Full `asset-viewer`, `csv`, `document-review` and `project-assets` suites pass (52 tests), plus `typecheck`, `biome check`, `docs-links`, `docs-bundle` and `docs-terminology`.

## Docs

- `docs/concepts/assets.md` - the asset viewer section now says links in a CSV cell or plain-text file are clickable.
- `.dev/architecture.md` - the autolink seam, the per-cell detection rule, and why the DOM stream is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y1byZqa5jWGA4E9hiP87d

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y1byZqa5jWGA4E9hiP87d)_