### PR TITLE
feat(web): lead with the subscription when a provider has one

### DIFF
--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -119,14 +119,16 @@ caching and token counting.
 
 Most providers accept a plain **API key**, and Anthropic and OpenAI also accept a
 **subscription sign-in** (Claude Pro/Max, or ChatGPT) - so you can put an existing plan
-to work instead of paying per token. You choose the method when you connect the provider.
+to work instead of paying per token. You choose the method when you connect the provider;
+where a subscription is available it is the one offered first, and an API key is a click away.
 Google is API-key only in Hezo for now: Antigravity has a consumer subscription (Login with Google),
 but Hezo cannot yet bring its keyring-only sign-in into a run container.
 
 ### Signing in to a subscription
 
-For **OpenAI** and **Anthropic**, Hezo runs the sign-in for you. Choose the subscription
-option, select **Sign in**, and Hezo walks you through it a step at a time. First it shows
+For **OpenAI** and **Anthropic**, Hezo runs the sign-in for you. These two open on the
+subscription option already selected, so just select **Sign in** (choose **API key**
+instead if that is what you want). Hezo walks you through it a step at a time. First it shows
 a short one-time code and a **Copy code** button. Then it offers the link: open it on any
 device - your phone is fine - sign in to that account, and enter the code. Hezo shows how
 long the code has left, and waits while you finish.

--- a/packages/web/src/components/provider-config-form.tsx
+++ b/packages/web/src/components/provider-config-form.tsx
@@ -132,8 +132,12 @@ export function ProviderConfigForm({
 	const updateProvider = useUpdateAiProviderConfig(editing?.id ?? '');
 	const info = AI_PROVIDER_INFO[provider];
 
+	// A provider that has a subscription opens on it: it is the credential the
+	// operator already owns, and the one Hezo can mint end to end. Editing keeps
+	// whatever the stored config uses, which is never guessed at.
 	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(
-		(editing?.auth_method as AiAuthMethod) ?? AiAuthMethod.ApiKey,
+		(editing?.auth_method as AiAuthMethod) ??
+			(info.supportsSubscription ? AiAuthMethod.Subscription : AiAuthMethod.ApiKey),
 	);
 	const [name, setName] = useState(() => editing?.label ?? defaultLabel(provider, configs));
 	const [nameEdited, setNameEdited] = useState(false);
@@ -276,21 +280,14 @@ export function ProviderConfigForm({
 			{info.supportsSubscription && (
 				<div className="flex flex-col gap-1.5">
 					<span className="text-eyebrow text-text-2">Authentication</span>
-					<div className="flex gap-2">
+					{/* Subscription leads, because it is the default and the path most
+					    operators want. `aria-pressed` is what makes this a segmented
+					    toggle rather than two buttons that happen to change colour. */}
+					<div className="flex flex-wrap gap-2">
 						<Button
 							type="button"
 							size="sm"
-							variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
-							onClick={() => {
-								setAuthMethod(AiAuthMethod.ApiKey);
-								setError(null);
-							}}
-						>
-							API key
-						</Button>
-						<Button
-							type="button"
-							size="sm"
+							aria-pressed={authMethod === AiAuthMethod.Subscription}
 							variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
 							onClick={() => {
 								setAuthMethod(AiAuthMethod.Subscription);
@@ -298,6 +295,18 @@ export function ProviderConfigForm({
 							}}
 						>
 							{info.runtimeLabel} subscription
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							aria-pressed={authMethod === AiAuthMethod.ApiKey}
+							variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
+							onClick={() => {
+								setAuthMethod(AiAuthMethod.ApiKey);
+								setError(null);
+							}}
+						>
+							API key
 						</Button>
 					</div>
 				</div>

--- a/packages/web/test/ai-provider-key-instructions.test.tsx
+++ b/packages/web/test/ai-provider-key-instructions.test.tsx
@@ -50,8 +50,13 @@ test('every pickable provider shows how-to-get-a-key instructions linking its ke
 	for (const { card, title, href } of EXPECTED_KEY_LINKS) {
 		await user.click(within(dialog).getByRole('button', { name: card }));
 
-		// The API-key mode is the default, so the instructions box renders
-		// immediately with a link to the provider's own key console.
+		// A provider with a subscription opens on that instead, so ask for the key
+		// mode where one is offered. The rest of the assertion is the same either way.
+		const apiKeyPill = within(dialog).queryByRole('button', { name: 'API key' });
+		if (apiKeyPill) await user.click(apiKeyPill);
+
+		// API-key mode renders the instructions box with a link to the provider's
+		// own key console.
 		await within(dialog).findByText(title);
 		await waitFor(() => {
 			const link = Array.from(dialog.querySelectorAll('a')).find(
@@ -79,16 +84,21 @@ test('switching Anthropic to subscription swaps the API-key instructions for the
 	await user.click(getByRole('button', { name: 'Add provider' }));
 	const dialog = await findByRole('dialog');
 
+	// Anthropic opens on its subscription, so those are the instructions on offer
+	// first - behind the manual-paste disclosure, since guided sign-in leads.
 	await user.click(within(dialog).getByRole('button', { name: 'Anthropic' }));
-	await within(dialog).findByText(/How to get your Anthropic API key/i);
-
-	await user.click(within(dialog).getByRole('button', { name: /Claude Code subscription/i }));
 	await user.click(within(dialog).getByRole('button', { name: /Paste credential manually/i }));
 	await within(dialog).findByText(/How to get your Claude subscription token/i);
 	expect(within(dialog).queryByText(/How to get your Anthropic API key/i)).toBeNull();
 
-	// And back: API-key mode restores the key instructions.
+	// And across: API-key mode swaps in the key instructions.
 	await user.click(within(dialog).getByRole('button', { name: 'API key' }));
 	await within(dialog).findByText(/How to get your Anthropic API key/i);
 	expect(within(dialog).queryByText(/How to get your Claude subscription token/i)).toBeNull();
+
+	// And back again, rather than the first render sticking. The manual-paste
+	// disclosure is already open from above - it is not reset by the pill.
+	await user.click(within(dialog).getByRole('button', { name: /Claude Code subscription/i }));
+	await within(dialog).findByText(/How to get your Claude subscription token/i);
+	expect(within(dialog).queryByText(/How to get your Anthropic API key/i)).toBeNull();
 });

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -238,8 +238,10 @@ test('can add an Anthropic API key via the settings UI', async () => {
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	// Pick the Anthropic card from the grid, then fill its API-key form.
+	// Pick the Anthropic card from the grid, then fill its API-key form. Anthropic
+	// opens on its subscription, so the key form is one pill away.
 	await user.click(getByRole('button', { name: 'Anthropic' }));
+	await user.click(getByRole('button', { name: 'API key' }));
 	const keyInput = container.querySelector('input[type="password"]') as HTMLInputElement;
 	fireEvent.change(keyInput, { target: { value: 'sk-ant-component-test-1234567890' } });
 	await user.click(getByRole('button', { name: 'Save' }));
@@ -639,8 +641,10 @@ test('blocks the app when no provider is configured and drops once one is added'
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 	expect(queryAllByRole('heading', { name: 'AI providers' }).length).toBe(0);
 
-	// Pick the Anthropic card from the grid, then fill its API-key form.
+	// Pick the Anthropic card from the grid, then fill its API-key form. Anthropic
+	// opens on its subscription, so the key form is one pill away.
 	await user.click(getByRole('button', { name: 'Anthropic' }));
+	await user.click(getByRole('button', { name: 'API key' }));
 	const keyInput = container.querySelector('input[type="password"]') as HTMLInputElement;
 	fireEvent.change(keyInput, { target: { value: 'sk-ant-gate-component-12345' } });
 	await user.click(getByRole('button', { name: 'Save' }));
@@ -953,6 +957,7 @@ test('adding a provider ends on a default-model step for the config it just crea
 
 	const dialog = await findByRole('dialog');
 	await user.click(await within(dialog).findByRole('button', { name: 'Anthropic' }));
+	await user.click(within(dialog).getByRole('button', { name: 'API key' }));
 	await user.type(await within(dialog).findByLabelText('API key'), 'sk-ant-add-flow-model-step');
 	await user.click(within(dialog).getByRole('button', { name: 'Add provider' }));
 
@@ -1044,17 +1049,19 @@ test('the add form warns that a rotating subscription runs one agent at a time',
 	const dialog = await findByRole('dialog');
 	await user.click(within(dialog).getByRole('button', { name: 'OpenAI' }));
 
-	// API key is the default, and has no such limit - nothing should be claimed.
-	expect(within(dialog).queryByText(/only one agent can use it at a time/)).toBeNull();
-
-	await user.click(within(dialog).getByRole('button', { name: /subscription/i }));
+	// Subscription is where this provider opens, so the limit is stated without
+	// the operator having to go looking for it.
 	await within(dialog).findByText(/only one agent can use it at a time/);
 
-	// And it goes away again if they switch back, rather than sticking.
+	// An API key carries no such limit, so nothing should be claimed of it.
 	await user.click(within(dialog).getByRole('button', { name: 'API key' }));
 	await waitFor(() =>
 		expect(within(dialog).queryByText(/only one agent can use it at a time/)).toBeNull(),
 	);
+
+	// And it comes back on the way in, rather than only rendering once.
+	await user.click(within(dialog).getByRole('button', { name: /subscription/i }));
+	await within(dialog).findByText(/only one agent can use it at a time/);
 });
 
 test('the providers list marks only the credential whose runs serialise', async () => {

--- a/packages/web/test/provider-auth-method-default.test.tsx
+++ b/packages/web/test/provider-auth-method-default.test.tsx
@@ -1,0 +1,133 @@
+import { AiProvider } from '@hezo/shared';
+import { within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+interface ProviderListResponse {
+	data: Array<{ id: string; label: string; auth_method: string }>;
+}
+
+/**
+ * Which auth method the provider form opens on, and in what order it offers the
+ * two.
+ *
+ * A provider that has a subscription opens on it: that is the credential the
+ * operator already owns and the one Hezo can mint end to end, so it leads and an
+ * API key is the deliberate second choice. A provider without one is unchanged -
+ * it has no pill row at all. Editing never guesses: it opens on whatever the
+ * stored config actually uses.
+ */
+
+/**
+ * Remove the harness's seeded credential so the setup gate renders its provider
+ * card grid - the same shortcut the other ai-provider specs use to reach the
+ * credential form without going through the settings modal.
+ */
+async function clearAiProviders() {
+	const { apiBase, token } = getTestContext();
+	const headers = { Authorization: `Bearer ${token}` };
+	const listRes = await apiBase('/api/ai-providers', { headers });
+	const { data } = (await listRes.json()) as ProviderListResponse;
+	for (const config of data) {
+		await apiBase(`/api/ai-providers/${config.id}`, { method: 'DELETE', headers });
+	}
+}
+
+async function postProvider(body: Record<string, unknown>) {
+	const { apiBase, token } = getTestContext();
+	return apiBase('/api/ai-providers', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+}
+
+test('a provider with a subscription opens on it, offered before the API key', async () => {
+	const { container, findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: clearAiProviders,
+	});
+
+	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
+	await user.click(getByRole('button', { name: 'Anthropic' }));
+
+	const subscription = await findByRole('button', { name: /Claude Code subscription/i });
+	const apiKey = getByRole('button', { name: 'API key' });
+
+	// Selected without the operator choosing it.
+	expect(subscription.getAttribute('aria-pressed')).toBe('true');
+	expect(apiKey.getAttribute('aria-pressed')).toBe('false');
+
+	// And offered first. DOCUMENT_POSITION_FOLLOWING means the API key pill comes
+	// after the subscription one, which is the whole ordering claim.
+	expect(
+		subscription.compareDocumentPosition(apiKey) & Node.DOCUMENT_POSITION_FOLLOWING,
+	).toBeTruthy();
+
+	// The form body follows the pill, so the key field is not on the default path.
+	await findByRole('button', { name: /Sign in with Claude Code/i });
+	expect(container.querySelector('input[type="password"]')).toBeNull();
+});
+
+test('choosing the API key pill switches the form and the pressed state', async () => {
+	const { container, findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: clearAiProviders,
+	});
+
+	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
+	await user.click(getByRole('button', { name: 'Anthropic' }));
+	await user.click(getByRole('button', { name: 'API key' }));
+
+	expect(getByRole('button', { name: 'API key' }).getAttribute('aria-pressed')).toBe('true');
+	expect(
+		getByRole('button', { name: /Claude Code subscription/i }).getAttribute('aria-pressed'),
+	).toBe('false');
+	expect(container.querySelector('input[type="password"]')).not.toBeNull();
+});
+
+test('a provider with no subscription still opens on its API key, with no pill row', async () => {
+	const { container, findByRole, getByRole, queryByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: clearAiProviders,
+	});
+
+	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
+	await user.click(getByRole('button', { name: 'DeepSeek' }));
+
+	// DeepSeek is api-key only, so there is nothing to choose between and the key
+	// field is the arrival state.
+	expect(queryByRole('button', { name: /subscription/i })).toBeNull();
+	expect(queryByRole('button', { name: 'API key' })).toBeNull();
+	expect(container.querySelector('input[type="password"]')).not.toBeNull();
+});
+
+test('editing an API-key config opens on API key, not on the subscription', async () => {
+	const { findByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			await postProvider({
+				provider: AiProvider.Anthropic,
+				api_key: 'sk-ant-stored-key-component',
+				auth_method: 'api_key',
+				label: 'Anthropic',
+			});
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' }, { timeout: 15_000 });
+	await user.click(await findByRole('button', { name: 'Edit Anthropic' }, { timeout: 15_000 }));
+
+	// The stored method wins over the add-flow default - flipping it would offer
+	// to replace a credential the operator never said to replace.
+	const dialog = await findByRole('dialog');
+	expect(within(dialog).getByRole('button', { name: 'API key' }).getAttribute('aria-pressed')).toBe(
+		'true',
+	);
+	expect(
+		within(dialog)
+			.getByRole('button', { name: /Claude Code subscription/i })
+			.getAttribute('aria-pressed'),
+	).toBe('false');
+});

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -482,8 +482,10 @@ export async function dismissAiProviderModal(page: Page) {
 		return;
 	}
 
-	// Pick the Anthropic card from the grid, then fill its API-key form.
+	// Pick the Anthropic card from the grid, then fill its API-key form. A
+	// provider with a subscription opens on that, so ask for the key form first.
 	await page.getByRole('button', { name: 'Anthropic' }).first().click();
+	await page.getByRole('button', { name: 'API key', exact: true }).first().click();
 	await page.locator('input[type="password"]').first().fill('sk-ant-e2e-test-key');
 	await page.getByRole('button', { name: 'Save' }).first().click();
 


### PR DESCRIPTION
The auth pill row offered **API key** first and selected it, for every provider - including the two where a subscription is the credential the operator already owns and the one Hezo can now mint end to end through the guided sign-in. The better path was the one you had to go looking for.

## What changes

Anthropic and OpenAI now open on their subscription, with that pill first and the API key second.

- **A provider without a subscription is untouched** - it has no pill row at all and still opens on its key field.
- **Editing never guesses.** The stored `auth_method` still wins, because flipping it would offer to replace a credential nobody asked to replace.
- **The server's fallback stays `api_key`.** `routes/ai-providers.ts` defaults an unqualified request to a key; that is a fail-safe against storing a raw key as a subscription blob, not a UI preference, so it is deliberately unchanged.

Both pills now carry `aria-pressed`, which is what makes the row a segmented toggle rather than two buttons that happen to change colour, and lets the tests assert selection without matching on Tailwind classes. The row wraps, so the longer pair of labels does not overflow a narrow viewport.

The default lives in `provider-config-form.tsx` - the only component that renders the row or picks a method. Its three callers (onboarding picker, Add dialog, Edit dialog) pick it up with no edits of their own.

## Tests

New `packages/web/test/provider-auth-method-default.test.tsx` covers the four claims: a subscription provider opens pre-selected on it and offers it first (asserted via `compareDocumentPosition`, not class names); the API key pill switches both the pressed state and the form body; a provider without a subscription has no pill row and opens on its key field; and editing an `api_key` config opens on API key.

Existing specs that clicked a provider and reached straight for its key field now ask for the key pill first - including `test/browser/helpers.ts`, the shared helper that gets **every** browser spec past the setup gate, which would otherwise have reddened the whole browser tier. Two specs whose premise was "API key is the default" were rewritten around the new default while keeping what they were actually testing (the serialization warning tracking the selected method, and the instructions box swapping with it).

## Docs

`docs/ai-models.md` told the reader to "choose the subscription option" - now stale, since it arrives selected. Updated there and in the neighbouring paragraph on picking a method.

## Verification

`bun run typecheck` and `bun run check` clean. Provider and onboarding component suites: 53 passed (`ai-providers`, `ai-provider-key-instructions`, `provider-cli-choice`, `subscription-login-panel`, `provider-auth-method-default`, `onboarding-direct`, `onboarding-home`). Docs guards (`docs-links`, `docs-terminology`, `docs-bundle`): 18 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDxDbXRU8Vo8XntkSA4voE)_