### PR TITLE
fix(providers): submit the guided sign-in code with a carriage return

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3667,8 +3667,10 @@ registers a flow in `subscriptionLoginService`. The host polls the merged log th
 `SandboxFiles` — never a byte channel, because Docker's exec has no TTY and Daytona's
 redirects stderr to a file drained only on close, so a challenge printed there would strand
 the flow. `GET …/:flowId` returns the challenge (URL, and a one-time code where the flow has
-one), `POST …/:flowId/code` writes the operator's code to the CLI's stdin FIFO, and `DELETE
-…/:flowId` cancels. Which runtimes can be driven is `RUNTIMES_WITH_GUIDED_SIGN_IN`
+one), `POST …/:flowId/code` writes the operator's code to the CLI's stdin FIFO terminated by a
+**carriage return** — the paste prompt is a raw-mode TUI, where nothing translates LF into
+CR and an LF arrives as an ordinary character that leaves the code sitting in the prompt
+unsubmitted — and `DELETE …/:flowId` cancels. Which runtimes can be driven is `RUNTIMES_WITH_GUIDED_SIGN_IN`
 (`@hezo/shared`, read by the web to decide whether to offer the button) paired with
 `SUBSCRIPTION_LOGIN_DRIVERS` (the server's argv, output parsers and harvest shape); a test
 asserts the two agree. Codex uses its device flow and needs nothing back; Claude Code needs

--- a/packages/server/src/services/sandbox/proc-scripts.ts
+++ b/packages/server/src/services/sandbox/proc-scripts.ts
@@ -445,10 +445,21 @@ export function buildSubscriptionLoginScript(opts: {
 	);
 }
 
-/** Deliver the operator's pasted code to a waiting login process. */
+/**
+ * Deliver the operator's pasted code to a waiting login process.
+ *
+ * **Terminated with CR, never LF.** A vendor CLI's paste prompt is a full-screen
+ * TUI reading a raw-mode terminal, where no line discipline translates one into
+ * the other and only `\r` is the return key - an LF is delivered as an ordinary
+ * character, so the code lands in the prompt's buffer and simply sits there
+ * unsubmitted until the flow times out. Measured against claude-code 2.1.250:
+ * the pasted text appears masked in the prompt and nothing else happens, where
+ * a CR runs the token exchange. A CLI reading lines canonically instead is
+ * unaffected, since `ICRNL` turns the CR back into its newline.
+ */
 export function buildSubscriptionLoginCodeScript(dir: string, code: string): string {
 	if (!/^\/[A-Za-z0-9._/-]*$/.test(dir)) throw new Error(`unsafe dir: ${JSON.stringify(dir)}`);
-	return `printf '%s\\n' ${shellQuote(code)} > ${shellQuote(`${dir}/${LOGIN_STDIN_FIFO}`)}`;
+	return `printf '%s\\r' ${shellQuote(code)} > ${shellQuote(`${dir}/${LOGIN_STDIN_FIFO}`)}`;
 }
 
 /**

--- a/packages/server/src/services/subscription-login.ts
+++ b/packages/server/src/services/subscription-login.ts
@@ -338,12 +338,26 @@ export class SubscriptionLoginService {
 					// The CLI exiting without a credential is terminal: nothing else
 					// is going to write one, so waiting out the TTL would only make
 					// the operator watch a spinner for fifteen minutes.
+					//
+					// One last harvest first, against freshly read output. A CLI
+					// issues its credential and exits in the same breath, and the log
+					// above was read a round trip before this check - so a credential
+					// written in between is in the container and not in `log`, and
+					// failing on the exit file alone would throw away a sign-in that
+					// actually succeeded.
 					if (await files.exists(LOGIN_EXIT_FILE)) {
-						await this.finish(id, {
-							status: 'failed',
-							error: `${driver.argv[0]} exited before a credential was issued`,
-							code: 'exited_without_credential',
-						});
+						const final = await files.read(LOGIN_LOG_FILE).catch(() => log);
+						const late = await this.tryHarvest(flow, files, final);
+						await this.finish(
+							id,
+							late
+								? { status: 'succeeded', credential: late }
+								: {
+										status: 'failed',
+										error: `${driver.argv[0]} exited before a credential was issued`,
+										code: 'exited_without_credential',
+									},
+						);
 						return;
 					}
 					if (Date.now() - startedAt > driver.completionTimeoutMs) {

--- a/packages/server/test/subscription-login-routes.test.ts
+++ b/packages/server/test/subscription-login-routes.test.ts
@@ -34,6 +34,16 @@ let authFile: string | null = null;
 let liveContainers: Set<string>;
 /** Set when the probe should report a CLI that no longer offers its flag. */
 let probeAnswers = true;
+/** Set once the fake CLI has exited. */
+let exitFile = false;
+/**
+ * Set to have the CLI issue its credential in the very round trip the watcher
+ * spends asking whether it has exited - the ordering a real CLI produces, since
+ * it prints its credential and exits in the same breath.
+ */
+let credentialArrivesWithExit = false;
+/** Every script the container was asked to run, for asserting on what was sent. */
+let execScripts: string[] = [];
 
 const CHALLENGE = [
 	'1. Open this link in your browser and sign in to your account',
@@ -45,9 +55,34 @@ const CHALLENGE = [
 
 const CODEX_AUTH_JSON = JSON.stringify({ tokens: { refresh_token: 'rt-from-container' } });
 
+const ESC = String.fromCharCode(0x1b);
+const CLAUDE_AUTHORIZE_URL =
+	'https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a&response_type=code';
+/** What `claude setup-token` has painted by the time it blocks on its prompt. */
+const CLAUDE_CHALLENGE = [
+	`${ESC}]8;id=155gj3v;${CLAUDE_AUTHORIZE_URL}${ESC}\\https://claude.com/cai/oauth/auth${ESC}]8;;${ESC}\\`,
+	'Paste code here if prompted >',
+].join('\r\n');
+/** The line it prints once the exchange lands. */
+const CLAUDE_TOKEN_LINE = `${ESC}[32mtoken:${ESC}[0m sk-ant-oat01-from-the-container\r\n`;
+
 function scriptedFiles(): SandboxFiles {
 	return {
-		exists: async (rel: string) => (rel.endsWith('auth.json') ? authFile !== null : rel === 'out'),
+		exists: async (rel: string) => {
+			if (rel.endsWith('auth.json')) return authFile !== null;
+			if (rel === 'exit') {
+				if (!exitFile) return false;
+				// The credential lands while this very answer is in flight, so the
+				// harvest that ran a round trip ago could not have seen it.
+				if (credentialArrivesWithExit) {
+					credentialArrivesWithExit = false;
+					authFile = CODEX_AUTH_JSON;
+					log += CLAUDE_TOKEN_LINE;
+				}
+				return true;
+			}
+			return rel === 'out';
+		},
 		read: async (rel: string) => {
 			if (rel.endsWith('auth.json')) {
 				if (authFile === null) throw new Error('no auth file yet');
@@ -81,6 +116,7 @@ function scriptedDocker(): ContainerEngine {
 		execCreate: async (_id: string, config: { Cmd: string[] }) => {
 			const execId = `exec-${++n}`;
 			scripts.set(execId, config.Cmd.join(' '));
+			execScripts.push(config.Cmd.join(' '));
 			return execId;
 		},
 		execStart: async (execId: string) => {
@@ -132,6 +168,9 @@ beforeEach(async () => {
 	log = '';
 	authFile = null;
 	probeAnswers = true;
+	exitFile = false;
+	credentialArrivesWithExit = false;
+	execScripts = [];
 	liveContainers = new Set();
 	await db.query('DELETE FROM ai_provider_configs');
 });
@@ -311,5 +350,88 @@ describe('submitting a code', () => {
 		const res = await post('/api/ai-providers/subscription-login/nonexistent/code', { code: '  ' });
 		expect(res.status).toBe(400);
 		expect((await res.json()).error.code).toBe('INVALID_CODE');
+	});
+
+	/**
+	 * The Anthropic flow end to end, which is the one that asks for a code: the
+	 * challenge comes out of an OSC 8 escape, the operator's code goes back in,
+	 * and the token is read off what the CLI printed rather than out of a file.
+	 */
+	it('carries the operator code into the CLI and stores the token it prints', async () => {
+		const start = await post('/api/ai-providers/subscription-login/start', {
+			provider: AiProvider.Anthropic,
+		});
+		expect(start.status).toBe(201);
+		const { flow_id } = (await start.json()).data;
+
+		log = CLAUDE_CHALLENGE;
+		const { body: challenge } = await pollUntil(flow_id, 'awaiting_user');
+		expect(challenge.url).toBe(CLAUDE_AUTHORIZE_URL);
+		// Anthropic's callback page displays the code instead of issuing one here.
+		expect(challenge.user_code).toBeNull();
+		expect(challenge.completion).toBe('code');
+
+		const submitted = await post(`/api/ai-providers/subscription-login/${flow_id}/code`, {
+			code: 'code-from-the-callback-page',
+		});
+		expect(submitted.status).toBe(200);
+
+		// Delivered as a keypress the CLI's raw-mode prompt submits on. An LF
+		// reaches the prompt as an ordinary character and the sign-in hangs to its
+		// timeout with the code sitting in the box - which is the whole failure.
+		const delivery = execScripts.find((script) => script.includes('code-from-the-callback-page'));
+		expect(delivery).toContain(String.raw`printf '%s\r'`);
+
+		// The CLI completes the exchange and prints its token.
+		log += CLAUDE_TOKEN_LINE;
+		const { body: done } = await pollUntil(flow_id, 'succeeded');
+		expect(done.config_id).toBeTruthy();
+		expect(JSON.stringify(done)).not.toContain('sk-ant-oat01-');
+
+		const stored = await db.query<{ auth_method: string }>(
+			'SELECT auth_method FROM ai_provider_configs WHERE id = $1',
+			[done.config_id],
+		);
+		expect(stored.rows[0].auth_method).toBe('subscription');
+		expect(liveContainers.size).toBe(0);
+	});
+});
+
+describe('a CLI that exits', () => {
+	/**
+	 * A CLI issues its credential and exits in the same breath, so the log the
+	 * watcher harvested is always a round trip older than the exit file it then
+	 * finds. Failing on that file alone throws away a sign-in that succeeded -
+	 * and does it at the very last step, after the operator has done everything
+	 * asked of them.
+	 */
+	it('harvests a credential written as the CLI exited, rather than reporting an empty exit', async () => {
+		const start = await post('/api/ai-providers/subscription-login/start', {
+			provider: AiProvider.OpenAI,
+		});
+		const { flow_id } = (await start.json()).data;
+		log = CHALLENGE;
+		await pollUntil(flow_id, 'awaiting_user');
+
+		exitFile = true;
+		credentialArrivesWithExit = true;
+
+		const { body: done } = await pollUntil(flow_id, 'succeeded');
+		expect(done.config_id).toBeTruthy();
+	});
+
+	it('still fails when the CLI really did exit with nothing to harvest', async () => {
+		const start = await post('/api/ai-providers/subscription-login/start', {
+			provider: AiProvider.OpenAI,
+		});
+		const { flow_id } = (await start.json()).data;
+		log = CHALLENGE;
+		await pollUntil(flow_id, 'awaiting_user');
+
+		exitFile = true;
+
+		const { body } = await pollUntil(flow_id, 'failed');
+		expect(body.code).toBe('exited_without_credential');
+		expect(liveContainers.size).toBe(0);
 	});
 });

--- a/packages/server/test/subscription-login-script.test.ts
+++ b/packages/server/test/subscription-login-script.test.ts
@@ -143,6 +143,12 @@ describe('buildSubscriptionLoginCodeScript', () => {
 		const script = buildSubscriptionLoginCodeScript('/tmp/flow', "a'; id #");
 		expect(script).toContain(`'a'\\''; id #'`);
 	});
+
+	it('ends the code with a carriage return, never a line feed', () => {
+		const script = buildSubscriptionLoginCodeScript('/tmp/flow', 'CODE-1234');
+		expect(script).toContain(String.raw`printf '%s\r'`);
+		expect(script).not.toContain(String.raw`\n`);
+	});
 });
 
 // Linux-only: the login script launches its CLI through `util-linux script`
@@ -217,6 +223,40 @@ describe.skipIf(process.platform !== 'linux')('the generated script, under real 
 		const cli = fakeCli(home, 'echo done; exit 0');
 
 		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
+		await waitFor(exited(dir));
+	});
+
+	/**
+	 * Raw mode is where CR and LF stop being interchangeable, and it is the mode
+	 * every vendor paste prompt runs in: nothing translates one into the other, so
+	 * only the byte actually sent arrives, and only `\r` reads as return. A
+	 * `read`-based stand-in cannot show this - canonical mode's `ICRNL` accepts
+	 * either - so this one puts its own terminal in raw mode and dumps the bytes
+	 * it was handed.
+	 */
+	it('delivers the code terminated by CR, which is what a raw-mode prompt submits on', async () => {
+		const home = tempDir();
+		const dir = join(tempDir(), 'flow');
+		const cli = fakeCli(
+			home,
+			[
+				'stty raw -echo',
+				'echo ready',
+				'dd bs=1 count=3 2>/dev/null | od -An -to1',
+				'stty sane',
+			].join('\n'),
+		);
+
+		await run('sh', ['-c', buildSubscriptionLoginScript({ dir, argv: [cli], holdSecs: 30 })]);
+		const log = () => readFileSync(join(dir, LOGIN_LOG_FILE), 'utf8');
+		await waitFor(() => log().includes('ready'));
+
+		await run('sh', ['-c', buildSubscriptionLoginCodeScript(dir, 'ab')]);
+		await waitFor(() => log().includes('141 142'));
+
+		// `a`, `b`, then 015 - CR. 012 would be the LF that leaves a TUI's prompt
+		// holding the code, unsubmitted, until the flow times out.
+		expect(log()).toContain('141 142 015');
 		await waitFor(exited(dir));
 	});
 


### PR DESCRIPTION
The Anthropic guided sign-in failed at its last step: the operator pastes the code from Anthropic's callback page, clicks Finish sign-in, and nothing happens until the flow expires.

## The bug

`POST …/:flowId/code` delivered the code to the CLI's stdin FIFO with `printf '%s\n'`. The paste prompt on the other end is a raw-mode TUI, where no line discipline translates LF into CR and only CR reads as return - so the code was typed into the prompt and left sitting there, unsubmitted, until the 15-minute completion timeout.

Reproduced against claude-code 2.1.250 driven by the real login script:

- with LF: the pasted text appears masked in the prompt (`***************`) and nothing else happens - no exchange, no exit;
- with CR: the CLI runs the token exchange immediately.

A CLI reading lines canonically is unaffected either way, because `ICRNL` turns the CR back into its newline. That is also why this went unnoticed: the executed test's stand-in CLI is a POSIX `read`, which accepts both terminators.

## The change

- `buildSubscriptionLoginCodeScript` terminates the code with `\r`.
- The watcher takes one final harvest against freshly read output before declaring `exited_without_credential`. A CLI issues its credential and exits in one breath, so the log the harvest read is always a round trip older than the exit file found immediately after it - failing on that file alone discarded a completed sign-in, at the same last step.

## Tests

- A raw-mode stand-in CLI that puts its own terminal in raw mode and dumps the bytes it was handed, so the terminator is asserted (`141 142 015`) rather than assumed. Fails on the old code with `141 142 012`.
- The Anthropic path end to end through the routes: challenge parsed out of the OSC 8 escape, code submitted, delivery script asserted to carry the CR, token harvested from what the CLI printed and stored as a subscription credential.
- The exit race, both directions: a credential arriving in the same round trip as the exit file is harvested; a genuinely empty exit still fails with `exited_without_credential`.

The existing `read`-based test is kept unchanged and still passes, which is the check that line-oriented CLIs are unaffected.

## Docs

`.dev/architecture.md` § Provider config & guided sign-in now records the CR terminator. No `docs/` page describes the FIFO mechanism.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDxDbXRU8Vo8XntkSA4voE)_