### PR TITLE
feat(web): crumb takes the task name only once the heading leaves, and scrolls sideways

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ Before writing a helper, check whether it already has a home. **Extend the seam;
 | Duration formatting (a settled figure, not a live tick) | `formatDuration` (`packages/web/src/lib/format-duration.ts`) |
 | A per-bucket stacked chart, and its axis/tooltip formatting | `StackedSeriesChart` + `chart-format.ts` (`packages/web/src/components/charts/`) |
 | A dropdown panel's vertical side + height clamp | `usePanelPlacement` (`hooks/use-panel-placement.ts`), pure math in `lib/panel-placement.ts` |
+| A breadcrumb row - one line, scrolling sideways rather than wrapping or truncating | `BreadcrumbRow` (`components/ui/breadcrumb.tsx`) - `Breadcrumb` renders through it; a caller with its own links takes the row, never a second `<nav>` |
 | An optimistic mutation | `useOptimisticMutation` (`hooks/use-optimistic-mutation.ts`) |
 | A server test context | `createTestContext()` (`test/helpers/context.ts`) |
 | A migration test | `createDataPreservationHarness()` (`test/helpers/migrate.ts`) |

--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Check, ChevronRight, Loader2, Pencil, X } from 'lucide-react';
-import { type RefObject, useEffect, useRef, useState } from 'react';
+import { type RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useAgentLookup } from '../../hooks/use-agent-lookup';
 import { type Task, useTaskAncestors, type useUpdateTask } from '../../hooks/use-tasks';
 import { formatDuration } from '../../lib/format-duration';
@@ -10,6 +10,7 @@ import { MarkdownProse } from '../markdown-prose';
 import { TaskPriorityBadge } from '../task-priority-badge';
 import { TaskStatusBadge } from '../task-status-badge';
 import { Badge } from '../ui/badge';
+import { BreadcrumbRow } from '../ui/breadcrumb';
 import { Tooltip } from '../ui/tooltip';
 import { MarkdownFieldEditor } from './markdown-field-editor';
 
@@ -29,34 +30,76 @@ interface TaskHeaderProps {
  * means the pinned breadcrumb is now covering content rather than sitting in
  * the page flow.
  *
+ * `topOffsetPx` shrinks the top of the scrollport by whatever is pinned over it,
+ * so "out of the top" means "out of sight" rather than "past the scrollport
+ * edge". The title sentinel needs it: the crumb band hides the heading a band's
+ * height before the heading actually leaves, and without the offset there is a
+ * stretch of scroll where neither the heading nor the crumb carries the name.
+ *
  * Reading the breadcrumb's own rect on every scroll event would force a layout
  * flush per frame on a thread that runs to hundreds of comments, so this asks
  * the question with one IntersectionObserver over a zero-height sentinel.
  */
-function useScrolledPast(ref: RefObject<HTMLElement | null>): boolean {
+function useScrolledPast(ref: RefObject<HTMLElement | null>, topOffsetPx = 0): boolean {
 	const [scrolledPast, setScrolledPast] = useState(false);
 	useEffect(() => {
-		// The component-test harness stubs IntersectionObserver to a no-op, so the
-		// crumb keeps its resting look there; the browser spec covers the pinning.
+		// The component-test harness stubs IntersectionObserver to report the target
+		// as intersecting, so the crumb keeps its resting look there - no hairline,
+		// no name. The browser spec covers both transitions.
 		if (typeof IntersectionObserver === 'undefined') return;
 		const el = ref.current;
 		if (!el) return;
 		// <main> is the scroll container - the window never scrolls (see __root.tsx).
 		const io = new IntersectionObserver(
 			([entry]) => setScrolledPast(entry ? !entry.isIntersecting : false),
-			{ root: document.querySelector('main') },
+			{ root: document.querySelector('main'), rootMargin: `-${topOffsetPx}px 0px 0px 0px` },
 		);
 		io.observe(el);
 		return () => io.disconnect();
-	}, [ref]);
+	}, [ref, topOffsetPx]);
 	return scrolledPast;
 }
 
 /**
+ * Height of everything pinned over the top of the shell scroller on this page:
+ * the project banners the crumb clears (published as `--container-banner-h`) plus
+ * the crumb's own band. That is the strip of `<main>` a reader cannot see into,
+ * and so the offset the title sentinel is judged against.
+ */
+function usePinnedBandHeight(navRef: RefObject<HTMLElement | null>, pinned: boolean): number {
+	const [band, setBand] = useState(0);
+	useLayoutEffect(() => {
+		// Only measurable while the crumb is actually pinned - that is when its own
+		// bottom edge marks the bottom of the strip. Taking it from the crumb's rect
+		// rather than adding up `--container-banner-h` and a height keeps the two
+		// halves in step: whatever ends up stacked above the crumb is already
+		// counted, because the crumb sits below it.
+		if (!pinned) return;
+		const el = navRef.current;
+		const main = document.querySelector('main');
+		if (!el || !main) return;
+		const measure = () => {
+			const next = Math.round(el.getBoundingClientRect().bottom - main.getBoundingClientRect().top);
+			// Only ever set a changed value: this feeds an effect dependency, and a
+			// fresh number every measurement would rebuild the observer in a loop.
+			setBand((prev) => (prev === next ? prev : next));
+		};
+		measure();
+		if (typeof ResizeObserver === 'undefined') return;
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		ro.observe(main);
+		return () => ro.disconnect();
+	}, [navRef, pinned]);
+	return band;
+}
+
+/**
  * Top-of-page header for a task: a breadcrumb of ancestor tasks ending in the
- * current identifier and the task's own name - pinned to the top of the shell
- * scroller at every breakpoint, so a long thread never leaves the reader without
- * the task's identity or a way back to the list - then the title, an inline mono
+ * current identifier - pinned to the top of the shell scroller at every
+ * breakpoint, so a long thread never leaves the reader without the task's
+ * identity or a way back to the list, and taking on the task's name once the
+ * heading below has scrolled out of sight - then the title, an inline mono
  * metadata row (status ·
  * priority · assignee) with a runs · duration · cost summary, the queued-wakeup
  * chip, and the description card. The title renames in place and the description
@@ -88,6 +131,14 @@ export function TaskHeader({
 	// clean top edge, drawn once content is passing underneath.
 	const restingSentinelRef = useRef<HTMLDivElement>(null);
 	const pinned = useScrolledPast(restingSentinelRef);
+	// Drives the handoff of the task's name from the heading to the crumb. The
+	// sentinel sits under the heading rather than on it, because TaskTitle swaps
+	// the <h1> for an <input> mid-rename and an observer on the heading would let
+	// go of the name for as long as the field is open.
+	const navRef = useRef<HTMLElement>(null);
+	const titleSentinelRef = useRef<HTMLDivElement>(null);
+	const band = usePinnedBandHeight(navRef, pinned);
+	const titleHidden = useScrolledPast(titleSentinelRef, band);
 	return (
 		<>
 			{/* Marks where the breadcrumb rests. `-mb-px` keeps it out of the layout. */}
@@ -102,19 +153,18 @@ export function TaskHeader({
 			    breathing room, so the resting position is unmoved; the route wrapper
 			    always leaves at least that much above (py-4 at its narrowest).
 
-			    NO `flex-wrap`: the crumb is one line at every width, and only the task
-			    name gives way. Everything ahead of it is `shrink-0`, the name alone is
-			    `min-w-0 truncate`, so the browser cuts it to whatever the column is
-			    rather than pushing the row to two lines. */}
-			<nav
-				aria-label="Breadcrumb"
+			    One line at every width: nothing here gives way, and BreadcrumbRow scrolls
+			    the overflow sideways instead, so a deep sub-task's whole chain stays
+			    reachable on the narrowest phone. */}
+			<BreadcrumbRow
+				ref={navRef}
 				data-pinned={pinned ? 'true' : 'false'}
-				className={`sticky top-[var(--container-banner-h,0px)] z-10 -mt-3 flex items-center gap-x-1 border-b border-transparent bg-bg pt-3 pb-2 text-[13px] font-mono text-text-2 transition-[border-color,box-shadow] duration-150 ${
+				className={`sticky top-[var(--container-banner-h,0px)] z-10 -mt-3 border-b border-transparent bg-bg pt-3 pb-2 text-[13px] font-mono text-text-2 transition-[border-color,box-shadow] duration-150 ${
 					pinned ? 'border-border shadow-xs' : ''
 				}`}
 				data-testid="task-breadcrumb"
 			>
-				<span className="flex shrink-0 items-center gap-x-1">
+				<span className="flex shrink-0 items-center gap-x-1 whitespace-nowrap">
 					<Link
 						to="/projects/$projectId/tasks"
 						params={{ projectId: taskProjectSlug }}
@@ -125,25 +175,8 @@ export function TaskHeader({
 					</Link>
 					<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
 				</span>
-				{/* Below `sm` the ancestor identifiers would spend the whole line, so they
-				    collapse to one ellipsis and the name keeps the room. The links stay in
-				    the accessibility tree (`sr-only`, not `hidden`), so a screen reader on
-				    a phone still gets the full path this stands in for. */}
-				{!!ancestors?.length && (
-					<span
-						aria-hidden="true"
-						className="flex shrink-0 items-center gap-x-1 sm:hidden"
-						data-testid="task-breadcrumb-ancestors-collapsed"
-					>
-						<span className="text-text-3">…</span>
-						<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
-					</span>
-				)}
 				{ancestors?.map((ancestor) => (
-					<span
-						key={ancestor.id}
-						className="sr-only items-center gap-x-1 sm:not-sr-only sm:flex sm:shrink-0"
-					>
+					<span key={ancestor.id} className="flex shrink-0 items-center gap-x-1 whitespace-nowrap">
 						<Link
 							to="/projects/$projectId/tasks/$taskId"
 							params={{ projectId: taskProjectSlug, taskId: ancestor.identifier.toLowerCase() }}
@@ -158,24 +191,36 @@ export function TaskHeader({
 				))}
 				{/* Identifier and name are one crumb, so they sit inside a single
 				    `aria-current` - a reader hears "HM-246, Fix the flaky test", not two
-				    separate items. The name is sans against the mono identifiers because
-				    it is prose, not something you quote, and `title` keeps the full text
-				    reachable once it truncates. */}
-				<span aria-current="page" className="flex min-w-0 items-center gap-x-1">
-					<span className="shrink-0">{task.identifier}</span>
-					<span aria-hidden="true" className="shrink-0 text-text-3">
-						·
-					</span>
-					<span
-						className="min-w-0 truncate font-sans text-text-3"
-						title={task.title}
-						data-testid="task-breadcrumb-title"
-					>
-						{task.title}
-					</span>
+				    separate items. The name is sans against the mono identifiers because it
+				    is prose, not something you quote.
+
+				    It joins the crumb only once the heading carrying it has gone under the
+				    band: while both are on screen the crumb would just be saying the title
+				    twice, and the identifier alone leaves the row short enough to read at a
+				    glance. */}
+				<span aria-current="page" className="flex shrink-0 items-center gap-x-1">
+					<span className="whitespace-nowrap">{task.identifier}</span>
+					{titleHidden && (
+						<>
+							<span aria-hidden="true" className="shrink-0 text-text-3">
+								·
+							</span>
+							<span
+								className="whitespace-nowrap font-sans text-text-3"
+								title={task.title}
+								data-testid="task-breadcrumb-title"
+							>
+								{task.title}
+							</span>
+						</>
+					)}
 				</span>
-			</nav>
+			</BreadcrumbRow>
 			<TaskTitle task={task} updateTask={updateTask} />
+			{/* Marks the foot of the heading: once this is under the pinned band, the
+			    name has left the page and the crumb picks it up. `-mb-px` keeps it out
+			    of the layout. */}
+			<div ref={titleSentinelRef} aria-hidden="true" className="h-px w-full -mb-px" />
 
 			{/* Wire spec - status / priority / assignee render as quiet-tint badges
 			    (treatment A, the default), color-coding state at a glance the same way

--- a/packages/web/src/components/ui/breadcrumb.tsx
+++ b/packages/web/src/components/ui/breadcrumb.tsx
@@ -1,13 +1,155 @@
 import { ChevronRight } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 export interface BreadcrumbSegment {
 	key: string;
 	label: ReactNode;
-	/** Full text for the title attribute when the label is truncated. */
+	/** Full text for the title attribute, for the widths where the row overflows. */
 	title?: string;
 	/** Navigation for non-leaf segments; the last segment never navigates. */
 	onNavigate?: () => void;
+}
+
+/** Which edges have more row beyond them, so only those get a fade. */
+interface EdgeState {
+	left: boolean;
+	right: boolean;
+}
+
+/** How far from an edge still counts as "at" it, in px. */
+const EDGE_EPSILON = 1;
+
+function readEdges(el: HTMLElement): EdgeState {
+	const max = el.scrollWidth - el.clientWidth;
+	if (max <= EDGE_EPSILON) return { left: false, right: false };
+	return {
+		left: el.scrollLeft > EDGE_EPSILON,
+		right: el.scrollLeft < max - EDGE_EPSILON,
+	};
+}
+
+/**
+ * A breadcrumb row: one line at every width, scrolling sideways rather than
+ * wrapping or truncating, so the whole trail stays reachable on the narrowest
+ * phone. This is the only home for that behaviour - `Breadcrumb` below, the task
+ * header's sticky crumb and the marketplace crumb all render through it, so a
+ * change to how a crumb overflows lands in one place.
+ *
+ * Callers bring their own children and their own positioning via `className`
+ * (the task crumb's sticky band, for instance); everything about the overflow
+ * belongs here. Children must be `shrink-0` and `whitespace-nowrap` - a segment
+ * that gives way defeats the scroller.
+ *
+ * `anchor="end"` starts the row at the current item, which is what a reader on a
+ * phone wants to see, and re-anchors when the row grows (the task crumb picks up
+ * the task name once the heading scrolls away). It backs off the moment the
+ * reader scrolls the row themselves.
+ */
+export function BreadcrumbRow({
+	children,
+	className = '',
+	anchor = 'end',
+	ref: externalRef,
+	'aria-label': ariaLabel = 'Breadcrumb',
+	'data-testid': testId,
+	'data-pinned': dataPinned,
+}: {
+	children: ReactNode;
+	className?: string;
+	anchor?: 'start' | 'end';
+	/** Object ref onto the row itself, for a caller that measures the band it occupies. */
+	ref?: RefObject<HTMLElement | null>;
+	'aria-label'?: string;
+	'data-testid'?: string;
+	'data-pinned'?: string;
+}) {
+	const ownRef = useRef<HTMLElement>(null);
+	const ref = externalRef ?? ownRef;
+	// The row's content, sized to itself (`w-max`) so the nav has something to
+	// scroll. Watching one stable element rather than the children means a segment
+	// appearing, a name changing or a font landing all report the same way.
+	const contentRef = useRef<HTMLDivElement>(null);
+	const [edges, setEdges] = useState<EdgeState>({ left: false, right: false });
+	// Set around our own scrollLeft writes so the scroll handler they fire is not
+	// mistaken for the reader taking over.
+	const programmatic = useRef(false);
+	const readerScrolled = useRef(false);
+	// The width we last anchored at, so a re-render that changes nothing does not
+	// yank a row the reader is part-way through.
+	const anchoredWidth = useRef(0);
+
+	const syncEdges = useCallback(() => {
+		const el = ref.current;
+		if (!el) return;
+		setEdges((prev) => {
+			const next = readEdges(el);
+			return prev.left === next.left && prev.right === next.right ? prev : next;
+		});
+	}, [ref]);
+
+	const onScroll = useCallback(() => {
+		if (!programmatic.current) readerScrolled.current = true;
+		syncEdges();
+	}, [syncEdges]);
+
+	useEffect(() => {
+		const el = ref.current;
+		const content = contentRef.current;
+		if (!el || !content) return;
+
+		const toEnd = () => {
+			programmatic.current = true;
+			el.scrollLeft = el.scrollWidth;
+			// The scroll event is dispatched asynchronously, so the flag has to
+			// outlive this frame.
+			requestAnimationFrame(() => {
+				programmatic.current = false;
+			});
+		};
+
+		const settle = () => {
+			if (anchor === 'end' && !readerScrolled.current && el.scrollWidth > anchoredWidth.current) {
+				anchoredWidth.current = el.scrollWidth;
+				toEnd();
+			}
+			syncEdges();
+		};
+
+		settle();
+		// happy-dom runs no layout, so it never reports an overflow to observe; the
+		// browser spec covers the scrolling. Guarded the way LazyMount guards its own.
+		if (typeof ResizeObserver === 'undefined') return;
+		// The nav for the width available, the content for the width wanted.
+		const ro = new ResizeObserver(settle);
+		ro.observe(el);
+		ro.observe(content);
+		return () => ro.disconnect();
+	}, [anchor, ref, syncEdges]);
+
+	// Only fade an edge that has something behind it - a row that fits is untouched,
+	// and the mask itself lives in `index.css` beside the `.breadcrumb-row` class.
+	const overflow = edges.left ? (edges.right ? 'both' : 'left') : edges.right ? 'right' : undefined;
+
+	return (
+		<nav
+			ref={ref}
+			aria-label={ariaLabel}
+			onScroll={onScroll}
+			data-testid={testId}
+			data-pinned={dataPinned}
+			data-overflow={overflow}
+			// `overflow-y-hidden` is deliberate: `overflow-x-auto` alone computes the
+			// other axis to `auto` too, which would hand this single line a vertical
+			// scrollbar of its own. `overscroll-x-contain` keeps a sideways swipe off
+			// the browser's back gesture. `min-w-0` is what lets the row scroll rather
+			// than push its parent wide when a caller drops it into a flex container.
+			className={`breadcrumb-row min-w-0 overflow-x-auto overflow-y-hidden overscroll-x-contain scrollbar-none ${className}`}
+		>
+			<div ref={contentRef} className="flex w-max items-center gap-x-1" data-breadcrumb-content="">
+				{children}
+			</div>
+		</nav>
+	);
 }
 
 /**
@@ -24,14 +166,10 @@ export function Breadcrumb({
 	'data-testid'?: string;
 }) {
 	return (
-		<nav
-			aria-label="Breadcrumb"
-			className="flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-2"
-			data-testid={testId}
-		>
+		<BreadcrumbRow className="text-[13px] font-mono text-text-2" data-testid={testId}>
 			{segments.map((seg, i) =>
 				i < segments.length - 1 ? (
-					<span key={seg.key} className="flex items-center gap-x-1">
+					<span key={seg.key} className="flex shrink-0 items-center gap-x-1 whitespace-nowrap">
 						<button
 							type="button"
 							onClick={seg.onNavigate}
@@ -43,11 +181,16 @@ export function Breadcrumb({
 						<ChevronRight className="h-3 w-3 shrink-0 text-text-3" />
 					</span>
 				) : (
-					<span key={seg.key} aria-current="page" className="text-text-1" title={seg.title}>
+					<span
+						key={seg.key}
+						aria-current="page"
+						className="shrink-0 whitespace-nowrap text-text-1"
+						title={seg.title}
+					>
 						{seg.label}
 					</span>
 				),
 			)}
-		</nav>
+		</BreadcrumbRow>
 	);
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -374,3 +374,42 @@ body {
 	letter-spacing: 0.08em;
 	text-transform: uppercase;
 }
+
+/* Hides the scrollbar on a row that scrolls sideways by design - a breadcrumb,
+   a chip rail - where a track would cost more of the band than it earns. Only
+   for rows whose overflow is otherwise obvious (an edge fade, a clipped word);
+   never on a region whose only clue that it scrolls is the bar itself. */
+@utility scrollbar-none {
+	scrollbar-width: none;
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}
+
+/* Breadcrumb rows (`BreadcrumbRow`) fade the edge that still has row behind it,
+   so a trail that scrolled out of view says so. `data-overflow` is written by the
+   component from its own scroll position, and is absent when the row fits. */
+.breadcrumb-row[data-overflow='both'] {
+	-webkit-mask-image: linear-gradient(
+		90deg,
+		transparent 0,
+		#000 14px,
+		#000 calc(100% - 20px),
+		transparent 100%
+	);
+	mask-image: linear-gradient(
+		90deg,
+		transparent 0,
+		#000 14px,
+		#000 calc(100% - 20px),
+		transparent 100%
+	);
+}
+.breadcrumb-row[data-overflow='left'] {
+	-webkit-mask-image: linear-gradient(90deg, transparent 0, #000 14px);
+	mask-image: linear-gradient(90deg, transparent 0, #000 14px);
+}
+.breadcrumb-row[data-overflow='right'] {
+	-webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 20px), transparent 100%);
+	mask-image: linear-gradient(90deg, #000 calc(100% - 20px), transparent 100%);
+}

--- a/packages/web/src/routes/marketplace/$slug.tsx
+++ b/packages/web/src/routes/marketplace/$slug.tsx
@@ -8,6 +8,7 @@ import { HiringForBanner } from '../../components/hiring-for-banner';
 import { marketplaceRosterRows, TeamRosterTable } from '../../components/team-roster-table';
 import { Avatar, getInitials } from '../../components/ui/avatar';
 import { Badge } from '../../components/ui/badge';
+import { BreadcrumbRow } from '../../components/ui/breadcrumb';
 import { Button } from '../../components/ui/button';
 import { DialogContent } from '../../components/ui/dialog';
 import { useAddMarketplaceTeam, useMarketplaceTeam } from '../../hooks/use-marketplace';
@@ -36,17 +37,21 @@ function MarketplaceTeamDetail() {
 				<HiringForBanner projectId={forProject} messageKey="agents.hire.hiringForTeam" />
 			)}
 
-			<nav className="flex items-center gap-1 text-[13px] text-text-2 mb-4" aria-label="Breadcrumb">
+			{/* Keeps its own `<Link>` rather than taking the `Breadcrumb` component,
+			    whose segments are buttons: this one is a real link, and middle-click and
+			    open-in-new-tab are worth more here than the shared markup. It still takes
+			    the shared row, so it scrolls the way every other crumb does. */}
+			<BreadcrumbRow className="mb-4 text-[13px] text-text-2">
 				<Link
 					to="/marketplace"
 					search={forProject ? { forProject } : {}}
-					className="hover:text-text-1 flex items-center gap-1"
+					className="hover:text-text-1 flex shrink-0 items-center gap-1 whitespace-nowrap"
 				>
-					<Store className="w-3.5 h-3.5" /> {t('marketplace.title')}
+					<Store className="w-3.5 h-3.5 shrink-0" /> {t('marketplace.title')}
 				</Link>
-				<ChevronRight className="w-3.5 h-3.5" />
-				<span className="text-text-1">{team?.name ?? slug}</span>
-			</nav>
+				<ChevronRight className="w-3.5 h-3.5 shrink-0" />
+				<span className="shrink-0 whitespace-nowrap text-text-1">{team?.name ?? slug}</span>
+			</BreadcrumbRow>
 
 			{isLoading ? (
 				<div className="flex items-center gap-2 text-text-2 text-[13px] py-8">

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -347,11 +347,13 @@ async function interactUntil(
 /**
  * Scopes a text query to the task page's `<h1>`.
  *
- * A task's title renders twice on its own page: the heading, and the breadcrumb
- * that carries the name beside the identifier. So a bare `findByText(title)`
- * matches two elements and throws. Pass this as the query's options argument
- * when the intent is "wait until the page for this task is up", which is what
- * the heading means:
+ * A task's title can render twice on its own page: the heading, and - once the
+ * heading has scrolled out of sight - the breadcrumb, which then carries the name
+ * beside the identifier. The harness reports every observed node as intersecting,
+ * so the crumb stays at rest here and the heading is the only copy; scoping to it
+ * says which one is meant, and keeps the query honest if that changes. Pass this
+ * as the query's options argument when the intent is "wait until the page for
+ * this task is up", which is what the heading means:
  *
  *     await findByText('Target task', taskHeadingQuery, { timeout: 10_000 });
  */

--- a/packages/web/test/task-breadcrumb.test.tsx
+++ b/packages/web/test/task-breadcrumb.test.tsx
@@ -10,7 +10,7 @@ test('sub-task header shows a breadcrumb link to its parent and navigates there'
 		childIdentifier: '',
 		parentIdentifier: '',
 	};
-	const { findByTestId, router, user } = await renderApp({
+	const { findByTestId, queryByTestId, router, user } = await renderApp({
 		initialPath: '/',
 		seed: async (ctx) => {
 			const ws = await seedWorkspace();
@@ -53,16 +53,11 @@ test('sub-task header shows a breadcrumb link to its parent and navigates there'
 	expect(parentLink.textContent).toBe(seeded.parentIdentifier);
 	expect(parentLink.getAttribute('href')).toContain(seeded.parentIdentifier.toLowerCase());
 
-	// The task's own name rides in the crumb beside its identifier, and carries
-	// the untruncated text in `title` for the widths where it is cut short.
-	const crumbTitle = await findByTestId('task-breadcrumb-title');
-	expect(crumbTitle.textContent).toBe('Child Task');
-	expect(crumbTitle.getAttribute('title')).toBe('Child Task');
-
-	// A sub-task also renders the below-`sm` stand-in for the ancestor chain. The
-	// links themselves stay in the tree at every width (sr-only, never `hidden`),
-	// which is why both are present here - happy-dom runs no media queries.
-	expect(await findByTestId('task-breadcrumb-ancestors-collapsed')).toBeTruthy();
+	// The task's own name is NOT in the crumb while the heading below still
+	// carries it - the crumb takes it over only once the heading has scrolled
+	// away. The harness reports every observed node as intersecting, so this is
+	// the resting state; the browser spec covers the handoff itself.
+	expect(queryByTestId('task-breadcrumb-title')).toBeNull();
 
 	// Clicking it navigates to the parent task.
 	await user.click(parentLink);
@@ -92,14 +87,11 @@ test('top-level task header shows a Tasks crumb and its identifier with no ances
 
 	const breadcrumb = await findByTestId('task-breadcrumb');
 	expect(breadcrumb.textContent).toContain(seeded.identifier);
-	// No parent → neither an ancestor crumb nor the ellipsis standing in for one,
-	// but the Tasks list crumb is always there.
+	// No parent → no ancestor crumb, but the Tasks list crumb is always there.
 	expect(queryByTestId('task-breadcrumb-ancestor')).toBeNull();
-	expect(queryByTestId('task-breadcrumb-ancestors-collapsed')).toBeNull();
 
-	// The name is carried at rest too, not only once the crumb pins.
-	const crumbTitle = await findByTestId('task-breadcrumb-title');
-	expect(crumbTitle.textContent).toBe('Solo Task');
+	// At rest the crumb is the identifier alone; the heading below has the name.
+	expect(queryByTestId('task-breadcrumb-title')).toBeNull();
 	const tasksLink = await findByTestId('task-breadcrumb-tasks');
 	expect(tasksLink.getAttribute('href')).toContain(`/projects/${seeded.projectSlug}/tasks`);
 

--- a/test/browser/task-breadcrumb-sticky.spec.ts
+++ b/test/browser/task-breadcrumb-sticky.spec.ts
@@ -1,10 +1,11 @@
-// Real CSS layout plus a viewport-conditional rule (testing decision tree,
-// points 1 & 2): the breadcrumb's pinning is `position: sticky` resolving
-// against the shell <main> scroller, asserted through `boundingBox()` before and
-// after a real scroll; and the one-line guarantee is a layout fact - whether the
-// segments share a line box, and whether the name truncated - which happy-dom
-// cannot answer because it runs no layout pass and no media queries. The crumb's
-// links, name and ancestor rendering stay covered by the component tests in
+// Real CSS layout (testing decision tree, point 1): the breadcrumb's pinning is
+// `position: sticky` resolving against the shell <main> scroller, asserted
+// through `boundingBox()` before and after a real scroll; the handoff of the task
+// name from the heading to the crumb turns on whether the heading is still
+// visible, which is a geometry question; and the one-line guarantee is a layout
+// fact - whether the segments share a line box, and whether the row overflows and
+// scrolls. happy-dom answers none of these, because it runs no layout pass. The
+// crumb's links and ancestor rendering stay covered by the component tests in
 // packages/web/test/task-breadcrumb.test.tsx.
 
 import { expect, test } from './fixtures';
@@ -64,6 +65,47 @@ async function scrollMain(page: Page, top: number): Promise<number> {
 	return main.evaluate((el) => el.scrollTop);
 }
 
+/**
+ * How far apart the tops of the crumb's segments are. One line box means ~0; two
+ * lines would spread them by a whole line-height.
+ */
+async function topSpreadOf(page: Page): Promise<number> {
+	return page.getByTestId('task-breadcrumb').evaluate((el) => {
+		const row = el.querySelector('[data-breadcrumb-content]');
+		const tops = Array.from(row?.children ?? [])
+			.filter((kid) => {
+				const cs = getComputedStyle(kid);
+				return cs.position !== 'absolute' && cs.display !== 'none';
+			})
+			.map((kid) => kid.getBoundingClientRect().top);
+		return Math.max(...tops) - Math.min(...tops);
+	});
+}
+
+/** How far the crumb could scroll sideways, and where it currently sits. */
+async function crumbScroll(page: Page): Promise<{ max: number; left: number }> {
+	return page
+		.getByTestId('task-breadcrumb')
+		.evaluate((el) => ({ max: el.scrollWidth - el.clientWidth, left: el.scrollLeft }));
+}
+
+/**
+ * The name lives in exactly one place at a time, and that place is whichever one
+ * the reader can see. Asserted together so a change that drops it from both - the
+ * failure mode the offset in `usePinnedBandHeight` exists to prevent - cannot pass
+ * as "the crumb is correct".
+ */
+async function expectNameCarriedOnce(page: Page, by: 'heading' | 'crumb') {
+	const crumbName = page.getByTestId('task-breadcrumb-title');
+	if (by === 'heading') {
+		await expect(page.getByTestId('task-title')).toBeInViewport();
+		await expect(crumbName).toHaveCount(0);
+	} else {
+		await expect(crumbName).toBeAttached();
+		await expect(page.getByTestId('task-title')).not.toBeInViewport();
+	}
+}
+
 test('desktop: the breadcrumb stays pinned to the top while the thread scrolls', async ({
 	sharedPage: page,
 	sharedWorkspace,
@@ -80,8 +122,10 @@ test('desktop: the breadcrumb stays pinned to the top while the thread scrolls',
 
 	const before = await crumb.boundingBox();
 	expect(before).not.toBeNull();
-	// At rest the crumb carries no hairline - the page keeps its clean top edge.
+	// At rest the crumb carries no hairline - the page keeps its clean top edge -
+	// and no name, because the heading right below it is still saying it.
 	await expect(crumb).toHaveAttribute('data-pinned', 'false');
+	await expectNameCarriedOnce(page, 'heading');
 
 	const scrolled = await scrollMain(page, 600);
 	// Proves the thread genuinely overflowed and we moved a meaningful amount.
@@ -99,9 +143,15 @@ test('desktop: the breadcrumb stays pinned to the top while the thread scrolls',
 	await expect(crumb).toContainText(task.identifier);
 	await expect(crumb).toHaveAttribute('data-pinned', 'true');
 
-	// Back at the top it lets go of the hairline again.
+	// The heading has gone, so the crumb is carrying the name now.
+	await expectNameCarriedOnce(page, 'crumb');
+	await expect(crumb).toContainText('Task with a long thread');
+
+	// Back at the top it lets go of the hairline, and hands the name back to the
+	// heading rather than saying it twice.
 	await scrollMain(page, 0);
 	await expect(crumb).toHaveAttribute('data-pinned', 'false');
+	await expectNameCarriedOnce(page, 'heading');
 });
 
 test('mobile: the breadcrumb stays pinned too', async ({ sharedPage: page, sharedWorkspace }) => {
@@ -118,21 +168,24 @@ test('mobile: the breadcrumb stays pinned too', async ({ sharedPage: page, share
 	const before = await crumb.boundingBox();
 	expect(before).not.toBeNull();
 	await expect(crumb).toHaveAttribute('data-pinned', 'false');
+	await expectNameCarriedOnce(page, 'heading');
 
 	const scrolled = await scrollMain(page, 600);
 	expect(scrolled).toBeGreaterThan(300);
 
 	// The phone is where the title leaves the screen soonest, so the crumb holds
-	// its band here as well - carrying the name, not just the identifier.
+	// its band here as well - and picks up the name, which is the whole point of
+	// holding it.
 	await expect(crumb).toBeInViewport();
 	const after = await crumb.boundingBox();
 	expect(after).not.toBeNull();
 	if (before && after) expect(Math.abs(after.y - before.y)).toBeLessThan(30);
 	await expect(crumb).toContainText(task.identifier);
 	await expect(crumb).toHaveAttribute('data-pinned', 'true');
+	await expectNameCarriedOnce(page, 'crumb');
 });
 
-test('the crumb stays one line when a deep sub-task has a long name on a narrow phone', async ({
+test('the crumb scrolls sideways rather than wrapping or hiding a segment at 320px', async ({
 	sharedPage: page,
 	sharedWorkspace,
 }) => {
@@ -165,7 +218,20 @@ test('the crumb stays one line when a deep sub-task has a long name on a narrow 
 		`/api/projects/${project.slug}/tasks/${parent.id}/sub-tasks`,
 		{ headers, data: { title: longTitle, assignee_id: assigneeId } },
 	);
-	const child = ((await childRes.json()) as { data: { identifier: string } }).data;
+	const child = ((await childRes.json()) as { data: { id: string; identifier: string } }).data;
+	// Enough thread that <main> overflows at this viewport, so the heading can
+	// actually be scrolled away and hand the name over.
+	await Promise.all(
+		Array.from({ length: 15 }, (_, i) =>
+			page.request.post(`/api/projects/${project.slug}/tasks/${child.id}/comments`, {
+				headers,
+				data: {
+					content_type: 'text',
+					content: { text: `seeded comment ${i}. ${'lorem ipsum '.repeat(8)}` },
+				},
+			}),
+		),
+	);
 
 	await page.goto(`/projects/${project.slug}/tasks/${child.identifier.toLowerCase()}`);
 	await waitForPageLoad(page);
@@ -176,34 +242,39 @@ test('the crumb stays one line when a deep sub-task has a long name on a narrow 
 	// One line, stated structurally rather than as a pixel budget: every segment
 	// that occupies flow shares a line box. Two lines would spread these tops by
 	// a whole line-height.
-	const topSpread = await crumb.evaluate((el) => {
-		const tops = Array.from(el.children)
-			.filter((kid) => {
-				const cs = getComputedStyle(kid);
-				return cs.position !== 'absolute' && cs.display !== 'none';
-			})
-			.map((kid) => kid.getBoundingClientRect().top);
-		return Math.max(...tops) - Math.min(...tops);
+	expect(await topSpreadOf(page)).toBeLessThan(2);
+
+	// Every ancestor is a real, reachable link at this width - there is no `sm`
+	// collapse standing in for the chain, and nothing is left screen-reader-only.
+	const ancestors = page.getByTestId('task-breadcrumb-ancestor');
+	await expect(ancestors).toHaveCount(1);
+	await expect(ancestors.first()).toBeInViewport();
+	await expect(page.getByTestId('task-breadcrumb-tasks')).toBeInViewport();
+
+	// A sideways swipe belongs to the row, never to the browser's back gesture.
+	await expect(crumb).toHaveCSS('overscroll-behavior-x', 'contain');
+
+	// Carrying the identifier alone, this chain fits even here. Scroll the heading
+	// away and the row takes on a name far longer than the viewport - which is the
+	// width at which a row that truncated instead of scrolling would lose it.
+	expect(await scrollMain(page, 600)).toBeGreaterThan(300);
+	await expectNameCarriedOnce(page, 'crumb');
+
+	const grown = await crumbScroll(page);
+	expect(grown.max).toBeGreaterThan(0);
+	// Anchored to the end as it grew, so the name is what the phone shows rather
+	// than the part of the trail the reader already knows.
+	expect(grown.left).toBeGreaterThan(0);
+	await expect(page.getByTestId('task-breadcrumb-title')).toBeInViewport();
+
+	// ...and the start of the trail is still reachable the other way, so nothing
+	// is stranded at the narrowest width the UX rules cover.
+	await crumb.evaluate((el) => {
+		el.scrollTo({ left: 0, behavior: 'instant' });
 	});
-	expect(topSpread).toBeLessThan(2);
+	await expect(page.getByTestId('task-breadcrumb-tasks')).toBeInViewport();
+	await expect(ancestors.first()).toBeInViewport();
 
-	// ...and it holds because the name gave way, not because this title happened
-	// to fit: the browser really did cut it.
-	const nameOverflow = await page
-		.getByTestId('task-breadcrumb-title')
-		.evaluate((el) => el.scrollWidth - el.clientWidth);
-	expect(nameOverflow).toBeGreaterThan(0);
-
-	// Below `sm` the ancestor identifiers give up their room to the name, leaving
-	// the ellipsis in their place. The links stay in the accessibility tree.
-	await expect(page.getByTestId('task-breadcrumb-ancestors-collapsed')).toBeVisible();
-	await expect(page.getByTestId('task-breadcrumb-ancestor')).toBeAttached();
-	await expect(page.getByTestId('task-breadcrumb-ancestor')).not.toBeInViewport();
-
-	// Widen past `sm` and the chain comes back in place of the ellipsis - the
-	// other half of the same rule, and the half no other test would catch if
-	// `sm:not-sr-only` stopped resolving.
-	await page.setViewportSize({ width: 1280, height: 800 });
-	await expect(page.getByTestId('task-breadcrumb-ancestor')).toBeVisible();
-	await expect(page.getByTestId('task-breadcrumb-ancestors-collapsed')).toBeHidden();
+	// Still one line with the name aboard - the row grew sideways, not downwards.
+	expect(await topSpreadOf(page)).toBeLessThan(2);
 });


### PR DESCRIPTION
## What

Two changes to breadcrumbs, both visible on the task page.

**The task crumb carries the name only once the heading has gone.** The task page said its title twice at rest - in the sticky crumb and in the `h1` right below it - and spent the crumb's only flexible segment on text the reader already had. It now reads `Tasks › HM-372 › HM-380` while the heading is on screen, and takes the name over once the heading passes under the pinned band.

**Every breadcrumb scrolls sideways** rather than wrapping to two lines (the shared primitive) or truncating and hiding segments (the task crumb), so the whole trail is reachable at any width. That behaviour lives once, in a new `BreadcrumbRow`.

Behaviour was prototyped and signed off before implementation: https://claude.ai/code/artifact/2a8ef625-48f1-470f-8281-6b6b0421dc14

## How

**`BreadcrumbRow`** (`components/ui/breadcrumb.tsx`) is the single home for the row's overflow: `overflow-x-auto`, a new `scrollbar-none` utility, `overscroll-x-contain` so a sideways swipe never triggers browser-back, and an edge-fade mask on whichever side still has row behind it. Children sit in an inner `flex w-max` div, which gives the `ResizeObserver` one stable element whose width *is* the content width - a segment appearing, a name changing or a font landing all report the same way.

Rows anchor to the **end** on mount and whenever the row grows, so a phone shows the current item and you scroll left for the parents; the anchor backs off the moment the reader scrolls the row themselves. That is also what brings the task name into view when it arrives, with no extra prop.

The shared `Breadcrumb` renders through it, so the goal, asset-grid and asset-viewer crumbs inherit it unchanged. The task and marketplace crumbs take the row directly rather than the component - both use real `Link`s, and middle-click and open-in-new-tab are worth more here than the shared `button onClick` markup.

**The handoff** generalizes the existing private `useScrolledPast` with a `topOffsetPx`, and adds a zero-height sentinel below the heading:

- The sentinel is observed, **not the `h1`** - `TaskTitle` swaps the heading for an `input` mid-rename, and watching the heading would drop the name for as long as the field is open.
- `usePinnedBandHeight` takes the offset from the pinned crumb's own rect against the shell `main` scroller, rather than adding `--container-banner-h` to a height. Whatever ends up stacked above the crumb is then already counted, because the crumb sits below it. Without the offset there is a band-height of scroll where *neither* surface carries the name.

With the row scrolling, the task crumb's below-`sm` `…` collapse is gone: ancestors are real, tappable links at every width instead of `sr-only`.

## Testing

- `task-breadcrumb.test.tsx` inverts its two name assertions - the name is now absent at rest - and drops the collapse assertions. `task-reparent.test.tsx` needed no change.
- `test/browser/task-breadcrumb-sticky.spec.ts` carries the geometry, per the repo's Playwright-vs-component decision tree. The pinning tests now also assert the name is carried by **exactly one** of heading and crumb at each end of the scroll, so a regression that drops it from both cannot pass. The 320px test asserts the row overflows, is end-anchored, has `overscroll-behavior-x: contain`, and that both ends of the trail are reachable.
- One finding from the browser run, folded into that test: with the name gone from the row at rest, a depth-2 chain now *fits* at 320px. Overflow only exists once the name arrives, so the test scrolls first and then measures.

Green locally: `typecheck`, `build`, `biome check`; `task-breadcrumb` + `task-reparent` (7); `goals` + `project-asset-folders` + `asset-viewer` + `marketplace` (48, unchanged); the three browser specs in real Chromium. The full `--package web` tier is left to CI.

`docs/concepts/assets.md` describes what each crumb links to, not how it overflows, so all three of its breadcrumb passages still hold - recorded in the `Docs-Checked:` trailer. No user-facing string changed, so the twelve catalogs are untouched. `AGENTS.md`'s seam registry gains the `BreadcrumbRow` row.