### PR TITLE
fix: canonicalize audited documentation links

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -39,7 +39,7 @@ each project's manifest focused while still letting broadly-useful know-how reac
 - **Author them yourself.** Open **Settings → Skills** (the global Skills page) and write
   one directly, choosing its scope (global, or a specific project) as you add it. The editor
   previews the markdown as you go.
-- **Search and add from [skills.sh](https://skills.sh).** With a skills.sh token
+- **Search and add from [skills.sh](https://www.skills.sh/).** With a skills.sh token
   configured, search the public registry and install a skill straight into your catalog.
 - **Let agents contribute.** While working, an agent can add a skill directly
   (`create_skill`) or, when you'd rather review first, file one for your approval
@@ -71,7 +71,7 @@ how to drive that service as a skill, and keeps the skill updated as it learns m
 teammates can use the connection without re-deriving the integration from vendor docs. The
 skill's scope follows the connector's: a connector shared with every project gets a global
 skill, a project's own connector a project skill. Where a good public skill already exists
-on [skills.sh](https://skills.sh), agents persist that one into your catalog instead of
+on [skills.sh](https://www.skills.sh/), agents persist that one into your catalog instead of
 writing their own, and layer anything project-specific as a separate project skill that
 references it.
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -242,7 +242,7 @@ HTTPS is essential for a working instance - OAuth-connected MCP servers only com
 their connect flow on an HTTPS address, installing Hezo on your phone needs a secure
 context, and the web app streams agent activity over a secure WebSocket. But a fresh
 server has a public IP and usually no domain. To bridge that, the deploy uses
-**[sslip.io](https://sslip.io)** - a DNS service where `<ip>.sslip.io` always resolves
+**[sslip.io](https://nip.io/)** - a DNS service where `<ip>.sslip.io` always resolves
 to `<ip>`. So `https://203.0.113.10.sslip.io` points straight at your server, and Caddy
 automatically obtains a real Let's Encrypt certificate for it. No domain to buy, no DNS
 to configure, and no browser warnings.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ the instance at a managed sandbox service instead (below).
   Docker all work - Hezo finds the daemon's socket automatically, whichever you use. On
   startup it checks for a working daemon and, if none is reachable, prints how to install
   or start one (with a link to
-  [Docker's install page](https://docs.docker.com/get-docker/)) and exits - so set one up
+  [Docker's install page](https://docs.docker.com/get-started/get-docker/)) and exits - so set one up
   first. On **Windows**, where the console window closes with the process and would take
   that message with it, Hezo instead shows a dialog and offers to open Docker Desktop in
   the Microsoft Store. See [Container runtimes](/docs/deployment/container-runtimes) for

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1221,7 +1221,7 @@ Two kinds:
 | `mcp_url` | `string` | No | URL of the MCP server (HTTP / SSE) - required for kind 'saas'. The OAuth dance is discovered by probing this URL for a 401 + WWW-Authenticate header. |
 | `mcp_transport` | `http` \| `sse` | No | Transport for the MCP server. Defaults to http. |
 | `provider_id` | `string` | No | Optional MCP capability-registry key (e.g. "datocms", "github"). When set, capability defaults from the shared registry pre-fill display name and allowed hosts. This is the MCP-server registry namespace - not the OAuth-broker provider (see oauth_provider_id). |
-| `base_url` | `string` | No | For kind 'api' - the REST API base URL agents call (e.g. https://www.googleapis.com/youtube/v3). |
+| `base_url` | `string` | No | For kind 'api' - the REST API base URL agents call (e.g. `https://www.googleapis.com/youtube/v3`). |
 | `allowed_hosts` | `string[]` | No | For kind 'api' - the hosts the credential may be sent to (e.g. ["*.googleapis.com"]). Required for api connectors. |
 | `auth` | `object` | No | For kind 'api' - where the credential rides. Defaults to an `Authorization: Bearer ` header when omitted (the right default for OAuth access tokens). |
 | `oauth_provider_id` | `string` | No | For kind 'api' only - a bundled OAuth-broker provider key (e.g. "google-youtube") to pre-select for the human. The provider is then LOCKED in the completion UI: the human finishes the OAuth device flow inline (in the task comment or on the Connectors page) by pasting only a client id - no provider picker. Omit for a plain API-key REST connector. |

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -4066,7 +4066,7 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe(
-					"For kind 'api' - the REST API base URL agents call (e.g. https://www.googleapis.com/youtube/v3).",
+					"For kind 'api' - the REST API base URL agents call (e.g. `https://www.googleapis.com/youtube/v3`).",
 				),
 			allowed_hosts: z
 				.array(z.string())

--- a/packages/server/src/services/docker-preflight.ts
+++ b/packages/server/src/services/docker-preflight.ts
@@ -13,7 +13,7 @@ import {
  * Covers Docker Engine (Linux), Docker Desktop (macOS/Windows), and the
  * post-install steps for starting the daemon.
  */
-export const DOCKER_INSTALL_URL = 'https://docs.docker.com/get-docker/';
+export const DOCKER_INSTALL_URL = 'https://docs.docker.com/get-started/get-docker/';
 
 /** Where the supported-runtime list and socket-discovery order are documented. */
 export const CONTAINER_RUNTIMES_DOCS_URL = 'https://hezo.ai/docs/deployment/container-runtimes';

--- a/packages/server/test/docker-preflight.test.ts
+++ b/packages/server/test/docker-preflight.test.ts
@@ -194,6 +194,7 @@ describe('formatDockerPreflightMessage', () => {
 
 	it('points at the Docker install page when nothing is installed', () => {
 		const msg = formatDockerPreflightMessage(notInstalled);
+		expect(DOCKER_INSTALL_URL).toBe('https://docs.docker.com/get-started/get-docker/');
 		expect(msg).toContain(DOCKER_INSTALL_URL);
 		expect(msg).toContain('A Docker-compatible container runtime is required');
 	});

--- a/packages/server/test/mcp-reference.test.ts
+++ b/packages/server/test/mcp-reference.test.ts
@@ -82,6 +82,14 @@ describe('MCP API reference (docs/reference/mcp-api.md)', () => {
 		expect(doc.section).toBe('Reference');
 		expect(doc.order).toBe(32);
 	});
+
+	it('renders the API base URL example as code instead of a navigation link', () => {
+		const { tools, onboarding } = collectReferenceTools();
+		const reference = generateMcpReference(tools, onboarding);
+		expect(reference).toContain(
+			"For kind 'api' - the REST API base URL agents call (e.g. `https://www.googleapis.com/youtube/v3`).",
+		);
+	});
 });
 
 describe('registry conventions', () => {


### PR DESCRIPTION
## What changed

- Render the YouTube API base URL example as inline code, preserving the documented value without emitting a broken navigation link.
- Update the Docker install, skills catalog, and sslip service links to the stable destinations reported by the audit.
- Keep the runtime Docker install prompt aligned with the documentation.
- Add regression assertions for the generated MCP reference and Docker install URL.

## Task

HM-673

## Verification

- Targeted red test: 2 expected failures before implementation.
- `bun run --cwd packages/server test -- test/mcp-reference.test.ts test/docker-preflight.test.ts`: 28 tests passed.
- `bun run check`: completed with existing warnings only.
- `bun run typecheck`: 5 tasks passed.
- Commit gate: lint, typecheck, full build, generated-doc freshness, and docs-link validation passed.
- External docs probes for skills.sh and nip.io were unreachable from the runner and correctly reported as non-blocking warnings.

## Deployment notes

Merge this PR before the website PR that pins commit `4bd67829`. No migration or configuration change is required.