### PR TITLE
fix(web): keep the task's created date relative, however old it is

### DIFF
--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -384,7 +384,7 @@ export function TaskSidebar({
 					<span className="text-text-3 block mb-1 uppercase tracking-wider font-medium">
 						Created
 					</span>
-					<RelativeTime iso={task.created_at} className="text-[13px] text-text-1" />
+					<RelativeTime iso={task.created_at} alwaysRelative className="text-[13px] text-text-1" />
 				</div>
 
 				<div>

--- a/packages/web/src/components/ui/relative-time.tsx
+++ b/packages/web/src/components/ui/relative-time.tsx
@@ -8,14 +8,15 @@ import { Tooltip } from './tooltip';
 
 /**
  * A timestamp rendered as a relative "X ago" label (or the absolute date once
- * it's older than a week), with the full local date+time always reachable via a
- * tooltip. On desktop the tooltip opens on hover; on touch a tap toggles it
- * (Radix tooltips never open on tap, so `open` is driven manually — matching
- * `CommentTimestampLink`).
+ * it's older than a week, unless `alwaysRelative` is set), with the full local
+ * date+time always reachable via a tooltip. On desktop the tooltip opens on
+ * hover; on touch a tap toggles it (Radix tooltips never open on tap, so `open`
+ * is driven manually — matching `CommentTimestampLink`).
  */
 export function RelativeTime({
 	iso,
 	compact = false,
+	alwaysRelative = false,
 	className,
 	side,
 	testId,
@@ -23,12 +24,16 @@ export function RelativeTime({
 	iso: string | null | undefined;
 	/** Use the compact "5m"/"3h"/"2d" form instead of the full "5 minutes ago". */
 	compact?: boolean;
+	/** Stay relative past the week cutoff, for a slot whose point is the age. */
+	alwaysRelative?: boolean;
 	className?: string;
 	side?: 'top' | 'right' | 'bottom' | 'left';
 	testId?: string;
 }) {
 	const [open, setOpen] = useState(false);
-	const label = compact ? formatRelativeTimeCompact(iso) : formatRelativeTime(iso);
+	const label = compact
+		? formatRelativeTimeCompact(iso, { alwaysRelative })
+		: formatRelativeTime(iso, { alwaysRelative });
 	if (!label) return null;
 	return (
 		<Tooltip content={formatDateTime(iso)} open={open} onOpenChange={setOpen} side={side}>

--- a/packages/web/src/lib/format-date.ts
+++ b/packages/web/src/lib/format-date.ts
@@ -82,15 +82,36 @@ export function formatDate(iso: string | null | undefined): string {
 }
 
 /**
+ * Options shared by both relative formatters.
+ *
+ * `alwaysRelative` keeps the phrase relative however old the timestamp is
+ * (`"2 months ago"`, `"1 year ago"`), for a slot whose whole point is the age -
+ * a metadata field labelled with what the timestamp means, sitting next to its
+ * absolute-date tooltip. Everywhere else the week cutoff stands, so a timestamp
+ * that is no longer in living memory reads as a date.
+ */
+export interface RelativeTimeOptions {
+	alwaysRelative?: boolean;
+}
+
+/** Whether a timestamp is old (or far enough in the future) to read as a date. */
+function fallsBackToDate(d: Date, { alwaysRelative = false }: RelativeTimeOptions): boolean {
+	return !alwaysRelative && Math.abs(Date.now() - d.getTime()) >= SEVEN_DAYS_MS;
+}
+
+/**
  * Relative label: `"30 seconds ago"`, `"1 hour ago"`, `"2 days ago"`, up to a
  * week; anything older (or more than a week in the future) falls back to the
- * absolute date. Near-future timestamps read as `"in 5 minutes"`. `''` when
- * unparsable.
+ * absolute date unless `alwaysRelative` is set. Near-future timestamps read as
+ * `"in 5 minutes"`. `''` when unparsable.
  */
-export function formatRelativeTime(iso: string | null | undefined): string {
+export function formatRelativeTime(
+	iso: string | null | undefined,
+	options: RelativeTimeOptions = {},
+): string {
 	const d = parseDate(iso);
 	if (!d) return '';
-	if (Math.abs(Date.now() - d.getTime()) >= SEVEN_DAYS_MS) return formatDateIn(d, activeLocale);
+	if (fallsBackToDate(d, options)) return formatDateIn(d, activeLocale);
 	return formatDistanceToNowStrict(d, {
 		addSuffix: true,
 		locale: DATE_FNS_LOCALES[activeLocale.language],
@@ -99,17 +120,20 @@ export function formatRelativeTime(iso: string | null | undefined): string {
 
 /**
  * Compact relative label for space-constrained spots: `"now"`, `"5m"`, `"3h"`,
- * `"2d"`; older than a week falls back to the absolute date. `''` when
- * unparsable.
+ * `"2d"`; older than a week falls back to the absolute date unless
+ * `alwaysRelative` is set. `''` when unparsable.
  *
  * The unit suffixes stay untranslated on purpose - they have to fit a fixed,
  * very narrow slot, and a localized abbreviation would overflow it.
  */
-export function formatRelativeTimeCompact(iso: string | null | undefined): string {
+export function formatRelativeTimeCompact(
+	iso: string | null | undefined,
+	options: RelativeTimeOptions = {},
+): string {
 	const d = parseDate(iso);
 	if (!d) return '';
 	const now = Date.now();
-	if (Math.abs(now - d.getTime()) >= SEVEN_DAYS_MS) return formatDateIn(d, activeLocale);
+	if (fallsBackToDate(d, options)) return formatDateIn(d, activeLocale);
 	if (differenceInSeconds(now, d) < 60) return 'now';
 	const minutes = differenceInMinutes(now, d);
 	if (minutes < 60) return `${minutes}m`;

--- a/packages/web/test/format-date.test.ts
+++ b/packages/web/test/format-date.test.ts
@@ -68,6 +68,13 @@ describe('formatRelativeTime', () => {
 		expect(formatRelativeTime(boundary)).toBe(absolute(boundary));
 	});
 
+	test('stays relative past the cutoff when asked', () => {
+		expect(formatRelativeTime(ago(9 * DAY), { alwaysRelative: true })).toBe('9 days ago');
+		expect(formatRelativeTime(ago(400 * DAY), { alwaysRelative: true })).toBe('1 year ago');
+		const future = new Date(NOW.getTime() + 30 * DAY).toISOString();
+		expect(formatRelativeTime(future, { alwaysRelative: true })).toBe('in 1 month');
+	});
+
 	test('reads as "in …" for near-future timestamps', () => {
 		const future = new Date(NOW.getTime() + HOUR).toISOString();
 		expect(formatRelativeTime(future)).toBe('in 1 hour');
@@ -92,6 +99,10 @@ describe('formatRelativeTimeCompact', () => {
 	test('falls back to the absolute date once older than 7 days', () => {
 		const iso = ago(8 * DAY);
 		expect(formatRelativeTimeCompact(iso)).toBe(absolute(iso));
+	});
+
+	test('counts on past the cutoff in days when asked', () => {
+		expect(formatRelativeTimeCompact(ago(9 * DAY), { alwaysRelative: true })).toBe('9d');
 	});
 
 	test('returns "" for empty or unparsable input', () => {

--- a/packages/web/test/relative-time.test.tsx
+++ b/packages/web/test/relative-time.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { RelativeTime } from '../src/components/ui/relative-time';
+import { formatDate } from '../src/lib/format-date';
 
 // The absolute-date tooltip content is driven by formatDateTime (covered in
 // format-date.test.ts) and rendered through the shared Radix <Tooltip>; its
@@ -32,6 +33,14 @@ test('honours the compact variant', () => {
 	const iso = new Date(NOW.getTime() - 3 * HOUR).toISOString();
 	const { container } = render(<RelativeTime iso={iso} compact />);
 	expect(container.querySelector('time')?.textContent).toBe('3h');
+});
+
+test('falls back to the absolute date past a week, and stays relative when asked', () => {
+	const iso = new Date(NOW.getTime() - 9 * 24 * HOUR).toISOString();
+	const { container: dated } = render(<RelativeTime iso={iso} />);
+	expect(dated.querySelector('time')?.textContent).toBe(formatDate(iso));
+	const { container: relative } = render(<RelativeTime iso={iso} alwaysRelative />);
+	expect(relative.querySelector('time')?.textContent).toBe('9 days ago');
 });
 
 test('renders nothing for an empty/unparsable timestamp', () => {


### PR DESCRIPTION
The **Created** field in the task meta panel showed a bare `18/08/2026` for any task older than a week - the shared seven-day cutoff in `formatRelativeTime` had kicked in. That slot is already labelled with what the timestamp means and carries the absolute date in its tooltip, so its whole job is the age; it should read `9 days ago` like every other timestamp in the app does while it is recent.

## What changed

- `formatRelativeTime` and `formatRelativeTimeCompact` take a `RelativeTimeOptions` argument with `alwaysRelative`, which skips the week cutoff.
- The `RelativeTime` component passes the flag through, so the tooltip, the `dateTime` attribute on the rendered `time` element and the touch behaviour are unchanged.
- The task sidebar's created timestamp sets it. Nothing else does - comments, audit rows and the rest keep the cutoff, so an old timestamp still reads as a date there.

## Tests

- `format-date.test.ts`: past-the-cutoff, far-past and future timestamps stay relative under the option, in both the full and the compact form.
- `relative-time.test.tsx`: a nine-day-old timestamp renders the absolute date by default and `9 days ago` with `alwaysRelative`.

No new user-facing string - the phrases come from the date-fns locale already selected per language.