### PR TITLE
feat(models): default OpenRouter connections to openrouter/auto

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3837,9 +3837,12 @@ model or jump price tier; version comparison reads `.` and `-` alike and drops d
 suffixes, so `claude-haiku-4-5-20251001` cannot outrank a later release on a date. The refresh
 **never touches an existing row** — it moves only the default offered to the next config
 added — and holds the previous pin on an unreachable provider, a rejected key or a family that
-matched nothing. Providers with no spec (the local runners) get no pin at all. It exists
-because a hardcoded id cannot notice its own retirement: a withdrawn one — once
-`gemini-1.5-flash`, the Google stop-hook judge — 404s on every run while the hook fails open.
+matched nothing. Providers with no spec (the local runners) get no pin at all. **OpenRouter's
+family is a single id**, `openrouter/auto`: a router has no version ladder inside it, and
+pinning one vendor line there discards the routing the operator chose OpenRouter for, so the
+refresh only ever confirms the catalog still lists that route. It exists because a hardcoded
+id cannot notice its own retirement: a withdrawn one — once `gemini-1.5-flash`, the Google
+stop-hook judge — 404s on every run while the hook fails open.
 
 **Reasoning effort.** Each run resolves an `agent_effort` level
 (`minimal|low|medium|high|max`) from the wakeup payload → `member_agents.default_effort` →

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -245,5 +245,9 @@ yours until you change it, and a refresh only moves the default offered to the *
 connection you add. If a provider is unreachable when the refresh runs, its previous
 default stands.
 
+**OpenRouter starts on `openrouter/auto`**, OpenRouter's own routing endpoint, which picks a
+model per request instead of fixing one. That is the routing you signed up for; pick a
+specific model from the list if you would rather choose yourself.
+
 Local model servers have no pinned default: the catalog is whatever you have pulled, so
 the CLI's own choice applies until you pick one.

--- a/packages/shared/src/model-pins.ts
+++ b/packages/shared/src/model-pins.ts
@@ -64,12 +64,13 @@ export const MODEL_PIN_SPECS: Partial<Record<AiProvider, ModelPinSpec>> = {
 	[AiProvider.Kimi]: { family: /^kimi-k[\d.]+(-code)?$/, fallback: 'kimi-k3' },
 	[AiProvider.XAi]: { family: /^grok-[\d.]+$/, fallback: 'grok-4.5' },
 	// OpenRouter is a router, not a vendor: "the latest model" across its whole
-	// catalog is not a question with an answer. The family names one vendor line
-	// known to serve tool use, which is what an agent run needs at all.
-	[AiProvider.OpenRouter]: {
-		family: /^anthropic\/claude-haiku-[\d.]+$/,
-		fallback: 'anthropic/claude-haiku-4.5',
-	},
+	// catalog is not a question with an answer, and pinning one vendor line inside
+	// it throws away the routing the operator came here for. So the pin names
+	// `openrouter/auto`, OpenRouter's own route, and lets it choose per request.
+	// The family is that one id exactly - an auto route carries no version to
+	// climb, so a refresh only ever confirms the catalog still lists it and holds
+	// the previous pin if it ever stops.
+	[AiProvider.OpenRouter]: { family: /^openrouter\/auto$/, fallback: 'openrouter/auto' },
 };
 
 /**

--- a/packages/shared/test/model-pins.test.ts
+++ b/packages/shared/test/model-pins.test.ts
@@ -121,6 +121,28 @@ describe('pickLatestModel', () => {
 		expect(pickLatestModel(AiProvider.XAi, catalog)).toBe('grok-4.5');
 	});
 
+	it('picks OpenRouter’s own auto route out of a catalog of vendor lines', () => {
+		const catalog = [
+			'anthropic/claude-haiku-4.5',
+			'anthropic/claude-opus-5',
+			'openrouter/auto',
+			'openai/gpt-5.3-codex',
+			'google/gemini-3.6-flash',
+		];
+		// A router's value is the routing: a vendor line inside its catalog would
+		// out-version the auto route on every comparison, so the family is that one
+		// id exactly and nothing else in the catalog is reachable from this pin.
+		expect(pickLatestModel(AiProvider.OpenRouter, catalog)).toBe('openrouter/auto');
+	});
+
+	it('holds the OpenRouter pin when the catalog stops listing the auto route', () => {
+		// Nothing else here is a sane substitute, so null - the caller keeps what it
+		// had rather than picking a vendor line the operator never chose.
+		expect(
+			pickLatestModel(AiProvider.OpenRouter, ['anthropic/claude-opus-5', 'openai/gpt-5.3-codex']),
+		).toBeNull();
+	});
+
 	it('holds the previous pin when the family matches nothing', () => {
 		// Renamed upstream, or a key that sees a restricted catalog. Null means the
 		// caller keeps what it had rather than pinning something from another tier.


### PR DESCRIPTION
## What

A newly added OpenRouter connection now starts on `openrouter/auto` instead of `anthropic/claude-haiku-4.5`.

`MODEL_PIN_SPECS[AiProvider.OpenRouter]` named one vendor line inside the router's catalog, which is a model choice made on the operator's behalf by the one provider they picked precisely so it would choose. The pin now names OpenRouter's own auto route and lets it route per request.

```diff
-	[AiProvider.OpenRouter]: {
-		family: /^anthropic\/claude-haiku-[\d.]+$/,
-		fallback: 'anthropic/claude-haiku-4.5',
-	},
+	[AiProvider.OpenRouter]: { family: /^openrouter\/auto$/, fallback: 'openrouter/auto' },
```

**The family is that one id exactly.** An auto route carries no version to climb, so the daily `model-pin-refresh` cron only ever confirms the catalog still lists it; if OpenRouter ever stops listing it, `pickLatestModel` returns null and the previous pin stands rather than a vendor line the operator never chose.

## Effect on a running instance

- **No stored connection changes.** `refreshModelPins` still never writes `ai_provider_configs.default_model` for an existing row.
- An instance already carrying `model_pin:openrouter = anthropic/claude-haiku-4.5` in `system_meta` keeps it until the next daily refresh, which then moves it to `openrouter/auto` on its own. No migration needed.
- A fresh instance, or one that has never had an OpenRouter credential, gets the new fallback immediately.

## The tradeoff, stated

The comment this replaces existed for a reason: `openrouter/auto` routes by capability and can resolve to an endpoint that does not serve tool use, which surfaces as a 404 naming neither the model nor the cause. That risk is real and is now accepted in exchange for the routing OpenRouter is chosen for; an operator who wants a fixed, known-tool-capable model picks one from the model list, which is one field away in the connection form.

For that reason the **live conformance fixture is deliberately left on `anthropic/claude-haiku-4.5`** (`packages/server/test/conformance/fixture.ts`): a live run needs a deterministic tool-capable endpoint, which is the opposite of what an auto route gives it.

## Tests

Two cases added to `packages/shared/test/model-pins.test.ts`:

- picks `openrouter/auto` out of a catalog of vendor lines that would each out-version it
- returns null (holds the previous pin) when the catalog stops listing the auto route

The existing `ships a fallback that its own family accepts` invariant covers the new pair automatically.

```
packages/shared  test/model-pins.test.ts   16 passed
packages/server  test/model-pins.test.ts    9 passed
bunx biome check --diagnostic-level=error .   clean
bun run typecheck                             5/5 successful
```

## Docs

- `.dev/architecture.md` § Pinned starting model — notes that OpenRouter's family is a single id and why.
- `docs/ai-models.md` § How the starting model is chosen — tells the user their OpenRouter connection starts on the auto route and that they can pick a specific model instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRCjkSFC9s6ExWDUgM5GvR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRCjkSFC9s6ExWDUgM5GvR)_