### PR TITLE
fix(runs): drop Claude Code's unrecognized-model noise on gateway providers

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3330,6 +3330,22 @@ see below), so it is the one provider that offers a choice. Every other provider
 one CLI and the UI omits the picker for it — for Ollama and LM Studio the Advanced disclosure
 then holds only the optional API key.
 
+**Off-registry model ids are the price of that gateway, and the run log paid it.** Claude Code
+resolves every model id against its own built-in registry and writes
+`[claude-code:unrecognized_model] {"model":…,"query_source":…}` to stderr for each one it cannot
+place - the run's own model (`query_source: sdk`), plus the haiku-slot id
+(`ANTHROPIC_DEFAULT_HAIKU_MODEL`) it uses for session titles and subagents. Pointed at a
+third-party gateway every id is off-registry by construction, so those lines were guaranteed
+noise on every run. The Claude Code stream parser now drops them for exactly the providers
+`claudeCodeProviderUsesCustomEndpoint` covers - the third-party gateways above and the two local
+runners - and relays them untouched on Anthropic, where an id the CLI cannot resolve is a real
+signal, and when the parser is built without a provider at all. That is the predicate's third
+consumer, alongside the Stop-hook judge model and the subagent default. Filtering is
+line-oriented, so the wrapper buffers a partial stderr line until its newline, drains it in
+`flush()`, and releases it unfiltered past a 64 KiB ceiling rather than buffering without bound.
+Nothing else rests on the CLI's registry: run cost is priced from `model_pricing` over the
+reported token buckets, never from the CLI's own rate card.
+
 The one-to-many shape is deliberately kept even at one alternate: it is what makes a second CLI
 for a provider a table row rather than a refactor.
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -2141,7 +2141,7 @@ export async function runAgent(
 		const priceFn = pricing
 			? (model: string | undefined, tokens: CostTokens) => pricing.costCents(model, tokens)
 			: undefined;
-		const parser = createAgentStreamParser(runtimeType, priceFn, modelOverride);
+		const parser = createAgentStreamParser(runtimeType, priceFn, modelOverride, provider);
 
 		const persistRotatedAuth = async (): Promise<void> => {
 			await persistRotatedSubscriptionAuth({

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -17,7 +17,12 @@
  * client parses in `parse-agent-log.ts`, so the log viewer's Done block shows
  * tokens uniformly across runtimes.
  */
-import { AgentRuntime, type CostTokens } from '@hezo/shared';
+import {
+	AgentRuntime,
+	type AiProvider,
+	type CostTokens,
+	claudeCodeProviderUsesCustomEndpoint,
+} from '@hezo/shared';
 import { HEZO_MCP_SERVER_NAME } from './runtime-adapters/types';
 
 export interface AgentRunUsage {
@@ -104,15 +109,20 @@ export function classifyRuntimeError(raw: string | undefined | null): string | n
  *   stream names no model. OpenCode reports token counts but never a model id,
  *   so without this every OpenCode run priced at $0 no matter what it spent. A
  *   model named in the stream still wins - this is the floor, not an override.
+ * @param provider the run's model provider, for the runtimes whose stderr noise
+ *   depends on which endpoint they were pointed at. Omitted, every parser keeps
+ *   its default behaviour, so an unknown provider never silences anything.
  */
 export function createAgentStreamParser(
 	runtime: AgentRuntime,
 	price: PriceModelFn = NO_PRICE,
 	runModel?: string | null,
+	provider?: AiProvider | null,
 ): AgentStreamParser {
 	return (STREAM_PARSER_FACTORIES[runtime] ?? createPassthroughParser)(
 		price,
 		runModel?.trim() || undefined,
+		provider ?? undefined,
 	);
 }
 
@@ -120,16 +130,21 @@ export function createAgentStreamParser(
  * Which parser reads which CLI's stream. A `Record` rather than a switch so a
  * runtime added to the enum without a parser is a compile error.
  *
- * Every factory takes the same two arguments and ignores what it does not need:
- * Claude Code and Gemini name their model in the stream, while Codex, OpenCode
- * and the two usage-less runtimes do not, and depend on the run's own model to
- * price at all.
+ * Every factory takes the same three arguments and ignores what it does not
+ * need: Claude Code and Gemini name their model in the stream, while Codex,
+ * OpenCode and the two usage-less runtimes do not, and depend on the run's own
+ * model to price at all. Only Claude Code reads the provider.
  */
 const STREAM_PARSER_FACTORIES: Record<
 	AgentRuntime,
-	(price: PriceModelFn, runModel: string | undefined) => AgentStreamParser
+	(
+		price: PriceModelFn,
+		runModel: string | undefined,
+		provider: AiProvider | undefined,
+	) => AgentStreamParser
 > = {
-	[AgentRuntime.ClaudeCode]: (price) => createClaudeCodeParser(price),
+	[AgentRuntime.ClaudeCode]: (price, _runModel, provider) =>
+		createClaudeCodeParser(price, provider),
 	[AgentRuntime.Codex]: (price, runModel) => createCodexParser(price, runModel),
 	[AgentRuntime.Gemini]: (price) => createGeminiParser(price),
 	// OpenCode emits JSONL whose shapes vary across versions and are not fully
@@ -551,7 +566,72 @@ function mcpToolCounts(
 	return counts;
 }
 
-function createClaudeCodeParser(price: PriceModelFn): AgentStreamParser {
+/**
+ * Claude Code writes one of these to stderr for every model id its built-in
+ * registry cannot resolve, once per (model, call site):
+ *
+ *   [claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}
+ *
+ * Pointed at a third-party Anthropic-compatible endpoint every id is off-registry
+ * by design - the run's own model, plus the haiku-slot id the CLI uses for its
+ * session-title and subagent calls - so the line is guaranteed noise on every
+ * run. On Anthropic itself it is a real signal (a `--model` the CLI cannot
+ * resolve), which is why the filter is scoped to the custom-endpoint providers
+ * rather than applied to the runtime as a whole. It costs nothing else: run cost
+ * is priced from `model_pricing`, never from the CLI's own rate card.
+ */
+const CLAUDE_UNRECOGNIZED_MODEL_PREFIX = '[claude-code:unrecognized_model]';
+
+/**
+ * Ceiling on the partial stderr line held back while waiting for its newline.
+ * Filtering is line-oriented, so a chunk splitting mid-line has to be buffered;
+ * a stream that never sends a newline must not grow that buffer without bound,
+ * and past this length the line cannot be the ~100-byte diagnostic anyway, so it
+ * is released unfiltered.
+ */
+const STDERR_FILTER_BUFFER_LIMIT = 64 * 1024;
+
+function isUnrecognizedModelLine(line: string): boolean {
+	return line.trimStart().startsWith(CLAUDE_UNRECOGNIZED_MODEL_PREFIX);
+}
+
+/**
+ * Wraps a parser so `onStderr` drops the lines above. Every other stderr byte
+ * reaches the log in its original order, including a line released early by the
+ * buffer ceiling and the fragment that completes it.
+ */
+function withUnrecognizedModelFilter(base: AgentStreamParser): AgentStreamParser {
+	let buffer = '';
+	return {
+		...base,
+		onStderr(chunk: string): string {
+			buffer += chunk;
+			const parts = buffer.split('\n');
+			buffer = parts.pop() ?? '';
+			let out = '';
+			for (const line of parts) {
+				if (isUnrecognizedModelLine(line)) continue;
+				out += `${line}\n`;
+			}
+			if (buffer.length > STDERR_FILTER_BUFFER_LIMIT) {
+				out += buffer;
+				buffer = '';
+			}
+			return out;
+		},
+		// The stdout tail first, then any stderr line that never got its newline -
+		// held back by the filter above, so it would otherwise be lost.
+		flush(): string {
+			const tail = base.flush();
+			const remainder = buffer;
+			buffer = '';
+			if (!remainder || isUnrecognizedModelLine(remainder)) return tail;
+			return `${tail}${remainder}`;
+		},
+	};
+}
+
+function createClaudeCodeParser(price: PriceModelFn, provider?: AiProvider): AgentStreamParser {
 	let usage: AgentRunUsage | null = null;
 	let modelId: string | undefined;
 	let terminalError: string | null = null;
@@ -709,13 +789,19 @@ function createClaudeCodeParser(price: PriceModelFn): AgentStreamParser {
 		return out;
 	};
 
-	return createJsonlParser(
+	const base = createJsonlParser(
 		renderEvent,
 		() => usage,
 		() => terminalError,
 		() => finalMessage,
 		() => mcpCounts,
 	);
+	// Untouched passthrough unless this run's endpoint makes the diagnostic
+	// unconditional, so an unknown provider never silences a real one.
+	if (!provider || !claudeCodeProviderUsesCustomEndpoint(provider, AgentRuntime.ClaudeCode)) {
+		return base;
+	}
+	return withUnrecognizedModelFilter(base);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -1,4 +1,10 @@
-import { AgentRuntime, type CostTokens, costCentsFromRate, type ModelRate } from '@hezo/shared';
+import {
+	AgentRuntime,
+	AiProvider,
+	type CostTokens,
+	costCentsFromRate,
+	type ModelRate,
+} from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import {
 	createAgentStreamParser,
@@ -1347,5 +1353,159 @@ describe('extractKimiUsageFromSessionLog', () => {
 		const usage = extractKimiUsageFromSessionLog(log, price);
 		expect(usage?.inputTokens).toBe(1000);
 		expect(usage?.costCents).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Claude Code stderr: the unrecognized-model diagnostic
+//
+// Pointed at a third-party Anthropic-compatible endpoint, the CLI cannot resolve
+// any of the model ids Hezo hands it and says so on stderr once per (model, call
+// site). Suppressed for exactly those providers, kept everywhere else.
+// ---------------------------------------------------------------------------
+
+const UNRECOGNIZED_RUN =
+	'[claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}';
+const UNRECOGNIZED_TITLE =
+	'[claude-code:unrecognized_model] {"model":"deepseek-v4-flash","query_source":"generate_session_title"}';
+
+describe('claude-code unrecognized-model stderr', () => {
+	it('drops the diagnostic on a third-party Anthropic-compatible provider', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		expect(parser.onStderr(`${UNRECOGNIZED_TITLE}\n`)).toBe('');
+		expect(parser.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe('');
+		expect(parser.flush()).toBe('');
+	});
+
+	it('keeps every other stderr line, including neighbours of a dropped one', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		const chunk = `before\n${UNRECOGNIZED_RUN}\nafter\n`;
+		expect(parser.onStderr(chunk)).toBe('before\nafter\n');
+	});
+
+	it('keeps the diagnostic on Anthropic, where it means a model the CLI cannot resolve', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.Anthropic,
+		);
+		expect(parser.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe(`${UNRECOGNIZED_RUN}\n`);
+	});
+
+	it('keeps the diagnostic when no provider is supplied, so an unknown one silences nothing', () => {
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		expect(parser.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe(`${UNRECOGNIZED_RUN}\n`);
+	});
+
+	it('drops it for a Moonshot credential running on Claude Code, not on its own CLI', () => {
+		const onClaudeCode = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.Kimi,
+		);
+		expect(onClaudeCode.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe('');
+
+		// The kimi runtime has its own parser and never sees this line; its stderr
+		// stays a straight passthrough.
+		const onKimi = createAgentStreamParser(AgentRuntime.Kimi, undefined, null, AiProvider.Kimi);
+		expect(onKimi.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe(`${UNRECOGNIZED_RUN}\n`);
+	});
+
+	it('drops it for a local provider, whose ids are off-registry too', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.Ollama,
+		);
+		expect(parser.onStderr(`${UNRECOGNIZED_RUN}\n`)).toBe('');
+	});
+
+	it('matches a line split across chunks rather than leaking half of it', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		const half = Math.floor(UNRECOGNIZED_RUN.length / 2);
+		expect(parser.onStderr(UNRECOGNIZED_RUN.slice(0, half))).toBe('');
+		expect(parser.onStderr(`${UNRECOGNIZED_RUN.slice(half)}\n`)).toBe('');
+	});
+
+	it('flush() releases a held partial line, and drops it when it is the diagnostic', () => {
+		const kept = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		expect(kept.onStderr('tail with no newline')).toBe('');
+		expect(kept.flush()).toBe('tail with no newline');
+
+		const dropped = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		expect(dropped.onStderr(UNRECOGNIZED_RUN)).toBe('');
+		expect(dropped.flush()).toBe('');
+	});
+
+	it('flush() still renders the buffered stdout event alongside the stderr tail', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		parser.onStdout('{"type":"system","subtype":"init","model":"deepseek-v4-pro","tools":[]}');
+		parser.onStderr('partial');
+		expect(parser.flush()).toBe('[session] model=deepseek-v4-pro tools=0\npartial');
+	});
+
+	it('releases an over-long partial line instead of buffering it without bound', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			undefined,
+			null,
+			AiProvider.DeepSeek,
+		);
+		const huge = 'x'.repeat(64 * 1024 + 1);
+		expect(parser.onStderr(huge)).toBe(huge);
+		// Released early, so the fragment completing it arrives next - concatenated,
+		// the log still reads as the original bytes.
+		expect(parser.onStderr('rest\n')).toBe('rest\n');
+		expect(parser.flush()).toBe('');
+	});
+
+	it('leaves stdout rendering untouched', () => {
+		const parser = createAgentStreamParser(
+			AgentRuntime.ClaudeCode,
+			price,
+			null,
+			AiProvider.DeepSeek,
+		);
+		expect(
+			parser.onStdout('{"type":"system","subtype":"init","model":"claude-x","tools":["Bash"]}\n'),
+		).toBe('[session] model=claude-x tools=1\n');
+		parser.onStdout(
+			'{"type":"result","subtype":"success","result":"done","usage":{"input_tokens":10,"output_tokens":5}}\n',
+		);
+		expect(parser.getUsage()?.inputTokens).toBe(10);
+		expect(parser.getFinalAssistantMessage()).toBe('done');
 	});
 });


### PR DESCRIPTION
Every run on a third-party Anthropic-compatible provider opened its log with two lines like these:

```
[claude-code:unrecognized_model] {"model":"deepseek-v4-flash","query_source":"generate_session_title"}
[session] model=deepseek-v4-pro tools=98 mcp: hezo=connected(79)
[claude-code:unrecognized_model] {"model":"deepseek-v4-pro","query_source":"sdk"}
```

They read as errors and are not. Claude Code resolves every model id against its own built-in registry and writes one of these to stderr per (model, call site); Hezo's parser relayed stderr byte-for-byte, so they landed in the run log verbatim.

## Why they fire

Pointed at a gateway (`PROVIDER_RUNTIME_ADAPTERS[DeepSeek]` and friends set `ANTHROPIC_BASE_URL` plus DeepSeek's own model ids), **every** id the CLI sees is off-registry by construction. The two lines map onto the two model slots:

| Line | Model | Source |
|---|---|---|
| 1st | `deepseek-v4-flash` | `ANTHROPIC_DEFAULT_HAIKU_MODEL` - the CLI's own session-title and subagent calls |
| 2nd | `deepseek-v4-pro` | the run's model, from `--model` |

Z.ai, Moonshot-on-Claude-Code and the local runners produce the same noise for the same reason.

## The change

`createClaudeCodeParser` now wraps its `onStderr` to drop those lines, scoped to exactly the providers `claudeCodeProviderUsesCustomEndpoint` already covers - the predicate's third consumer, after the Stop-hook judge model and the subagent default.

The scoping is the point. On Anthropic the same line means a `--model` the CLI genuinely cannot resolve, so it is relayed untouched there, and a parser built with no provider keeps today's passthrough rather than silencing a diagnostic it cannot vouch for. Every other runtime's parser is unchanged.

Filtering is line-oriented, so the wrapper buffers a partial stderr line until its newline and drains it in `flush()`; past a 64 KiB ceiling it releases the fragment unfiltered rather than buffering without bound. Bytes reach the log in their original order either way.

Nothing else rested on the CLI's registry: run cost is priced from `model_pricing` over the reported token buckets, never from the CLI's own rate card, so these lines never affected accounting.

## Tests

12 cases in `packages/server/test/agent-stream-parser.test.ts`: dropped on DeepSeek / Moonshot-on-Claude-Code / Ollama, kept on Anthropic and with no provider, kept on the `kimi` runtime, neighbouring stderr lines preserved, a line split across chunks still matched, `flush()` releasing vs dropping a held partial, `flush()` still rendering the buffered stdout event alongside it, the 64 KiB release path, and stdout rendering untouched.

`agent-stream-parser{,-branches,-coverage}`, `agent-chat-parser`, the nine `agent-runner` files, `runtime-adapters`, `docs-links` and `docs-terminology` all pass locally, plus `biome check`, `typecheck` and `bun run build`.

## Docs

Added the off-registry-model-ids paragraph to `.dev/architecture.md` § 6, beside the gateway-provider defaults. No `docs/` page describes run-log stderr content.

## Noted, not fixed

Two things I found while tracing this and deliberately left alone:

- `.dev/architecture.md:2576` has a pre-existing truncated sentence - `interleaved stdout/stderr (recorded in full, ` + "`[stderr]`" + `-prefixed, with a 10 MB` - with an unclosed paren and no following clause. Completing it means inventing the missing text.
- `DISABLE_NON_ESSENTIAL_MODEL_CALLS=1` is already set in `CLAUDE_CODE_QUIET_ENV`, yet the CLI still resolved a model for `generate_session_title`, before the `[session]` init line. The log line only proves a model was resolved, not that a request went out; if one does, its tokens are not in the stream-json usage, so it would be provider spend Hezo never sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR4cGDaGbFTJuiU8y7bvSX


---
_Generated by [Claude Code](https://claude.ai/code/session_01UR4cGDaGbFTJuiU8y7bvSX)_