### PR TITLE
fix(connectors): report an unverifiable probe as a notice, not a failure

### DIFF
--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -298,13 +298,21 @@ at any time from the same control.
 
 ## Checking a connector yourself
 
-Every hosted connector's row carries a **Test connection** button, on both the project's
-Connectors page and the global **Settings → Connectors** page. Press it whenever you want
-to know where a connector stands, whatever its badge says.
+Every hosted connector you have not disconnected carries a **Test connection** button on its
+row, on both the project's Connectors page and the global **Settings → Connectors** page.
+Press it whenever you want to know where a connector stands, whatever its badge says.
 
 It runs the same check Hezo runs on its own: it opens an MCP handshake with the server,
 using the connector's stored credential, and tells you what came back. A reachable server
 also re-lists its methods, so the allowlist reflects whatever the server advertises today.
+
+One case it cannot answer. When a connector's credential is a `__HEZO_SECRET_*__`
+placeholder in one of its headers, that value is filled in by the egress proxy as an agent's
+request leaves the container - and this check does not go through the proxy, so it sends the
+header without the credential. Hezo tells you so rather than guessing: the result reads as a
+notice, not a failure, and says the connector still reaches agent runs. What it confirms is
+that the server is up; whether that credential is still accepted is not something this button
+can tell you.
 
 Use it when a row says **Connected** but carries a warning underneath, when an agent
 reports that a connector's tools are missing, or after the provider tells you an outage is
@@ -314,7 +322,8 @@ week can still be sitting on the row long after the server came back. This butto
 you clear it.
 
 Local (stdio) servers and REST API connectors have no button: neither has an MCP endpoint
-to hand-shake with, so there is nothing to check from here.
+to hand-shake with, so there is nothing to check from here. Nor does a **Revoked** row -
+its credential is already gone, and the check is refused until you connect it again.
 
 ## When a connector stops working
 

--- a/packages/server/src/services/connectors/method-discovery.ts
+++ b/packages/server/src/services/connectors/method-discovery.ts
@@ -562,7 +562,10 @@ export function describeDiscoveryFailure(result: { reason: string; detail?: stri
 		case 'unsupported_kind':
 			return 'Method access applies to hosted MCP servers only.';
 		case 'not_connected':
-			return 'Connect this server before listing its methods.';
+			// Neutral about what the caller was doing: both the method list and the
+			// card's Test connection button surface this, and it is the second one
+			// an operator is most likely to be holding when they read it.
+			return 'Connect this server first.';
 		case 'locked':
 			return 'Hezo is locked, so this connector’s credential can’t be read. Unlock and try again.';
 		case 'not_found':

--- a/packages/web/src/components/connector-test-button.tsx
+++ b/packages/web/src/components/connector-test-button.tsx
@@ -1,13 +1,32 @@
-import { ConnectorTransport } from '@hezo/shared';
+import { ConnectorProbeError, ConnectorTransport } from '@hezo/shared';
 import { RefreshCw } from 'lucide-react';
 import {
 	type Connector,
 	type ConnectorMethodsScope,
+	type ConnectorProbeVerdict,
 	useTestConnector,
 } from '../hooks/use-connectors';
 import { toast } from '../hooks/use-toast';
 import { useI18n } from '../lib/i18n';
 import { Button } from './ui/button';
+
+/**
+ * How loudly each probe outcome is reported.
+ *
+ * Keyed on the outcome itself, never on `reachable`, which conflates two unlike
+ * things: an `unverifiable` connector is one that works and that Hezo cannot
+ * check from where it stands, and reporting it in red under "Something went
+ * wrong" contradicted the last sentence of the note it was carrying.
+ *
+ * A table so a value added to {@link ConnectorProbeError} is a compile error
+ * here rather than a silent demotion to whatever the fallback happened to be.
+ */
+const REPORT_PROBE: Record<NonNullable<ConnectorProbeVerdict['probe']>, (note: string) => void> = {
+	ok: (note) => toast.success(note),
+	unverifiable: (note) => toast.info(note),
+	[ConnectorProbeError.AuthRequired]: (note) => toast.error(note),
+	[ConnectorProbeError.Unreachable]: (note) => toast.error(note),
+};
 
 /**
  * Re-check this connector's server now, from the connector card.
@@ -19,10 +38,10 @@ import { Button } from './ui/button';
  * credentialed connectors entirely, meaning that notice could outlive the
  * outage indefinitely.
  *
- * Hosted servers only. A local (stdio) server has no endpoint to reach and an
- * API connector is called directly by the agent, so neither has anything to
- * hand-shake with; the route refuses both, and offering a button that always
- * fails would be worse than offering none.
+ * Hosted servers only, and not once revoked. A local (stdio) server has no
+ * endpoint to reach, an API connector is called directly by the agent, and a
+ * revoked row's credential is already gone - the probe refuses all three, and
+ * offering a button that always fails would be worse than offering none.
  */
 export function ConnectorTestButton({
 	connector,
@@ -34,17 +53,18 @@ export function ConnectorTestButton({
 }) {
 	const { t } = useI18n();
 	const test = useTestConnector(scope);
-	if (connector.kind !== ConnectorTransport.Saas) return null;
+	if (connector.kind !== ConnectorTransport.Saas || connector.revoked_at) return null;
 
 	const run = () => {
 		test.mutate(connector.id, {
 			// The note is authored server-side next to the outcomes it describes, so
 			// it stays the single wording for a probe result across every surface.
-			onSuccess: (result) => {
-				const note = result.verdict?.note;
-				if (!note) return;
-				if (result.verdict?.reachable) toast.success(note);
-				else toast.error(note);
+			onSuccess: ({ verdict }) => {
+				if (!verdict?.note) return;
+				// A null outcome is a refusal that never reached the server - locked,
+				// not connected, gone - so it is a fault, and reported as one.
+				const report = verdict.probe ? REPORT_PROBE[verdict.probe] : toast.error;
+				report(verdict.note);
 			},
 			onError: (e) => toast.error((e as Error).message),
 		});

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -19,10 +19,19 @@ import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
  */
 async function seedSaasConnector(
 	ws: SeededWorkspace,
-	input: { name: string; url: string; withDcr?: boolean; probed?: boolean },
+	input: {
+		name: string;
+		url: string;
+		withDcr?: boolean;
+		probed?: boolean;
+		/** Static headers, e.g. a `__HEZO_SECRET_*__` placeholder the egress proxy
+		 * substitutes at request time and the probe therefore strips. */
+		headers?: Record<string, string>;
+	},
 ): Promise<{ id: string; name: string }> {
 	const { apiBase, db } = getTestContext();
 	const config: Record<string, unknown> = { url: input.url };
+	if (input.headers) config.headers = input.headers;
 	if (input.withDcr) {
 		config.dcr = {
 			client_id: 'dcr-client-id',
@@ -588,6 +597,113 @@ test('Test connection reports a server that does not answer', async () => {
 	await waitFor(() => {
 		expect(document.body.textContent).toContain('did not answer');
 	});
+});
+
+/**
+ * Answer the connector test route with a fixed verdict.
+ *
+ * The `unverifiable` outcome needs a real cross-origin 401, which happy-dom's
+ * same-origin policy blocks before a status ever reaches the probe. What broke
+ * was the web's mapping from verdict to toast severity, not the probe, so the
+ * verdict is supplied and the mapping is what gets exercised. The outcomes
+ * themselves are covered against a live server in
+ * `packages/server/test/connector-test-route.test.ts`.
+ */
+function interceptConnectorTest(verdict: {
+	reachable: boolean;
+	probe: string | null;
+	note: string;
+}): { restore: () => void } {
+	const patched = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const urlStr =
+			input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+		const path = new URL(urlStr, 'http://localhost').pathname;
+		if (/\/connectors\/[^/]+\/test$/.test(path)) {
+			return new Response(JSON.stringify({ data: { verdict, connector: null } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return patched(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+	return {
+		restore: () => {
+			globalThis.fetch = patched;
+		},
+	};
+}
+
+test('a connector Hezo cannot verify from here is reported as a notice, not an error', async () => {
+	// The connector's credential rides a placeholder header the egress proxy
+	// substitutes at request time. The probe strips it, so it goes out with less
+	// than a run does and its 401 says nothing about the connector either way.
+	const intercept = interceptConnectorTest({
+		reachable: false,
+		probe: 'unverifiable',
+		note: "This server wants a credential, and this connector's own credential is a placeholder the egress proxy substitutes at request time, which Hezo can't reproduce from here. It still reaches agent runs.",
+	});
+	try {
+		let slug = '';
+		const { findByText, user, router } = await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				slug = ws.internalSlug;
+				await seedSaasConnector(ws, {
+					name: 'placeholder-auth',
+					url: 'https://mcp.placeholder.example/mcp',
+					headers: { Authorization: 'Bearer __HEZO_SECRET_TRACKER_KEY__' },
+				});
+			},
+		});
+		await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+		const row = (await findByText('placeholder-auth')).closest(
+			'[data-testid="connector-row"]',
+		) as HTMLElement;
+
+		await user.click(within(row).getByTestId('connector-test'));
+
+		// Scoped to this note's own toast: the store is module-level, so earlier
+		// specs in this file have left their own toasts in the DOM, and Radix renders
+		// a second announcement copy of each. The title sits immediately before the
+		// description inside one toast, which is the pairing under test.
+		const titles = (await screen.findAllByText(/placeholder the egress proxy substitutes/))
+			.map((d) => d.previousElementSibling?.textContent)
+			.filter((t): t is string => !!t);
+		// The regression this guards: severity was keyed on `reachable`, false here,
+		// so a connector that works was announced under the error title - directly
+		// contradicting the last sentence of the note it was carrying.
+		expect(titles).toContain('Heads up');
+		expect(titles).not.toContain('Something went wrong');
+	} finally {
+		intercept.restore();
+	}
+});
+
+test('a revoked connector offers no Test connection button', async () => {
+	let slug = '';
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			const { id } = await seedSaasConnector(ws, {
+				name: 'gone',
+				url: 'https://mcp.linear.example/mcp',
+			});
+			await getTestContext().db.query(
+				`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`,
+				[id],
+			);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	// The probe refuses a revoked row outright, so the button could only ever
+	// report a failure - the same reason the non-hosted kinds get none.
+	const row = (await findByText('gone')).closest('[data-testid="connector-row"]') as HTMLElement;
+	expect(within(row).queryByTestId('connector-test')).toBeNull();
 });
 
 test('connectors with no MCP server to reach offer no Test connection button', async () => {


### PR DESCRIPTION
Pressing **Test connection** on a working connector announced **"Something went wrong"** directly above a note whose own last sentence read *"It still reaches agent runs."*

## The cause

Severity was keyed on the verdict's `reachable`, which is not a synonym for healthy. It is false for `unverifiable` too - and that outcome means the probe went out carrying **less** credential than a real run does.

A connector whose credential is a `__HEZO_SECRET_*__` placeholder header has that value filled in by the egress proxy as the request leaves the container. The probe does not go through the proxy, so `buildProbeHeaders` strips the placeholder rather than sending it literally. The 401 that comes back is about the probe, not the connector, and says nothing in either direction - which is exactly what the note explains, under a red error title.

So the one connector shape most likely to be read as broken was the one that was fine.

## The fix

Severity now reads the outcome itself, as a table rather than a branch, so a value added to `ConnectorProbeError` is a compile error here instead of a silent misclassification:

| Outcome | Report |
|---|---|
| `ok` | success |
| `unverifiable` | **notice** |
| `auth_required` | error |
| `unreachable` | error |
| `null` - a refusal that never reached the server (locked, not connected, gone) | error |

## Two smaller faults in the same surface

- **A revoked row offered the button.** The probe refuses revoked rows outright, so it could only ever report a failure. Hidden, for the same reason the non-hosted kinds get no button.
- **That refusal read "Connect this server before listing its methods"** - wording from when the method list was its only caller. Now neutral, since the test button is the caller an operator is most likely holding when they read it.

## Docs

The page claimed the check runs "using the connector's stored credential", with no exception - the overclaim behind the confusing report. It now states plainly what the placeholder case can and cannot tell you (the server is up; whether the credential is still accepted is not knowable from here), and that a revoked row has no button.

## Tests

| Suite | Covers |
|---|---|
| `packages/web/test/connectors-page.test.tsx` | An `unverifiable` verdict is reported under the notice title and not the error title; a revoked row offers no button |

The verdict is supplied by a fetch stub, following `interceptAuthStart` in `instance-connectors.test.tsx`: the outcome needs a real cross-origin 401, which happy-dom's same-origin policy blocks before a status ever reaches the probe. What regressed was the web's mapping from verdict to severity, and that is what the spec exercises; the outcomes themselves are already covered against a live server in `packages/server/test/connector-test-route.test.ts`.

The new assertion is scoped to its own toast rather than the page body - the toast store is module-level, so earlier specs in the file leave theirs in the DOM, and a body-wide matcher passed or failed on their titles.

Green: `typecheck`, `build`, `biome`, server `--pattern connector --pattern method-discovery` (196) and `--pattern docs` (73), web `--pattern connector --pattern i18n` (84).

## Not addressed

**Test connection still cannot exercise a placeholder-substituted credential.** The probe runs in-process and substitution belongs to the egress proxy, so for those connectors the button confirms the server is up and nothing more. Making it substitute server-side is feasible - the probe already decrypts stored OAuth tokens and API keys - but that widens where a secret is resolved, so it is a deliberate call to make separately rather than fold in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kpjT5L4zLB3XZhRh5Ht3R