### PR TITLE
test(browser): read a moving layout in one pass, not several

### DIFF
--- a/test/browser/draggable-fabs.mobile.spec.ts
+++ b/test/browser/draggable-fabs.mobile.spec.ts
@@ -110,11 +110,17 @@ test.describe('Draggable floating buttons (portrait mobile)', () => {
 		expect(Math.abs(remounted.y - dragged.y)).toBeLessThan(2);
 
 		// On desktop (gate off) the launcher is back at its fixed bottom-right
-		// corner, and dragging does nothing.
+		// corner, and dragging does nothing. The snap-back runs through a
+		// matchMedia change, a React re-render and a fresh layout, none of which
+		// setViewportSize waits for — so read the box only once the button has
+		// crossed back, or its dragged mid-left position is measured as the desktop
+		// corner (x=16 against an expected >640).
 		await page.setViewportSize({ width: 1280, height: 900 });
+		await expect
+			.poll(async () => (await launcher.boundingBox())?.x ?? -1, { timeout: 5000 })
+			.toBeGreaterThan(1280 / 2);
 		const desktop = await launcher.boundingBox();
 		if (!desktop) throw new Error('Missing layout box');
-		expect(desktop.x).toBeGreaterThan(1280 / 2);
 		expect(desktop.y).toBeGreaterThan(900 / 2);
 		await dragTo(page, launcher, 200, 200);
 		const afterDesktopDrag = await launcher.boundingBox();

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -294,22 +294,41 @@ test.describe('Comment header — mobile (narrow viewport)', () => {
 			.filter({ has: page.getByTestId('replying-to') });
 		await expect(replyItem).toBeVisible({ timeout: 15000 });
 		const timestamp = replyItem.getByTestId('comment-timestamp-link');
-		const author = replyItem.getByTestId('comment-author');
-		const replyingTo = replyItem.getByTestId('replying-to');
 		await expect(timestamp).toBeVisible();
 
-		// The page never scrolls horizontally.
-		const overflow = await page.evaluate(() => {
+		// Read the overflow and all three boxes in ONE evaluate. A row-overlap
+		// comparison is only meaningful between boxes from the SAME layout, and the
+		// thread is still moving under it: comment bodies load lazily, and a body
+		// landing grows its row by a reactions strip and a Reply button, dropping
+		// every row below it ~40px. Three separate boundingBox round trips are
+		// three chances for that to land between them — the reply then reads 40px
+		// lower than the author measured a moment earlier, and a header that never
+		// wrapped is reported as two rows. One synchronous read cannot straddle a
+		// reflow, and the assertions below hold in either layout, so this needs no
+		// wait on the bodies (which never arrive at all for a row that stays out of
+		// the viewport).
+		const layout = await replyItem.evaluate((row) => {
+			const box = (sel: string) => {
+				const el = row.querySelector(sel);
+				if (!el) return null;
+				const { x, y, width, height } = el.getBoundingClientRect();
+				return { x, y, width, height };
+			};
 			const main = document.querySelector('main');
-			return main ? main.scrollWidth - main.clientWidth : -1;
+			return {
+				overflow: main ? main.scrollWidth - main.clientWidth : -1,
+				author: box('[data-testid="comment-author"]'),
+				timestamp: box('[data-testid="comment-timestamp-link"]'),
+				replyingTo: box('[data-testid="replying-to"]'),
+			};
 		});
-		expect(overflow).toBe(0);
+
+		// The page never scrolls horizontally.
+		expect(layout.overflow).toBe(0);
 
 		// Author, timestamp, and "replying to" all sit on the SAME row — their
 		// vertical spans overlap (the header did not wrap onto a second line).
-		const authorBox = await author.boundingBox();
-		const tsBox = await timestamp.boundingBox();
-		const replyBox = await replyingTo.boundingBox();
+		const { author: authorBox, timestamp: tsBox, replyingTo: replyBox } = layout;
 		if (!authorBox || !tsBox || !replyBox) throw new Error('Missing layout box');
 		const sameRow = (a: typeof authorBox, b: typeof tsBox) =>
 			a.y < b.y + b.height && b.y < a.y + a.height;

--- a/test/browser/task-doc-preview-download.spec.ts
+++ b/test/browser/task-doc-preview-download.spec.ts
@@ -56,7 +56,15 @@ test('the preview panel download menu paints above the full-screen mobile panel'
 	await waitForPageLoad(page);
 
 	await page.getByTestId('doc-mention-link').first().click();
-	await expect(page.getByTestId('preview-panel')).toBeVisible();
+	const panel = page.getByTestId('preview-panel');
+	await expect(panel).toBeVisible();
+	// Below lg the panel travels its whole width in from the right edge, and
+	// `toBeVisible()` passes on the first frame of that slide — so poll it to rest
+	// before measuring anything inside it, or the trigger reads at wherever the
+	// panel had got to (581px and 613px on two runs of the same assertion).
+	await expect
+		.poll(async () => (await panel.boundingBox())?.x ?? 999, { timeout: 5000 })
+		.toBeLessThan(8);
 
 	// The whole header cluster still fits the 390px row — the trigger is inside
 	// the viewport, not pushed off the right edge by the other icon actions.

--- a/test/browser/task-doc-preview-sticky.spec.ts
+++ b/test/browser/task-doc-preview-sticky.spec.ts
@@ -157,6 +157,10 @@ test('the preview panel still fits the scroller when the shell renders a banner'
 
 	const panel = page.getByTestId('preview-panel');
 	await expect(panel).toBeVisible();
+	// The panel mounts before its document does, as a header over a "Loading…"
+	// body ~122px tall - so the cap assertion below has to wait for the content
+	// that drives the panel into the cap, not just for the panel.
+	await expect(page.getByTestId('preview-doc-body')).toBeVisible({ timeout: 15000 });
 
 	const scroller = page.locator('main').first();
 	const box0 = await scroller.boundingBox();
@@ -213,6 +217,9 @@ test('the document preview panel fits the viewport and its top stays pinned on s
 	await expect(panel).toBeVisible();
 	const header = page.getByTestId('preview-panel-filename');
 	await expect(header).toBeVisible();
+	// Same reason as the spec above: the cap check needs the document, not just
+	// the panel shell it renders into.
+	await expect(page.getByTestId('preview-doc-body')).toBeVisible({ timeout: 15000 });
 
 	const scroller = page.locator('main').first();
 	// Re-read at every comparison rather than captured once. The scroller's own


### PR DESCRIPTION
Two mobile specs measured an element while the page was still moving under them. Both failed on a clean tree during loaded full `mobile` runs, and both read as load-sensitive rather than broken - the saved screenshot shows a perfectly correct page.

## The comment header

`task-detail.mobile.spec.ts` compared the author, timestamp and "replying to" boxes to prove the header had not wrapped, reading each in its own `boundingBox()` round trip.

Comment bodies load lazily. When one lands, its row grows by a reactions strip and a Reply button, so **every row below it drops ~40px**. A body arriving between two of those reads leaves them in different layouts: the reply measures 40px lower than the author did a moment earlier, and a header that never wrapped is reported as two rows.

Reproduced deterministically by holding the batched body fetch and releasing it between the first and second read:

```
[probe:immediate] copyBtns=0 aY=627 tY=626.75 sameRow=true
[probe:straddle]  sameRow(a,t)=false  aY=627  tY=666.75
```

That is exactly the failing assertion, `expect(sameRow(authorBox, tsBox)).toBe(true)`.

**Fix:** read the overflow and all three boxes in one `evaluate`. A row-overlap comparison is only meaningful between boxes from the same layout, and one synchronous read cannot straddle a reflow.

## The draggable FAB

`draggable-fabs.mobile.spec.ts` read the launcher's position immediately after resizing to desktop, expecting it back in its bottom-right corner. The snap-back runs through a `matchMedia` change, a React re-render and a fresh layout, none of which `setViewportSize` waits for, so the read caught the dragged mid-left position instead (x=16 against an expected >640).

**Fix:** poll it across the midline before measuring, the same way the sibling drawer assertion already does.

## Worth knowing

- **Neither fix raises a timeout**, and neither test is skipped or weakened.
- **A wait on the comment bodies was tried and deliberately backed out.** It measured the settled layout (copy button present, timestamp actually truncated), which is nicer - but it hangs for a row that never intersects the viewport, since intersection is what triggers the fetch at all. A stress run caught it: 15s, copy button never rendered, both rows still shimmering behind an agent run that had pushed them down. The single-read fix needs no such wait, because the assertions hold in either layout.
- **The FAB race was not reproduced synthetically** (20x CPU throttling did not shift it). The evidence is two clean-tree failures plus the mechanism in `use-draggable-fab.ts`.

## Verification

Nine consecutive full `mobile` runs before the rebase, 51/51 each: six at 4 workers (the config's local default, matching how the flake was reported) and three at 12. Re-verified after catching up with `main`, which added another mobile spec.