### PR TITLE
test(container-hours): seed the ledger against the window it is billed in

### DIFF
--- a/.dev/seam-registry.md
+++ b/.dev/seam-registry.md
@@ -53,6 +53,7 @@ rather than here, is how a codebase ends up with two of everything.
 | A migration test | `createDataPreservationHarness()` (`test/helpers/migrate.ts`) |
 | A component test | `renderApp()` + `seed*()` (`packages/web/test/helpers/`) |
 | A complete test double | `createStubDocker()` (`test/helpers/app.ts`) - never a hand-rolled partial |
+| Seeding container uptime a calendar-window reader will bill | `seedUptimeStretch()` / `seedMonthToDateSeconds()` (`test/helpers/uptime.ts`) - web tests reach them through `@hezo/server/test/helpers/uptime` |
 | A CLI runtime's own quirk (env, flags, model-id form, usage recovery, run-end behaviour) | that runtime's `services/runtime-adapters/<runtime>.ts`, its section in `agent-stream-parser.ts`, or its `RUNTIME_*` row (`@hezo/shared`) |
 | An AI provider's own quirk (endpoint, credential env, subscription blob, judge model) | that provider's `PROVIDER_RUNTIME_ADAPTERS` entry (`@hezo/shared`), or its row in the per-provider table that owns the behaviour |
 

--- a/.dev/writing-tests.md
+++ b/.dev/writing-tests.md
@@ -22,6 +22,7 @@ in `AGENTS.md`; this is the how.
 - Use `ctx.app` / `ctx.baseUrl` / `ctx.port` — never a shared singleton, never a hardcoded port. No mutable state shared between files.
 - Pure logic tests can call functions directly.
 - GitHub OAuth/repo/SSH-key tests use `test/helpers/github-sim.ts` — set `GITHUB_API_BASE_URL` and `GITHUB_OAUTH_BASE_URL` before the context boots.
+- **Seed against the window the assertion reads, never a flat offset from `now()`.** A reader that clips to a calendar window bills only the part of the seeded row inside it, so `now() - interval '1 hour'` banks most of an hour in *last* month during the first hour of a new one and every fixed expectation reads the clipping as a bug — green all month, red on the release that lands after midnight UTC on the 1st. Seed through `test/helpers/uptime.ts` for container hours, and assert the width it hands back; elsewhere, cut the seed to the window and derive the expectation from what it actually covers.
 - `HEZO_SKIP_DOCKER=1` swaps in the in-process fake (`services/fake-docker.ts`). **Test/CI-only — never expose it to users.** The supported backends are the real ones (a local Docker-compatible runtime, or a managed sandbox service), so the fake must not appear in CLI/preflight output, `docs/`, README or `--help`; `docker-preflight.test.ts` guards this. Code comments and `.dev/` may reference it.
 
 ### Test-setup performance

--- a/packages/server/test/container-uptime-ledger.test.ts
+++ b/packages/server/test/container-uptime-ledger.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../src/services/sandbox/pool-db';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestTeam, projectSlugForTeamSlug } from './helpers/app';
+import { seedUptimeStretch } from './helpers/uptime';
 
 let app: Hono<Env>;
 let db: Db;
@@ -223,51 +224,58 @@ describe('aggregation', () => {
 	it('sums concurrent containers rather than merging them', async () => {
 		// Two containers up for the same hour is two container-hours - which is
 		// exactly what a provider bills, and exactly where per-agent run hours go
-		// wrong by merging runs that shared one container.
-		for (const id of ['c-par-a', 'c-par-b']) {
-			await db.query(
-				`INSERT INTO container_uptime_entries (project_id, container_id, started_at, ended_at, backend)
-				 VALUES ($1, $2, now() - interval '1 hour', now(), 'docker')`,
-				[projectId, id],
-			);
-		}
+		// wrong by merging runs that shared one container. Asserted against the
+		// span the seed actually banked: on the first hour of a month the
+		// month-to-date window is narrower than the hour asked for, and a merging
+		// reader still differs from a summing one by the same factor of two.
+		const span = await seedUptimeStretch(db, {
+			containers: ['c-par-a', 'c-par-b'],
+			minutes: 60,
+			projectId,
+		});
 		const totals = await containerHoursTotals(db, projectId);
-		expect(totals.month_seconds).toBe(2 * 3600);
+		expect(totals.month_seconds).toBe(2 * span);
 	});
 
 	it('bills an open interval up to now rather than counting it as zero', async () => {
-		await db.query(
-			`INSERT INTO container_uptime_entries (project_id, container_id, started_at, backend)
-			 VALUES ($1, 'c-open', now() - interval '30 minutes', 'docker')`,
-			[projectId],
-		);
+		const banked = await seedUptimeStretch(db, {
+			containers: ['c-open'],
+			minutes: 30,
+			projectId,
+			open: true,
+		});
 		const totals = await containerHoursTotals(db, projectId);
-		expect(totals.month_seconds).toBeGreaterThanOrEqual(29 * 60);
-		expect(totals.month_seconds).toBeLessThanOrEqual(31 * 60);
+		expect(totals.month_seconds).toBeGreaterThanOrEqual(banked);
+		expect(totals.month_seconds).toBeLessThanOrEqual(banked + 60);
 		expect(totals.open_intervals).toBe(1);
 	});
 
 	it('reports chat hours inside the total, not beside it', async () => {
-		await db.query(
-			`INSERT INTO container_uptime_entries (project_id, container_id, started_at, ended_at, reserved_for_chat, backend)
-			 VALUES ($1, 'c-chat-h', now() - interval '1 hour', now(), true, 'docker'),
-			        ($1, 'c-task-h', now() - interval '1 hour', now(), false, 'docker')`,
-			[projectId],
-		);
+		const chat = await seedUptimeStretch(db, {
+			containers: ['c-chat-h'],
+			minutes: 60,
+			projectId,
+			chat: true,
+		});
+		const task = await seedUptimeStretch(db, {
+			containers: ['c-task-h'],
+			minutes: 60,
+			projectId,
+		});
 		const totals = await containerHoursTotals(db, projectId);
-		expect(totals.month_seconds).toBe(2 * 3600);
-		expect(totals.month_chat_seconds).toBe(3600);
+		expect(totals.month_seconds).toBe(chat + task);
+		expect(totals.month_chat_seconds).toBe(chat);
 	});
 
 	it('scopes a project read to that project and keeps the instance read whole', async () => {
-		await db.query(
-			`INSERT INTO container_uptime_entries (project_id, container_id, started_at, ended_at, backend)
-			 VALUES ($1, 'c-mine', now() - interval '1 hour', now(), 'docker'),
-			        ($2, 'c-theirs', now() - interval '2 hours', now(), 'docker')`,
-			[projectId, otherProjectId],
-		);
-		expect((await containerHoursTotals(db, projectId)).month_seconds).toBe(3600);
-		expect((await containerHoursTotals(db, null)).month_seconds).toBe(3 * 3600);
+		const mine = await seedUptimeStretch(db, { containers: ['c-mine'], minutes: 60, projectId });
+		const theirs = await seedUptimeStretch(db, {
+			containers: ['c-theirs'],
+			minutes: 120,
+			projectId: otherProjectId,
+		});
+		expect((await containerHoursTotals(db, projectId)).month_seconds).toBe(mine);
+		expect((await containerHoursTotals(db, null)).month_seconds).toBe(mine + theirs);
 	});
 
 	it("keeps a deleted project's hours under one heading rather than dropping them", async () => {
@@ -289,16 +297,24 @@ describe('aggregation', () => {
 	it('counts only the part of an interval that falls inside this month', async () => {
 		// Straddles the month boundary. The month-to-date figure is what the hours
 		// cap is enforced against, so banking the whole interval would cut an
-		// instance off partway through its first day.
-		await db.query(
+		// instance off partway through its first day. It ends an hour into the
+		// month or now, whichever came first - a stretch that has not finished
+		// happening is not one the meter has any business billing.
+		const seeded = await db.query<{ seconds: number }>(
 			`INSERT INTO container_uptime_entries (project_id, container_id, started_at, ended_at, backend)
 			 VALUES ($1, 'c-month',
 			         date_trunc('month', now() AT TIME ZONE 'UTC') - interval '2 hours',
-			         date_trunc('month', now() AT TIME ZONE 'UTC') + interval '1 hour',
-			         'docker')`,
+			         LEAST(date_trunc('month', now() AT TIME ZONE 'UTC') + interval '1 hour',
+			               date_trunc('second', now())),
+			         'docker')
+			 RETURNING EXTRACT(EPOCH FROM
+			   (ended_at - date_trunc('month', now() AT TIME ZONE 'UTC')))::int AS seconds`,
 			[projectId],
 		);
-		expect(await monthToDateContainerSeconds(db)).toBe(3600);
+		// Non-zero, or the equality below would hold for a reader that banked
+		// nothing at all.
+		expect(seeded.rows[0].seconds).toBeGreaterThan(0);
+		expect(await monthToDateContainerSeconds(db)).toBe(seeded.rows[0].seconds);
 	});
 
 	it('emits every bucket in the window, including the quiet ones', async () => {

--- a/packages/server/test/helpers/uptime.ts
+++ b/packages/server/test/helpers/uptime.ts
@@ -1,0 +1,114 @@
+/**
+ * Seeding the container-hours ledger against the window it will be billed in.
+ *
+ * `services/container-hours.ts` counts only the part of a stretch that has
+ * already happened inside the window it was asked about. A seed written as a
+ * flat `now() - interval '1 hour'` therefore banks 51 minutes of *last* month
+ * during the first hour of a new one, and a fixed `3600` expectation reads that
+ * clipping as a bug - a whole-suite failure every month, on the release PR that
+ * happens to land just after midnight UTC.
+ *
+ * Every seed here is cut to the month so far and hands back the seconds it
+ * really banks, so the assertion built on it holds at any hour of any day.
+ */
+
+import type { Db } from '../../src/db/database';
+
+/** The reader's own month boundary, so seed and assertion cannot drift apart. */
+const MONTH_START = `date_trunc('month', now() AT TIME ZONE 'UTC')`;
+
+/**
+ * Whole seconds of the current UTC month already elapsed - the widest stretch a
+ * single container can have banked in it so far.
+ */
+async function monthWindowSeconds(db: Db): Promise<number> {
+	const res = await db.query<{ seconds: number }>(
+		`SELECT floor(EXTRACT(EPOCH FROM (now() - ${MONTH_START})))::int AS seconds`,
+	);
+	const seconds = res.rows[0]?.seconds ?? 0;
+	if (seconds <= 0) {
+		throw new Error(
+			'the UTC month is under a second old - no container time can have been banked in it yet',
+		);
+	}
+	return seconds;
+}
+
+export interface UptimeStretchOptions {
+	/** One row per container, every one of them over the same span. */
+	containers: string[];
+	/** How long the span is, at most: it is cut to the month so far. */
+	minutes: number;
+	projectId?: string | null;
+	/** Held by the assistant chat rather than by task work. */
+	chat?: boolean;
+	/** Leave it running - `ended_at` stays null and the reader bills it to now. */
+	open?: boolean;
+}
+
+/**
+ * Seed one stretch per container, all of them over the same span.
+ *
+ * Returns the seconds that span banks this month, so a caller asserts
+ * `n * width` rather than a figure that only holds mid-month. For an open
+ * stretch that is what it had banked at seeding time, which only grows.
+ */
+export async function seedUptimeStretch(db: Db, opts: UptimeStretchOptions): Promise<number> {
+	const window = await monthWindowSeconds(db);
+	const seconds = Math.min(opts.minutes * 60, window);
+	const ids = opts.containers.map((_, i) => `$${i + 5}`).join(', ');
+	const res = await db.query<{ seconds: number }>(
+		// `date_trunc('second', ...)` on both ends: a whole-second span banks a whole
+		// number of seconds, so the width returned here and the reader's own
+		// `SUM(...)::int` cannot disagree by a rounded half.
+		`WITH span AS (
+		   SELECT date_trunc('second', now()) - ($2::int * interval '1 second') AS started_at,
+		          date_trunc('second', now()) AS ended_at
+		 )
+		 INSERT INTO container_uptime_entries
+		     (project_id, container_id, started_at, ended_at, reserved_for_chat, backend)
+		 SELECT $1, c, span.started_at,
+		        CASE WHEN $3::bool THEN NULL ELSE span.ended_at END, $4::bool, 'docker'
+		   FROM span, unnest(ARRAY[${ids}]::text[]) AS c
+		 RETURNING floor(EXTRACT(EPOCH FROM (COALESCE(ended_at, now()) - started_at)))::int AS seconds`,
+		[opts.projectId ?? null, seconds, opts.open === true, opts.chat === true, ...opts.containers],
+	);
+	return res.rows[0]?.seconds ?? 0;
+}
+
+/** How many concurrent stretches one seed may take before it is a mistake. */
+const MAX_STRETCHES = 5_000;
+
+/**
+ * Seed exactly `seconds` of container time banked so far this month.
+ *
+ * Container-seconds sum across containers, so ten hours of them fit inside the
+ * first ten minutes of a month - as sixty containers, which is how a fleet
+ * spends them. One long stretch instead would run past `now()`, where the meter
+ * stops, and a cap enforced against the month-to-date figure would never trip.
+ */
+export async function seedMonthToDateSeconds(
+	db: Db,
+	seconds: number,
+	opts: { projectId?: string | null; chat?: boolean } = {},
+): Promise<void> {
+	if (seconds <= 0) return;
+	const window = await monthWindowSeconds(db);
+	const stretches = Math.ceil(seconds / window);
+	if (stretches > MAX_STRETCHES) {
+		throw new Error(
+			`${seconds}s needs ${stretches} concurrent stretches to fit in the ${window}s of this month so far - seed less, or seed it as one stretch and assert the clipped figure`,
+		);
+	}
+	await db.query(
+		// Every stretch starts at the month boundary and the last one is short, so
+		// the total is exact rather than a multiple of the window.
+		`INSERT INTO container_uptime_entries
+		     (project_id, container_id, started_at, ended_at, reserved_for_chat, backend)
+		 SELECT $1, 'ctr-' || gen_random_uuid()::text, ${MONTH_START},
+		        ${MONTH_START} + LEAST($2::int, $3::int - (g - 1) * $2::int) * interval '1 second',
+		        $4, 'docker'
+		   FROM generate_series(1, $5::int) AS g`,
+		[opts.projectId ?? null, window, seconds, opts.chat === true, stretches],
+	);
+}

--- a/packages/server/test/run-concurrency-capacity.test.ts
+++ b/packages/server/test/run-concurrency-capacity.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../src/services/run-concurrency';
 import { createStubDocker } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
+import { seedMonthToDateSeconds } from './helpers/uptime';
 
 /**
  * A stub engine so the budget resolves the same way it does in production: from
@@ -316,17 +317,13 @@ describe('container capacity', () => {
 	describe('the container-hours allowance', () => {
 		/** `hours` of closed uptime already spent this calendar month. */
 		async function seedSpentHours(hours: number): Promise<void> {
-			await db.query(
-				`INSERT INTO container_uptime_entries (container_id, started_at, ended_at, backend)
-				 VALUES ('spent', date_trunc('month', now() AT TIME ZONE 'UTC'),
-				         date_trunc('month', now() AT TIME ZONE 'UTC') + ($1::int * interval '1 hour'),
-				         'docker')`,
-				[hours],
-			);
+			await seedMonthToDateSeconds(db, hours * 3600);
 		}
 
 		it('never trips while no cap is set, however many hours were spent', async () => {
-			await seedSpentHours(10_000);
+			// The very spend that exhausts the ten-hour cap below: with no cap set
+			// the meter is never consulted at all.
+			await seedSpentHours(10);
 			expect((await getActiveContainers(db, engine)).hoursExhausted).toBe(false);
 		});
 

--- a/packages/web/test/budget-tabs.test.tsx
+++ b/packages/web/test/budget-tabs.test.tsx
@@ -1,3 +1,4 @@
+import { seedMonthToDateSeconds } from '@hezo/server/test/helpers/uptime';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedWorkspace } from './helpers/seed';
@@ -11,16 +12,17 @@ import { seedProject, seedWorkspace } from './helpers/seed';
  * carry a tab strip of its own, is asserted to have none.
  */
 
-/** A closed uptime interval of `minutes`, ending now. */
+/**
+ * `minutes` of closed container time banked so far this month.
+ *
+ * Not one interval `minutes` long: the tiles below read a month-to-date figure,
+ * and on the first hour of a month a stretch that far back is mostly last
+ * month's - which is what the meter would rightly report, leaving every fixed
+ * expectation here short.
+ */
 async function seedUptime(projectId: string, minutes: number, chat = false): Promise<void> {
 	const { db } = getTestContext();
-	await db.query(
-		`INSERT INTO container_uptime_entries
-		     (project_id, container_id, started_at, ended_at, reserved_for_chat, backend)
-		 VALUES ($1, 'ctr-' || gen_random_uuid()::text,
-		         now() - ($2::int * interval '1 minute'), now(), $3, 'docker')`,
-		[projectId, minutes, chat],
-	);
+	await seedMonthToDateSeconds(db, minutes * 60, { projectId, chat });
 }
 
 /** Insert a finished run of `minutes`, for the per-agent figure on the Spend tab. */


### PR DESCRIPTION
Fixes the eight test failures on CI run [3109](https://github.com/hezo-ai/hezo/actions/runs/33453511308), which ran nine minutes into September.

## What was wrong

`services/container-hours.ts` bills only the part of a stretch that has already happened inside the window it was asked about - that clipping is the module's whole purpose, and it is correct. The tests around it were not:

- **A flat `now() - interval '1 hour'` seed asserted as a whole 3600.** Nine minutes into a UTC month, 51 of those 60 minutes belong to *August*, so `month_seconds` came back 1095 instead of 7200 and the test read the clipping as a bug. Five cases in `container-uptime-ledger.test.ts`, one in `budget-tabs.test.tsx`.
- **The mirror-image seed in `run-concurrency-capacity.test.ts`:** ten hours booked from the month boundary *forwards*, so almost all of it sat in the future, where the meter rightly stops. The month-to-date figure reached 548 seconds and the ten-hour cap those tests exist to trip was never reached.

Neither seed is data production can produce: a stretch that has not finished happening is not one the meter has any business billing. Both are green all month and red on whatever lands just after midnight UTC on the 1st - this time the 0.57.0 release PR.

## What changed

New `packages/server/test/helpers/uptime.ts`, reached from both packages:

- `seedUptimeStretch()` cuts a stretch to the month so far and returns the seconds it actually banks, so a case asserts `2 * span` rather than a constant that only holds mid-month.
- `seedMonthToDateSeconds()` seeds an exact figure as concurrent stretches inside the elapsed window - which is how a fleet spends ten container-hours in ten minutes anyway. It refuses a seed that would need more than 5,000 of them rather than quietly banking less than asked.

Every assertion still says what it said before: two containers over one span is twice one of them, the chat share sits inside the total rather than beside it, an instance read is the sum of the project reads, and the two hours before a month boundary stay out of the month-to-date figure.

Also documented, since nothing else would catch the next one: the seeding rule in `.dev/writing-tests.md`, the helper in `.dev/seam-registry.md`.

## Testing

All three suites run green **at 00:33 UTC on the 1st** - the exact window that broke CI:

- `container-uptime-ledger.test.ts` - 29 passed
- `run-concurrency-capacity.test.ts` - 30 passed
- `budget-tabs.test.tsx` - 6 passed

Plus `bunx tsc` and `biome check` on the changed files, and the pre-commit hook's own lint/typecheck/build.

No source change: `packages/server/src` and `packages/web/src` are untouched.

## Note for the release PR

[#1066](https://github.com/hezo-ai/hezo/pull/1066) is cut from `main` and does not carry this fix, so re-running its jobs will fail identically until this merges and the release branch is re-cut or has `main` merged into it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1kmzABhQLmHkaXKpi1Q2X)_