### PR TITLE
Bill every container-uptime stretch, and re-queue a run the shutdown drain killed

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -599,16 +599,37 @@ ceiling would mostly fire on legitimately expensive work.
 `container_uptime_entries` (migration 071) records **one row per running stretch**, not
 per container lifetime: a managed backend bills a started sandbox for vCPU + RAM + disk
 and a stopped one for reserved disk only, so a suspend/resume cycle is two rows with a
-free gap between them. Writes live inside `upsertPoolMember` / `setPoolMemberState` /
-`removePoolMember` (`services/sandbox/uptime-ledger.ts`, called from `pool-db.ts`), so the
-ledger cannot drift from the lifecycle it records - the same reasoning that puts the wake
-receipt inside `fireCommentWakeups`. The interval opens at the `creating` upsert rather
+free gap between them. **Every write of `container_pool_members.state` moves the interval,
+through one funnel** - `syncUptimeForState` in `pool-db.ts`, calling
+`services/sandbox/uptime-ledger.ts` - so the ledger cannot drift from the lifecycle it
+records, the same reasoning that puts the wake receipt inside `fireCommentWakeups`.
+
+The funnel replaced per-writer calls, and the reason it exists is what those calls got
+wrong: they had been added to the two **cold** writers (provision, resume) and not to the
+three **warm** ones (`claimPoolMember`, `releasePoolMember`, `reclaimBusyPoolMembers`).
+The warm three are the only writers an ordinary run touches, so a container that reached a
+running state without an interval could never acquire one and billed nothing for the rest
+of its life - while still reporting its full allocation in the run log, since that reads
+the member row. On a backend whose sandboxes outlive a Hezo restart, that was the normal
+case rather than an edge one. The warm writers open only on a row their own `RETURNING`
+says moved, so a container the pool believes is stopped is never billed - the one
+direction cost accounting may not fail in. `reconcilePoolMembers` carries the repair for a
+member that is already running and already unbilled (`ensurePoolMemberUptimeOpen`), riding
+the liveness round trip it already makes and starting the bill at `now()` rather than at an
+invented start; `markPoolMemberRunning` covers the two paths that start a container in
+place and would otherwise tell only `projects`. Forgetting the whole pool at once
+(`clearAllPoolMembers`, used by the backend switch) closes every open interval first,
+because dropping the member rows alone strands them open and an open interval bills to
+`now()` for ever.
+
+The interval opens at the `creating` upsert rather
 than at ready, because on a managed backend the build is the longest phase of a cold start
 and bills like any other minute. `end_reason` separates an ordinary stop from a
 cross-project eviction (`ContainerUptimeEndReason.Suspended`, passed down from
 `executeRetirementPlan`), which is the only contention signal the series can show. A
 unique partial index on `(container_id) WHERE ended_at IS NULL` makes open and close
-idempotent on every path that reaches them.
+idempotent on every path that reaches them, which is what lets the repair pass and the warm
+writers call open unconditionally.
 
 Reads (`services/container-hours.ts`) **clip each interval to each window** rather than
 attributing it to the bucket it started in - `agent-hours.ts` attributes by start, which

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2664,6 +2664,22 @@ orphan pass's verdict for a run that never started is itself non-destructive: it
 the row `Cancelled`, hands the *original* wakeup back to the queue (`claimed` → `queued`)
 and spends no strike of the lost-run escalation, so the
 work is redispatched rather than lost or reported as a failure the operator must act on.
+**A clean shutdown hands the work back too, and has to - nothing downstream can.** The
+drain (`drainRunningRuns`) aborts every in-flight run with `server_shutdown`, and that abort
+used to finalize the row `Failed` and settle its wakeup `failed`, both before the process
+exited. Every recovery predicate in the codebase - `reconcileDatabaseOnStartup`,
+`detectOrphanedRuns`, `healStaleRunState`, `requeueContainerKilledRuns` - looks for a run
+left `running` or `queued`, so a *hard crash* recovered and an *orderly drain* dropped the
+work outright: the better the shutdown behaved, the more certainly the task stopped, while
+the row's own message promised a re-queue nothing delivered. The abort now routes through
+`finalizeRequeue` at all three points a shutdown can land (the phase checkpoints, the exec
+rejection, the setup window), so the wakeup returns to `queued` while the process is still
+up and the 5 s cron dispatches it when Hezo is next running. The boot pass still covers the
+crash and the drain-deadline overrun, which are the cases that genuinely leave a row
+non-terminal. `RUN_LOST_TO_SHUTDOWN_ERROR` is a clause rather than a sentence for this
+reason: `finalizeRequeue` adds what became of the work and `recordHandbackOutcome` adds
+where to find it, so no writer asserts an outcome it has not yet attempted.
+
 The handback itself is one seam, `settleWakeupForRun` (`services/wakeup.ts`), shared with
 `JobManager.onAgentComplete`: the two answered the same question separately, which is how
 the sweeper's `claimed` guard ended up missing from the completion path and how both ended

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1384,7 +1384,21 @@ export async function runAgent(
 ): Promise<RunResult> {
 	const startTime = Date.now();
 
-	if (signal?.aborted) return abortedResult(startTime);
+	// A shutdown landing before the run row even exists still owes the work, and
+	// there is no row to hand it back through - so here the handback is the flag
+	// alone. `settleWakeupForRun` returns the wakeup to the queue on it, and
+	// `recordHandbackOutcome` is skipped downstream for want of a run id, which is
+	// the right answer: no run happened, so there is nothing to annotate.
+	if (signal?.aborted) {
+		const preRunReason = runAbortReason(signal);
+		return preRunReason === 'server_shutdown'
+			? {
+					...abortedResult(startTime),
+					requeued: true,
+					requeueReason: WakeupSkipReason.ServerShutdown,
+				}
+			: abortedResult(startTime);
+	}
 
 	// The run executes in the project's team (see buildRunContext); for instance
 	// agents working another team's project this differs from agent.team_id.

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1121,7 +1121,8 @@ async function buildRunContext(
 export type ContainerExitAbortReason = 'container_error' | 'container_stopped';
 /**
  * Reasons the runner tags on a run's AbortSignal. A bare abort — a user cancel via
- * `cancelTask`, server shutdown, or the stale-dispatch reaper — carries none.
+ * `cancelTask`, or the stale-dispatch reaper — carries none. Shutdown is tagged, and
+ * is the one reason that hands the work back rather than ending the run.
  *
  * `tunnel_lost` is the runner's own: the container reaches Hezo only through the
  * run tunnel, so a tunnel that dies mid-run leaves the agent unable to read a
@@ -1148,9 +1149,12 @@ const RUN_ABORT_REASONS: readonly string[] = [
  * Deliberately distinguishable from `reconcileOnStartup`'s "Server restarted
  * while run in flight": this one means the drain saw it coming, that one means
  * it did not. Which of the two a run wears says whether the shutdown was orderly.
+ *
+ * A clause, not a sentence, because it is handed to `finalizeRequeue`: that adds
+ * what became of the work, and `recordHandbackOutcome` adds where to find it. It
+ * previously promised a re-queue on its own, which nothing then delivered.
  */
-export const RUN_LOST_TO_SHUTDOWN_ERROR =
-	'Server shut down while this run was in flight; it will be re-queued when Hezo comes back.';
+export const RUN_LOST_TO_SHUTDOWN_ERROR = 'Server shut down while this run was in flight';
 
 function runAbortReason(signal?: AbortSignal): RunAbortReason | null {
 	const reason = signal?.reason as unknown;
@@ -1162,7 +1166,10 @@ function runAbortReason(signal?: AbortSignal): RunAbortReason | null {
 /**
  * Terminal status for an aborted run: a wall-clock timeout is `TimedOut` (and drives an
  * automatic same-task continuation — see `JobManager.onAgentComplete`), container death and
- * a lost tunnel are `Failed`, and a bare abort (user cancel / shutdown) is `Cancelled`.
+ * a lost tunnel are `Failed`, and a bare abort (a user cancel) is `Cancelled`.
+ *
+ * `server_shutdown` never reaches here: it is handed back before any caller asks for
+ * a status, and a handback finalizes `Cancelled` with `handed_back` on the row.
  */
 function abortedRunStatus(reason: RunAbortReason | null): HeartbeatRunStatus {
 	if (reason === 'run_timeout') return HeartbeatRunStatus.TimedOut;
@@ -1506,11 +1513,76 @@ export async function runAgent(
 		else signal.addEventListener('abort', () => runAbort.abort(signal.reason), { once: true });
 	}
 
+	/**
+	 * Give up waiting on the instance and hand the work back to the queue.
+	 *
+	 * Reached from both waits a run can sit in - container capacity, and the
+	 * rotating provider credential - once either passes its ceiling, and from a
+	 * shutdown that killed the run mid-flight. None of the three is a verdict on
+	 * the run: the instance is busy, or going away, not the agent failing. So the
+	 * row is finalized `Cancelled` rather than `Failed`, and the caller re-queues
+	 * the wakeup.
+	 *
+	 * Finalizing it is the load-bearing part. A row left `queued` here is
+	 * abandoned: nothing returns to it, it still matches `isTaskBusyInDb` so it
+	 * blocks the retry of the very wakeup it came from, and 120s later the orphan
+	 * pass reaps it as `Orphaned: run never started` and counts it toward the
+	 * lost-run escalation. A terminal row does none of that, so the requeued
+	 * wakeup is free to dispatch on the next tick.
+	 */
+	const finalizeRequeue = async (
+		reason: string,
+		requeueReason: WakeupSkipReason,
+	): Promise<RunResult> => {
+		releaseCredentialLock?.();
+		const message = `${reason} - returning this run to the queue.`;
+		emit('stdout', `[runner] ${message}\n`);
+		const durationMs = Date.now() - startTime;
+		await deps.logs.end(streamId);
+		await updateHeartbeatRun(
+			deps.db,
+			heartbeatRunId,
+			{
+				status: HeartbeatRunStatus.Cancelled,
+				exitCode: -1,
+				durationMs,
+				error: message,
+				// Deliberately NOT stamping `cancel_reason` here. Whether the work is
+				// actually carried is not known until the caller settles the wakeup,
+				// and the guard there can bite. Writing `handed_back` at this point
+				// asserted an outcome before attempting it - the same defect the orphan
+				// sweeper was restructured to avoid - and left it standing when the
+				// handback failed. `JobManager.settleWakeupForRun` records it once the
+				// answer is in, through the recorder the sweeper shares.
+			},
+			runBroadcast,
+		);
+		return {
+			success: false,
+			exitCode: -1,
+			stderr: reason,
+			durationMs,
+			heartbeatRunId,
+			requeued: true,
+			requeueReason,
+		};
+	};
+
 	const finalizeAbort = async (): Promise<RunResult> => {
+		const abortReason = runAbortReason(runAbort.signal);
+		// A shutdown is not a verdict on this run, and the work is still owed. Hand
+		// it back here, while the process is still up, because boot recovery cannot
+		// do it afterwards: it scans for runs left `running` or `queued`, and an
+		// orderly drain leaves neither - it finalizes the row and settles the wakeup
+		// before exiting. The better the shutdown behaved, the more certainly the
+		// work was dropped.
+		if (abortReason === 'server_shutdown') {
+			return finalizeRequeue(RUN_LOST_TO_SHUTDOWN_ERROR, WakeupSkipReason.ServerShutdown);
+		}
 		releaseCredentialLock?.();
 		const durationMs = Date.now() - startTime;
 		await deps.logs.end(streamId);
-		const reason = runAbortReason(runAbort.signal);
+		const reason = abortReason;
 		const status = abortedRunStatus(reason);
 		await updateHeartbeatRun(
 			deps.db,
@@ -1720,59 +1792,6 @@ export async function runAgent(
 			   AND queued_reason IS DISTINCT FROM $1`,
 			[CAPACITY_PARK_QUEUED_REASON, heartbeatRunId, HeartbeatRunStatus.Queued],
 		);
-	};
-
-	/**
-	 * Give up waiting on the instance and hand the work back to the queue.
-	 *
-	 * Reached from both waits a run can sit in - container capacity, and the
-	 * rotating provider credential - once either passes its ceiling. Neither is a
-	 * failure: the instance is busy, not the agent. So the row is finalized
-	 * `Cancelled` rather than `Failed`, and the caller re-queues the wakeup.
-	 *
-	 * Finalizing it is the load-bearing part. A row left `queued` here is
-	 * abandoned: nothing returns to it, it still matches `isTaskBusyInDb` so it
-	 * blocks the retry of the very wakeup it came from, and 120s later the orphan
-	 * pass reaps it as `Orphaned: run never started` and counts it toward the
-	 * lost-run escalation. A terminal row does none of that, so the requeued
-	 * wakeup is free to dispatch on the next tick.
-	 */
-	const finalizeRequeue = async (
-		reason: string,
-		requeueReason: WakeupSkipReason,
-	): Promise<RunResult> => {
-		releaseCredentialLock?.();
-		const message = `${reason} - returning this run to the queue.`;
-		emit('stdout', `[runner] ${message}\n`);
-		const durationMs = Date.now() - startTime;
-		await deps.logs.end(streamId);
-		await updateHeartbeatRun(
-			deps.db,
-			heartbeatRunId,
-			{
-				status: HeartbeatRunStatus.Cancelled,
-				exitCode: -1,
-				durationMs,
-				error: message,
-				// Deliberately NOT stamping `cancel_reason` here. Whether the work is
-				// actually carried is not known until the caller settles the wakeup,
-				// and the guard there can bite. Writing `handed_back` at this point
-				// asserted an outcome before attempting it - the same defect the orphan
-				// sweeper was restructured to avoid - and left it standing when the
-				// handback failed. `JobManager.settleWakeupForRun` records it once the
-				// answer is in, through the recorder the sweeper shares.
-			},
-			runBroadcast,
-		);
-		return {
-			success: false,
-			exitCode: -1,
-			stderr: reason,
-			durationMs,
-			heartbeatRunId,
-			requeued: true,
-			requeueReason,
-		};
 	};
 
 	// Human-friendly label for run-scoped logs (egress proxy, ssh-agent) and for
@@ -2918,6 +2937,17 @@ export async function runAgent(
 				}
 			}
 
+			// The drain's own path: aborting the exec rejects here, and until now that
+			// wrote a terminal `failed` row and settled the wakeup `failed` too, so
+			// boot recovery could match neither. Handing back instead re-queues the
+			// wakeup while the process is still up, which is what the message on the
+			// row has always promised. The kill above has already torn the tree down,
+			// and no lost-run strike is spent: a shutdown is not the run failing.
+			if (reason === 'server_shutdown') {
+				await cleanupRunArtifacts();
+				return finalizeRequeue(RUN_LOST_TO_SHUTDOWN_ERROR, WakeupSkipReason.ServerShutdown);
+			}
+
 			emit('stderr', `\n[runner] ${errorMessage}\n`);
 
 			await deps.logs.end(streamId);
@@ -2981,6 +3011,11 @@ export async function runAgent(
 		// exec block and is not in scope. The `finally` below is what releases the
 		// tunnel, both host ports and the container claim on this path, which is the
 		// job it was written for.
+		// A shutdown landing inside the setup window strands the same work as one
+		// landing mid-exec, and has the same answer.
+		if (runAbortReason(runAbort.signal) === 'server_shutdown') {
+			return finalizeRequeue(RUN_LOST_TO_SHUTDOWN_ERROR, WakeupSkipReason.ServerShutdown);
+		}
 		const verdict = throwVerdict(error);
 		const durationMs = Date.now() - startTime;
 		log.error(`Run ${heartbeatRunId} failed before the agent could start:`, error);

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -56,9 +56,11 @@ import {
 	claimPoolMember,
 	clearProjectContainerIfNamed,
 	decidePoolAcquisition,
+	ensurePoolMemberUptimeOpen,
 	listPoolContainerIds,
 	listPoolMembersForReconcile,
 	loadPoolMembers,
+	markPoolMemberRunning,
 	readPoolMemberAllocation,
 	recordPoolMemberMemoryIfUnknown,
 	releasePoolMember,
@@ -876,6 +878,10 @@ export async function ensureProjectContainerRunning(
 			if (info) {
 				// Container exists but is stopped — start it in place.
 				await docker.startContainer(proj.container_id);
+				// The pool is told too, not just `projects`: its member still reads
+				// `suspended`, and a member the pool believes is down bills nothing while
+				// the container it names is up. No-op when no member names this container.
+				await markPoolMemberRunning(db, proj.container_id);
 				await db.query(
 					`UPDATE projects
 					 SET container_status = $1::container_status, container_error = NULL,
@@ -2784,7 +2790,22 @@ export async function reconcilePoolMembers(
 			);
 		}
 
-		if (info.State.Running) continue;
+		if (info.State.Running) {
+			// The repair the ledger cannot do for itself. A container can reach a
+			// running state with no open interval - a member older than the ledger, or
+			// one closed while the container stayed up - and it then bills nothing for
+			// the rest of its life: the warm paths open on a row that moved, which a
+			// container nobody claims never does, and this pass used to be the one
+			// thing that looks at a healthy member and it just walked past. Rides the
+			// round trip already made above, like the memory learn.
+			//
+			// `idle`/`busy` only: `error` means the pool has stopped believing this
+			// container is up, and `creating` opened its interval at the upsert.
+			if (member.state === 'idle' || member.state === 'busy') {
+				await ensurePoolMemberUptimeOpen(db, member.containerId);
+			}
+			continue;
+		}
 		// Only a member the pool believed was up. `suspended` is already stopped,
 		// and `creating`/`error` are outside the ladder - a container still coming
 		// up legitimately reads not-running, and judging it dead here would fail

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -91,7 +91,7 @@ import {
 	sumProjectContainerMemoryGb,
 } from './run-concurrency';
 import { recordHandbackOutcome } from './run-handback';
-import { reclaimBusyPoolMembers } from './sandbox/pool-db';
+import { markPoolMemberRunning, reclaimBusyPoolMembers } from './sandbox/pool-db';
 import type { SshAgentServer } from './ssh-agent';
 import { reportTelemetry } from './telemetry';
 import { ensureUpdateStaged, isSupervisedWorker, readUpdateState } from './updater';
@@ -1366,6 +1366,10 @@ export class JobManager {
 				if (info.State.Running) continue;
 
 				await docker.startContainer(row.container_id);
+				// The pool hears about it too. Its member still reads `suspended` after a
+				// restart-time start, and a container the pool believes is down bills
+				// nothing while it is up.
+				await markPoolMemberRunning(db, row.container_id);
 				await db.query(
 					'UPDATE projects SET container_error = NULL, container_last_started_at = now() WHERE id = $1',
 					[row.id],

--- a/packages/server/src/services/sandbox/pool-db.ts
+++ b/packages/server/src/services/sandbox/pool-db.ts
@@ -21,6 +21,7 @@ import {
 } from './pool';
 import {
 	closeUptimeInterval,
+	closeUptimeIntervalsForMembers,
 	openUptimeInterval,
 	setUptimeIntervalChatReservation,
 } from './uptime-ledger';
@@ -34,6 +35,71 @@ import {
  * rather than as zero (which would recycle instantly) or as unbounded.
  */
 const DEFAULT_DISK_CEILING_SQL = String(poolDiskCeilingBytes(DEFAULT_CONTAINER_DISK_GB));
+
+/**
+ * Move a container's uptime interval to match the state just written.
+ *
+ * **Every write of `container_pool_members.state` goes through here.** The ledger
+ * used to be called from the two writers that happened to think of it, which left
+ * the three that did not - claim, release and the boot reclaim - moving a
+ * container between states while billing nothing for it. That is less a missed
+ * call site than a missing rule: a state write and its interval are one act, and
+ * separating them means the next transition anyone adds is billed nowhere.
+ *
+ * `suspended` and `error` both mean the container is no longer running and no
+ * longer billing compute; anything else means it is. `endReason` names *why* a
+ * stretch ended, which the state alone cannot say - the pool spells every
+ * not-running container `suspended` whether the idle sweep stopped it, it exited
+ * on its own, or another project's run evicted it to free budget memory.
+ *
+ * Opening is idempotent, so a caller may reach here for a container that is
+ * already billing. What a caller must not do is reach here for a row that did
+ * **not** move: the pool believes a stopped container is stopped, and opening an
+ * interval for one would over-bill, which is the single direction cost accounting
+ * may never fail in.
+ */
+async function syncUptimeForState(
+	db: Db,
+	containerId: string,
+	state: PoolMemberState | 'creating' | 'error',
+	endReason?: ContainerUptimeEndReason,
+): Promise<void> {
+	if (state === 'suspended') {
+		await closeUptimeInterval(db, containerId, endReason ?? ContainerUptimeEndReason.Stopped);
+		return;
+	}
+	if (state === 'error') {
+		// The pool has lost confidence that this container is up, so it stops
+		// billing on the pool's own evidence. `Reconciled` rather than `Stopped`:
+		// nobody asked for this stop, and the close time is when the fault was
+		// noticed rather than when the container actually went.
+		await closeUptimeInterval(db, containerId, endReason ?? ContainerUptimeEndReason.Reconciled);
+		return;
+	}
+	// creating, idle or busy - the container is up. A resume opens a NEW interval
+	// rather than reopening the closed one, which is what makes a suspend/resume
+	// cycle read as two billed stretches with a free gap between them.
+	await openUptimeInterval(db, containerId);
+}
+
+/**
+ * Open an interval for a container the pool already believes is up, if it has none.
+ *
+ * The repair half of the rule above. A container can reach a running state with
+ * no interval - a member older than the ledger itself, or one whose interval was
+ * closed while the container stayed up - and nothing else heals it: the warm
+ * paths reach a running container through claim and release, and both of those
+ * open only on a row that moved, which a container nobody claims never does.
+ *
+ * Billing starts at `now()`, deliberately. The real start is unknowable here, and
+ * inventing one bills for time this instance cannot show its own evidence for.
+ *
+ * Exported so the liveness pass can call it without importing the ledger, which
+ * would put a second writer outside this file.
+ */
+export async function ensurePoolMemberUptimeOpen(db: Db, containerId: string): Promise<void> {
+	await openUptimeInterval(db, containerId);
+}
 
 /**
  * Record whether a container is holding committed work that reached no durable
@@ -167,11 +233,7 @@ export async function upsertPoolMember(
 	);
 	// After the member write, never before: the ledger reads the container's
 	// shape, owner and chat pin straight off the row this just settled.
-	if (state === 'suspended') {
-		await closeUptimeInterval(db, containerId, ContainerUptimeEndReason.Stopped);
-	} else {
-		await openUptimeInterval(db, containerId);
-	}
+	await syncUptimeForState(db, containerId, state);
 }
 
 /**
@@ -207,7 +269,13 @@ export async function claimPoolMember(
 		  RETURNING container_id`,
 		[containerId, lastTaskId],
 	);
-	return res.rows.length > 0;
+	if (res.rows.length === 0) return false;
+	// The row moved out of `idle`, so the pool believes this container is up. A
+	// warm container taken straight off the ladder is the common case that reaches
+	// a run without passing through provision or resume, so this is the only point
+	// its interval can open.
+	await syncUptimeForState(db, containerId, 'busy');
+	return true;
 }
 
 /**
@@ -255,13 +323,18 @@ export async function releasePoolMember(
 	containerId: string,
 	lastTaskId: string | null,
 ): Promise<void> {
-	await db.query(
+	const res = await db.query<{ container_id: string }>(
 		`UPDATE container_pool_members
 		    SET state = 'idle', last_task_id = COALESCE($2, last_task_id),
 		        last_released_at = now(), updated_at = now()
-		  WHERE container_id = $1 AND state <> 'suspended'`,
+		  WHERE container_id = $1 AND state <> 'suspended'
+		 RETURNING container_id`,
 		[containerId, lastTaskId],
 	);
+	// `RETURNING` because the guard above means the row may not have moved: a
+	// container suspended under a running run is left alone, and billing one the
+	// pool believes is stopped is the over-bill this must not do.
+	if (res.rows.length > 0) await syncUptimeForState(db, containerId, 'idle');
 }
 
 /**
@@ -290,20 +363,7 @@ export async function setPoolMemberState(
 		  WHERE container_id = $1 AND state IS DISTINCT FROM $2::container_pool_state`,
 		[containerId, state],
 	);
-	if (state === 'suspended') {
-		await closeUptimeInterval(db, containerId, endReason ?? ContainerUptimeEndReason.Stopped);
-	} else if (state === 'error') {
-		// The pool has lost confidence that this container is up, so it stops
-		// billing on the pool's own evidence. `Reconciled` rather than `Stopped`:
-		// nobody asked for this stop, and the close time is when the fault was
-		// noticed rather than when the container actually went.
-		await closeUptimeInterval(db, containerId, endReason ?? ContainerUptimeEndReason.Reconciled);
-	} else {
-		// idle or busy - the container is up. A resume opens a NEW interval rather
-		// than reopening the closed one, which is what makes a suspend/resume cycle
-		// read as two billed stretches with a free gap between them.
-		await openUptimeInterval(db, containerId);
-	}
+	await syncUptimeForState(db, containerId, state, endReason);
 }
 
 /**
@@ -317,6 +377,53 @@ export async function setPoolMemberState(
 export async function removePoolMember(db: Db, containerId: string): Promise<void> {
 	await closeUptimeInterval(db, containerId, ContainerUptimeEndReason.Destroyed);
 	await db.query(`DELETE FROM container_pool_members WHERE container_id = $1`, [containerId]);
+}
+
+/**
+ * Forget every member at once, closing what they were billing first.
+ *
+ * The backend switch destroys every container the outgoing backend was running
+ * and then drops the rows describing them. Dropping the rows alone would strand
+ * each open interval for ever - an open interval bills to `now()`, so the switch
+ * would quietly accrue hours on containers that no longer exist. `Destroyed` is
+ * the honest reason: that is what just happened to them.
+ *
+ * Returns how many members were forgotten.
+ */
+export async function clearAllPoolMembers(db: Db): Promise<number> {
+	await closeUptimeIntervalsForMembers(db, ContainerUptimeEndReason.Destroyed);
+	const res = await db.query<{ container_id: string }>(
+		'DELETE FROM container_pool_members RETURNING container_id',
+	);
+	return res.rows.length;
+}
+
+/**
+ * Record that a container came up outside the pool's own lifecycle calls.
+ *
+ * Two paths start a container in place and tell only `projects`: the on-demand
+ * start, and the boot self-heal. The member each leaves behind still reads
+ * `suspended`, so the pool believes a running container is stopped and bills
+ * nothing for it until something suspends and resumes it again.
+ *
+ * `WHERE state = 'suspended'` is the whole safety of this. It can only promote a
+ * container the pool already thought was down, so it can never demote a `busy`
+ * member out from under the run holding it, and never re-advertises a member that
+ * a lifecycle call is part-way through retiring.
+ *
+ * Returns whether the row moved.
+ */
+export async function markPoolMemberRunning(db: Db, containerId: string): Promise<boolean> {
+	const res = await db.query<{ container_id: string }>(
+		`UPDATE container_pool_members
+		    SET state = 'idle', updated_at = now()
+		  WHERE container_id = $1 AND state = 'suspended'
+		 RETURNING container_id`,
+		[containerId],
+	);
+	if (res.rows.length === 0) return false;
+	await syncUptimeForState(db, containerId, 'idle');
+	return true;
 }
 
 /**
@@ -342,7 +449,13 @@ export async function reclaimBusyPoolMembers(db: Db): Promise<string[]> {
 		  WHERE state = 'busy'
 		 RETURNING container_id`,
 	);
-	return res.rows.map((r) => r.container_id);
+	const ids = res.rows.map((r) => r.container_id);
+	// Each of these was `busy` a moment ago, so the pool believes it is up. On a
+	// backend whose containers outlive a Hezo restart nothing re-provisions and
+	// nothing resumes, so without this the whole fleet reaches its next run
+	// through the warm path alone and bills nothing for the rest of its life.
+	for (const id of ids) await syncUptimeForState(db, id, 'idle');
+	return ids;
 }
 
 /**

--- a/packages/server/src/services/sandbox/switch-backend.ts
+++ b/packages/server/src/services/sandbox/switch-backend.ts
@@ -34,6 +34,7 @@ import { SandboxBackendError } from './errors';
 import type { SandboxBackendHolder } from './holder';
 import { INSTANCE_LABEL } from './labels';
 import { openSandboxBackend } from './open';
+import { clearAllPoolMembers } from './pool-db';
 import type { ContainerEngine } from './types';
 
 const log = logger.child('sandbox-switch');
@@ -125,7 +126,9 @@ async function destroyAll(db: Db, engine: ContainerEngine, dataDir: string): Pro
 	// The records go regardless of whether each destroy succeeded: they name
 	// containers on a backend this instance is about to stop talking to, so
 	// keeping them would leave the pool handing out ids that resolve to nothing.
-	await db.query('DELETE FROM container_pool_members');
+	// Through the pool rather than a DELETE of its own, so the uptime intervals
+	// these members were billing are closed rather than stranded open for ever.
+	await clearAllPoolMembers(db);
 	await db.query(
 		`UPDATE projects SET container_id = NULL, container_status = NULL
 		  WHERE container_id IS NOT NULL OR container_status IS NOT NULL`,

--- a/packages/server/src/services/sandbox/uptime-ledger.ts
+++ b/packages/server/src/services/sandbox/uptime-ledger.ts
@@ -87,6 +87,33 @@ export async function closeUptimeInterval(
 }
 
 /**
+ * Close every open interval whose container the pool still describes.
+ *
+ * The set-based twin of {@link closeUptimeInterval}, for the one caller that
+ * forgets the whole pool at once: a backend switch destroys every container the
+ * outgoing backend was running, so every stretch they were billing ends with
+ * them. Written here rather than at that call site so the ledger keeps its single
+ * writer, and as one statement rather than a loop because the row count is the
+ * fleet size.
+ *
+ * Left open, those intervals would bill to `now()` for ever, on containers that
+ * no longer exist, on a backend this instance has stopped talking to.
+ */
+export async function closeUptimeIntervalsForMembers(
+	db: Db,
+	reason: ContainerUptimeEndReason,
+): Promise<void> {
+	await db.query(
+		`UPDATE container_uptime_entries e
+		    SET ended_at = now(), end_reason = $1
+		  WHERE e.ended_at IS NULL
+		    AND EXISTS (SELECT 1 FROM container_pool_members m
+		                 WHERE m.container_id = e.container_id)`,
+		[reason],
+	);
+}
+
+/**
  * Carry a container's chat pin onto its open interval.
  *
  * The pin is set *after* the container exists - the chat claims an idle member

--- a/packages/server/test/container-uptime-ledger.test.ts
+++ b/packages/server/test/container-uptime-ledger.test.ts
@@ -20,6 +20,12 @@ import {
 	monthToDateContainerSeconds,
 } from '../src/services/container-hours';
 import {
+	claimPoolMember,
+	clearAllPoolMembers,
+	ensurePoolMemberUptimeOpen,
+	markPoolMemberRunning,
+	reclaimBusyPoolMembers,
+	releasePoolMember,
 	removePoolMember,
 	setPoolMemberChatReservation,
 	setPoolMemberState,
@@ -354,5 +360,178 @@ describe('GET /container-hours', () => {
 		const data = (await res.json()).data as { bucket: string; buckets: unknown[] };
 		expect(data.bucket).toBe('week');
 		expect(data.buckets).toHaveLength(12);
+	});
+});
+
+/**
+ * The warm paths, which is where the ledger was silently not being written.
+ *
+ * `upsertPoolMember` and `setPoolMemberState` were the only two writers that
+ * opened an interval, and both are cold: a provision, or a resume. An ordinary
+ * run reaches a warm container through `claimPoolMember` and hands it back
+ * through `releasePoolMember`, and a restart moves the whole fleet through
+ * `reclaimBusyPoolMembers` - none of which touched the ledger. So a container
+ * that reached a running state without an interval could never acquire one, and
+ * billed nothing for the rest of its life while showing its full allocation in
+ * the run log. That is not a case, it is a class, so the last test here asserts
+ * the invariant rather than the symptom.
+ */
+describe('every pool state write moves the ledger', () => {
+	const GB = 2 ** 30;
+
+	/**
+	 * A container that is up and pooled but carries no open interval - the state an
+	 * instance that upgraded onto the ledger is in, and the state a container is
+	 * left in when its interval is closed while it stays up.
+	 */
+	const warmWithNoInterval = async (containerId: string): Promise<void> => {
+		await upsertPoolMember(db, projectId, containerId, 'idle', { memoryBytes: GB });
+		await db.query('DELETE FROM container_uptime_entries WHERE container_id = $1', [containerId]);
+	};
+
+	const openRows = async (containerId: string): Promise<IntervalRow[]> =>
+		(await intervals(containerId)).filter((r) => r.ended_at === null);
+
+	it('opens an interval when a run claims a warm container', async () => {
+		// The exact production fault: the container was up, correctly pooled, and
+		// reported 4 GB in its own run header, while Budget -> Hours read zero.
+		await warmWithNoInterval('warm-claim');
+		expect(await claimPoolMember(db, 'warm-claim', null)).toBe(true);
+
+		const rows = await openRows('warm-claim');
+		expect(rows).toHaveLength(1);
+		expect(rows[0].project_id).toBe(projectId);
+		// Copied off the member, so the ledger cannot disagree with the pool.
+		expect(Number(rows[0].memory_bytes)).toBe(GB);
+	});
+
+	it('opens an interval when a run hands a warm container back', async () => {
+		await upsertPoolMember(db, projectId, 'warm-release', 'idle', { memoryBytes: GB });
+		await claimPoolMember(db, 'warm-release', null);
+		await db.query('DELETE FROM container_uptime_entries');
+
+		await releasePoolMember(db, 'warm-release', null);
+		expect(await openRows('warm-release')).toHaveLength(1);
+	});
+
+	it('does not bill a suspended container that a release walked past', async () => {
+		// `releasePoolMember` guards on `state <> 'suspended'`, so the row does not
+		// move here. Opening anyway would bill a container the pool believes is
+		// stopped, which is the one direction cost accounting may never fail in.
+		await upsertPoolMember(db, projectId, 'parked', 'idle', { memoryBytes: GB });
+		await upsertPoolMember(db, projectId, 'parked', 'suspended');
+		await db.query('DELETE FROM container_uptime_entries');
+
+		await releasePoolMember(db, 'parked', null);
+		expect(await intervals('parked')).toHaveLength(0);
+	});
+
+	it('opens intervals for the containers the boot reclaim returns to the pool', async () => {
+		// A backend whose sandboxes outlive a Hezo restart never re-provisions and
+		// never resumes, so this is the only point the whole fleet passes through.
+		await upsertPoolMember(db, projectId, 'reclaim-a', 'idle', { memoryBytes: GB });
+		await upsertPoolMember(db, otherProjectId, 'reclaim-b', 'idle', { memoryBytes: GB });
+		await claimPoolMember(db, 'reclaim-a', null);
+		await claimPoolMember(db, 'reclaim-b', null);
+		await db.query('DELETE FROM container_uptime_entries');
+
+		expect((await reclaimBusyPoolMembers(db)).sort()).toEqual(['reclaim-a', 'reclaim-b']);
+		expect(await openRows('reclaim-a')).toHaveLength(1);
+		expect(await openRows('reclaim-b')).toHaveLength(1);
+	});
+
+	it('promotes a container started outside the pool, and bills it', async () => {
+		await upsertPoolMember(db, projectId, 'oob', 'idle', { memoryBytes: GB });
+		await upsertPoolMember(db, projectId, 'oob', 'suspended');
+		expect(await openRows('oob')).toHaveLength(0);
+
+		expect(await markPoolMemberRunning(db, 'oob')).toBe(true);
+		expect(await openRows('oob')).toHaveLength(1);
+		// A resume is a new stretch, never a reopened one.
+		expect(await intervals('oob')).toHaveLength(2);
+	});
+
+	it('never demotes a container a run is holding', async () => {
+		// The boot self-heal and the on-demand start both call this, and both can
+		// race a live run. `WHERE state = 'suspended'` is what makes that safe.
+		await upsertPoolMember(db, projectId, 'held', 'idle', { memoryBytes: GB });
+		await claimPoolMember(db, 'held', null);
+
+		expect(await markPoolMemberRunning(db, 'held')).toBe(false);
+		const state = await db.query<{ state: string }>(
+			'SELECT state::text AS state FROM container_pool_members WHERE container_id = $1',
+			['held'],
+		);
+		expect(state.rows[0].state).toBe('busy');
+	});
+
+	it('closes what the fleet was billing before a backend switch forgets it', async () => {
+		// Left open, each of these bills to now() for ever - on containers that no
+		// longer exist, on a backend the instance has stopped talking to.
+		await upsertPoolMember(db, projectId, 'switch-a', 'idle', { memoryBytes: GB });
+		await upsertPoolMember(db, otherProjectId, 'switch-b', 'idle', { memoryBytes: GB });
+
+		expect(await clearAllPoolMembers(db)).toBe(2);
+		for (const id of ['switch-a', 'switch-b']) {
+			const rows = await intervals(id);
+			expect(rows).toHaveLength(1);
+			expect(rows[0].ended_at).not.toBeNull();
+			expect(rows[0].end_reason).toBe(ContainerUptimeEndReason.Destroyed);
+		}
+		const members = await db.query('SELECT container_id FROM container_pool_members');
+		expect(members.rows).toHaveLength(0);
+	});
+
+	it('repairs a running container idempotently', async () => {
+		// What the liveness pass calls. Twice must not bill the same minutes twice.
+		await warmWithNoInterval('healed');
+		await ensurePoolMemberUptimeOpen(db, 'healed');
+		await ensurePoolMemberUptimeOpen(db, 'healed');
+		expect(await openRows('healed')).toHaveLength(1);
+	});
+
+	/**
+	 * The structural guard. Every case above is one transition; this is the rule
+	 * they are all instances of, walked across every exported state writer in turn.
+	 * A new writer that forgets the ledger fails here rather than shipping and
+	 * under-billing quietly for weeks.
+	 */
+	it('holds the invariant across every state writer', async () => {
+		const id = 'invariant';
+		const check = async (label: string): Promise<void> => {
+			const res = await db.query<{ state: string }>(
+				'SELECT state::text AS state FROM container_pool_members WHERE container_id = $1',
+				[id],
+			);
+			const state = res.rows[0]?.state ?? 'absent';
+			const up = state === 'creating' || state === 'idle' || state === 'busy';
+			expect({ label, state, open: (await openRows(id)).length }).toEqual({
+				label,
+				state,
+				open: up ? 1 : 0,
+			});
+		};
+
+		await upsertPoolMember(db, projectId, id, 'creating', { memoryBytes: GB });
+		await check('provisioning starts');
+		await upsertPoolMember(db, projectId, id, 'idle', { memoryBytes: GB });
+		await check('provisioning finishes');
+		// Wiped before each warm step, so the walk asserts that these writers *open*
+		// rather than merely inheriting the interval the provision left behind. That
+		// distinction is the whole fault: they all inherited, and none opened.
+		await db.query('DELETE FROM container_uptime_entries');
+		await claimPoolMember(db, id, null);
+		await check('a run claims it');
+		await db.query('DELETE FROM container_uptime_entries');
+		await releasePoolMember(db, id, null);
+		await check('the run hands it back');
+		await setPoolMemberState(db, id, 'suspended');
+		await check('the idle sweep stops it');
+		await markPoolMemberRunning(db, id);
+		await check('something starts it out of band');
+		await setPoolMemberState(db, id, 'error');
+		await check('the pool loses confidence in it');
+		await removePoolMember(db, id);
+		await check('it is destroyed');
 	});
 });

--- a/packages/server/test/run-timeout.test.ts
+++ b/packages/server/test/run-timeout.test.ts
@@ -479,6 +479,33 @@ describe('shutdown handback (runAgent + JobManager)', () => {
 		expect(result.requeueReason).toBe(WakeupSkipReason.ServerShutdown);
 	});
 
+	it('hands back a shutdown that lands in the setup window', async () => {
+		// The fourth landing point: after the container is acquired and before the
+		// exec, where the credential lock, the tunnel and `buildRunContext` run. A
+		// throw there with the signal already aborted is the shape the drain makes
+		// at that moment, and it has its own branch because the exec catch is not
+		// reached from here at all.
+		const ac = new AbortController();
+		const deps = makeDeps({
+			openExecChannel: async () => {
+				ac.abort('server_shutdown');
+				throw new Error('tunnel torn down by shutdown');
+			},
+		});
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.requeued).toBe(true);
+		expect(result.requeueReason).toBe(WakeupSkipReason.ServerShutdown);
+	});
+
 	it('still fails a bare pre-run abort rather than re-queueing it', async () => {
 		// A user cancel arriving in the same window is a decision to stop, not work
 		// owed - so the handback must be reasoned from the reason, not from the fact

--- a/packages/server/test/run-timeout.test.ts
+++ b/packages/server/test/run-timeout.test.ts
@@ -414,6 +414,90 @@ describe('shutdown handback (runAgent + JobManager)', () => {
 		expect(run.rows[0].error).toContain('returning this run to the queue');
 	});
 
+	it('hands back a run the drain caught before it had a row at all', async () => {
+		// The earliest landing point, and the one with no row to hand back through:
+		// the drain can abort between the dispatch and the run's first write. The
+		// work is owed exactly as much as it is mid-exec, so the flag alone carries
+		// it - there is simply nothing to annotate.
+		const ac = new AbortController();
+		ac.abort('server_shutdown');
+
+		const result = await runAgent(
+			makeDeps(),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.requeued).toBe(true);
+		expect(result.requeueReason).toBe(WakeupSkipReason.ServerShutdown);
+		// No run row, deliberately: none was ever created, so none is invented.
+		expect(result.heartbeatRunId).toBeUndefined();
+	});
+
+	it('hands back a run the drain caught between phases', async () => {
+		// The third landing point: `finalizeAbort`, reached at a phase checkpoint
+		// rather than on the exec rejection. Aborting while the container is being
+		// acquired puts the run on the checkpoint before it is marked running.
+		//
+		// Every rung of the acquire ladder aborts, not just the provision one: which
+		// rung this takes depends on whether a sibling case left a warm container on
+		// the shared project, so hooking only `startContainer` passed alone and
+		// failed in a full run.
+		const ac = new AbortController();
+		const shutdown = () => ac.abort('server_shutdown');
+		const deps = makeDeps({
+			startContainer: async () => {
+				shutdown();
+			},
+			createContainer: async () => {
+				shutdown();
+				return { Id: 'container-123', Warnings: [] };
+			},
+			inspectContainer: async () => {
+				shutdown();
+				return {
+					Id: 'container-123',
+					State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+					Config: { Image: 'test' },
+				};
+			},
+		});
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.requeued).toBe(true);
+		expect(result.requeueReason).toBe(WakeupSkipReason.ServerShutdown);
+	});
+
+	it('still fails a bare pre-run abort rather than re-queueing it', async () => {
+		// A user cancel arriving in the same window is a decision to stop, not work
+		// owed - so the handback must be reasoned from the reason, not from the fact
+		// that the signal was already aborted.
+		const ac = new AbortController();
+		ac.abort();
+
+		const result = await runAgent(
+			makeDeps(),
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.requeued).toBeFalsy();
+	});
+
 	it('returns the wakeup to the queue, which is the promise the message makes', async () => {
 		await resetTaskHistory();
 		// The wakeup this run was dispatched for, claimed as a live dispatch leaves it.

--- a/packages/server/test/run-timeout.test.ts
+++ b/packages/server/test/run-timeout.test.ts
@@ -1,4 +1,11 @@
-import { ContainerStatus, HeartbeatRunStatus, WakeupSource } from '@hezo/shared';
+import {
+	ContainerStatus,
+	HeartbeatRunStatus,
+	RunCancelReason,
+	WakeupSkipReason,
+	WakeupSource,
+	WakeupStatus,
+} from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -359,5 +366,103 @@ describe('timeout continuation (JobManager)', () => {
 			[taskId],
 		);
 		expect(failed.rows.length).toBe(0); // failure ping suppressed for a continuing timeout
+	});
+});
+
+/**
+ * Shutdown is the one abort reason that hands the work back instead of ending the
+ * run, and it has to, because nothing downstream can do it afterwards.
+ *
+ * The drain finalizes the run row and settles its wakeup before the process
+ * exits, and every recovery predicate in the codebase - `reconcileDatabaseOnStartup`,
+ * `detectOrphanedRuns`, `healStaleRunState`, `requeueContainerKilledRuns` - looks
+ * for a row left `running` or `queued`. So an orderly shutdown dropped the work
+ * outright while a hard crash recovered: the better the shutdown behaved, the more
+ * certainly the task stopped. The row's own message promised a re-queue that no
+ * code delivered.
+ */
+describe('shutdown handback (runAgent + JobManager)', () => {
+	it('finalizes a shutdown-aborted run as cancelled and asks for a re-queue', async () => {
+		const ac = new AbortController();
+		const deps = makeDeps({
+			execStart: async () => {
+				ac.abort('server_shutdown');
+				throw new DOMException('Aborted', 'AbortError');
+			},
+		});
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.requeued).toBe(true);
+		expect(result.requeueReason).toBe(WakeupSkipReason.ServerShutdown);
+
+		const run = await db.query<{ status: string; error: string }>(
+			'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		// `cancelled`, not `failed`. A shutdown is not a verdict on the agent, and a
+		// terminal `failed` row is precisely what boot recovery cannot match.
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
+		expect(run.rows[0].error).toContain('Server shut down while this run was in flight');
+		expect(run.rows[0].error).toContain('returning this run to the queue');
+	});
+
+	it('returns the wakeup to the queue, which is the promise the message makes', async () => {
+		await resetTaskHistory();
+		// The wakeup this run was dispatched for, claimed as a live dispatch leaves it.
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+			 VALUES ($1, $2, $3::wakeup_source, 'claimed', $4::jsonb) RETURNING id`,
+			[agentId, teamId, WakeupSource.Timer, JSON.stringify({ task_id: taskId })],
+		);
+		const runRow = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, 'cancelled', now()) RETURNING id`,
+			[teamId, agentId, taskId],
+		);
+		const manager = createJobManager();
+
+		await (manager as any).onAgentComplete(
+			agentId,
+			'engineer',
+			taskId,
+			taskIdentifier,
+			teamId,
+			wakeup.rows[0].id,
+			undefined,
+			{
+				success: false,
+				exitCode: -1,
+				stdout: '',
+				stderr: 'Server shut down while this run was in flight',
+				durationMs: 1,
+				heartbeatRunId: runRow.rows[0].id,
+				requeued: true,
+				requeueReason: WakeupSkipReason.ServerShutdown,
+			},
+		);
+
+		const w = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeup.rows[0].id],
+		);
+		// Queued, so the 5s cron picks it up when the process is next up. This is the
+		// half that was missing: the drain settled it `failed` and it stayed there.
+		expect(w.rows[0].status).toBe(WakeupStatus.Queued);
+
+		const row = await db.query<{ cancel_reason: string | null }>(
+			'SELECT cancel_reason FROM heartbeat_runs WHERE id = $1',
+			[runRow.rows[0].id],
+		);
+		// Recorded only once the handback is known to have landed, and it is what
+		// keeps a dead Retry button off a run whose work is already carried.
+		expect(row.rows[0].cancel_reason).toBe(RunCancelReason.HandedBack);
 	});
 });

--- a/packages/server/test/sandbox-pool-db.test.ts
+++ b/packages/server/test/sandbox-pool-db.test.ts
@@ -178,6 +178,13 @@ describe('reconcilePoolMembers', () => {
 			typeof reconcilePoolMembers
 		>[0]);
 
+	const openIntervals = async (): Promise<string[]> => {
+		const r = await db.query<{ container_id: string }>(
+			'SELECT container_id FROM container_uptime_entries WHERE ended_at IS NULL ORDER BY container_id',
+		);
+		return r.rows.map((x) => x.container_id);
+	};
+
 	const stateOf = async (containerId: string): Promise<string | undefined> =>
 		(
 			await db.query<{ state: string }>(
@@ -200,7 +207,10 @@ describe('reconcilePoolMembers', () => {
 	afterAll(() => db.close());
 	// Each case owns the whole table: a member left behind by a previous case
 	// would be judged missing by the next one's engine and inflate its count.
-	beforeEach(() => db.query('DELETE FROM container_pool_members'));
+	beforeEach(async () => {
+		await db.query('DELETE FROM container_pool_members');
+		await db.query('DELETE FROM container_uptime_entries');
+	});
 
 	it('drops a busy member whose container is gone — the case nothing else repairs', async () => {
 		await seed('gone-busy', 'busy', 300);
@@ -208,6 +218,34 @@ describe('reconcilePoolMembers', () => {
 		const result = await reconcile(engine(['live-busy']));
 		expect(result.dropped).toBe(1);
 		expect(await remaining()).toEqual(['live-busy']);
+	});
+
+	it('opens a missing interval for a container it finds running', async () => {
+		// The repair for the fault that read as "0 containers up now" on a live
+		// container. A member can reach a running state with no interval - older
+		// than the ledger, or closed while the container stayed up - and the warm
+		// paths only open on a row that moves, which a container nobody claims
+		// never does. This pass used to `continue` straight past exactly those.
+		await seed('running-unbilled', 'idle', 300);
+		await seed('running-busy', 'busy', 300);
+		await seed('broken', 'error', 300);
+		expect(await openIntervals()).toEqual([]);
+
+		await reconcile(engine(['running-unbilled', 'running-busy', 'broken']));
+
+		// `error` stays unbilled: the pool has stopped believing that one is up.
+		expect(await openIntervals()).toEqual(['running-busy', 'running-unbilled']);
+	});
+
+	it('does not bill the same minutes twice when it sweeps again', async () => {
+		await seed('swept-twice', 'idle', 300);
+		await reconcile(engine(['swept-twice']));
+		await reconcile(engine(['swept-twice']));
+		const all = await db.query<{ n: number }>(
+			'SELECT COUNT(*)::int AS n FROM container_uptime_entries WHERE container_id = $1',
+			['swept-twice'],
+		);
+		expect(all.rows[0].n).toBe(1);
 	});
 
 	it('leaves a member alone when the engine could not answer', async () => {

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -961,6 +961,12 @@ export const WakeupSkipReason = {
 	 */
 	CredentialBusy: 'credential_busy',
 	/**
+	 * Hezo shut down with this run in flight, so the drain handed the work back
+	 * rather than failing it. Nothing clears this one - the wakeup is queued
+	 * again immediately and dispatches when the process is next up.
+	 */
+	ServerShutdown: 'server_shutdown',
+	/**
 	 * The instance has burned its monthly container-hours allowance, so no new
 	 * container may start. Distinct from `InstanceAtCapacity` because nothing the
 	 * instance does will clear it: retiring a container frees memory but not


### PR DESCRIPTION
Two bookkeeping faults found from a live instance. Unrelated in mechanism, identical in shape: a write that only fires on some of the paths that reach it.

## 1. Container hours were recorded only on cold paths

**Symptom.** Budget → Hours read `0s` today/week/month and "0 containers up now" while a run was executing, its own log header reading `Container 5d6481de-eb7 · 4 GB RAM · 4 GB disk`. The container was up, correctly pooled, and billing nothing. After a restart the page began recording, with a single bar on the current day and nothing for the preceding 28 days of continuous uptime.

**Cause.** `container_uptime_entries` had exactly two writers that opened an interval - `upsertPoolMember` (provision) and `setPoolMemberState` (resume). Both are cold. The three writers an ordinary run touches never opened one:

| Pool write | Transition | Opened an interval? | How often |
|---|---|---|---|
| `upsertPoolMember` | provision | yes | cold start only |
| `setPoolMemberState` | resume | yes | after a suspend |
| `claimPoolMember` | idle → busy | **no** | every run |
| `releasePoolMember` | busy → idle | **no** | every run |
| `reclaimBusyPoolMembers` | boot, busy → idle | **no** | every restart |

And nothing could heal it: `reconcilePoolMembers`, the one recurring pass that inspects every member, did `if (info.State.Running) continue;` - walking past exactly the containers that needed repairing. So once a running container lacked an interval it billed nothing for the rest of its life. On a backend whose sandboxes outlive a Hezo restart this is the normal case, not an edge one.

**Fix.** Every state write funnels through `syncUptimeForState`, so a transition cannot be added without its interval. The warm writers open only on a row their own `RETURNING` says moved - a container the pool believes is stopped is never billed, the one direction cost accounting may not fail in. Three further leaks closed in the same area:

- `reconcilePoolMembers` now repairs a running member that has no interval, riding the liveness round trip it already makes. Billing starts at `now()`; the real start is unknowable and inventing one bills for unevidenced time.
- The backend switch bulk-deleted `container_pool_members` with a raw `DELETE`, stranding every open interval for ever - and an open interval bills to `now()`. It goes through `clearAllPoolMembers`, which closes them first.
- The on-demand start and the boot self-heal started a container in place and told only `projects`. `markPoolMemberRunning` tells the pool, guarded on `state = 'suspended'` so it can never demote a `busy` member under a live run.

**No migration and no backfill** - the repair pass heals existing members within one sweep, and a backfill would have to invent a `started_at`.

## 2. A run killed by a clean shutdown was never re-queued

**Symptom.** A run recorded *"Server shut down while this run was in flight; it will be re-queued when Hezo comes back."* Nothing delivered that. The task sat idle until a human pressed Retry.

**Cause.** The re-queue code exists, but its predicate cannot match the row. `drainRunningRuns` aborts with `server_shutdown`, a *named* reason, so `abortedRunStatus` took the `Failed` arm and finalized the run terminal before the process exited; its wakeup settled `failed` in the same drain. Boot recovery scans `status IN ('running','queued')`, and so do `detectOrphanedRuns`, `healStaleRunState` and `requeueContainerKilledRuns`. Both rows were terminal, so every one of them excluded it.

The result is backwards: a hard crash recovered, an orderly drain dropped the work. **The better the shutdown behaved, the more certainly the task stopped.**

**Fix.** Route `server_shutdown` through `finalizeRequeue` - the machinery already there for the capacity and credential waits. It finalizes the row `Cancelled`, and the settle path returns the wakeup to `queued` and stamps `handed_back` once the handback is known to have landed. The promise is then kept by construction, while the process is still up, rather than depending on a pass that never sees the row.

**A shutdown can land at four points, and all four now hand back.** The first three were fixed together; the fourth was found by chasing this patch's own coverage report, and was still dropping the work:

1. **Before the run has a row** - `runAgent` bails at the top for a signal already aborted, before the heartbeat row exists. No row to annotate, so the handback is the flag alone: the wakeup returns to the queue and `recordHandbackOutcome` is correctly skipped for want of a run id. A bare abort here still fails, since a user cancel is a decision to stop rather than work owed.
2. **A phase checkpoint** (`finalizeAbort`).
3. **The exec rejection** - the drain's own usual path.
4. **The setup window** - between the container claim and the exec, where the credential lock, the tunnel and `buildRunContext` run.

Deliberately not done: matching on the error string, which is the anti-pattern migration 066 was written to retire, and a new boot predicate, which would still race whatever the drain had already written.

A drain that overruns its 10s deadline still leaves the row `running`, so the existing boot pass covers that unchanged - both paths now recover. If the handback itself fails, `recordHandbackOutcome` stamps `abandoned` and posts the notice, so the reader gets a Retry affordance rather than silence. The web tier needed no change: it reads the Retry gate off `RUN_CANCEL_BEHAVIOUR`, and `handed_back` correctly offers none.

## Tests

Every new test was checked to fail with its fix reverted, not merely to pass alongside it. Where that check does not hold, it is said so below.

- **Ledger** (`container-uptime-ledger.test.ts`, +10): each warm writer against a container that is up with no interval; the suspended-release case that must stay unbilled; the out-of-band promotion and its refusal to demote a `busy` member; the backend-switch close; and a **structural walk** asserting the invariant after every exported state writer - a member the pool believes is up has exactly one open interval, one it believes is down has none. The next writer that forgets the ledger fails there rather than under-billing silently.
- **Reconcile** (`sandbox-pool-db.test.ts`, +2): the repair opens a missing interval for a running member, leaves an `error` member unbilled, and does not bill the same minutes twice on a second sweep.
- **Shutdown** (`run-timeout.test.ts`, +5): one per landing point, plus the bare-abort case that must still fail. One further test drives `onAgentComplete` with a hand-built requeued result to assert the wakeup returns to `queued` and the row is stamped `handed_back` - that one documents the settle contract and passes either way, so it is not a regression guard for this bug.

The checkpoint test hooks every rung of the container-acquire ladder rather than just the provision one: which rung it takes depends on whether a sibling case left a warm container on the shared project, so hooking `startContainer` alone passed in isolation and failed in a full run.

Local sweeps green: `container`, `pool`, `agent-runner`, `job-manager`, `wakeup`, `run-`, and the shared package. Four `sandbox-open` / `sandbox-backend-store` failures reproduce identically on a clean tree - the dev container has no Docker daemon - so they are environmental; CI's `test-backend` shards cover them and pass. `test-postgres` and `test-s3` could not be run locally and are green in CI.

## Notes

No commit stages an upgrade-bearing path, so none carries `Upgrade-Checked:`. The second commit stages `packages/shared/src/` and carries `Translations-Checked:`; it adds one `WakeupSkipReason` value, stored in a `TEXT` column with no migration, and the web tier renders no label from it.

One thing found while reading and **not** changed here, worth a follow-up: the Hours chart assigns series colours largest-total-first from a fixed order, which puts `success` beside `warning` in most stacks - measured protanopia separation ΔE 6.6 against a target of 8 (normal vision is comfortable at 20.7), and in dark mode all four series sit between lightness 0.71 and 0.82, so the stack reads as one mass. Re-stepping only the dark values would address both without touching the hue order.