### PR TITLE
fix(egress): tell a literal body placeholder apart from a credential

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -4288,9 +4288,9 @@ probe, its auto-rebind of the bind host, and the run/chat abort gate it fed were
 along with `--container-bind-host`. A tunnel that cannot be established fails the run
 directly, with the error from the exec channel.
 
-For each request the proxy terminates TLS, matches placeholders **in the URL and headers**,
-loads the named secret, verifies the host against `allowed_hosts`, substitutes, and
-forwards. **Request bodies** are forwarded byte-for-byte by default and never buffered —
+For each request the proxy terminates TLS, matches placeholders **in the URL, the headers,
+and - whenever it buffered one - the request body**, loads the named secret, verifies the
+host against `allowed_hosts`, substitutes, and forwards. **Request bodies** are forwarded byte-for-byte by default and never buffered —
 except a narrowly-gated path for secrets a human has opted into body substitution
 (`secrets.allow_body_substitution`): a `POST`/`PUT`/`PATCH` with an uncompressed
 `application/json` body and a fixed `Content-Length` ≤ 8 KB is buffered, has its placeholders
@@ -4303,6 +4303,20 @@ POST that returns a token (the agent then uses that token via the `Authorization
 Failures are explicit HTTP errors returned to the agent: `unknown_secret` (400),
 `secret_not_allowed_for_host` (403), `secret_not_allowed_in_body` (403), `body_too_large`
 (413), `secrets_unavailable` (503, master key locked).
+
+**An MCP `tools/call` sits inside that buffering window**, being a POST of small
+fixed-length `application/json` - so every tool-call payload an agent sends is scanned,
+and a placeholder written into a *tool argument* as literal text (a doc, a test fixture,
+a code comment about the grammar) is refused exactly like a credential the agent meant to
+send. The refusal stays: the proxy cannot read intent, and forwarding instead would ship
+an inert placeholder that 401s upstream with nothing naming the cause. What it does do is
+tell the two apart structurally rather than by inspecting the prose - headers and the URL
+are substituted **before** the body, so `secretsUsed` already records whether this same
+secret is on the wire by a route the proxy supports. `secret_not_allowed_in_body` carries
+that as `deliveredElsewhere`, and `describeFailure` picks one of two messages from it:
+already-sent-in-a-header ("remove the literal text"), or not-sent-at-all ("ask an admin to
+enable body substitution"). The code and the 403 are unchanged, since
+`reportConnectorRunRejection` keys off the code.
 
 **Destination guard** (`services/egress/net-guard.ts`). The proxy runs in the **host's**
 network namespace and will dial whatever an authenticated caller names, so it refuses

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -1472,10 +1472,16 @@ function describeFailure(failure: SubstitutionFailure): FailureDescription {
 				message: `Secret ${failure.name} is not permitted for host ${failure.host}.`,
 			};
 		case 'secret_not_allowed_in_body':
+			// Two very different mistakes share this code. Telling them apart matters:
+			// the old single message sent an agent that had merely written the
+			// placeholder as literal text off to enable body substitution on a
+			// credential it never meant to send, which is also not its call to make.
 			return {
 				statusCode: 403,
 				code: 'secret_not_allowed_in_body',
-				message: `Secret ${failure.name} is not permitted in request bodies. Enable body substitution for this credential to use it in a JSON payload.`,
+				message: failure.deliveredElsewhere
+					? `Secret ${failure.name} was already substituted into this request's headers, so the credential has been sent. The text __HEZO_SECRET_${failure.name}__ also appears in the JSON body, and Hezo does not substitute secrets into request bodies. Remove that literal text from the body content.`
+					: `A __HEZO_SECRET_${failure.name}__ placeholder appears in this JSON request body. Hezo substitutes secrets into headers and the URL, never into a body unless an admin has enabled body substitution on that credential. If you meant to send the credential in the payload, ask an admin to enable it. If the placeholder is literal text you are trying to write, it cannot be sent through the proxy.`,
 			};
 		case 'secrets_unavailable':
 			return {

--- a/packages/server/src/services/egress/substitution.ts
+++ b/packages/server/src/services/egress/substitution.ts
@@ -42,7 +42,16 @@ export interface ResolvedSecret {
 export type SubstitutionFailure =
 	| { kind: 'unknown_secret'; name: string }
 	| { kind: 'secret_not_allowed_for_host'; name: string; host: string }
-	| { kind: 'secret_not_allowed_in_body'; name: string }
+	| {
+			kind: 'secret_not_allowed_in_body';
+			name: string;
+			/** Whether this same secret was already substituted into a header or the
+			 * URL of this request. When it was, the credential is already on its way
+			 * and the body occurrence is the placeholder used as literal text - a
+			 * different mistake from meaning to send the credential in the payload,
+			 * and a different remedy. */
+			deliveredElsewhere: boolean;
+	  }
 	| { kind: 'secrets_unavailable' };
 
 export interface SubstitutionResult {
@@ -214,7 +223,17 @@ export function substituteRequest(
 		const hostFailure = checkAccess(name);
 		if (hostFailure) return hostFailure;
 		const secret = secrets.get(name);
-		if (!secret?.allowBodySubstitution) return { kind: 'secret_not_allowed_in_body', name };
+		if (!secret?.allowBodySubstitution) {
+			// Headers and the URL are substituted before the body (below), so
+			// `secretsUsed` already tells us whether this credential is on the wire
+			// by a route the proxy does support. Structural, so it stays true for a
+			// payload no phrase-matcher would recognise.
+			return {
+				kind: 'secret_not_allowed_in_body',
+				name,
+				deliveredElsewhere: secretsUsed.has(name),
+			};
+		}
 		return null;
 	};
 

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -264,6 +264,78 @@ describe('EgressProxy', () => {
 		}
 	}, 30_000);
 
+	// An MCP `tools/call` over Streamable HTTP is a POST of small fixed-length
+	// application/json, so it lands inside the body-buffering window and every
+	// tool-call payload gets scanned. An agent writing the literal placeholder
+	// text into a tool argument therefore trips the body gate even though its
+	// credential is already being delivered by the header the runtime configured.
+	// The refusal is right; the message has to name which mistake it is.
+	it('tells an agent the credential was already sent when an mcp tool-call body repeats it', async () => {
+		const runId = `run-${Date.now()}-body-mcp`;
+		await insertSecret('MCP_GITHUB_DELIVERED', 'gho-never-leaked', ['127.0.0.1']);
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			const res = await fetchThroughProxy({
+				proxyHost: '127.0.0.1',
+				proxyPort: allocated.proxyPort,
+				url: `${upstreamUrl}/mcp/`,
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					authorization: 'Bearer __HEZO_SECRET_MCP_GITHUB_DELIVERED__',
+				},
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'tools/call',
+					params: {
+						name: 'create_or_update_file',
+						arguments: { content: 'docs say Bearer __HEZO_SECRET_MCP_GITHUB_DELIVERED__ here' },
+					},
+				}),
+			});
+			expect(res.status).toBe(403);
+			const parsed = JSON.parse(res.body);
+			// The code is load-bearing for `reportRejection`, so only the prose moves.
+			expect(parsed.error).toBe('secret_not_allowed_in_body');
+			expect(parsed.message).toContain('already substituted into this request');
+			expect(parsed.message).toContain('Remove that literal text from the body content.');
+			// The old message sent the agent after an admin-only toggle it did not need.
+			expect(parsed.message).not.toContain('ask an admin to enable it');
+			for (const req of upstreamRequests) {
+				expect(req.body.includes('gho-never-leaked')).toBe(false);
+			}
+		} finally {
+			await proxy.releaseRunProxy(runId);
+		}
+	}, 30_000);
+
+	it('points at the admin opt-in when a body placeholder was not sent any other way', async () => {
+		const runId = `run-${Date.now()}-body-only`;
+		await insertSecret('UMAMI_PW_BODYONLY', 'never-leaked-bodyonly', ['127.0.0.1']);
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			const res = await fetchThroughProxy({
+				proxyHost: '127.0.0.1',
+				proxyPort: allocated.proxyPort,
+				url: `${upstreamUrl}/api/auth/login`,
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: '{"password":"__HEZO_SECRET_UMAMI_PW_BODYONLY__"}',
+			});
+			expect(res.status).toBe(403);
+			const parsed = JSON.parse(res.body);
+			expect(parsed.error).toBe('secret_not_allowed_in_body');
+			expect(parsed.message).toContain('ask an admin to enable it');
+			expect(parsed.message).not.toContain('already substituted into this request');
+			for (const req of upstreamRequests) {
+				expect(req.body.includes('never-leaked-bodyonly')).toBe(false);
+			}
+		} finally {
+			await proxy.releaseRunProxy(runId);
+		}
+	}, 30_000);
+
 	it('does not substitute a body placeholder on a non-allowed host', async () => {
 		const runId = `run-${Date.now()}-body-host`;
 		await insertSecret('UMAMI_PW_HOST', 'never-leaked-host', ['only.example'], true);

--- a/packages/server/test/egress-substitution.test.ts
+++ b/packages/server/test/egress-substitution.test.ts
@@ -311,10 +311,44 @@ describe('substituteRequest', () => {
 				},
 				secrets,
 			);
-			expect(result.failure).toEqual({ kind: 'secret_not_allowed_in_body', name: 'UMAMI_PW' });
+			expect(result.failure).toEqual({
+				kind: 'secret_not_allowed_in_body',
+				name: 'UMAMI_PW',
+				deliveredElsewhere: false,
+			});
 			expect(result.body).toBe('{"password":"__HEZO_SECRET_UMAMI_PW__"}');
 			expect(result.bodyChanged).toBe(false);
 			expect(result.secretsUsed.size).toBe(0);
+		});
+
+		// The MCP shape: the connector's credential rides the Authorization header
+		// the runtime configured, and the same placeholder turns up in the tool-call
+		// arguments because the agent is writing that literal text somewhere. The
+		// credential is already on the wire, so the body occurrence is content.
+		it('reports a body placeholder as already delivered when the header carried it', () => {
+			const secrets = new Map([
+				['MCP_GITHUB', makeSecret('MCP_GITHUB', 'gho_real', ['api.githubcopilot.com'])],
+			]);
+			const result = substituteRequest(
+				{
+					...baseRequest,
+					host: 'api.githubcopilot.com',
+					url: 'https://api.githubcopilot.com/mcp/',
+					headers: { authorization: 'Bearer __HEZO_SECRET_MCP_GITHUB__' },
+					body: '{"method":"tools/call","params":{"arguments":{"body":"__HEZO_SECRET_MCP_GITHUB__"}}}',
+				},
+				secrets,
+			);
+			expect(result.failure).toEqual({
+				kind: 'secret_not_allowed_in_body',
+				name: 'MCP_GITHUB',
+				deliveredElsewhere: true,
+			});
+			// The header pass still ran and still counted, so the discriminator is a
+			// fact about this request rather than a guess about the payload.
+			expect(result.headers.authorization).toBe('Bearer gho_real');
+			expect([...result.secretsUsed]).toEqual(['MCP_GITHUB']);
+			expect(result.bodyChanged).toBe(false);
 		});
 
 		it('still enforces allowed_hosts on body placeholders', () => {


### PR DESCRIPTION
## What prompted this

A Codex run reported "GitHub MCP auth is broken" and proposed rebinding the GitHub connector from Codex's `http_headers` to `bearer_token_env_var`. **That diagnosis was wrong and no auth change is needed** - `http_headers` is a documented, supported Codex key, it is the only static-header key Codex reads (`toml.ts:50-58`), and `bearer_token_env_var` is deliberately reserved for descriptors carrying a real token (in practice only the built-in `hezo` server's JWT, since `bearerTokenStorage: 'env-var'` makes `validate.ts:69-80` reject a token inlined into a config file). Connector descriptors never populate `bearerToken`.

What was actually failing is Hezo's own egress proxy, and it is a real papercut.

## The papercut

An MCP `tools/call` over Streamable HTTP is a POST of small fixed-length `application/json`, so it lands inside the proxy's body-buffering window (`proxy.ts:938`, `proxy.ts:1631-1644`) and `proxy.ts:1047` hands the buffered body to `substituteRequest`. Every tool-call payload therefore gets scanned for placeholders.

An agent writing the literal `__HEZO_SECRET_*__` text into a *tool argument* - a doc, a test fixture, a code comment about the grammar - hit a 403 saying:

> Secret X is not permitted in request bodies. Enable body substitution for this credential to use it in a JSON payload.

which points at an admin-only toggle for a credential the agent never meant to send.

## The change

Keep the refusal. The proxy cannot read intent, and forwarding instead would ship an inert placeholder that 401s upstream with nothing naming the cause (`substitution.ts:210-212` is deliberate).

Discriminate **structurally** rather than by inspecting the payload, per AGENTS.md's "reach for a structural signal before a phrase". Headers and the URL are substituted before the body, so `secretsUsed` already records whether the same secret is on the wire by a route the proxy supports.

- `substitution.ts` - `secret_not_allowed_in_body` gains `deliveredElsewhere`, set from `secretsUsed.has(name)`.
- `proxy.ts` - `describeFailure` picks one of two messages from that flag: already-sent-in-a-header ("remove that literal text from the body content") or not-sent-at-all ("ask an admin to enable it"). The `code` and the 403 are unchanged, so `reportConnectorRunRejection` keeps keying off the code.

## Tests

- `egress-substitution.test.ts` - updated the existing `toEqual` for the new field, plus a new case asserting `deliveredElsewhere: true` when the header carried the same secret.
- `egress-proxy.test.ts` - two proxy-level cases: an MCP-shaped `tools/call` body whose arguments repeat the placeholder while `Authorization` carries it, and the body-only case. Both assert the unchanged error code, the right wording, and that no upstream body contains the real value.

Both new proxy tests were confirmed to fail against the old message before the fix, so they pin it rather than passing vacuously.

## Docs

`.dev/architecture.md` §7 opened with "matches placeholders **in the URL and headers**", contradicting the body paragraph directly beneath it and the likely source of the "headers only" impression. Corrected, and added the MCP `tools/call` note plus the two-message split.

## Not in scope

No change to `renderHttpBlock` or the Codex auth binding; `runtime-adapters.test.ts` and `toml.test.ts` stay green to prove it.

## Verification

```
bunx vitest run test/egress-substitution.test.ts test/egress-proxy.test.ts \
                test/runtime-adapters.test.ts test/toml.test.ts   # 188 passed
bun run typecheck   # clean
bunx biome check --diagnostic-level=error .   # clean
bun run build   # clean, no generated-file drift
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qsDWzDQSHonXFwLeLSib9

---
_Generated by [Claude Code](https://claude.ai/code/session_019qsDWzDQSHonXFwLeLSib9)_