### PR TITLE
docs(mcp): record that Claude Code does surface initialize instructions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -6051,6 +6051,26 @@ descriptions at all.
 initialization, so a second handshake would be rejected). Passing `instructions` to
 `new McpServer(...)` therefore reaches nobody - a silent no-op.
 
+**Measured: Claude Code does surface it, as a system-reminder in the message stream.** The
+field was shipped additively because nothing verified that a client passes it to the model at
+all. It does, on Claude Code **2.1.238**: a stub stdio MCP server carried a canary in
+`instructions` and in no tool name, description or schema, and a local recorder stood in for
+the provider's `/v1/messages` so the request bodies could be read directly rather than inferred
+from a model's answer. The main-loop turn - identified by the stub's tool appearing in its tool
+list - carried the canary inside a `<system-reminder>` block headed `# MCP Server Instructions`
+then `## <server-name>`, as a `system`-role entry in the `messages` array, not in the top-level
+`system` parameter. The control run, identical but with the field omitted, produced the same
+tool surface with no header and no canary in any of its requests, so `instructions` is what
+carried it. Auxiliary requests the CLI makes on the side (status summarisation, zero tools) do
+not carry it, which is expected.
+
+**That result does not license trimming a tool description.** Only Claude Code was measured, of
+the six runtimes in `AgentRuntime`; only a single-turn `-p` invocation was exercised, so
+whether the block persists across the turns of a long run is unknown; and reaching the context
+window is not the model *attending* to it, which no measurement of the wire can show. So the
+convention prose still duplicated across tool descriptions stays where it is - moving it is
+gated on a tool-selection harness that could detect the regression, not on this gate.
+
 **`tools/list` is projected per caller** (`mcp/tool-visibility.ts`). Every authenticated
 principal used to receive the whole registry, so a worker agent scoped to one project carried
 `create_team`, the CEO's project-creation tools and every Captain-only prompt editor — schemas


### PR DESCRIPTION
#1029 shipped the `initialize` result's `instructions` field **additively on purpose**, because nothing had verified the assumption the whole follow-up rests on:

> a convention stated only in `instructions` actually reaches the model.

If false, the ~16 KB trim it was meant to unblock is dead - the prose would be deleted, not relocated - and #1029 is a 3.3 KB regression to revert. That question is now settled for one runtime, and this records the answer so nobody re-derives it.

## The gate passes

Claude Code **2.1.238** surfaces it. A stub stdio MCP server carried a canary in `instructions` and in **no** tool name, description or schema; a local recorder stood in for the provider's `/v1/messages`, so the request bodies were read directly rather than inferred from a model's answer - which removes the confabulation failure mode the plan's negative control existed to catch.

The main-loop turn, identified by the stub's tool appearing in its 38-tool list, carried the canary inside a `<system-reminder>` block:

```
# MCP Server Instructions
## gate
```

as a `system`-role entry in the `messages` array, **not** in the top-level `system` parameter.

**Absent-instructions control** (same server, field omitted): 5 requests, same tool surface with `mcp__gate__ping` present, no header and no canary in any of them. So the field is what carried it.

Auxiliary requests the CLI makes on the side (status summarisation, zero tools) do not carry it, which is expected.

## What it does not settle

Recorded alongside the result, because these are what still gate the trim:

- **Only Claude Code was measured**, of the six runtimes in `AgentRuntime`.
- **Only a single-turn `-p` invocation** was exercised, so whether the block persists across the turns of a long run is unknown.
- **Reaching the context window is not the model attending to it**, which no measurement of the wire can show.

So the convention prose still duplicated across tool descriptions stays exactly where it is. Moving it remains gated on a tool-selection harness that could detect the regression, not on this gate. Nothing in the repo can detect one today - `describeAgentCliConformance` names the tool in its own prompt and never runs in CI.

Note the version: Hezo's existing tool-payload measurements were taken against Claude Code 2.1.220 (`agent-stream-parser.ts`). Client behaviour is exactly what was under test, so the version is recorded with the result.

## What changed

20 lines in `.dev/architecture.md`, appended to the `instructions` section #1029 added. No code, no behaviour.

## Testing

The experiment is its own verification; it ran outside the repo and left nothing behind. `bun run build`, `bun run typecheck` and `bunx biome check` all ran clean via the pre-commit hook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgyasGxRakBVVhg3B3UEzx)_