### PR TITLE
fix(deploy): serialize provisioned config safely

### DIFF
--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -34,7 +34,7 @@ runcmd:
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into
   # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
-  # provision.sh persists them into the service's config file. sslmode=require encrypts
+  # provision.sh persists them into the CommonJS config. sslmode=require encrypts
   # without verifying the certificate; for verified TLS use sslmode=verify-full plus
   # &sslrootcert=/etc/hezo/db-ca.crt when the provider signs with its own CA (most do).
   # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -75,17 +75,143 @@ RELEASE_TAG="${HEZO_RELEASE_TAG:-latest}"
 # firewall rule cannot drift apart.
 APP_PORT=3100
 
-# Cloud-init can seed optional settings (managed database / asset storage, domain
-# override) into deploy.env before this script runs — pick them up. Explicit shell
-# environment still wins over the file.
-if [[ -f "${DEPLOY_ENV}" ]]; then
+log() { echo "[hezo-provision] $*"; }
+
+# BEGIN CONFIG ADAPTER FUNCTIONS
+load_env_file() {
+	local path="$1" allowed="$2" key value
+	[[ -f "${path}" ]] || return 0
 	while IFS='=' read -r key value; do
-		[[ "${key}" =~ ^(HEZO_[A-Z_]+|BEHIND_GATEWAY)$ ]] || continue
+		[[ "${key}" =~ ${allowed} ]] || continue
 		if [[ -z "${!key:-}" ]]; then
 			export "${key}=${value}"
 		fi
-	done <"${DEPLOY_ENV}"
-fi
+	done <"${path}"
+}
+
+json_string() {
+	local input="$1" output="" char escaped code index
+	local LC_ALL=C
+	for ((index = 0; index < ${#input}; index++)); do
+		char="${input:index:1}"
+		case "${char}" in
+		'"') output+='\"' ;;
+		'\') output+='\\' ;;
+		$'\b') output+='\b' ;;
+		$'\f') output+='\f' ;;
+		$'\n') output+='\n' ;;
+		$'\r') output+='\r' ;;
+		$'\t') output+='\t' ;;
+		*)
+			printf -v code '%d' "'${char}"
+			if ((code < 32)); then
+				printf -v escaped '\\u%04x' "${code}"
+				output+="${escaped}"
+			else
+				output+="${char}"
+			fi
+			;;
+		esac
+	done
+	printf '"%s"' "${output}"
+}
+
+prepare_config_values() {
+	if [[ -n "${HEZO_DATABASE_POOL_SIZE:-}" ]]; then
+		if [[ ! "${HEZO_DATABASE_POOL_SIZE}" =~ ^([1-9]|[1-9][0-9]|100)$ ]]; then
+			echo "HEZO_DATABASE_POOL_SIZE must be an integer from 1 to 100." >&2
+			return 1
+		fi
+		HEZO_DATABASE_POOL_SIZE_JSON="${HEZO_DATABASE_POOL_SIZE}"
+	else
+		HEZO_DATABASE_POOL_SIZE_JSON=""
+	fi
+	WEB_URL_FILE_JSON="$(json_string "${WEB_URL_FILE}")"
+	DATA_DIR_JSON="$(json_string "${DATA_DIR}")"
+	HEZO_DATABASE_URL_JSON="$(json_string "${HEZO_DATABASE_URL:-}")"
+	HEZO_ASSET_STORAGE_URL_JSON="$(json_string "${HEZO_ASSET_STORAGE_URL:-}")"
+}
+
+load_legacy_config() {
+	LEGACY_ENV_CARRIED=""
+	if [[ -f "${LEGACY_ENV}" && ! -f "${CONFIG_FILE}" ]]; then
+		while IFS='=' read -r key value; do
+			[[ "${key}" =~ ^(HEZO_DATA_DIR|HEZO_WEB_URL|HEZO_DATABASE_URL|HEZO_DATABASE_POOL_SIZE|HEZO_ASSET_STORAGE_URL)$ ]] || continue
+			if [[ -z "${!key:-}" ]]; then
+				export "${key}=${value}"
+				LEGACY_ENV_CARRIED+=" ${key}"
+			fi
+		done <"${LEGACY_ENV}"
+		log "Found ${LEGACY_ENV} from a pre-0.50 install."
+		if [[ -n "${LEGACY_ENV_CARRIED}" ]]; then
+			log "Carrying into ${CONFIG_FILE}:${LEGACY_ENV_CARRIED}"
+		fi
+		if [[ -n "${HEZO_WEB_URL:-}" && ! -s "${WEB_URL_FILE}" ]]; then
+			echo "${HEZO_WEB_URL}" >"${WEB_URL_FILE}"
+			log "Seeded ${WEB_URL_FILE} with ${HEZO_WEB_URL}"
+		fi
+	fi
+}
+
+write_hezo_config() {
+	[[ -f "${CONFIG_FILE}" ]] && return
+	# Mode 600: this file can hold database and object-storage credentials.
+	install -m 600 /dev/null "${CONFIG_FILE}"
+	cat >"${CONFIG_FILE}" <<EOF
+// Hezo configuration. Edit and restart: systemctl restart hezo
+// Reference: https://hezo.ai/docs/deployment/configuration
+//
+// Do NOT put your master key in this file. Hezo keeps it in memory only and comes up
+// locked after each restart by design; unlock it from the browser gate. A copy of the
+// key on disk next to the encrypted data would let anyone who reads this box decrypt
+// your vault.
+const { existsSync, readFileSync } = require('node:fs');
+
+// Written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
+const webUrlFile = ${WEB_URL_FILE_JSON};
+
+module.exports = {
+	dataDir: ${DATA_DIR_JSON},
+	webUrl: existsSync(webUrlFile) ? readFileSync(webUrlFile, 'utf8').trim() : '',
+EOF
+	# Managed data hosting (optional): persist the database / asset-storage settings
+	# provided at provision time. To wire them into an already-provisioned host, edit
+	# this file directly and restart hezo - see
+	# docs/deployment/one-click.md § Using managed data hosting.
+	if [[ -n "${HEZO_DATABASE_URL:-}" || -n "${HEZO_DATABASE_POOL_SIZE_JSON}" ]]; then
+		{
+			printf '\tdatabase: {\n'
+			[[ -n "${HEZO_DATABASE_URL:-}" ]] && printf '\t\turl: %s,\n' "${HEZO_DATABASE_URL_JSON}"
+			[[ -n "${HEZO_DATABASE_POOL_SIZE_JSON}" ]] && printf '\t\tpoolSize: %s,\n' "${HEZO_DATABASE_POOL_SIZE_JSON}"
+			printf '\t},\n'
+		} >>"${CONFIG_FILE}"
+	fi
+	if [[ -n "${HEZO_ASSET_STORAGE_URL:-}" ]]; then
+		printf '\tassetStorage: { url: %s },\n' "${HEZO_ASSET_STORAGE_URL_JSON}" >>"${CONFIG_FILE}"
+	fi
+	echo "};" >>"${CONFIG_FILE}"
+}
+
+retire_legacy_config() {
+	if [[ -n "${LEGACY_ENV_CARRIED}" && -f "${CONFIG_FILE}" && -f "${LEGACY_ENV}" ]]; then
+		mv "${LEGACY_ENV}" "${LEGACY_ENV}.migrated"
+		log "Renamed ${LEGACY_ENV} to ${LEGACY_ENV}.migrated (no longer read)."
+	fi
+}
+
+write_firstboot_env() {
+	install -m 600 /dev/null "${DEPLOY_ENV}"
+	[[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]] && printf 'HEZO_DOMAIN_OVERRIDE=%s\n' "${HEZO_DOMAIN_OVERRIDE}" >>"${DEPLOY_ENV}"
+	[[ -n "${HEZO_SWAP_SIZE:-}" ]] && printf 'HEZO_SWAP_SIZE=%s\n' "${HEZO_SWAP_SIZE}" >>"${DEPLOY_ENV}"
+	[[ -n "${BEHIND_GATEWAY}" ]] && printf 'BEHIND_GATEWAY=%s\n' "${BEHIND_GATEWAY}" >>"${DEPLOY_ENV}"
+	return 0
+}
+# END CONFIG ADAPTER FUNCTIONS
+
+# Cloud-init can seed optional settings (managed database / asset storage, domain
+# override) into deploy.env before this script runs - pick them up as literal data.
+# Explicit shell environment still wins over the file.
+load_env_file "${DEPLOY_ENV}" '^(HEZO_[A-Z_]+|BEHIND_GATEWAY)$'
 
 # Resolved once so every branch below reads the same answer, and so `set -u`
 # never trips on an unset optional flag.
@@ -95,8 +221,6 @@ if [[ "${BEHIND_GATEWAY}" == "1" && -z "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
 	echo "and this machine's own address is not the one users reach it by." >&2
 	exit 1
 fi
-
-log() { echo "[hezo-provision] $*"; }
 
 # ---------------------------------------------------------------------------
 # 1a. Migrate a pre-0.50 /etc/hezo/hezo.env
@@ -110,31 +234,13 @@ log() { echo "[hezo-provision] $*"; }
 #     nothing.
 # ---------------------------------------------------------------------------
 LEGACY_ENV="/etc/hezo/hezo.env"
-LEGACY_ENV_CARRIED=""
-if [[ -f "${LEGACY_ENV}" && ! -f "${CONFIG_FILE}" ]]; then
-	while IFS='=' read -r key value; do
-		[[ "${key}" =~ ^(HEZO_DATA_DIR|HEZO_WEB_URL|HEZO_DATABASE_URL|HEZO_DATABASE_POOL_SIZE|HEZO_ASSET_STORAGE_URL)$ ]] || continue
-		if [[ -z "${!key:-}" ]]; then
-			export "${key}=${value}"
-			LEGACY_ENV_CARRIED+=" ${key}"
-		fi
-	done <"${LEGACY_ENV}"
-	log "Found ${LEGACY_ENV} from a pre-0.50 install."
-	if [[ -n "${LEGACY_ENV_CARRIED}" ]]; then
-		log "Carrying into ${CONFIG_FILE}:${LEGACY_ENV_CARRIED}"
-	fi
-	# The generated config reads its webUrl from the side file hezo-firstboot
-	# writes, and firstboot will not re-run here - its sentinel was set the day
-	# this host was provisioned. Seed the file from the old variable instead of
-	# special-casing the generator, so both paths keep one mechanism.
-	if [[ -n "${HEZO_WEB_URL:-}" && ! -s "${WEB_URL_FILE}" ]]; then
-		echo "${HEZO_WEB_URL}" >"${WEB_URL_FILE}"
-		log "Seeded ${WEB_URL_FILE} with ${HEZO_WEB_URL}"
-	fi
-fi
+load_legacy_config
 
 # An operator who moved the data dir keeps it. Everything below writes to this path.
 DATA_DIR="${HEZO_DATA_DIR:-${DATA_DIR}}"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+	prepare_config_values
+fi
 
 # ---------------------------------------------------------------------------
 # 1. Swap file — give low-RAM hosts a memory cushion so the install itself and
@@ -286,62 +392,16 @@ curl -fsSL -o /usr/local/bin/hezo "${BINARY_URL}"
 chmod +x /usr/local/bin/hezo
 
 # ---------------------------------------------------------------------------
-# 4. Data dir + environment file (never overwrite an operator-edited env file)
+# 4. Data dir + config file (never overwrite an operator-edited config file)
 # ---------------------------------------------------------------------------
 install -d -m 700 /etc/hezo
 install -d -m 755 "${DATA_DIR}"
-if [[ ! -f "${CONFIG_FILE}" ]]; then
-	# Mode 600: this file can hold database and object-storage credentials.
-	install -m 600 /dev/null "${CONFIG_FILE}"
-	cat >"${CONFIG_FILE}" <<EOF
-// Hezo configuration. Edit and restart: systemctl restart hezo
-// Reference: https://hezo.ai/docs/deployment/configuration
-//
-// Do NOT put your master key in this file. Hezo keeps it in memory only and comes up
-// locked after each restart by design; unlock it from the browser gate. A copy of the
-// key on disk next to the encrypted data would let anyone who reads this box decrypt
-// your vault.
-const { existsSync, readFileSync } = require('node:fs');
+write_hezo_config
+retire_legacy_config
 
-// Written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
-const webUrlFile = '${WEB_URL_FILE}';
-
-module.exports = {
-	dataDir: '${DATA_DIR}',
-	webUrl: existsSync(webUrlFile) ? readFileSync(webUrlFile, 'utf8').trim() : '',
-EOF
-	# Managed data hosting (optional): persist the database / asset-storage settings
-	# provided at provision time. To wire them into an already-provisioned host, edit
-	# this file directly and restart hezo — see
-	# docs/deployment/one-click.md § Using managed data hosting.
-	if [[ -n "${HEZO_DATABASE_URL:-}" || -n "${HEZO_DATABASE_POOL_SIZE:-}" ]]; then
-		{
-			echo "	database: {"
-			[[ -n "${HEZO_DATABASE_URL:-}" ]] && echo "		url: '${HEZO_DATABASE_URL}',"
-			[[ -n "${HEZO_DATABASE_POOL_SIZE:-}" ]] && echo "		poolSize: ${HEZO_DATABASE_POOL_SIZE},"
-			echo "	},"
-		} >>"${CONFIG_FILE}"
-	fi
-	if [[ -n "${HEZO_ASSET_STORAGE_URL:-}" ]]; then
-		echo "	assetStorage: { url: '${HEZO_ASSET_STORAGE_URL}' }," >>"${CONFIG_FILE}"
-	fi
-	echo "};" >>"${CONFIG_FILE}"
-fi
-
-# Now that the settings live in the config file, take the old one out of the way:
-# nothing reads it any more, and leaving it invites a hand-edit that does nothing.
-if [[ -n "${LEGACY_ENV_CARRIED}" && -f "${CONFIG_FILE}" && -f "${LEGACY_ENV}" ]]; then
-	mv "${LEGACY_ENV}" "${LEGACY_ENV}.migrated"
-	log "Renamed ${LEGACY_ENV} to ${LEGACY_ENV}.migrated (no longer read)."
-fi
-
-# Persist optional settings the first-boot unit reads (domain override, swap size).
-if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" || -n "${HEZO_SWAP_SIZE:-}" || -n "${BEHIND_GATEWAY}" ]]; then
-	install -m 600 /dev/null "${DEPLOY_ENV}"
-	[[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]] && echo "HEZO_DOMAIN_OVERRIDE=${HEZO_DOMAIN_OVERRIDE}" >>"${DEPLOY_ENV}"
-	[[ -n "${HEZO_SWAP_SIZE:-}" ]] && echo "HEZO_SWAP_SIZE=${HEZO_SWAP_SIZE}" >>"${DEPLOY_ENV}"
-	[[ -n "${BEHIND_GATEWAY}" ]] && echo "BEHIND_GATEWAY=${BEHIND_GATEWAY}" >>"${DEPLOY_ENV}"
-fi
+# Keep only settings the first-boot unit still needs. Managed credentials now live
+# in the root-only CommonJS config and must not remain in a second file.
+write_firstboot_env
 
 # ---------------------------------------------------------------------------
 # 5. Caddy (reverse proxy, automatic HTTPS, WebSocket passthrough)
@@ -399,11 +459,14 @@ cat >/usr/local/sbin/hezo-firstboot.sh <<'EOF'
 # writes it where Caddy (/etc/caddy/hezo.env) and Hezo (/etc/hezo/web-url, read
 # by /etc/hezo/hezo.config.cjs) each pick it up.
 set -euo pipefail
+EOF
+declare -f load_env_file >>/usr/local/sbin/hezo-firstboot.sh
+cat >>/usr/local/sbin/hezo-firstboot.sh <<'EOF'
 
 SENTINEL="/var/lib/hezo/.firstboot-done"
 [[ -f "${SENTINEL}" ]] && exit 0
 
-[[ -f /etc/hezo/deploy.env ]] && . /etc/hezo/deploy.env
+load_env_file /etc/hezo/deploy.env '^(HEZO_DOMAIN_OVERRIDE|HEZO_SWAP_SIZE|BEHIND_GATEWAY)$'
 
 # Ensure host swap exists before Caddy/Hezo start (no-op if already active). On the
 # machine-image path this is where swap first gets created, since provision.sh

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -87,7 +87,7 @@ runcmd:
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
   # To use a managed database and/or object storage for assets, seed the URLs into
   # /etc/hezo/deploy.env (root-only, mode 600 - not /etc/environment: they carry credentials).
-  # provision.sh persists them into the service's env file. sslmode=require encrypts
+  # provision.sh persists them into the CommonJS config. sslmode=require encrypts
   # without verifying the certificate; for verified TLS use sslmode=verify-full plus
   # &sslrootcert=/etc/hezo/db-ca.crt when the provider signs with its own CA (most do).
   # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]

--- a/packages/server/test/deploy-scripts.test.ts
+++ b/packages/server/test/deploy-scripts.test.ts
@@ -1,5 +1,6 @@
-import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -7,15 +8,112 @@ const REPO_ROOT = join(import.meta.dirname, '../../..');
 
 /**
  * The deploy scripts run as root on a fresh host, install packages and rewrite
- * the firewall. Nothing here can execute them, so this covers the two things a
- * static check genuinely can: that they parse, and that the behind-a-gateway
- * flag actually gates the parts that would fight the gateway.
+ * the firewall. Static checks cover their syntax and gateway guards. The
+ * config adapter is isolated in shell functions, so its file migration and
+ * generated CommonJS can run against a temporary directory here.
  *
  * A syntax error in one of these is invisible until a real provision run fails
  * halfway through, having already half-configured the host.
  */
 
 const DEPLOY = join(REPO_ROOT, 'deploy');
+const PROVISION = readFileSync(join(DEPLOY, 'provision.sh'), 'utf8');
+const CLOUD_INIT = readFileSync(join(DEPLOY, 'cloud-init/hezo.cloud-config.yaml'), 'utf8');
+const ONE_CLICK = readFileSync(join(REPO_ROOT, 'docs/deployment/one-click.md'), 'utf8');
+
+const CONFIG_FUNCTIONS_START = '# BEGIN CONFIG ADAPTER FUNCTIONS';
+const CONFIG_FUNCTIONS_END = '# END CONFIG ADAPTER FUNCTIONS';
+
+function configFunctions(): string {
+	const start = PROVISION.indexOf(CONFIG_FUNCTIONS_START);
+	const end = PROVISION.indexOf(CONFIG_FUNCTIONS_END);
+	expect(start, 'config helper start marker').toBeGreaterThan(-1);
+	expect(end, 'config helper end marker').toBeGreaterThan(start);
+	return PROVISION.slice(start + CONFIG_FUNCTIONS_START.length, end);
+}
+
+interface GeneratedConfig {
+	dataDir: string;
+	webUrl: string;
+	database?: { url?: string; poolSize?: number };
+	assetStorage?: { url: string };
+}
+
+function runConfigAdapter(
+	env: Record<string, string>,
+	mode: 'existing' | 'legacy' | 'managed' = 'managed',
+): {
+	config?: GeneratedConfig;
+	configExists: boolean;
+	commandExecuted: boolean;
+	deployEnvContents: string;
+	legacyMigrated: boolean;
+	stderr: string;
+	status: number;
+} {
+	const dir = mkdtempSync(join(tmpdir(), 'hezo-provision-config-'));
+	try {
+		const configFile = join(dir, 'hezo.config.cjs');
+		const commandMarker = join(dir, 'command-ran');
+		const deployEnv = join(dir, 'deploy.env');
+		const legacyEnv = join(dir, 'hezo.env');
+		const webUrlFile = join(dir, 'web-\'url\\"path');
+		const { DEPLOY_CONTENT = '', LEGACY_CONTENT = '', ...adapterEnv } = env;
+		if (DEPLOY_CONTENT)
+			writeFileSync(deployEnv, DEPLOY_CONTENT.replaceAll('__COMMAND_MARKER__', commandMarker));
+		if (mode === 'legacy') writeFileSync(legacyEnv, LEGACY_CONTENT);
+		if (mode === 'existing')
+			writeFileSync(configFile, 'module.exports = { dataDir: "/existing" };');
+		const harness = join(dir, 'config-harness.sh');
+		writeFileSync(
+			harness,
+			`set -euo pipefail\n${configFunctions()}\nlog() { :; }\n` +
+				'load_env_file "$DEPLOY_ENV" \'^(HEZO_[A-Z_]+|BEHIND_GATEWAY)$\'\n' +
+				`BEHIND_GATEWAY="\${BEHIND_GATEWAY:-}"\n` +
+				'if [[ "$1" == "legacy" ]]; then\n' +
+				'  load_legacy_config\n' +
+				'fi\n' +
+				`DATA_DIR="\${HEZO_DATA_DIR:-\${DATA_DIR}}"\n` +
+				'if [[ ! -f "$CONFIG_FILE" ]]; then prepare_config_values || exit $?; fi\n' +
+				'write_hezo_config\n' +
+				'if [[ "$1" == "legacy" ]]; then retire_legacy_config; fi\n' +
+				'write_firstboot_env\n',
+		);
+		const result = spawnSync('bash', [harness, mode], {
+			encoding: 'utf8',
+			env: {
+				PATH: process.env.PATH ?? '/usr/bin:/bin',
+				CONFIG_FILE: configFile,
+				DEPLOY_ENV: deployEnv,
+				LEGACY_ENV: legacyEnv,
+				WEB_URL_FILE: webUrlFile,
+				DATA_DIR: '/var/lib/hezo',
+				...adapterEnv,
+			},
+		});
+		const configExists = existsSync(configFile);
+		const config = configExists
+			? (JSON.parse(
+					execFileSync(
+						process.execPath,
+						['-e', 'process.stdout.write(JSON.stringify(require(process.argv[1])))', configFile],
+						{ encoding: 'utf8' },
+					),
+				) as GeneratedConfig)
+			: undefined;
+		return {
+			config,
+			configExists,
+			commandExecuted: existsSync(commandMarker),
+			deployEnvContents: readFileSync(deployEnv, 'utf8'),
+			legacyMigrated: existsSync(`${legacyEnv}.migrated`),
+			stderr: result.stderr,
+			status: result.status ?? 1,
+		};
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
 
 function shellScripts(dir: string): string[] {
 	const out: string[] = [];
@@ -43,7 +141,7 @@ describe('deploy shell scripts', () => {
 });
 
 describe('the behind-a-gateway seam in provision.sh', () => {
-	const script = readFileSync(join(DEPLOY, 'provision.sh'), 'utf8');
+	const script = PROVISION;
 
 	/** The lines of the `if`/`else` arm that `marker` sits in. */
 	function guardAbove(marker: string): string {
@@ -87,5 +185,180 @@ describe('the behind-a-gateway seam in provision.sh', () => {
 
 	it('documents the flag where an operator reading the script will find it', () => {
 		expect(script).toMatch(/^#\s+BEHIND_GATEWAY\s/m);
+	});
+});
+
+describe('the one-click managed-backend configuration contract', () => {
+	it.each([
+		['the checked-in cloud-init file', CLOUD_INIT],
+		['the one-click documentation sample', ONE_CLICK],
+	])('%s seeds both managed-backend URLs through deploy.env', (_name, sample) => {
+		expect(sample).toContain('/etc/hezo/deploy.env');
+		expect(sample).toMatch(/provision\.sh persists them into the CommonJS config/);
+		expect(sample).toMatch(
+			/HEZO_DATABASE_URL=postgres:\/\/hezo:PASSWORD@db-host:5432\/hezo\?sslmode=require.*>> \/etc\/hezo\/deploy\.env/,
+		);
+		expect(sample).toMatch(
+			/HEZO_ASSET_STORAGE_URL=s3:\/\/ACCESS_KEY:SECRET@endpoint\/bucket.*>> \/etc\/hezo\/deploy\.env/,
+		);
+	});
+
+	it('carries ordinary deploy.env inputs into the generated CommonJS config', () => {
+		expect(PROVISION).toContain('DEPLOY_ENV="/etc/hezo/deploy.env"');
+		expect(PROVISION).toContain(`done <"\${path}"`);
+		expect(PROVISION).toContain(`export "\${key}=\${value}"`);
+		expect(PROVISION).not.toMatch(/(?:^|\n)\s*(?:[.]|source)\s+\/etc\/hezo\/deploy\.env/m);
+		expect(PROVISION).toContain('declare -f load_env_file >>/usr/local/sbin/hezo-firstboot.sh');
+		expect(PROVISION).toContain(
+			"load_env_file /etc/hezo/deploy.env '^(HEZO_DOMAIN_OVERRIDE|HEZO_SWAP_SIZE|BEHIND_GATEWAY)$'",
+		);
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: [
+				'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket',
+				'HEZO_DATABASE_POOL_SIZE=25',
+				'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require',
+				'',
+			].join('\n'),
+		});
+		expect(result).toMatchObject({
+			config: {
+				assetStorage: { url: 's3://ACCESS_KEY:SECRET@endpoint/bucket' },
+				database: {
+					poolSize: 25,
+					url: 'postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require',
+				},
+			},
+			deployEnvContents: '',
+			status: 0,
+		});
+	});
+
+	it('keeps literal firstboot settings while removing managed credentials from deploy.env', () => {
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: [
+				'HEZO_DOMAIN_OVERRIDE=hezo.example.test',
+				'HEZO_SWAP_SIZE=2G',
+				'BEHIND_GATEWAY=1',
+				'HEZO_DATABASE_URL=postgres://hezo:password@db-host:5432/hezo',
+				'HEZO_ASSET_STORAGE_URL=s3://key:secret@endpoint/bucket',
+				'',
+			].join('\n'),
+		});
+		expect(result).toMatchObject({
+			deployEnvContents: [
+				'HEZO_DOMAIN_OVERRIDE=hezo.example.test',
+				'HEZO_SWAP_SIZE=2G',
+				'BEHIND_GATEWAY=1',
+				'',
+			].join('\n'),
+			status: 0,
+		});
+	});
+
+	it('preserves quotes and backslashes from deploy.env in every generated string value', () => {
+		const dataDir = '/var/lib/hezo/user\'s\\"data';
+		const databaseUrl = 'postgres://hezo:pa\'ss\\"word@db-host:5432/hezo';
+		const assetUrl = 's3://key:sec\'ret\\"piece@endpoint/bucket';
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: [
+				`HEZO_DATA_DIR=${dataDir}`,
+				`HEZO_ASSET_STORAGE_URL=${assetUrl}`,
+				`HEZO_DATABASE_URL=${databaseUrl}`,
+				'',
+			].join('\n'),
+		});
+		expect(result.status).toBe(0);
+		expect(result.stderr).toBe('');
+		expect(result.config).toMatchObject({
+			assetStorage: { url: assetUrl },
+			database: { url: databaseUrl },
+			dataDir,
+		});
+	});
+
+	it('treats command substitutions in deploy.env values as data and removes the credential copy', () => {
+		const databaseUrl = 'postgres://hezo:$(touch __COMMAND_MARKER__)@db-host:5432/hezo';
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: `HEZO_DATABASE_URL=${databaseUrl}\n`,
+		});
+		expect(result).toMatchObject({
+			commandExecuted: false,
+			config: { database: { url: expect.stringContaining('$(touch ') } },
+			deployEnvContents: '',
+			status: 0,
+		});
+	});
+
+	it('serializes shell-provided control characters without changing their values', () => {
+		const dataDir = '/var/lib/hezo/control\b\f\n\r\t\u0001';
+		const result = runConfigAdapter({ DATA_DIR: dataDir });
+		expect(result).toMatchObject({ config: { dataDir }, status: 0 });
+	});
+
+	it('leaves an existing config untouched even when stale provision inputs are invalid', () => {
+		const result = runConfigAdapter(
+			{ DEPLOY_CONTENT: 'HEZO_DATABASE_POOL_SIZE=not-a-number\n' },
+			'existing',
+		);
+		expect(result).toMatchObject({
+			config: { dataDir: '/existing' },
+			status: 0,
+		});
+	});
+
+	it.each([
+		['1', 1],
+		['100', 100],
+	])('accepts database pool-size boundary %s', (poolSize, expected) => {
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: `HEZO_DATABASE_POOL_SIZE=${poolSize}\n`,
+		});
+		expect(result).toMatchObject({
+			config: { database: { poolSize: expected } },
+			status: 0,
+		});
+	});
+
+	it('carries legacy values exactly and retires the legacy env only after writing config', () => {
+		const dataDir = "/srv/hezo/legacy's\\data";
+		const databaseUrl = "postgres://hezo:old'pass\\word@db-host:5432/hezo";
+		const assetUrl = "s3://key:old'secret\\part@endpoint/bucket";
+		const result = runConfigAdapter(
+			{
+				LEGACY_CONTENT: [
+					`HEZO_DATA_DIR=${dataDir}`,
+					'HEZO_WEB_URL=https://legacy.example.test',
+					`HEZO_DATABASE_URL=${databaseUrl}`,
+					'HEZO_DATABASE_POOL_SIZE=17',
+					`HEZO_ASSET_STORAGE_URL=${assetUrl}`,
+					'',
+				].join('\n'),
+			},
+			'legacy',
+		);
+		expect(result).toMatchObject({
+			config: {
+				assetStorage: { url: assetUrl },
+				database: { poolSize: 17, url: databaseUrl },
+				dataDir,
+				webUrl: 'https://legacy.example.test',
+			},
+			legacyMigrated: true,
+			status: 0,
+		});
+	});
+
+	it.each([
+		'0',
+		'101',
+		'1; globalThis.injected = true',
+		'10.5',
+	])('rejects invalid database pool size %s before writing config', (poolSize) => {
+		const result = runConfigAdapter({
+			DEPLOY_CONTENT: `HEZO_DATABASE_POOL_SIZE=${poolSize}\n`,
+		});
+		expect(result.status).not.toBe(0);
+		expect(result.configExists).toBe(false);
+		expect(result.stderr).toContain('HEZO_DATABASE_POOL_SIZE must be an integer from 1 to 100');
 	});
 });


### PR DESCRIPTION
## Summary

- serialize every string written to `/etc/hezo/hezo.config.cjs` as a JSON-compatible JavaScript literal
- validate `HEZO_DATABASE_POOL_SIZE` as an integer from 1 to 100 before writing config
- parse `deploy.env` as literal data, remove managed credentials after migration, and use the same safe loader at first boot
- preserve legacy `/etc/hezo/hezo.env` migration and existing operator-edited configs
- extend the deployment contract suite across managed, legacy, hostile-value, and upgrade paths

## Ticket

HM-594

## Verification

- `bun run test --skip-browser --skip-bun-native --pattern deploy-scripts --pattern docs-bundle --pattern docs-links --pattern config-file --pattern removed-env --pattern asset-storage-url --pattern db-postgres-url` - 134 passed
- `bun run build` - passed
- `bun run typecheck` - passed
- `bun run check` - exit 0 with 323 pre-existing warnings
- Bash syntax, YAML parsing, `git diff --check`, and added-line policy sweeps - passed

## Deployment notes

No manual migration is required. Existing config files are left untouched. On a fresh or legacy provision, managed settings move into the root-only CommonJS config and `deploy.env` is reduced to first-boot-only settings.

This PR must not be merged before the QA and approval gates are complete.