### PR TITLE
feat(mcp): send the registry conventions as initialize instructions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -5989,6 +5989,27 @@ unapproved caller is served the onboarding tools (`register`, `connection_status
 nothing else. Only `tools/list` and `tools/call` from an authenticated principal reach the
 registry.
 
+**Registry-wide conventions ride the `initialize` result, not the tool descriptions.**
+`mcpConventionLines()` (`mcp/mcp-reference.ts`) is authored once and rendered to two surfaces:
+the reference page prints it as its Conventions section, and `handleMcpRequest`'s `initialize`
+branch sends it as the protocol's `instructions` field - once per session, ~3.3 KB. Two clauses
+that point at the page's own layout are reworded for the wire; a test asserts those are the
+only two that differ.
+
+This exists because a convention stated on a tool is serialized once **per tool** on every
+`tools/list`. The `project` parameter's 128-character description costs ~9 KB that way, across
+70 tools - 7% of the whole payload from one string. `tools.ts` is already DRY about it
+(`projectArg()` is a shared factory), so the duplication is in the serialization, not the
+source, and no amount of editing `tools.ts` reaches it. `SHARED_INSTRUCTIONS` cannot serve as
+that home either: it is built inside `resolveTemplate` for an agent run's system prompt, so an
+external API-key MCP caller never receives it, and `GET /SKILL.md` carries no parameter
+descriptions at all.
+
+**The `instructions` field must go on the hand-rolled response.** `handleMcpRequest` answers
+`initialize` itself rather than delegating to the SDK (the proxy client has already negotiated
+initialization, so a second handshake would be rejected). Passing `instructions` to
+`new McpServer(...)` therefore reaches nobody - a silent no-op.
+
 **`tools/list` is projected per caller** (`mcp/tool-visibility.ts`). Every authenticated
 principal used to receive the whole registry, so a worker agent scoped to one project carried
 `create_team`, the CEO's project-creation tools and every Captain-only prompt editor — schemas

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -605,6 +605,68 @@ function renderTool(tool: McpReferenceTool, meta: ToolDocMeta): string[] {
  * registry order within each category, and categories follow
  * `MCP_REFERENCE_CATEGORY_ORDER`.
  */
+/**
+ * The calling conventions that hold across the whole registry - project scope,
+ * errors, paging, result caps, excerpts, secrets.
+ *
+ * Authored once and rendered to two surfaces. The reference page prints them as
+ * a section; the MCP server sends them as the `instructions` field of its
+ * `initialize` result, which reaches a client once per session. Stating a
+ * convention here rather than in each tool is what keeps it out of all 81 tool
+ * descriptions, where it would otherwise be serialized on every `tools/list`.
+ *
+ * Two clauses differ by surface because they point at page furniture the wire
+ * has no equivalent for.
+ */
+export function mcpConventionLines(surface: 'docs' | 'wire'): string[] {
+	return [
+		'- **Project scope (`project`):** most tools take an optional `project` (slug or ID).',
+		'  Omit it to act in the project your run is already in; an API key and instance agents',
+		'  (CEO/Coach) must name the project they are acting in.',
+		"- **Authorization:** every call is scoped to the resolved project's team and the caller",
+		'  must have access to it. Tools that restrict callers further note it under',
+		surface === 'docs' ? '  **Authorization** below.' : '  their own description.',
+		'- **Errors:** a handled failure comes back as `{ "error": "<message>" }` in the tool',
+		'  result (the HTTP response itself stays successful).',
+		'- **Paging is the norm, in one of three shapes.** A read that can return many rows,',
+		'  or content with no size ceiling, always returns a bounded slice plus the cursor to',
+		'  continue. A response carrying `has_more: true`, `next_cursor`, `next_offset`, or',
+		'  `next_index` is telling you it is partial - keep calling until the cursor is null or',
+		'  `has_more` is false. Treating the first page as the whole set is the one failure',
+		'  mode none of these shapes can protect you from.',
+		'  - **Lists** take `limit` (default 50, ceiling 200) and an opaque `cursor`, and return',
+		'    `{ items, next_cursor, has_more }`. Pass back the `next_cursor` you were given;',
+		'    do not construct or parse one. `list_comments` also still accepts `before`',
+		'    (a comment `id` or `public_id`) to resume from a comment you already know.',
+		'  - **Large single content** (`read_project_doc`, `get_agent_system_prompt`,',
+		'    `get_run_log`) takes `offset` plus `max_bytes` and returns a UTF-8 window with',
+		'    `next_offset`. Note `get_run_log` defaults to the log **tail**; pass `offset: 0`',
+		'    to read a run that failed early, since the tail cannot reach the start.',
+		'  - **Batch tools** (`get_agent_system_prompts`) return as many items as fit plus',
+		'    `next_index`; call again with the same `items` and `start_index` set to it.',
+		'- **Result size:** a tool result is capped at 64 KB (higher for a few full-resource',
+		'  inspection tools, e.g. `get_agent_system_prompt`). Over the cap the whole result is',
+		'  discarded and you get `{ "error": "result_too_large", "remedies": [...] }`. The',
+		'  `remedies` are built from the parameters that tool actually declares, so follow',
+		'  them rather than guessing - and when the tool takes a batch, they name the exact',
+		'  item count to retry with. Split the work and retry; do not fall back to one call',
+		'  per item, and do not narrow what you cover to whatever fits in one call.',
+		'- **Excerpts (`excerpt_chars`):** list tools return long free-text fields as excerpts',
+		'  with `_truncated`/`_length` companions, so one page cannot be dominated by a few',
+		'  large rows. An excerpt is cut to fill `excerpt_chars`, so it usually stops',
+		'  mid-sentence; always check the `_truncated` companion rather than judging from',
+		'  whether the text reads as complete. To get the whole value, call the matching',
+		'  single-item read - `get_task` for a task, `get_comment` for a comment,',
+		'  `read_project_doc` for a doc - not a larger `excerpt_chars`.',
+		'- **Secrets:** agents reference secrets by placeholder (`__HEZO_SECRET_<NAME>__`); the',
+		"  egress proxy substitutes the real value only for the secret's `allowed_hosts`.",
+		surface === 'docs'
+			? '- **Write tools:** tools marked _Write tool_ persist data - a successful call from an'
+			: '- **Write tools:** a tool that persists data - a successful call from an',
+		'  agent run marks the run as having produced output.',
+	];
+}
+
 export function generateMcpReference(
 	tools: McpReferenceTool[],
 	onboarding: McpReferenceTool[],
@@ -650,48 +712,7 @@ export function generateMcpReference(
 		'',
 		'## Conventions',
 		'',
-		'- **Project scope (`project`):** most tools take an optional `project` (slug or ID).',
-		'  Omit it to act in the project your run is already in; an API key and instance agents',
-		'  (CEO/Coach) must name the project they are acting in.',
-		"- **Authorization:** every call is scoped to the resolved project's team and the caller",
-		'  must have access to it. Tools that restrict callers further note it under',
-		'  **Authorization** below.',
-		'- **Errors:** a handled failure comes back as `{ "error": "<message>" }` in the tool',
-		'  result (the HTTP response itself stays successful).',
-		'- **Paging is the norm, in one of three shapes.** A read that can return many rows,',
-		'  or content with no size ceiling, always returns a bounded slice plus the cursor to',
-		'  continue. A response carrying `has_more: true`, `next_cursor`, `next_offset`, or',
-		'  `next_index` is telling you it is partial - keep calling until the cursor is null or',
-		'  `has_more` is false. Treating the first page as the whole set is the one failure',
-		'  mode none of these shapes can protect you from.',
-		'  - **Lists** take `limit` (default 50, ceiling 200) and an opaque `cursor`, and return',
-		'    `{ items, next_cursor, has_more }`. Pass back the `next_cursor` you were given;',
-		'    do not construct or parse one. `list_comments` also still accepts `before`',
-		'    (a comment `id` or `public_id`) to resume from a comment you already know.',
-		'  - **Large single content** (`read_project_doc`, `get_agent_system_prompt`,',
-		'    `get_run_log`) takes `offset` plus `max_bytes` and returns a UTF-8 window with',
-		'    `next_offset`. Note `get_run_log` defaults to the log **tail**; pass `offset: 0`',
-		'    to read a run that failed early, since the tail cannot reach the start.',
-		'  - **Batch tools** (`get_agent_system_prompts`) return as many items as fit plus',
-		'    `next_index`; call again with the same `items` and `start_index` set to it.',
-		'- **Result size:** a tool result is capped at 64 KB (higher for a few full-resource',
-		'  inspection tools, e.g. `get_agent_system_prompt`). Over the cap the whole result is',
-		'  discarded and you get `{ "error": "result_too_large", "remedies": [...] }`. The',
-		'  `remedies` are built from the parameters that tool actually declares, so follow',
-		'  them rather than guessing - and when the tool takes a batch, they name the exact',
-		'  item count to retry with. Split the work and retry; do not fall back to one call',
-		'  per item, and do not narrow what you cover to whatever fits in one call.',
-		'- **Excerpts (`excerpt_chars`):** list tools return long free-text fields as excerpts',
-		'  with `_truncated`/`_length` companions, so one page cannot be dominated by a few',
-		'  large rows. An excerpt is cut to fill `excerpt_chars`, so it usually stops',
-		'  mid-sentence; always check the `_truncated` companion rather than judging from',
-		'  whether the text reads as complete. To get the whole value, call the matching',
-		'  single-item read - `get_task` for a task, `get_comment` for a comment,',
-		'  `read_project_doc` for a doc - not a larger `excerpt_chars`.',
-		'- **Secrets:** agents reference secrets by placeholder (`__HEZO_SECRET_<NAME>__`); the',
-		"  egress proxy substitutes the real value only for the secret's `allowed_hosts`.",
-		'- **Write tools:** tools marked _Write tool_ persist data - a successful call from an',
-		'  agent run marks the run as having produced output.',
+		...mcpConventionLines('docs'),
 		'',
 	];
 

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { verifyToken } from '../middleware/auth';
 import { storeUploadedAsset } from '../routes/assets';
 import type { ContainerDeps } from '../services/containers';
 import type { WebSocketManager } from '../services/ws';
+import { mcpConventionLines } from './mcp-reference';
 import {
 	handleConnectionStatusTool,
 	handleRegisterTool,
@@ -103,6 +104,29 @@ export function audienceOf(name: string): ToolAudience | undefined {
 	return toolDefs.find((t) => t.name === name)?.audience;
 }
 
+/**
+ * The registry-wide calling conventions, sent once per session as the
+ * `initialize` result's `instructions`.
+ *
+ * This is the only surface above an individual tool that reaches an MCP caller
+ * on the wire. Without it a convention has nowhere to live but the tool
+ * descriptions, where one sentence becomes 70 copies on every `tools/list` -
+ * `project` alone costs ~9 KB that way. `SHARED_INSTRUCTIONS` is not a
+ * substitute: it is built for an agent run's system prompt, so an external
+ * API-key caller never sees it, and `GET /SKILL.md` carries no parameter
+ * descriptions at all.
+ *
+ * Authored with the reference page in `mcp-reference.ts` so the two cannot
+ * disagree.
+ */
+let instructionsCache: string | null = null;
+function mcpInstructions(): string {
+	if (instructionsCache === null) {
+		instructionsCache = mcpConventionLines('wire').join('\n');
+	}
+	return instructionsCache;
+}
+
 function extractBearer(c: Context<Env>): string | null {
 	const header = c.req.header('Authorization');
 	if (!header?.startsWith('Bearer ')) return null;
@@ -180,6 +204,10 @@ export async function handleMcpRequest(c: Context<Env>): Promise<Response> {
 				protocolVersion: '2025-03-26',
 				capabilities: { tools: {} },
 				serverInfo: { name: 'hezo', version: '0.1.0' },
+				// Hand-rolled rather than delegated to the SDK (see the branch above),
+				// so this is the only place `instructions` can reach a caller -
+				// passing it to `new McpServer(...)` would be a silent no-op.
+				instructions: mcpInstructions(),
 			},
 		});
 	}

--- a/packages/server/test/mcp-reference.test.ts
+++ b/packages/server/test/mcp-reference.test.ts
@@ -9,6 +9,7 @@ import {
 	generateMcpReference,
 	MCP_REFERENCE_CATEGORY_ORDER,
 	type McpReferenceTool,
+	mcpConventionLines,
 	TOOL_DOC_META,
 } from '../src/mcp/mcp-reference';
 import { ONBOARDING_TOOLS } from '../src/mcp/onboarding';
@@ -80,5 +81,30 @@ describe('MCP API reference (docs/reference/mcp-api.md)', () => {
 		expect(doc.title).toBe('MCP API reference');
 		expect(doc.section).toBe('Reference');
 		expect(doc.order).toBe(32);
+	});
+});
+
+describe('registry conventions', () => {
+	// Authored once and rendered to two surfaces: the reference page prints them
+	// as a section, the MCP server sends them as `initialize` instructions. One
+	// source is the point - a convention stated per tool costs its bytes once per
+	// tool on every `tools/list`.
+	it('renders the same conventions to both surfaces, bar the page furniture', () => {
+		const docs = mcpConventionLines('docs');
+		const wire = mcpConventionLines('wire');
+		expect(wire.length).toBe(docs.length);
+		const differing = docs.filter((line, i) => line !== wire[i]);
+		// Exactly the two clauses that point at the reference page's own layout.
+		expect(differing).toEqual([
+			'  **Authorization** below.',
+			expect.stringContaining('_Write tool_'),
+		]);
+	});
+
+	it('covers the conventions no single tool schema can convey', () => {
+		const wire = mcpConventionLines('wire').join('\n');
+		for (const topic of ['`project`', 'Paging is the norm', 'result_too_large', 'excerpt_chars']) {
+			expect(wire, topic).toContain(topic);
+		}
 	});
 });

--- a/packages/server/test/mcp-server-branch-cov.test.ts
+++ b/packages/server/test/mcp-server-branch-cov.test.ts
@@ -82,6 +82,40 @@ describe('handleMcpRequest branches', () => {
 		expect(result.protocolVersion).toBeDefined();
 	});
 
+	it('carries the registry conventions as initialize instructions', async () => {
+		// The only surface above an individual tool that reaches a caller on the
+		// wire. Without it a convention has nowhere to live but the 81 tool
+		// descriptions, where one sentence is serialized once per tool on every
+		// `tools/list`.
+		const { json } = await rpc({ jsonrpc: '2.0', id: 8, method: 'initialize', params: {} });
+		const instructions = (json.result as { instructions?: string }).instructions ?? '';
+		expect(instructions.length).toBeGreaterThan(1000);
+		// The conventions a caller cannot infer from any single tool's schema.
+		expect(instructions).toContain('**Project scope (`project`):**');
+		expect(instructions).toContain('Omit it to act in the project your run is already in');
+		expect(instructions).toContain('**Paging is the norm');
+		expect(instructions).toContain('result_too_large');
+		expect(instructions).toContain('__HEZO_SECRET_<NAME>__');
+	});
+
+	it('states the conventions without the reference page furniture', async () => {
+		// Same source as docs/reference/mcp-api.md, so two clauses that point at
+		// page layout are reworded for the wire rather than shipped verbatim.
+		const { json } = await rpc({ jsonrpc: '2.0', id: 9, method: 'initialize', params: {} });
+		const instructions = (json.result as { instructions?: string }).instructions ?? '';
+		expect(instructions).not.toContain('**Authorization** below');
+		expect(instructions).not.toContain('_Write tool_');
+	});
+
+	it('serves identical instructions on every initialize', async () => {
+		// Cached, and constant: a caller that reconnects must not see it drift.
+		const a = await rpc({ jsonrpc: '2.0', id: 10, method: 'initialize', params: {} });
+		const b = await rpc({ jsonrpc: '2.0', id: 11, method: 'initialize', params: {} });
+		expect((a.json.result as { instructions?: string }).instructions).toBe(
+			(b.json.result as { instructions?: string }).instructions,
+		);
+	});
+
 	it('unauthenticated tools/list returns only the onboarding tools', async () => {
 		const { json } = await rpc({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
 		const tools = (json.result as { tools: Array<{ name: string }> }).tools;


### PR DESCRIPTION
## The problem, measured

Hezo's `tools/list` payload is **126,321 bytes** (~29-36k tokens); a worker agent receives **100,891** after per-caller projection. Of it, **~81% is prose** and only **~15% is genuine schema structure**.

The prose is not badly written. It is *duplicated by serialization*:

| String | Sites | Bytes on the wire |
|---|---|---|
| `project` parameter | **70** | **8,960** |
| `cursor` parameter | 15 | 2,955 |
| Paging sentence in descriptions | 19 | 3,477 |
| `limit` parameter | 15 | 870 |

`tools.ts` is already DRY - `projectArg()`, `listPagingArgs()` and `filterArg` are shared factories. One string becomes seventy copies on every `tools/list`. **No amount of editing `tools.ts` reaches this**, because the duplication happens at serialization time. What was missing is somewhere *above* an individual tool for a convention to live.

## What this adds

MCP's `initialize` result carries an optional `instructions` field, sent **once per session**. Hezo set none. It now carries the registry-wide conventions - project scope, errors, paging, result caps, excerpts, secrets - at ~3.3 KB.

`mcpConventionLines()` is authored once and rendered to two surfaces: `docs/reference/mcp-api.md` prints it as its Conventions section, and the server sends it on the wire. Two clauses point at the reference page's own layout ("**Authorization** below", "_Write tool_") and are reworded for the wire; a test asserts those are **the only two** that differ. The generated page comes out byte-identical to before this change.

### The trap worth knowing

`handleMcpRequest` answers `initialize` **itself** rather than delegating to the SDK - the proxy client has already negotiated initialization, so a second handshake would be rejected. Passing `instructions` to `new McpServer(...)` would therefore reach nobody. It has to go on the hand-rolled response, and the code now says so.

## Why not the alternatives

- **`TOOL_DOC_META`** renders only into `docs/reference/mcp-api.md`, which reaches a model only via the docs bundle at the CEO prompt's `HEZO_DOCS` marker with `embedDocs: true` - set in exactly one place (`chat-session-manager.ts:1928`, the CEO live chat). All ~36 KB of `returns`/`auth` is invisible at call time to essentially every agent run. Moving prose there is a deletion, not a relocation.
- **`SHARED_INSTRUCTIONS`** is built inside `resolveTemplate` for an agent run's system prompt, so an external API-key MCP caller never receives it - and `GET /SKILL.md` carries no parameter descriptions at all. `instructions` is the only surface that serves both audiences.

## Scope: additive only

**Nothing is removed from any tool description here.** Whether a client actually surfaces `instructions` to the model is the open question this exists to answer, and it must be answered before a single description is trimmed on the strength of it. If Claude Code does not surface it, the follow-up does not happen.

The follow-up, if it does: ~16 KB from collapsing the convention parameters, `project` last and most carefully - a wrong `project` is not a failed call, it is a successful write to another team's data.

## Risk disclosure

This change removes nothing, so it carries no tool-selection risk. Worth recording for the follow-up, though: **nothing in this repo can detect a tool-selection regression.** The only live-model harness, `describeAgentCliConformance`, names the tool in its own prompt (`test/conformance/agent-cli.ts:136`), so it tests transport rather than choice - and it never runs in CI, being gated on `HEZO_<PROVIDER>_API_KEY`. There are two logged precedents of that regression; `mcp-goals.test.ts:261-272` exists *because* agents misfiled goals until doctrine was added to that description.

## Testing

`bun run typecheck` clean, `bunx biome check` clean.

- `mcp-server-branch-cov`: 22 passed - instructions present and substantive, page furniture absent, identical across reconnects
- `mcp-reference`: 6 passed - includes the cross-surface guard asserting exactly two clauses differ
- `mcp-tools` 427, `mcp-tool-visibility` 8, `docs-bundle` 9, `docs-terminology` 3, `llms-txt` 3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgyasGxRakBVVhg3B3UEzx)_