### PR TITLE
feat(agents): fan a review out to sub-agents at the reviewer's discretion

### DIFF
--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -167,10 +167,11 @@ const SHARED_INSTRUCTIONS = `
 - Sub-agents are for work within YOUR run. For delegating work to other team members, use sub-tasks.
 
 ### Reviewing a Teammate's Work
-- **Review a teammate's finished work with adversarial sub-agents - one per review dimension, ten at most.** Your role's own prose names the dimensions. Give each sub-agent one dimension and the whole artefact, and task it with proving the work wrong rather than confirming it right.
+- **Review a teammate's finished work yourself, one dimension at a time.** Your role's own prose names the dimensions. A runtime without sub-agents has no other method.
+- **Fan the review out to adversarial sub-agents when the work earns it - one per dimension, ten at most.** Fan out when the change spans several areas, or carries risk one pass cannot hold, and whenever the task asks for a deeper review. A small, contained change stays in your own run.
+- **A sub-agent you launch to review is briefed to prove the work wrong, never to confirm it right.** Give it one dimension and the whole artefact.
 - **Reconcile the sub-agent reports into one findings list before you post.** Verify each finding against the artefact yourself and drop what you cannot reproduce. Merge what several dimensions raised, and rank the rest by severity.
 - **A sub-agent reviewing work never edits it.** A sub-agent that rewrites what it reviews destroys the evidence for the finding.
-- Without sub-agents on your runtime, work the dimensions yourself one at a time.
 
 ### When Something Is Too Big, Split It — Don't Shrink the Job
 - **A rejection for being too big is an instruction to split the work, not to give up on it and not to drop to one item at a time.** Halve the batch and retry; halve again if it still doesn't fit. Going straight from "one call failed" to "one call per item" is the slowest possible recovery — it costs you N round trips for work that usually fits in two or three — and it is almost never what the limit was asking for.

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -462,7 +462,7 @@ describe('template resolver', () => {
 	// that had been silently superseded. The prompt previously covered only the initial
 	// delegation decision and the cancel-then-absorb variant.
 
-	it("tells every agent to review a teammate's work with adversarial sub-agents", async () => {
+	it("lets every agent judge when a teammate's review earns adversarial sub-agents", async () => {
 		const result = await resolveSystemPrompt(db, 'Simple prompt', { teamId });
 
 		// Reviewing a teammate's finished work is not one role's job — QA, Security,
@@ -471,11 +471,20 @@ describe('template resolver', () => {
 		// mechanism lives here, at the surface that reaches all of them, and each
 		// role doc supplies only its own dimensions.
 		expect(result).toContain('adversarial sub-agents');
-		// The cap is what bounds the spend this rule adds across every team.
+		// The reviewer's own run is the default. Fanning out unconditionally spent up
+		// to ten sub-agent runs on every review on every team, including one-line
+		// changes, which is not what most reviews are worth.
+		expect(result).toContain("Review a teammate's finished work yourself, one dimension at a time");
+		// Discretion, not abdication: the fan-out stays available and the triggers say
+		// when it is earned, so a large or risky change still gets it unasked.
+		expect(result).toContain('when the work earns it');
+		expect(result).toContain('whenever the task asks for a deeper review');
+		// The cap is what bounds the spend once an agent does fan out.
 		expect(result).toContain('ten at most');
-		// The adversarial brief is the whole point: a sub-agent asked to confirm the
-		// work finds it fine. This is the clause a later reword would soften first.
-		expect(result).toContain('proving the work wrong rather than confirming it right');
+		// The adversarial brief is the whole point of fanning out: a sub-agent asked to
+		// confirm the work finds it fine. This is the clause a later reword would
+		// soften first — softening *when* to fan out already happened here.
+		expect(result).toContain('prove the work wrong, never to confirm it right');
 		// A finding nobody reproduced is noise handed to the author as fact.
 		expect(result).toContain('drop what you cannot reproduce');
 		// A sub-agent that rewrites what it reviews destroys the evidence, and on a
@@ -483,7 +492,7 @@ describe('template resolver', () => {
 		expect(result).toContain('never edits it');
 		// Of the CLIs the agent image installs, only the Claude Code family is wired
 		// for sub-agents, so the coverage must not depend on having them.
-		expect(result).toContain('Without sub-agents on your runtime');
+		expect(result).toContain('runtime without sub-agents');
 	});
 	it('routes post-delegation feedback to the delegate rather than letting the manager absorb it', async () => {
 		const result = await resolveSystemPrompt(db, 'Simple prompt', { teamId });


### PR DESCRIPTION
## What

Reviewing a teammate's finished work was an unconditional fan-out: one adversarial sub-agent per review dimension, ten at most, on every review. That rule sits in `SHARED_INSTRUCTIONS`, so it reached **every agent on every run** — QA, Security, the Architect, the Coach, the Risk Verifier, Content Editors and every Captain, plus any future hire given a review duty.

A one-line fix therefore cost the same ten sub-agent runs as a whole feature, which is not what most reviews are worth.

This makes the fan-out a judgement call.

## The rule, before and after

```diff
 ### Reviewing a Teammate's Work
-- **Review a teammate's finished work with adversarial sub-agents - one per review dimension, ten at most.** Your role's own prose names the dimensions. Give each sub-agent one dimension and the whole artefact, and task it with proving the work wrong rather than confirming it right.
+- **Review a teammate's finished work yourself, one dimension at a time.** Your role's own prose names the dimensions. A runtime without sub-agents has no other method.
+- **Fan the review out to adversarial sub-agents when the work earns it - one per dimension, ten at most.** Fan out when the change spans several areas, or carries risk one pass cannot hold, and whenever the task asks for a deeper review. A small, contained change stays in your own run.
+- **A sub-agent you launch to review is briefed to prove the work wrong, never to confirm it right.** Give it one dimension and the whole artefact.
 - **Reconcile the sub-agent reports into one findings list before you post.** ...
 - **A sub-agent reviewing work never edits it.** ...
-- Without sub-agents on your runtime, work the dimensions yourself one at a time.
```

The default is now the reviewer working the dimensions in its own run. Sub-agents are spent when the work earns it, on three named triggers, so a large or risky change still gets the fan-out unasked and a requester who wants one can always ask.

The mechanism is otherwise unchanged and still governs a fan-out once it happens: the ten cap, the adversarial brief, the reconcile-and-verify step, and the rule that a reviewing sub-agent never edits what it reviews. The brief moves into a bullet of its own because the bullet that used to carry it now states the default instead.

The old trailing line for a runtime without sub-agents becomes a clause on the default, where it is a restatement of the normal path rather than a fallback. Coverage still never depends on having sub-agents.

## Scope

The rule existed in exactly one authored place. Everything else the sweep turned up is a different mechanism and is unchanged:

- `agents/investment/risk-verifier.md` and `captain.md` — a role-level verification gate, not a sub-agent fan-out.
- `agents/investment/equity-analyst.md`, `agents/app-dev/architect.md` — sub-agents for parallel *research*.
- `skills/deep-research.md` — an adversarial *method*, no sub-agents.
- `agents/app-dev/qa-engineer.md` — supplies the eight dimensions the shared rule asks each role for. Orthogonal to when you fan out.

No marketplace regeneration: `SHARED_INSTRUCTIONS` is appended at run time by `resolveSystemPrompt` and is never baked into `marketplace/teams/*.json`.

## Tests

`template-resolver.test.ts` guards this prose. Per the assertion invariant in `.dev/writing-agent-prompts.md`, both removed assertion strings were replaced in the same commit and three were added for the new rule:

| Assertion | Action |
|---|---|
| `proving the work wrong rather than confirming it right` | reworded → `prove the work wrong, never to confirm it right` |
| `Without sub-agents on your runtime` | reworded → `runtime without sub-agents` |
| `Review a teammate's finished work yourself, one dimension at a time` | added — the new default |
| `when the work earns it`, `whenever the task asks for a deeper review` | added — the discretion and its trigger |
| `adversarial sub-agents`, `ten at most`, `drop what you cannot reproduce`, `never edits it` | kept |

The `comm` diff over the assertion inventory shows exactly those two removals and five additions, net +3 (308 → 311).

## Verification

- `template-resolver` (146), `qa-review-dimensions` (14), `prompt-style` (24), `marketplace` (54), `agent-prompt` (21) — all pass
- Siblings quoting shared prose: `qa-ci-merge-gate`, `mention-handoff-prompt`, `connector-recipes-skill`, `mcp-tools` (428), `description-tasks`, `agent-types`, `coach`, `default-skills`, `resolve-partials`, `captain-required-duties` — all pass
- `bun run typecheck` clean; both commit hooks passed without bypass
- `checkPromptStyle` over the reworked section reports **no findings** (bullets 27/52/31/40/22 words, longest sentence 24)

## Note

`agents/app-dev/team.json` v31 and the `latest_notes` it generates still describe the fan-out as unconditional. Changelog entries are an append-only record of what shipped at that version, so it was deliberately left alone; marketplace browsers will read the stale emphasis until the next app-dev version bump carries a correction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjMELXAX3gxWXZWCce7dFj)_