### PR TITLE
test(web): cover the broker form's device-flow view

### DIFF
--- a/packages/web/test/connector-oauth-broker-form.test.tsx
+++ b/packages/web/test/connector-oauth-broker-form.test.tsx
@@ -1,0 +1,122 @@
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { withI18n } from './helpers/i18n';
+
+// The broker form's own transport is stubbed: what these assert is the step-two
+// view it hands to `DeviceCodeSteps` once a flow has started. The existing
+// broker specs stop at the form and never submit it, so that view - and the
+// promise that submitting no longer opens a tab behind the operator - had
+// nothing covering it.
+const brokerDeviceStart = vi.fn();
+const pollBrokerDeviceFlow = vi.fn();
+
+vi.mock('../src/hooks/use-oauth-connections', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../src/hooks/use-oauth-connections')>()),
+	useOAuthProviders: () => ({ data: [] }),
+	useBrokerDeviceStart: () => ({ mutate: brokerDeviceStart }),
+	pollBrokerDeviceFlow: (...args: unknown[]) => pollBrokerDeviceFlow(...args),
+}));
+
+const { ConnectorOAuthBrokerForm } = await import('../src/components/connector-oauth-broker-form');
+
+const FLOW = {
+	flow_id: 'flow-1',
+	user_code: 'HJKD-9QWE',
+	verification_uri: 'https://www.google.com/device',
+	expires_in: 900,
+	interval: 5,
+};
+
+function renderForm() {
+	return render(
+		withI18n(
+			<ConnectorOAuthBrokerForm
+				projectId="ops"
+				connectorId="conn-1"
+				connectorLabel="YouTube"
+				lockedProviderId="google-youtube"
+			/>,
+		),
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// The flow parks awaiting authorization, so the poll loop stays quiet.
+	pollBrokerDeviceFlow.mockImplementation(() => new Promise(() => {}));
+});
+
+test('submitting the client id hands the started flow to the step rail', async () => {
+	const user = userEvent.setup();
+	const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+	const { getByTestId, findByTestId, queryByTestId } = renderForm();
+
+	await user.type(getByTestId('broker-client-id'), 'client-abc');
+	await user.click(getByTestId('broker-submit'));
+
+	// The form calls start with what the operator entered, then renders whatever
+	// the flow resolves to - here, step one of the rail.
+	expect(brokerDeviceStart).toHaveBeenCalledTimes(1);
+	const [input, handlers] = brokerDeviceStart.mock.calls[0] as [
+		{ client_id: string; connectorId: string },
+		{ onSuccess: (flow: typeof FLOW) => void },
+	];
+	expect(input.client_id).toBe('client-abc');
+	expect(input.connectorId).toBe('conn-1');
+
+	handlers.onSuccess(FLOW);
+
+	expect((await findByTestId('device-code-value')).textContent).toBe('HJKD-9QWE');
+	expect(getByTestId('device-code-step-copy').getAttribute('data-state')).toBe('active');
+	expect(queryByTestId('broker-form')).toBeNull();
+
+	// The behaviour this PR changed: starting a flow no longer pops a tab the
+	// operator did not ask for, before the code is even on screen.
+	expect(openSpy).not.toHaveBeenCalled();
+	expect(queryByTestId('device-code-open')).toBeNull();
+
+	openSpy.mockRestore();
+});
+
+test('the started flow carries its expiry into the countdown', async () => {
+	const user = userEvent.setup();
+	const { getByTestId, findByTestId } = renderForm();
+
+	await user.type(getByTestId('broker-client-id'), 'client-abc');
+	await user.click(getByTestId('broker-submit'));
+	const [, handlers] = brokerDeviceStart.mock.calls[0] as [
+		unknown,
+		{ onSuccess: (flow: typeof FLOW) => void },
+	];
+	handlers.onSuccess(FLOW);
+
+	// `expires_in` is a duration; the rail pins it to a deadline and counts down.
+	expect((await findByTestId('device-code-expiry')).textContent).toContain('15:00');
+});
+
+test('a client id is required before a flow is started', async () => {
+	const user = userEvent.setup();
+	const { getByTestId, findByText } = renderForm();
+
+	await user.click(getByTestId('broker-submit'));
+
+	await findByText('Enter the OAuth client ID.');
+	expect(brokerDeviceStart).not.toHaveBeenCalled();
+});
+
+test('a failed start reports the reason and keeps the form on screen', async () => {
+	const user = userEvent.setup();
+	const { getByTestId, findByText } = renderForm();
+
+	await user.type(getByTestId('broker-client-id'), 'client-abc');
+	await user.click(getByTestId('broker-submit'));
+	const [, handlers] = brokerDeviceStart.mock.calls[0] as [
+		unknown,
+		{ onError: (err: Error) => void },
+	];
+	handlers.onError(new Error('device_code_url is not reachable'));
+
+	await findByText('device_code_url is not reachable');
+	await waitFor(() => expect(getByTestId('broker-form')).toBeTruthy());
+});


### PR DESCRIPTION
Follow-up to #1041 (merged). Test-only - no source changes.

#1041 moved three surfaces onto `DeviceCodeSteps` and shipped tests for two of them. The third, `ConnectorOAuthBrokerForm`, had none: the existing broker specs (`connectors-page`, `connect-required-comment`) stop at the form and never submit it, so the step-two view it renders once a flow has started was never exercised - before that PR or after it. Coveralls put the changed lines in that file at 3 of 18.

Four tests over the started flow:

- submitting hands the flow to the rail, with the code on step one and the form gone
- `expires_in` reaches the countdown as a deadline (`15:00`)
- a missing client id is refused before any flow is started
- a failed start reports its reason and keeps the form on screen

The first also pins the behaviour change #1041 made on this surface: starting a flow no longer fires `window.open` behind the operator, and step two's link is not on screen until the code has been copied.

The form's own transport is stubbed (`useBrokerDeviceStart`, `pollBrokerDeviceFlow`), so what these assert is the view rather than the round trip - the same shape as `subscription-login-panel.test.tsx` from #1041.

Ran locally: the new spec plus the four suites around it (`device-code-steps`, `subscription-login-panel`, `connectors-page`, `connect-required-comment`) - 53 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EotFkhYAyUe1BvYJXWfGA4


---
_Generated by [Claude Code](https://claude.ai/code/session_01EotFkhYAyUe1BvYJXWfGA4)_