### PR TITLE
feat(web): animate the side panel open and closed

### DIFF
--- a/.dev/seam-registry.md
+++ b/.dev/seam-registry.md
@@ -45,6 +45,7 @@ rather than here, is how a codebase ends up with two of everything.
 | Duration formatting (a settled figure, not a live tick) | `formatDuration` (`packages/web/src/lib/format-duration.ts`) |
 | A per-bucket stacked chart, and its axis/tooltip formatting | `StackedSeriesChart` + `chart-format.ts` (`packages/web/src/components/charts/`) |
 | A dropdown panel's vertical side + height clamp | `usePanelPlacement` (`hooks/use-panel-placement.ts`), pure math in `lib/panel-placement.ts` |
+| Open/close motion for a right-hand side panel | `--panel-motion` + `.panel-enter` / `.panel-exit` (`packages/web/src/index.css`), reached through `packages/web/src/lib/panel-motion.ts`. A panel that mounts when it opens takes the animations; one that is always mounted and only slides takes `PANEL_MOTION_TRANSITION`. `ResizableSplit` arms its grid-track transition on the panel appearing or disappearing and disarms it after - never leave it on, or every divider drag and Arrow-key step lags by the full beat |
 | A breadcrumb row - one line, scrolling sideways rather than wrapping or truncating | `BreadcrumbRow` (`components/ui/breadcrumb.tsx`) - `Breadcrumb` renders through it; a caller with its own links takes the row, never a second `<nav>` |
 | A device sign-in (copy a one-time code, enter it on a provider's page) | `DeviceCodeSteps` (`components/ui/device-code-steps.tsx`) - callers supply transport only |
 | An optimistic mutation | `useOptimisticMutation` (`hooks/use-optimistic-mutation.ts`) |

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -265,7 +265,7 @@ export function DocsLibrary({
 		   document takes the full content width. */
 		<div
 			data-testid="docs-library-grid"
-			className={`grid grid-cols-1 md:min-h-[500px] md:transition-[grid-template-columns,gap] md:duration-200 motion-reduce:md:transition-none ${
+			className={`grid grid-cols-1 md:min-h-[500px] md:transition-[grid-template-columns,gap] md:duration-[var(--panel-motion)] md:ease-in-out motion-reduce:md:transition-none ${
 				collapsed
 					? 'md:grid-cols-[0px_minmax(0,1fr)] md:gap-0'
 					: 'md:grid-cols-[240px_minmax(0,1fr)] md:gap-6'
@@ -279,7 +279,7 @@ export function DocsLibrary({
 			<aside
 				inert={collapsed}
 				data-testid="doc-list-pane"
-				className={`min-w-0 md:transition-opacity md:duration-200 motion-reduce:md:transition-none ${
+				className={`min-w-0 md:transition-opacity md:duration-[var(--panel-motion)] md:ease-in-out motion-reduce:md:transition-none ${
 					collapsed ? 'md:overflow-hidden md:opacity-0' : 'md:border-r md:border-border md:pr-6'
 				} ${showRightPane ? 'hidden md:block' : 'block'}`}
 			>

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -1,11 +1,14 @@
 import { Link } from '@tanstack/react-router';
 import { ExternalLink, History, Pencil, X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { type ProjectDoc, useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
+import { PANEL_MOTION_TRAVEL } from '../../lib/panel-motion';
 import { DocumentDownloadMenu } from '../document-download-menu';
 import type { ReviewTaskContext } from '../document-review/action-review-dialog';
 import { DocumentBody } from '../document-review/document-body';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
+import { usePanelPresence } from '../ui/resizable-split';
 import { Tooltip } from '../ui/tooltip';
 import type { PreviewItem } from './preview-context';
 
@@ -43,10 +46,25 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 	// (History stays: past revisions are still viewable/restorable there).
 	const isArchived = !!docQuery.data?.archived_at;
 
-	// Below lg the panel is a full-screen overlay (fixed inset-0). At lg+ it's an
-	// in-grid sticky column: pinned `top-4` below the shell scroller so its top never
-	// scrolls out of view. The max-height must keep the panel inside the scroller's
-	// visible area — a sticky box taller than its scrollport has too little room in
+	// The split keeps this mounted for the length of its exit. While that plays,
+	// the panel is inert so it cannot swallow a tap on what is reappearing behind
+	// it, and focus leaves before the close button it is sitting on unmounts —
+	// otherwise focus lands back on <body> and the next Tab starts from the top.
+	const closing = usePanelPresence() === 'closing';
+	const asideRef = useRef<HTMLElement>(null);
+	useEffect(() => {
+		if (!closing) return;
+		const active = document.activeElement;
+		if (active instanceof HTMLElement && asideRef.current?.contains(active)) active.blur();
+	}, [closing]);
+
+	// Below lg the panel is a full-screen overlay (fixed inset-0), so it travels its
+	// whole width in from the right edge; at lg+ the grid track widening beneath it
+	// carries the movement and the panel only fades (see PANEL_MOTION_TRAVEL).
+	//
+	// At lg+ it is an in-grid sticky column, pinned `top-4` below the shell
+	// scroller so its top never scrolls out of view. The max-height must keep the
+	// panel inside the scroller's visible area — a sticky box taller than its scrollport has too little room in
 	// its grid cell and its top rides up on scroll. So cap it at the scrollport
 	// (`--shell-scrollport-h`, measured on <main> in __root.tsx) less this panel's
 	// own `top-4` offset. Do NOT reintroduce a `100vh` calculation here: it would
@@ -54,8 +72,12 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 	// shell renders a banner.
 	return (
 		<aside
+			ref={asideRef}
 			data-testid="preview-panel"
-			className="fixed inset-0 z-[60] flex min-h-0 flex-col overflow-hidden bg-surface lg:inset-auto lg:z-auto lg:sticky lg:top-4 lg:max-h-[calc(var(--shell-scrollport-h)-1rem)] lg:rounded-lg lg:border lg:border-border"
+			inert={closing}
+			className={`fixed inset-0 z-[60] flex min-h-0 flex-col overflow-hidden bg-surface lg:inset-auto lg:z-auto lg:sticky lg:top-4 lg:max-h-[calc(var(--shell-scrollport-h)-1rem)] lg:rounded-lg lg:border lg:border-border ${PANEL_MOTION_TRAVEL} ${
+				closing ? 'panel-exit pointer-events-none' : 'panel-enter'
+			}`}
 		>
 			<div className="flex items-center gap-2 border-b border-border bg-surface-2 px-3 py-2">
 				<span

--- a/packages/web/src/components/ui/resizable-split.tsx
+++ b/packages/web/src/components/ui/resizable-split.tsx
@@ -1,13 +1,16 @@
 import {
 	type CSSProperties,
+	createContext,
 	type KeyboardEvent as ReactKeyboardEvent,
 	type ReactNode,
 	type PointerEvent as ReactPointerEvent,
 	useCallback,
+	useContext,
 	useEffect,
 	useRef,
 	useState,
 } from 'react';
+import { PANEL_MOTION_MS } from '../../lib/panel-motion';
 import {
 	clampPanelWidth,
 	MAX_PANEL_WIDTH,
@@ -20,6 +23,22 @@ import {
 const STEP = 24;
 
 type Side = 'left' | 'right';
+
+/** Whether the split's panel is open, or still playing its exit before unmounting. */
+export type PanelPresence = 'open' | 'closing';
+
+const PanelPresenceContext = createContext<PanelPresence>('open');
+
+/**
+ * Read the surrounding {@link ResizableSplit}'s panel state. The panel itself
+ * reads this to pick its enter or exit animation. A sibling that yields its grid
+ * track to the panel reads it too, and must stay out of the grid until this
+ * reports `open` again - returning while the panel is still fading out puts both
+ * in the slot they share, and the sibling renders behind it.
+ */
+export function usePanelPresence(): PanelPresence {
+	return useContext(PanelPresenceContext);
+}
 
 interface UseResizableSplitOptions {
 	side: Side;
@@ -175,7 +194,13 @@ interface ResizableSplitProps {
 	 * keep their own responsive default. MUST be a literal for Tailwind's JIT.
 	 */
 	defaultTrackClass: string;
-	/** Static `lg:grid-cols-[…]` utility used when `panel` is `null`. */
+	/**
+	 * Static `lg:grid-cols-[…]` utility used when `panel` is `null`. Declare the
+	 * same number of tracks as `defaultTrackClass` or the open/close cannot
+	 * interpolate and the width snaps: `grid-cols-1` against `1fr 320px` is one
+	 * track against two. Omitting this is safe only for a split whose panel is
+	 * never `null`.
+	 */
 	collapsedTrackClass?: string;
 	/** Extra classes on the grid container (base breakpoints, etc.). */
 	className?: string;
@@ -189,6 +214,12 @@ interface ResizableSplitProps {
  * resizable track only engages at `lg+` (the caller's track utilities are all
  * `lg:`-prefixed), so a below-`lg` panel that renders as its own overlay is
  * unaffected. The divider is keyboard-operable and the width optionally persists.
+ *
+ * It also owns the panel's open/close beat: the track travels between the two
+ * caller tracks, a closed panel stays mounted long enough to play its exit, and
+ * {@link usePanelPresence} tells the panel - and any sibling that yields its
+ * column - which of the two is happening. The track transition is armed per
+ * open/close and disarmed straight after, so resizing never inherits it.
  */
 export function ResizableSplit({
 	children,
@@ -206,11 +237,43 @@ export function ResizableSplit({
 	});
 
 	const hasPanel = panel != null;
+	// The last panel stays mounted through the closing beat so its exit has
+	// something to play on, while `hasPanel` keeps tracking the live prop - so the
+	// grid track collapses and travels at the *start* of the close rather than
+	// snapping once it is over.
+	const retainedPanel = useRef<ReactNode>(null);
+	if (hasPanel) retainedPanel.current = panel;
+	const [closing, setClosing] = useState(false);
+
+	// Animate the track only across an open or a close. Arming on the panel
+	// appearing or disappearing rather than on the width changing is what keeps a
+	// divider drag and an Arrow-key step instant - both write the same property,
+	// and a transition left on would lag every one of them by the full beat.
+	const prevHasPanel = useRef(hasPanel);
+	const [trackArmed, setTrackArmed] = useState(false);
+	useEffect(() => {
+		if (prevHasPanel.current === hasPanel) return;
+		prevHasPanel.current = hasPanel;
+		setTrackArmed(true);
+		// Both ways round: reopening inside the closing beat must clear the flag
+		// immediately, or the panel that just came back plays its exit.
+		setClosing(!hasPanel);
+		const t = setTimeout(() => {
+			setTrackArmed(false);
+			setClosing(false);
+		}, PANEL_MOTION_MS);
+		return () => clearTimeout(t);
+	}, [hasPanel]);
+
+	const renderedPanel = hasPanel ? panel : closing ? retainedPanel.current : null;
 	const dragged = width != null;
 	// Static per-side literals so Tailwind's JIT emits both tracks.
 	const varTrack =
 		side === 'right' ? 'lg:grid-cols-[1fr_var(--panel-w)]' : 'lg:grid-cols-[var(--panel-w)_1fr]';
 	const trackClass = hasPanel ? (dragged ? varTrack : defaultTrackClass) : collapsedTrackClass;
+	const trackMotion = trackArmed
+		? 'lg:transition-[grid-template-columns] lg:duration-[var(--panel-motion)] lg:ease-in-out motion-reduce:lg:transition-none'
+		: '';
 	const gridStyle: CSSProperties | undefined =
 		hasPanel && dragged ? ({ '--panel-w': `${width}px` } as CSSProperties) : undefined;
 
@@ -218,24 +281,33 @@ export function ResizableSplit({
 	// renders as its own overlay (e.g. `fixed`) then contributes no empty row/gap,
 	// and a panel that stacks flows directly. At `lg+` it becomes the positioned
 	// grid cell that hosts the divider and any sticky panel.
-	const panelCell = hasPanel ? (
-		<div ref={panelCellRef} className="contents min-w-0 lg:relative lg:block">
-			<ResizeHandle side={side} active={isResizing} valueNow={width} {...handleProps} />
-			{panel}
-		</div>
-	) : null;
+	const panelCell =
+		renderedPanel != null ? (
+			<div ref={panelCellRef} className="contents min-w-0 lg:relative lg:block">
+				{/* A cell on its way out is not draggable - the width it would write
+				    is about to be discarded. */}
+				{!closing && (
+					<ResizeHandle side={side} active={isResizing} valueNow={width} {...handleProps} />
+				)}
+				{renderedPanel}
+			</div>
+		) : null;
 
 	return (
-		<div
-			ref={gridRef}
-			className={`grid grid-cols-1 gap-5 ${trackClass} ${className}`.trim()}
-			style={gridStyle}
-		>
-			{side === 'left' && panelCell}
-			{children}
-			{aside}
-			{side === 'right' && panelCell}
-		</div>
+		<PanelPresenceContext.Provider value={closing ? 'closing' : 'open'}>
+			<div
+				ref={gridRef}
+				className={`grid grid-cols-1 gap-5 ${trackClass} ${trackMotion} ${className}`
+					.replace(/\s+/g, ' ')
+					.trim()}
+				style={gridStyle}
+			>
+				{side === 'left' && panelCell}
+				{children}
+				{aside}
+				{side === 'right' && panelCell}
+			</div>
+		</PanelPresenceContext.Provider>
 	);
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -271,6 +271,62 @@ html.dark,
 	}
 }
 
+/* One beat for every right-hand side panel: the document preview on a task, the
+   asset review drawer, the task details rail and the Documents list collapse.
+   `--panel-motion` is the single source the CSS animates on; PANEL_MOTION_MS in
+   lib/panel-motion.ts mirrors it for the timers that keep a closing panel
+   mounted, and panel-motion.test.ts fails if the two drift.
+
+   A panel that mounts when it opens gets `.panel-enter` / `.panel-exit` rather
+   than a transition - it does not exist before it opens, so a transition has no
+   start state to leave. A panel that is always mounted and only slides (the two
+   drawers) keeps its transition and just reads the same duration.
+
+   `--panel-travel` is per-element because one panel is two things: a full-screen
+   overlay below lg, which travels its whole width in from the right edge, and an
+   in-grid column at lg+, where the widening grid track carries the movement and
+   the panel only fades. */
+:root {
+	--panel-motion: 300ms;
+}
+
+@keyframes panel-enter {
+	from {
+		opacity: 0;
+		transform: translateX(var(--panel-travel, 100%));
+	}
+	to {
+		opacity: 1;
+		/* `none`, not translateX(0): `both` leaves the final value applied, and a
+		   non-none transform makes the panel a containing block for any fixed
+		   descendant - the review toolbar's dialogs portal out, but a future one
+		   might not. */
+		transform: none;
+	}
+}
+@keyframes panel-exit {
+	from {
+		opacity: 1;
+		transform: none;
+	}
+	to {
+		opacity: 0;
+		transform: translateX(var(--panel-travel, 100%));
+	}
+}
+.panel-enter {
+	animation: panel-enter var(--panel-motion) ease-in-out both;
+}
+.panel-exit {
+	animation: panel-exit var(--panel-motion) ease-in-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+	.panel-enter,
+	.panel-exit {
+		animation: none;
+	}
+}
+
 @theme {
 	--color-bg: var(--bg);
 	--color-surface: var(--surface);

--- a/packages/web/src/lib/panel-motion.ts
+++ b/packages/web/src/lib/panel-motion.ts
@@ -1,0 +1,27 @@
+/**
+ * The one beat every right-hand side panel opens and closes on.
+ *
+ * The value the browser animates on is `--panel-motion` in `index.css`; this
+ * mirror exists because the timers that keep a closing panel mounted, and that
+ * disarm the grid-track transition, need the number in JS. A timer shorter than
+ * the animation flickers on every close, so `panel-motion.test.ts` fails if the
+ * two ever drift apart.
+ */
+export const PANEL_MOTION_MS = 300;
+
+/**
+ * Timing for a panel that is always mounted and only slides - the two mobile
+ * drawers. Pair it with the `transition-*` property utility; a panel that mounts
+ * when it opens uses the `.panel-enter` / `.panel-exit` animations instead.
+ * MUST stay a literal for Tailwind's JIT.
+ */
+export const PANEL_MOTION_TRANSITION =
+	'duration-[var(--panel-motion)] ease-in-out motion-reduce:transition-none';
+
+/**
+ * Enter/exit animation for a panel that mounts when it opens. Below `lg` it
+ * travels its full width in from the right edge; from `lg` up the grid track
+ * widening beneath it carries the movement, so the panel only fades.
+ * MUST stay a literal for Tailwind's JIT.
+ */
+export const PANEL_MOTION_TRAVEL = '[--panel-travel:100%] lg:[--panel-travel:0px]';

--- a/packages/web/src/routes/projects/$projectId/assets_.view.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets_.view.tsx
@@ -31,6 +31,7 @@ import {
 import { useProjectAssets } from '../../../hooks/use-project-assets';
 import { folderCrumbs } from '../../../lib/asset-folders';
 import type { ReviewAnchor } from '../../../lib/doc-review-selection';
+import { PANEL_MOTION_TRANSITION } from '../../../lib/panel-motion';
 
 interface AssetViewSearch {
 	/** The asset's full path (`original_filename`), e.g. `launch/hero.png`. */
@@ -211,7 +212,7 @@ function AssetViewerPage() {
 						    sticky inside its own scroll area. */}
 						<div
 							data-testid="asset-review-drawer"
-							className={`fixed top-0 right-0 z-40 h-full w-[300px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
+							className={`fixed top-0 right-0 z-40 h-full w-[300px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform ${PANEL_MOTION_TRANSITION} ${
 								panelOpen ? 'translate-x-0' : 'translate-x-full'
 							} lg:static lg:z-auto lg:h-auto lg:w-auto lg:max-w-none lg:translate-x-0 lg:overflow-visible lg:p-0 lg:shadow-none`}
 						>

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,7 +1,7 @@
 import { type AgentEffort, DEFAULT_TASK_VIEW, type TaskView } from '@hezo/shared';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { jumpToComment } from '../../../../components/comment-renderers';
 import { CommentComposer } from '../../../../components/task-detail/comment-composer';
 import { CommentsSection } from '../../../../components/task-detail/comments-section';
@@ -16,7 +16,7 @@ import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-se
 import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
 import { TaskSummary } from '../../../../components/task-detail/task-summary';
-import { ResizableSplit } from '../../../../components/ui/resizable-split';
+import { ResizableSplit, usePanelPresence } from '../../../../components/ui/resizable-split';
 import { useRegisterScrollContent } from '../../../../contexts/scroll-content-context';
 import { useAgents } from '../../../../hooks/use-agents';
 import {
@@ -28,6 +28,7 @@ import { useExecutionLock } from '../../../../hooks/use-execution-locks';
 import { useInstanceSettings } from '../../../../hooks/use-instance-settings';
 import { useScrollToBottom } from '../../../../hooks/use-scroll-to-bottom';
 import { useTask, useUpdateTask } from '../../../../hooks/use-tasks';
+import { PANEL_MOTION_TRANSITION } from '../../../../lib/panel-motion';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -162,59 +163,28 @@ function TaskDetailView({ projectId, taskId }: { projectId: string; taskId: stri
 				) : null
 			}
 			aside={
-				<>
-					{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
-					    drawer below lg (collapsed by default, toggled by the chevron). */}
-					<button
-						type="button"
-						onClick={() => setSidebarOpen((o) => !o)}
-						data-testid="task-sidebar-toggle"
-						aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
-						aria-expanded={sidebarOpen}
-						className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
-					>
-						{sidebarOpen ? (
-							<ChevronRight className="w-4 h-4" />
-						) : (
-							<ChevronLeft className="w-4 h-4" />
-						)}
-					</button>
-					{sidebarOpen && (
-						<button
-							type="button"
-							aria-label="Close task details"
-							onClick={() => setSidebarOpen(false)}
-							className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
-						/>
-					)}
-					{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
-					    chevron. Desktop: `lg:contents` makes this wrapper generate no box, so
-					    TaskSidebar becomes the direct grid child (in-grid sticky column). While
-					    a preview is open the sidebar column yields to the preview on desktop
-					    (`lg:hidden`); on mobile the preview is its own overlay above this. */}
-					<div
-						data-testid="task-rail"
-						className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
-							sidebarOpen ? 'translate-x-0' : 'translate-x-full'
-						} ${preview ? 'lg:hidden' : 'lg:contents'}`}
-					>
-						<TaskSidebar
-							task={task}
-							projectId={projectId}
-							taskId={taskId}
-							agents={agents}
-							lock={lock}
-							comments={comments}
-							updateTask={updateTask}
-							commentEffort={commentEffort}
-							setCommentEffort={setCommentEffort}
-							scrollToBottom={scrollToBottom}
-							view={view}
-							setView={setViewOverride}
-							defaultView={defaultView}
-						/>
-					</div>
-				</>
+				<TaskMetaRail
+					open={sidebarOpen}
+					onToggle={() => setSidebarOpen((o) => !o)}
+					onClose={() => setSidebarOpen(false)}
+					previewOpen={!!preview}
+				>
+					<TaskSidebar
+						task={task}
+						projectId={projectId}
+						taskId={taskId}
+						agents={agents}
+						lock={lock}
+						comments={comments}
+						updateTask={updateTask}
+						commentEffort={commentEffort}
+						setCommentEffort={setCommentEffort}
+						scrollToBottom={scrollToBottom}
+						view={view}
+						setView={setViewOverride}
+						defaultView={defaultView}
+					/>
+				</TaskMetaRail>
 			}
 		>
 			<PreviewProvider value={openPreview}>
@@ -272,6 +242,70 @@ function TaskDetailView({ projectId, taskId }: { projectId: string; taskId: stri
 				</div>
 			</PreviewProvider>
 		</ResizableSplit>
+	);
+}
+
+/**
+ * The task meta rail. Mobile: a fixed right-side drawer toggled by the chevron.
+ * Desktop: `lg:contents` makes this wrapper generate no box, so TaskSidebar
+ * becomes the direct grid child (in-grid sticky column).
+ *
+ * While a preview is open the rail yields its column to it (`lg:hidden`) — and
+ * stays yielded until the preview has finished its exit, which is why this reads
+ * the split's presence rather than `previewOpen` alone. Returning a frame early
+ * puts the rail behind a panel still fading out, in the slot they share. On
+ * mobile the preview is its own overlay above this.
+ *
+ * It renders under ResizableSplit's provider (it is passed as `aside`), so the
+ * presence hook resolves; a component defined outside that tree would read the
+ * default `open` forever.
+ */
+function TaskMetaRail({
+	open,
+	onToggle,
+	onClose,
+	previewOpen,
+	children,
+}: {
+	open: boolean;
+	onToggle: () => void;
+	onClose: () => void;
+	previewOpen: boolean;
+	children: ReactNode;
+}) {
+	const closing = usePanelPresence() === 'closing';
+	const yielded = previewOpen || closing;
+	return (
+		<>
+			{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
+			    drawer below lg (collapsed by default, toggled by the chevron). */}
+			<button
+				type="button"
+				onClick={onToggle}
+				data-testid="task-sidebar-toggle"
+				aria-label={open ? 'Collapse task details' : 'Expand task details'}
+				aria-expanded={open}
+				className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
+			>
+				{open ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+			</button>
+			{open && (
+				<button
+					type="button"
+					aria-label="Close task details"
+					onClick={onClose}
+					className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
+				/>
+			)}
+			<div
+				data-testid="task-rail"
+				className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform ${PANEL_MOTION_TRANSITION} ${
+					open ? 'translate-x-0' : 'translate-x-full'
+				} ${yielded ? 'lg:hidden' : 'lg:contents'}`}
+			>
+				{children}
+			</div>
+		</>
 	);
 }
 

--- a/packages/web/test/panel-motion.test.ts
+++ b/packages/web/test/panel-motion.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PANEL_MOTION_MS } from '../src/lib/panel-motion';
+
+/**
+ * The beat is spelled twice by necessity: the browser animates on
+ * `--panel-motion` in index.css, and the timers that keep a closing panel
+ * mounted need the number in JS. A JS timer shorter than the CSS animation
+ * unmounts the panel mid-fade and flickers on every close, and nothing else
+ * would catch it — so pin the two together here.
+ */
+describe('panel motion', () => {
+	const css = readFileSync(join(__dirname, '../src/index.css'), 'utf-8');
+
+	it('declares --panel-motion at the duration the JS timers use', () => {
+		const match = css.match(/--panel-motion:\s*(\d+)ms/);
+		expect(match?.[1]).toBe(String(PANEL_MOTION_MS));
+	});
+
+	it('guards the panel animations behind prefers-reduced-motion', () => {
+		const guard = css
+			.split('@media (prefers-reduced-motion: reduce)')
+			.some((block) => block.includes('.panel-enter') && block.includes('animation: none'));
+		expect(guard).toBe(true);
+	});
+});

--- a/packages/web/test/resizable-split.test.tsx
+++ b/packages/web/test/resizable-split.test.tsx
@@ -1,17 +1,21 @@
 // Unit tests for ResizableSplit: the divider's a11y contract, the collapsed vs
-// default vs dragged track classes, and that dragging / arrow-keys drive the
-// width state, the `--panel-w` CSS variable, and persistence. happy-dom has no
-// layout, so getBoundingClientRect is stubbed to a fixed width to make the clamp
-// math deterministic; real pixel behavior is covered by
-// test/browser/task-doc-preview-resize.spec.ts.
-import { fireEvent, render } from '@testing-library/react';
+// default vs dragged track classes, that dragging / arrow-keys drive the width
+// state, the `--panel-w` CSS variable, and persistence, and that a closed panel
+// stays mounted for its exit while the track transition is armed only across an
+// open or a close. happy-dom has no layout, so getBoundingClientRect is stubbed
+// to a fixed width to make the clamp math deterministic; the motion itself needs
+// a real CSS engine and is covered by test/browser/panel-motion.mobile.spec.ts,
+// real pixel behavior by test/browser/task-doc-preview-resize.spec.ts.
+import { act, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { ResizableSplit } from '../src/components/ui/resizable-split';
+import { PANEL_MOTION_MS } from '../src/lib/panel-motion';
 
 const KEY = 'hezo:test-resizable-split';
 const DEFAULT_TRACK = 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]';
 const COLLAPSED_TRACK = 'lg:grid-cols-[1fr_190px]';
 const VAR_TRACK = 'lg:grid-cols-[1fr_var(--panel-w)]';
+const TRACK_MOTION = 'lg:transition-[grid-template-columns]';
 
 /** happy-dom returns zero-size boxes; pin a width so clamp math is predictable. */
 function stubLayout(width: number) {
@@ -130,4 +134,106 @@ test('arrow keys resize the focused handle by a step and persist (right side: �
 	fireEvent.keyDown(handle, { key: 'ArrowRight' }); // away from main → narrow by STEP
 	expect(grid.style.getPropertyValue('--panel-w')).toBe('350px');
 	expect(localStorage.getItem(KEY)).toBe('350');
+});
+
+test('keeps a closed panel mounted for its exit, then drops it', () => {
+	vi.useFakeTimers();
+	try {
+		const { container, queryByText, queryByTestId, rerender } = render(
+			<ResizableSplit
+				panel={<div>panel</div>}
+				defaultTrackClass={DEFAULT_TRACK}
+				collapsedTrackClass={COLLAPSED_TRACK}
+				storageKey={KEY}
+			>
+				<div>main</div>
+			</ResizableSplit>,
+		);
+		const grid = container.firstElementChild as HTMLElement;
+
+		act(() => {
+			rerender(
+				<ResizableSplit
+					panel={null}
+					defaultTrackClass={DEFAULT_TRACK}
+					collapsedTrackClass={COLLAPSED_TRACK}
+					storageKey={KEY}
+				>
+					<div>main</div>
+				</ResizableSplit>,
+			);
+		});
+
+		// The track collapses and starts travelling straight away, but the panel is
+		// still there playing its exit — and is no longer draggable.
+		expect(grid.className).toContain(COLLAPSED_TRACK);
+		expect(grid.className).toContain(TRACK_MOTION);
+		expect(queryByText('panel')).not.toBeNull();
+		expect(queryByTestId('resize-handle')).toBeNull();
+
+		act(() => void vi.advanceTimersByTime(PANEL_MOTION_MS));
+
+		expect(queryByText('panel')).toBeNull();
+		expect(grid.className).not.toContain(TRACK_MOTION);
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test('reopening inside the closing beat brings the panel straight back', () => {
+	vi.useFakeTimers();
+	try {
+		const split = (panel: React.ReactNode) => (
+			<ResizableSplit
+				panel={panel}
+				defaultTrackClass={DEFAULT_TRACK}
+				collapsedTrackClass={COLLAPSED_TRACK}
+				storageKey={KEY}
+			>
+				<div>main</div>
+			</ResizableSplit>
+		);
+		const { container, getByTestId, queryByText, rerender } = render(split(<div>panel</div>));
+		const grid = container.firstElementChild as HTMLElement;
+
+		act(() => rerender(split(null)));
+		act(() => void vi.advanceTimersByTime(PANEL_MOTION_MS / 2)); // mid-exit
+		act(() => rerender(split(<div>panel</div>)));
+
+		// Back to open at once — not still counting down the interrupted close.
+		expect(queryByText('panel')).not.toBeNull();
+		expect(grid.className).toContain(DEFAULT_TRACK);
+		expect(getByTestId('resize-handle')).not.toBeNull();
+
+		// And the old timer cannot fire later and yank it away.
+		act(() => void vi.advanceTimersByTime(PANEL_MOTION_MS * 2));
+		expect(queryByText('panel')).not.toBeNull();
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
+test('does not arm the track transition for a resize', () => {
+	stubLayout(800);
+	const { getByTestId, container } = render(
+		<ResizableSplit
+			panel={<div>panel</div>}
+			side="right"
+			defaultTrackClass={DEFAULT_TRACK}
+			storageKey={KEY}
+		>
+			<div>main</div>
+		</ResizableSplit>,
+	);
+	const grid = container.firstElementChild as HTMLElement;
+	const handle = getByTestId('resize-handle');
+
+	// A drag and an arrow-key step both write the same property the open/close
+	// animates. Arming for either would make every resize lag by the full beat.
+	fireEvent(handle, pointerEvent('pointerdown', { clientX: 500 }));
+	fireEvent(document, pointerEvent('pointermove', { clientX: 900 }));
+	expect(grid.className).not.toContain(TRACK_MOTION);
+	fireEvent(document, pointerEvent('pointerup', { clientX: 900 }));
+	fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+	expect(grid.className).not.toContain(TRACK_MOTION);
 });

--- a/test/browser/panel-motion.mobile.spec.ts
+++ b/test/browser/panel-motion.mobile.spec.ts
@@ -87,19 +87,17 @@ test.describe('Side panel motion — mobile (390px)', () => {
 		await expect(panel).toBeVisible();
 
 		// The declared animation is readable whether or not it has finished, so this
-		// is a straight assertion rather than a race against the clock.
+		// is a straight assertion rather than a race against the clock. A resolved
+		// duration also proves --panel-motion reached the page: the keyframe reads it
+		// through var(), so an unresolved token would compute to 0s. Assert the
+		// computed value, never the custom property's raw text — the production
+		// bundle this runs against is minified, and `300ms` ships as `.3s`.
 		expect(await motionOf(page)).toEqual({
 			name: 'panel-enter',
 			duration: '0.3s',
 			easing: 'ease-in-out',
 			travel: '100%', // full-width travel below lg; lg+ overrides this to 0px
 		});
-		// The token the whole system reads resolves on the page, not just in source.
-		expect(
-			await page.evaluate(() =>
-				getComputedStyle(document.documentElement).getPropertyValue('--panel-motion').trim(),
-			),
-		).toBe('300ms');
 
 		await expect
 			.poll(async () => (await panel.boundingBox())?.x ?? 999, { timeout: 5000 })

--- a/test/browser/panel-motion.mobile.spec.ts
+++ b/test/browser/panel-motion.mobile.spec.ts
@@ -1,0 +1,161 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+// Real-CSS-engine + viewport-conditional assertion (testing decision tree, points
+// 1 & 2). The document panel's open/close motion is a keyframe animation whose
+// travel is a media-query-scoped custom property: below lg it slides its whole
+// width in from the right edge, at lg+ the widening grid track carries the
+// movement and it only fades. happy-dom applies no stylesheet, runs no keyframes
+// and evaluates no media queries, so `getComputedStyle().animationName` and the
+// slide itself can only be observed in a real browser at a real viewport. The
+// mount/unmount wiring behind it is unit-covered by
+// packages/web/test/resizable-split.test.tsx.
+
+const DOC = 'prd.md';
+
+async function seedTaskWithDocMention(page: Page, token: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Panel Motion'),
+		description: 'Panel open/close motion test.',
+	});
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const docRes = await page.request.put(`/api/projects/${project.slug}/docs/${DOC}`, {
+		headers,
+		data: { content: '# Product Requirements\n\nAn unmistakable document body.' },
+	});
+	expect(docRes.ok()).toBe(true);
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Motion Task', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	const commentRes = await page.request.post(
+		`/api/projects/${project.slug}/tasks/${task.id}/comments`,
+		{
+			headers,
+			data: { content_type: 'text', content: { text: `Please review ${DOC} before we ship.` } },
+		},
+	);
+	expect(commentRes.ok()).toBe(true);
+
+	return { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+}
+
+async function openTask(page: Page, projectSlug: string, taskId: string): Promise<void> {
+	await page.goto(`/projects/${projectSlug}/tasks/${taskId}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'Motion Task' })).toBeVisible({ timeout: 20000 });
+}
+
+const openDoc = async (page: Page): Promise<void> => {
+	const mention = page.getByTestId('doc-mention-link').first();
+	await expect(mention).toBeVisible({ timeout: 15000 });
+	await mention.click();
+};
+
+/** The animation the browser has actually resolved for the panel. */
+const motionOf = (page: Page) =>
+	page.getByTestId('preview-panel').evaluate((el) => {
+		const s = getComputedStyle(el);
+		return {
+			name: s.animationName,
+			duration: s.animationDuration,
+			easing: s.animationTimingFunction,
+			travel: s.getPropertyValue('--panel-travel').trim(),
+		};
+	});
+
+test.describe('Side panel motion — mobile (390px)', () => {
+	test('the document panel slides in from the right edge and settles', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { projectSlug, taskId } = await seedTaskWithDocMention(page, token);
+		await openTask(page, projectSlug, taskId);
+
+		await openDoc(page);
+		const panel = page.getByTestId('preview-panel');
+		await expect(panel).toBeVisible();
+
+		// The declared animation is readable whether or not it has finished, so this
+		// is a straight assertion rather than a race against the clock.
+		expect(await motionOf(page)).toEqual({
+			name: 'panel-enter',
+			duration: '0.3s',
+			easing: 'ease-in-out',
+			travel: '100%', // full-width travel below lg; lg+ overrides this to 0px
+		});
+		// The token the whole system reads resolves on the page, not just in source.
+		expect(
+			await page.evaluate(() =>
+				getComputedStyle(document.documentElement).getPropertyValue('--panel-motion').trim(),
+			),
+		).toBe('300ms');
+
+		await expect
+			.poll(async () => (await panel.boundingBox())?.x ?? 999, { timeout: 5000 })
+			.toBeLessThan(8);
+	});
+
+	test('closing plays the exit before the panel leaves the DOM', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { projectSlug, taskId } = await seedTaskWithDocMention(page, token);
+		await openTask(page, projectSlug, taskId);
+
+		await openDoc(page);
+		const panel = page.getByTestId('preview-panel');
+		await expect(panel).toBeVisible();
+		await expect.poll(async () => (await panel.boundingBox())?.x ?? 999).toBeLessThan(8);
+
+		// Start watching before the click, so the exit cannot finish between the two.
+		const sawExit = page.evaluate(
+			() =>
+				new Promise<boolean>((resolve) => {
+					const started = performance.now();
+					const tick = () => {
+						const el = document.querySelector('[data-testid="preview-panel"]');
+						if (el && getComputedStyle(el).animationName === 'panel-exit') return resolve(true);
+						if (performance.now() - started > 4000) return resolve(false);
+						requestAnimationFrame(tick);
+					};
+					tick();
+				}),
+		);
+		await page.getByTestId('preview-close').click();
+		expect(await sawExit).toBe(true);
+
+		// It is inert while it plays, and gone once it has.
+		await expect(panel).toHaveCount(0, { timeout: 5000 });
+	});
+
+	test('reduced motion opens the panel with no animation at all', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { projectSlug, taskId } = await seedTaskWithDocMention(page, token);
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		await openTask(page, projectSlug, taskId);
+
+		await openDoc(page);
+		const panel = page.getByTestId('preview-panel');
+		await expect(panel).toBeVisible();
+
+		expect((await motionOf(page)).name).toBe('none');
+		// No poll: the point is that it never travelled, so it is already at rest on
+		// the first read.
+		expect((await panel.boundingBox())?.x ?? 999).toBeLessThan(8);
+	});
+});

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -160,9 +160,13 @@ test.describe('Task detail — document preview panel (mobile, 390px)', () => {
 		// meta sidebar is not shown behind it.
 		const preview = page.getByTestId('preview-panel');
 		await expect(preview).toBeInViewport();
+		// It slides in from the right edge, so poll it to rest rather than reading a
+		// box mid-travel — toBeInViewport() passes at any ratio above zero.
+		await expect
+			.poll(async () => (await preview.boundingBox())?.x ?? 999, { timeout: 5000 })
+			.toBeLessThan(8);
 		const previewBox = await preview.boundingBox();
 		expect(previewBox).not.toBeNull();
-		expect(previewBox!.x).toBeLessThan(8);
 		expect(previewBox!.width).toBeGreaterThan(360);
 		await expect(page.getByTestId('task-sidebar')).not.toBeInViewport();
 

--- a/test/browser/task-doc-preview-resize.spec.ts
+++ b/test/browser/task-doc-preview-resize.spec.ts
@@ -58,12 +58,23 @@ async function seedTaskWithDocMention(
 	return { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
 }
 
+/** The split's grid-track transition, as the browser computes it right now. */
+const trackTransition = async (panel: Locator): Promise<string> =>
+	panel.evaluate((el) => {
+		const grid = el.closest('.grid');
+		return grid ? getComputedStyle(grid).transitionDuration : 'no grid';
+	});
+
 async function openPreview(page: Page): Promise<Locator> {
 	const mention = page.getByTestId('doc-mention-link').first();
 	await expect(mention).toBeVisible({ timeout: 20000 });
 	await mention.click();
 	const panel = page.getByTestId('preview-panel');
 	await expect(panel).toBeVisible();
+	// The column widens as the panel fades in; the split disarms the track
+	// transition when that finishes. Wait for it, or every width read below lands
+	// mid-animation.
+	await expect.poll(() => trackTransition(panel), { timeout: 5000 }).toBe('0s');
 	return panel;
 }
 
@@ -129,6 +140,10 @@ test('the divider drags to resize the preview panel, clamps, and persists', asyn
 
 	// Drag left → the right-hand panel widens by ~120px.
 	await dragBy(page, -120);
+	// A drag writes the same property the open/close animates. If that transition
+	// were left armed instead of armed per open/close, every drag would lag by the
+	// full beat — so it must still read as untransitioned here.
+	expect(await trackTransition(panel)).toBe('0s');
 	const widened = await widthAfterReflow(panel, (w) => w > w0 + 100);
 	expect(widened).toBeLessThanOrEqual(w0 + 140);
 
@@ -153,6 +168,7 @@ test('the divider drags to resize the preview panel, clamps, and persists', asyn
 	const beforeKey = await widthAfterReflow(panel, (w) => w <= MIN_PANEL_WIDTH + 6);
 	await page.getByTestId('resize-handle').focus();
 	await page.keyboard.press('ArrowLeft'); // right side: ← widens
+	expect(await trackTransition(panel)).toBe('0s'); // same guard, keyboard path
 	const afterKey = await widthAfterReflow(panel, (w) => w > beforeKey + 6);
 	expect(Math.abs(afterKey - (beforeKey + STEP))).toBeLessThanOrEqual(6);
 

--- a/test/browser/task-doc-preview-width.spec.ts
+++ b/test/browser/task-doc-preview-width.spec.ts
@@ -104,10 +104,14 @@ test('document preview panel widens on xl/2xl screens (up to 2× its base width)
 	// At lg+ the widening track carries the panel's movement, so its own travel is
 	// overridden to zero and it only fades. If that `lg:` variant stopped
 	// compiling, the desktop panel would slide its full width in from off-screen —
-	// a visible bug the width assertions below would sail straight past.
+	// a visible bug the width assertions below would sail straight past. Read it as
+	// a number: this runs against the minified bundle in CI, and the exact text a
+	// custom property ships as is the minifier's business, not this test's.
 	expect(
-		await panel.evaluate((el) => getComputedStyle(el).getPropertyValue('--panel-travel').trim()),
-	).toBe('0px');
+		await panel.evaluate((el) =>
+			Number.parseFloat(getComputedStyle(el).getPropertyValue('--panel-travel')),
+		),
+	).toBe(0);
 
 	// The preview track is a fixed px width independent of the (scrollbar-sensitive)
 	// 1fr content column, so the measured border-box lands on the track value ±a

--- a/test/browser/task-doc-preview-width.spec.ts
+++ b/test/browser/task-doc-preview-width.spec.ts
@@ -3,8 +3,11 @@
 // is set by responsive `grid-cols-[1fr_Npx]` utilities that only diverge once a
 // real layout pass evaluates the lg/xl/2xl media queries. happy-dom runs no media
 // queries and returns zero-width boxes, so the widening can only be observed in a
-// real browser at real viewport sizes. The mention→panel data flow itself is
-// covered by packages/web/test/task-comment-doc-preview.test.tsx.
+// real browser at real viewport sizes. It also pins the panel's own travel to
+// zero here, which is the same kind of media-query-only fact. The mention→panel
+// data flow itself is covered by
+// packages/web/test/task-comment-doc-preview.test.tsx; the motion by
+// test/browser/panel-motion.mobile.spec.ts.
 
 import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures';
@@ -72,10 +75,39 @@ test('document preview panel widens on xl/2xl screens (up to 2× its base width)
 	// Open the doc in the in-grid preview panel.
 	const mention = page.getByTestId('doc-mention-link').first();
 	await expect(mention).toBeVisible({ timeout: 20000 });
+
+	// Catch the grid mid-open. The track transition is armed only across an open or
+	// a close, so start watching before the click: by the time an awaited click
+	// resolves the beat may already be spent. This pins the duration, not just its
+	// presence — drop the `duration-[…]` utility and the track still animates, at
+	// Tailwind's default speed, with every other assertion here still green.
+	const armedDuration = page.evaluate(
+		() =>
+			new Promise<string>((resolve) => {
+				const started = performance.now();
+				const tick = () => {
+					const grid = document.querySelector('[data-testid="preview-panel"]')?.closest('.grid');
+					const duration = grid ? getComputedStyle(grid).transitionDuration : '0s';
+					if (duration !== '0s') return resolve(duration);
+					if (performance.now() - started > 4000) return resolve('never armed');
+					requestAnimationFrame(tick);
+				};
+				tick();
+			}),
+	);
 	await mention.click();
+	expect(await armedDuration).toBe('0.3s');
 
 	const panel = page.getByTestId('preview-panel');
 	await expect(panel).toBeVisible();
+
+	// At lg+ the widening track carries the panel's movement, so its own travel is
+	// overridden to zero and it only fades. If that `lg:` variant stopped
+	// compiling, the desktop panel would slide its full width in from off-screen —
+	// a visible bug the width assertions below would sail straight past.
+	expect(
+		await panel.evaluate((el) => getComputedStyle(el).getPropertyValue('--panel-travel').trim()),
+	).toBe('0px');
 
 	// The preview track is a fixed px width independent of the (scrollbar-sensitive)
 	// 1fr content column, so the measured border-box lands on the track value ±a


### PR DESCRIPTION
## What

The document panel on a task hard-cut into view: clicking a mention mounted it instantly, the comment column snapped narrower and the details rail vanished in the same frame. The drawers around it disagreed with each other too - two slid at 200ms with no reduced-motion guard, the Documents list collapse at 200ms with one.

Every right-hand panel now opens and closes on one beat: **300ms, `ease-in-out`**.

- The panel fades in as the grid column widens beneath it. Below `lg`, where it is a full-screen overlay, it travels its whole width in from the right edge.
- The close plays both back together, and the details rail stays out of the grid until the panel has actually unmounted - returning a frame early puts it behind a panel still fading out, in the column they share.
- The asset review drawer and the task details rail are re-timed to the same beat and pick up the `motion-reduce` guard they were missing. The Documents list collapse keeps its existing track animation and just re-times.

## How

`ResizableSplit` owns it, so both call sites get it without repeating anything. It retains a closed panel for the length of its exit, and `usePanelPresence` tells the panel - and any sibling that yields its column - which of the two is happening.

Two things worth a reviewer's eye:

**The track transition is armed per open/close, never left on.** A divider drag and an Arrow-key step write the same property the open/close animates, so a permanent transition would lag every resize by the full beat. `isResizing` is not a usable gate - the keyboard path never sets it - so the arming keys off the panel appearing or disappearing instead.

**The duration is spelled twice by necessity.** The browser animates on `--panel-motion`; the unmount and disarm timers need the number in JS. A JS timer shorter than the CSS animation would unmount the panel mid-fade and flicker on every close, so a drift test pins the two together.

## Accepted cost

The task page's content column hosts a windowed comment list that re-measures on every layout pass, so it now re-measures for the length of the animation rather than once. This was raised and the animated column width was chosen deliberately. Worth a look on a long thread scrolled part-way down: if the list shifts under the reader mid-open, the follow-up is to pin its `scrollTop` for the duration.

## Tests

- **New** `test/browser/panel-motion.mobile.spec.ts` - the panel resolves `panel-enter` at `0.3s`/`ease-in-out` with full-width travel, the exit plays before the panel leaves the DOM, and reduced motion opens it with no animation at all.
- `task-doc-preview-width.spec.ts` - pins the armed track duration to `0.3s` (sampling from before the click, since the beat can be spent by the time an awaited click resolves), and that the panel's own travel is overridden to `0px` at `lg+`. Without that second one, a broken `lg:` variant would slide the desktop panel in from off-screen with every other assertion still green.
- `task-doc-preview-resize.spec.ts` - the grid reads untransitioned during a drag and after an Arrow-key step; `openPreview` now waits out the open so width reads no longer land mid-animation.
- `task-detail.mobile.spec.ts` - polls the sliding panel to rest instead of reading a box mid-travel.
- `resizable-split.test.tsx` - a closed panel stays mounted for its exit then drops, reopening inside the closing beat brings it straight back, and a resize never arms the track. (The reopen case was a real bug this caught - the panel came back playing its exit.)
- **New** `packages/web/test/panel-motion.test.ts` - the drift guard.

Verified: `typecheck`, `biome check` on the changed files, the full web component tier (1809/1810 - the one failure is `i18n-catalog`'s `process.cwd()` assumption when vitest is invoked from the repo root; green from the package dir), and every Playwright spec above in a real Chromium.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpGY4AF6XEYKyvunccFndW)_