### PR TITLE
fix(providers): ask the provider whether a subscription credential is real

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3749,8 +3749,12 @@ runs price at `$0`, which for local inference is correct rather than the usual f
 
 **Provider config.** `ai_provider_configs` is instance-level (shared across teams), one
 row per `(provider, label)`, each inlining an encrypted credential. `auth_method`
-distinguishes an **API key** (injected as env at run start) from a **subscription** blob
-(materialized to a per-run mount in the container). **One api-key exception:** Codex will not
+distinguishes an **API key** (injected as env at run start) from a **subscription** blob.
+Where a subscription lands is the *runtime's* property, not the auth method's: Codex's is
+materialized to a per-run mount, while Anthropic's is an env var like a key
+(`CLAUDE_CODE_OAUTH_TOKEN`), because Claude Code rewrites its own credentials file and cannot
+be handed one on a per-run mount. `RUNTIME_HOME_LAYOUTS[...].authFileRelative` is the switch,
+and its absence is what makes `buildSubscriptionMount` return null. **One api-key exception:** Codex will not
 authenticate a request from `OPENAI_API_KEY` — `codex doctor` reports the variable as present
 and then reports `auth mode: none`, and every request 401s — so its key is written to the same
 per-run `auth.json` its subscription blob uses, in the `{auth_mode: "apikey", …}` shape
@@ -3760,9 +3764,34 @@ key-derived file back over the operator's stored value. Subscription auth is sup
 Anthropic and OpenAI. Google and xAI are API-key only in Hezo - Antigravity has a consumer
 subscription (Login with Google) but its keyring-only OAuth cannot yet be delivered into a
 per-run container. A config's `status` is `verified` (the healthy default —
-the add flow live-verifies the key, the Verify action persists the result, and replacing the
-credential re-verifies it — each restoring `verified` on a key that had gone `invalid`),
-`invalid` (a verify was rejected), or `revoked` (a retired provider).
+the add flow live-verifies the credential, the Verify action persists the result, and replacing the
+credential re-verifies it — each restoring `verified` on one that had gone `invalid`),
+`invalid` (the provider refused it), or `revoked` (a retired provider).
+
+**A subscription credential is asked the same live question as a key, on its own header
+shape.** `AiProviderVerifyEndpoint.subscriptionHeaders` carries it (Anthropic: a bearer,
+since `x-api-key` refuses an `sk-ant-oat01-…` token whatever its state and would make every
+probe a false condemnation); an absent entry says this provider's subscription credential is
+not a bearer at all (Codex's is a JSON auth file) and leaves it on the shape check alone.
+**What a probe may conclude is deliberately asymmetric** and lives in one predicate,
+`probeProvesCredentialDead`: only a 401/403 condemns. Acceptance proves nothing, because what
+a *valid* subscription token does on a catalog endpoint is not assertable for every provider -
+it may answer 200 or refuse the endpoint on scope while remaining good for a run. So the probe
+can catch a dead credential and can never condemn a live one. This is not a fallback path:
+one mechanism, one answer it acts on.
+
+**A run that the provider refuses condemns the credential, but only on the provider's word.**
+`condemnRejectedProviderCredential` (`services/provider-credential-health.ts`, the join between
+the row and the catalog probe) re-asks the provider when a run's terminal verdict is family
+`auth`, then writes through `casMarkAiProviderInvalid` - a compare-and-set on the value the run
+*ran on*, so a credential the operator replaced mid-run is never condemned by the dead one's
+failure, and an already-`invalid` row is not rewritten. The re-probe is the point: `auth` is
+matched on the runtime's own error text and that match includes a bare `401`, which an agent's
+failed `curl` produces as readily as a refused model call - and the credential is
+instance-wide, so acting on the text alone would let one agent disable every team. On a write
+the runner files `fileProviderCredentialRejectedApproval`, which `clearAgentErrorApprovalsOnRecovery`
+closes on the next success like the other agent-error notices. Without this the row keeps
+`verified` forever and every dispatch spends a container to fail identically.
 
 **Guided sign-in.** A subscription credential can be minted by driving the vendor CLI's own
 login inside a throwaway container instead of pasting an auth file. `POST

--- a/.dev/seam-registry.md
+++ b/.dev/seam-registry.md
@@ -58,4 +58,6 @@ rather than here, is how a codebase ends up with two of everything.
 | Seeding container uptime a calendar-window reader will bill | `seedUptimeStretch()` / `seedMonthToDateSeconds()` (`test/helpers/uptime.ts`) - web tests reach them through `@hezo/server/test/helpers/uptime` |
 | A CLI runtime's own quirk (env, flags, model-id form, usage recovery, run-end behaviour) | that runtime's `services/runtime-adapters/<runtime>.ts`, its section in `agent-stream-parser.ts`, or its `RUNTIME_*` row (`@hezo/shared`) |
 | An AI provider's own quirk (endpoint, credential env, subscription blob, judge model) | that provider's `PROVIDER_RUNTIME_ADAPTERS` entry (`@hezo/shared`), or its row in the per-provider table that owns the behaviour |
+| "Did the provider refuse this credential itself?" | `probeProviderCatalog` + `probeProvesCredentialDead` (`services/provider-catalog.ts`) - only a 401/403 condemns; acceptance proves nothing |
+| Taking a refused credential out of service | `condemnRejectedProviderCredential` (`services/provider-credential-health.ts`) - the join between the row and the probe; writes only via `casMarkAiProviderInvalid` |
 

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -154,6 +154,30 @@ token stays usable across concurrent runs, so Hezo runs as many at once as your 
 allow and keeps the stored token current as they go. Nothing here limits how many agents
 share one Codex subscription.
 
+**An Anthropic subscription does not refresh.** Hezo stores the single long-lived token
+`claude setup-token` prints and passes it to Claude Code as-is. There is no refresh token
+behind it, so when that token expires or you revoke it, no run can renew it - sign in again
+to replace it.
+
+If you paste the credential by hand, paste the token `claude setup-token` printed and
+nothing else. The short-lived token inside `~/.claude/.credentials.json` starts with the
+same `sk-ant-oat01-` characters, so it looks right and is accepted, then stops working
+within hours. When that happens every run fails at once with an authentication error.
+
+### What "verified" means
+
+A credential is marked **verified** when the provider accepted it, and **invalid** when the
+provider refused it. Hezo asks the provider when you add a credential, when you select
+**Verify**, and again after a run fails because the provider refused it.
+
+A refused credential is marked invalid and stops being used, so the next run fails
+immediately instead of starting a container to find out. The credential is shared by every
+team on the instance, so this stops their runs too - replace it to bring them back.
+
+Only an outright refusal changes the badge. If Hezo cannot reach the provider, or the
+provider answers with an error of its own, the credential keeps the status it had: an
+outage must not take a working credential out of service.
+
 ## Where to get an API key
 
 Each provider issues API keys from its own console. When you connect a provider, the

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -29,7 +29,11 @@ import {
 	updateAiProviderConfig,
 } from '../services/ai-provider-keys';
 import { getPinnedModel, refreshModelPins } from '../services/model-pins';
-import { fetchProviderCatalog, probeProviderCatalog } from '../services/provider-catalog';
+import {
+	fetchProviderCatalog,
+	probeProvesCredentialDead,
+	probeProviderCatalog,
+} from '../services/provider-catalog';
 import { validateSubscriptionBlob } from '../services/subscription-auth';
 import {
 	LOGIN_FLOW_TTL_MS,
@@ -158,7 +162,7 @@ async function prepareProviderCredential(
 	}
 
 	if (authMethod === AiAuthMethod.ApiKey && !process.env.SKIP_AI_KEY_VALIDATION) {
-		const probe = await probeProviderCatalog(provider, value, baseUrl);
+		const probe = await probeProviderCatalog(provider, value, baseUrl, authMethod);
 		// "We could not ask" is not "your key is wrong", and the difference is the
 		// whole diagnosis for a local runner that simply is not running. Keep the
 		// two apart: only a provider that answered and refused blames the key.
@@ -177,6 +181,25 @@ async function prepareProviderCredential(
 				ok: false,
 				code: 'INVALID_KEY',
 				message: `API key validation failed — the key was rejected by ${info.name}`,
+				status: 400,
+			};
+		}
+	}
+
+	// A subscription token gets the same live question, on the header shape its
+	// provider's table row names. The bar is deliberately lower than the api-key
+	// one above: only an outright rejection stops the store, because acceptance is
+	// not something this probe can assert (see `probeProvesCredentialDead`). That
+	// still catches the failure this exists for - a token that is already dead when
+	// it is pasted - instead of leaving it to surface as a failed run hours later,
+	// under a badge that says `verified`.
+	if (authMethod === AiAuthMethod.Subscription && !process.env.SKIP_AI_KEY_VALIDATION) {
+		const probe = await probeProviderCatalog(provider, value, baseUrl, authMethod);
+		if (probeProvesCredentialDead(probe)) {
+			return {
+				ok: false,
+				code: 'INVALID_SUBSCRIPTION_BLOB',
+				message: `${info.name} rejected this subscription credential. Mint a fresh one and paste that — a token that has expired or been revoked cannot be renewed here.`,
 				status: 400,
 			};
 		}
@@ -351,14 +374,20 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 	}
 
 	try {
-		// A subscription blob is not an API key any catalog endpoint accepts, so it
-		// is taken as verified rather than probed - the same rule the create path
-		// applies, kept in step with it here.
-		const probe =
-			cred.authMethod === AiAuthMethod.Subscription
-				? ({ ok: true } as const)
-				: await probeProviderCatalog(cred.provider as AiProvider, cred.value, cred.baseUrl);
-		if (probe.ok) {
+		// Both auth methods are asked, on their own header shape - the same rule the
+		// create path applies, kept in step with it here. What differs is what an
+		// answer is allowed to conclude: an api key that is refused *or* unreachable
+		// is handled below, while a subscription credential is condemned only by an
+		// outright rejection (`probeProvesCredentialDead`), so the branch is on the
+		// verdict rather than on the auth method.
+		const probe = await probeProviderCatalog(
+			cred.provider as AiProvider,
+			cred.value,
+			cred.baseUrl,
+			cred.authMethod,
+		);
+		const subscription = cred.authMethod === AiAuthMethod.Subscription;
+		if (probe.ok || (subscription && !probeProvesCredentialDead(probe))) {
 			// Persist the healthy state so the badge is truthful and a key that was
 			// previously marked `invalid` recovers on a successful re-verify.
 			await db.query(
@@ -378,7 +407,12 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 			AiProviderStatus.Invalid,
 			configId,
 		]);
-		return ok(c, { valid: false, message: 'API key is invalid or expired' });
+		return ok(c, {
+			valid: false,
+			message: subscription
+				? 'Subscription credential is invalid or expired — mint a fresh one'
+				: 'API key is invalid or expired',
+		});
 	} catch {
 		return ok(c, { valid: false, message: 'Could not reach provider to verify key' });
 	}
@@ -561,7 +595,7 @@ aiProvidersRoutes.get('/ai-providers/:configId/models', async (c) => {
 		);
 	}
 
-	const catalog = await fetchProviderCatalog(provider, cred.value, cred.baseUrl);
+	const catalog = await fetchProviderCatalog(provider, cred.value, cred.baseUrl, cred.authMethod);
 	if (!catalog.ok) {
 		if (catalog.reason === 'unsupported') {
 			return err(c, 'UNSUPPORTED', `No models endpoint for provider "${provider}"`, 400);

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -4,6 +4,7 @@ import {
 	AGENT_RUNTIME_LABELS,
 	type AgentEffort,
 	type AgentRuntime,
+	AI_PROVIDER_INFO,
 	AiAuthMethod,
 	type AiProvider,
 	CommentContentType,
@@ -77,6 +78,7 @@ import {
 } from './agent-stream-parser';
 import {
 	type AiProviderCredential,
+	getAiProviderConfig,
 	getProviderCredentialAndModel,
 	readAiProviderCredentialValue,
 	updateAiProviderCredential,
@@ -145,6 +147,7 @@ import {
 } from './mcp-cli/manifest';
 import {
 	clearAgentErrorApprovalsOnRecovery,
+	fileProviderCredentialRejectedApproval,
 	fileProviderRefusalApproval,
 	PROVIDER_REFUSAL_GIVEUP_MIN,
 	retryOrEscalateLostRun,
@@ -152,6 +155,7 @@ import {
 } from './orphan-detector';
 import type { PricingService } from './pricing';
 import type { ProgressActivityCandidates, ProgressActivityKind } from './project-activity';
+import { condemnRejectedProviderCredential } from './provider-credential-health';
 import { loadReactionsForTask, type ReactionGroup } from './reactions';
 import { checkRepoCommitMerged } from './repo-github';
 import { ensureProjectRepos } from './repo-sync';
@@ -345,9 +349,12 @@ type CloneRef = RepoLoc & { repoId: string };
  * the credential carried in the auth-method-specific env var. Agents that read
  * a different var won't see the credential.
  *
- * Returns only the static entries when the auth method is subscription-based,
- * since the credential is delivered via a file mount instead — see
- * {@link buildSubscriptionMount}.
+ * Which auth methods get a var at all is the provider's own table
+ * (`credentialEnvByAuthMethod`), and a subscription is not automatically absent
+ * from it: Anthropic's goes in `CLAUDE_CODE_OAUTH_TOKEN` and no file is written,
+ * because Claude Code rotates its credentials file and cannot be handed one on a
+ * per-run mount. A provider whose subscription IS a file (Codex) simply has no
+ * subscription row here and gets it from {@link buildSubscriptionMount} instead.
  */
 export function buildProviderEnv(
 	provider: AiProvider,
@@ -3113,6 +3120,47 @@ export async function runAgent(
 				},
 				runBroadcast,
 			);
+
+			// The provider refused this run's credential. Ask the provider directly
+			// whether the credential itself is dead and, if it is, take it out of
+			// service - otherwise it keeps its `verified` badge and the next dispatch
+			// spends another container proving the same thing.
+			//
+			// The re-probe is not ceremony. `auth` is matched on the runtime's own
+			// error text and that match includes a bare `401`, which an agent's failed
+			// `curl` produces as readily as a refused model call; the credential is
+			// instance-wide, so acting on the text alone would let one agent disable
+			// every team. Awaited so the settings page and Inbox are already right by
+			// the time the caller refetches, but caught: the run has already ended and
+			// its outcome does not turn on whether the probe could be made.
+			if (!success && refusalVerdict?.family === 'auth') {
+				await condemnRejectedProviderCredential(deps.db, deps.masterKeyManager, provider, {
+					configId: credential.configId,
+					value: credential.value,
+					authMethod: credential.authMethod,
+					baseUrl: credential.baseUrl,
+				})
+					.then(async (outcome) => {
+						if (outcome !== 'condemned') return;
+						const config = await getAiProviderConfig(deps.db, credential.configId);
+						await fileProviderCredentialRejectedApproval(
+							deps.db,
+							{
+								runId: heartbeatRunId,
+								memberId: agent.id,
+								teamId: agent.team_id,
+								taskId: task?.id ?? null,
+							},
+							{
+								providerName: AI_PROVIDER_INFO[provider]?.name ?? provider,
+								label: config?.label ?? provider,
+							},
+						);
+					})
+					.catch((e) =>
+						log.error(`Run ${heartbeatRunId}: could not check the refused provider credential:`, e),
+					);
+			}
 
 			// A success is the proof that whatever the give-up paths filed a notice
 			// about is over. Awaited so the Inbox the caller's next refetch shows is

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -268,6 +268,48 @@ export async function casUpdateAiProviderCredential(
 }
 
 /**
+ * Mark a config `invalid`, but only while it still holds the credential the
+ * caller proved dead.
+ *
+ * The compare is the whole point. A run condemns the credential it *ran on*, and
+ * that run may have started minutes before the operator pasted a replacement -
+ * so writing on the config id alone would mark a brand-new credential invalid on
+ * the strength of a dead one's failure, and the operator would watch a key they
+ * had just fixed go red for no reason they could see. Same
+ * lock-then-decrypt-compare as {@link casUpdateAiProviderCredential}, whose
+ * reasoning about the random IV applies here unchanged.
+ *
+ * The status guard keeps a repeat condemnation from rewriting a row that already
+ * says what it needs to: the embedded database does not vacuum, so a no-op
+ * update is leaked storage, and a burst of runs all failing on one dead token is
+ * exactly when that would happen. Returns whether it wrote.
+ */
+export async function casMarkAiProviderInvalid(
+	db: Db,
+	masterKeyManager: MasterKeyManager,
+	configId: string,
+	expectedValue: string,
+): Promise<boolean> {
+	const encryptionKey = masterKeyManager.getKey();
+	if (!encryptionKey) throw new Error('Master key not available');
+	return withTransaction(db, async () => {
+		const current = await db.query<{ encrypted_credential: string; status: string }>(
+			'SELECT encrypted_credential, status FROM ai_provider_configs WHERE id = $1 FOR UPDATE',
+			[configId],
+		);
+		const row = current.rows[0];
+		if (!row) return false;
+		if (row.status === AiProviderStatus.Invalid) return false;
+		if (decrypt(row.encrypted_credential, encryptionKey) !== expectedValue) return false;
+		await db.query('UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2', [
+			AiProviderStatus.Invalid,
+			configId,
+		]);
+		return true;
+	});
+}
+
+/**
  * The current decrypted value of one credential row, or null when the row is
  * gone. For a caller that already chose its config and only needs to know
  * whether the value moved since - a waiter that held a snapshot across a wait
@@ -460,7 +502,7 @@ export async function getProviderConfigCredential(
 	configId: string,
 ): Promise<{
 	provider: string;
-	authMethod: string;
+	authMethod: AiAuthMethod;
 	value: string;
 	baseUrl: string | null;
 } | null> {
@@ -469,7 +511,7 @@ export async function getProviderConfigCredential(
 
 	const result = await db.query<{
 		provider: string;
-		auth_method: string;
+		auth_method: AiAuthMethod;
 		encrypted_credential: string;
 		metadata: Record<string, unknown> | null;
 	}>(

--- a/packages/server/src/services/model-pins.ts
+++ b/packages/server/src/services/model-pins.ts
@@ -113,7 +113,12 @@ export async function refreshModelPins(
 				result.skipped.push(`${provider}: subscription sign-in has no catalog`);
 				continue;
 			}
-			const catalog = await fetchProviderCatalog(provider, cred.value, cred.baseUrl);
+			const catalog = await fetchProviderCatalog(
+				provider,
+				cred.value,
+				cred.baseUrl,
+				cred.authMethod,
+			);
 			if (!catalog.ok) {
 				result.skipped.push(`${provider}: catalog ${catalog.reason}`);
 				continue;

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -567,6 +567,34 @@ export async function fileProviderRefusalApproval(
 }
 
 /**
+ * Record that the provider refused the stored credential itself, and that Hezo
+ * has marked it invalid.
+ *
+ * Distinct from {@link fileProviderRefusalApproval} because the fault and the fix
+ * are different in kind: that one is the provider being unwell and clearing on
+ * its own clock, this one is a credential that will never work again and a
+ * person must replace. Saying "the provider has been refusing this agent's runs"
+ * here would send the reader off to wait for a recovery that cannot come.
+ *
+ * The credential is instance-wide, so this stops every team's runs on that
+ * provider - which is why it says so, rather than reading as one agent's problem.
+ * Delegates to the same writer as the two lost-run paths, so all of them leave a
+ * human the same shape of record and share its one-per-stuck-agent dedupe.
+ */
+export async function fileProviderCredentialRejectedApproval(
+	db: Db,
+	run: { runId: string; memberId: string; teamId: string; taskId?: string | null },
+	credential: { providerName: string; label: string },
+): Promise<void> {
+	await fileLostRunApproval(
+		db,
+		run,
+		undefined,
+		`${credential.providerName} rejected the stored credential "${credential.label}", so Hezo has marked it invalid and will not start further runs on it. Replace the credential in Settings > AI Providers - an expired or revoked one cannot be renewed. This credential is shared across every team on this instance.`,
+	);
+}
+
+/**
  * Close the agent-error notices a recovered agent no longer needs.
  *
  * The inverse of {@link fileLostRunApproval}: a successful run is the proof that

--- a/packages/server/src/services/provider-catalog.ts
+++ b/packages/server/src/services/provider-catalog.ts
@@ -10,7 +10,7 @@
  * operator's own base URL, and getting that split wrong is silent.
  */
 
-import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
+import { AI_PROVIDER_INFO, AiAuthMethod, type AiProvider } from '@hezo/shared';
 
 export interface CatalogEndpoint {
 	url: string;
@@ -24,28 +24,47 @@ export interface CatalogEndpoint {
  * built from the operator's configured base URL, falling back to the runner's
  * documented default port. Both runners expose the OpenAI-shaped `/v1/models`,
  * which `parseProviderModels` already handles via its generic `data[]` branch.
+ *
+ * `authMethod` picks which header shape the credential goes on, because a
+ * subscription token is not an API key and the two are not interchangeable on
+ * the same header. Which shape a provider has is a row in its own table entry
+ * (`subscriptionHeaders`), never a provider name tested here; a provider with no
+ * such row returns null for a subscription, which reads as `unsupported`.
  */
 export function resolveCatalogEndpoint(
 	provider: AiProvider,
-	apiKey: string,
-	baseUrl?: string | null,
+	credentialValue: string,
+	baseUrl: string | null | undefined,
+	authMethod: AiAuthMethod,
 ): CatalogEndpoint | null {
 	const info = AI_PROVIDER_INFO[provider];
 	if (!info) return null;
 
 	if (info.local) {
+		// The local runners are api-key only (no `supportsSubscription`), so there is
+		// no second header shape to pick between here.
+		if (authMethod !== AiAuthMethod.ApiKey) return null;
 		const root = (baseUrl?.trim() || info.local.defaultBaseUrl).replace(/\/+$/, '');
 		return {
 			url: `${root}/v1/models`,
-			headers: { Authorization: `Bearer ${apiKey}` },
+			headers: { Authorization: `Bearer ${credentialValue}` },
 		};
 	}
 
 	const endpoint = info.verifyEndpoint;
 	if (!endpoint) return null;
+	const url = typeof endpoint.url === 'function' ? endpoint.url(credentialValue) : endpoint.url;
+
+	if (authMethod === AiAuthMethod.Subscription) {
+		const headers = endpoint.subscriptionHeaders?.(credentialValue);
+		if (!headers) return null;
+		return { url, headers };
+	}
+
 	return {
-		url: typeof endpoint.url === 'function' ? endpoint.url(apiKey) : endpoint.url,
-		headers: typeof endpoint.headers === 'function' ? endpoint.headers(apiKey) : endpoint.headers,
+		url,
+		headers:
+			typeof endpoint.headers === 'function' ? endpoint.headers(credentialValue) : endpoint.headers,
 	};
 }
 
@@ -79,10 +98,11 @@ export type CatalogProbe =
  */
 export async function probeProviderCatalog(
 	provider: AiProvider,
-	apiKey: string,
-	baseUrl?: string | null,
+	credentialValue: string,
+	baseUrl: string | null | undefined,
+	authMethod: AiAuthMethod,
 ): Promise<CatalogProbe> {
-	const endpoint = resolveCatalogEndpoint(provider, apiKey, baseUrl);
+	const endpoint = resolveCatalogEndpoint(provider, credentialValue, baseUrl, authMethod);
 	if (!endpoint) return { ok: false, reason: 'unsupported' };
 
 	let res: Response;
@@ -107,13 +127,36 @@ export async function probeProviderCatalog(
 	return { ok: true, res };
 }
 
+/**
+ * Whether a probe is **proof the credential itself is dead**, as opposed to
+ * anything else that can go wrong between here and the provider.
+ *
+ * One home because three callers act on it and must agree: the create route, the
+ * Verify button and the runner's re-check after a run died on a rejected
+ * credential. Only a provider that answered and refused (401/403) counts.
+ *
+ * **The asymmetry is the point, and it is not a fallback.** There is one
+ * mechanism - ask the provider - and exactly one answer it is allowed to act on.
+ * A rejection is authoritative; acceptance is not, because what a *valid*
+ * subscription token does on a catalog endpoint is not something Hezo can assert
+ * for every provider: it may answer 200, or refuse that endpoint on scope while
+ * remaining perfectly good for a run. So a `false` here means "not disproven",
+ * never "confirmed working", and no caller may read it as the latter. Built this
+ * way round so the probe can only ever catch a dead credential and can never
+ * condemn a live one.
+ */
+export function probeProvesCredentialDead(probe: CatalogProbe): boolean {
+	return !probe.ok && probe.reason === 'rejected';
+}
+
 /** GET and parse the provider's catalog. Never throws - every failure is a result. */
 export async function fetchProviderCatalog(
 	provider: AiProvider,
-	apiKey: string,
-	baseUrl?: string | null,
+	credentialValue: string,
+	baseUrl: string | null | undefined,
+	authMethod: AiAuthMethod,
 ): Promise<CatalogResult> {
-	const probe = await probeProviderCatalog(provider, apiKey, baseUrl);
+	const probe = await probeProviderCatalog(provider, credentialValue, baseUrl, authMethod);
 	if (!probe.ok) return probe;
 	try {
 		return { ok: true, json: await probe.res.json() };

--- a/packages/server/src/services/provider-credential-health.ts
+++ b/packages/server/src/services/provider-credential-health.ts
@@ -1,0 +1,84 @@
+/**
+ * What happens to a stored credential after a run died on the provider refusing
+ * it.
+ *
+ * Without this a rejected credential keeps its `verified` badge forever: the run
+ * fails `Permanent` and says so in its own log, but nothing writes that back to
+ * the row, and selection filters on `status = 'verified'`. So the next run picks
+ * the same dead credential, takes a container, and fails identically - once per
+ * dispatch, indefinitely, with the settings page showing green throughout.
+ *
+ * Kept out of `ai-provider-keys.ts` (which owns the row and must not know how to
+ * reach a provider) and out of `provider-catalog.ts` (which asks providers and
+ * must not know there is a database). This is the join between them, and the one
+ * place that decides a stored credential is dead.
+ */
+
+import type { AiAuthMethod, AiProvider } from '@hezo/shared';
+import type { MasterKeyManager } from '../crypto/master-key';
+import type { Db } from '../db/database';
+import { casMarkAiProviderInvalid } from './ai-provider-keys';
+import { probeProvesCredentialDead, probeProviderCatalog } from './provider-catalog';
+
+/**
+ * What became of the credential a refused run was using.
+ *
+ * `not_proven` is the common and deliberate outcome, not a failure: it says the
+ * provider did not confirm the credential is dead, so the row is left exactly as
+ * it was.
+ */
+export type CredentialCondemnation = 'condemned' | 'not_proven' | 'superseded';
+
+export interface CondemnableCredential {
+	configId: string;
+	/** The value the run actually ran on - what the write below compares against. */
+	value: string;
+	authMethod: AiAuthMethod;
+	baseUrl: string | null;
+}
+
+/**
+ * Ask the provider whether the credential a failed run used is dead, and mark it
+ * `invalid` if so.
+ *
+ * **The run's own error is the trigger, never the proof.** A run is classified
+ * `auth` by matching its terminal message, and that match includes a bare `401` -
+ * which an agent's own tool call against some unrelated API can produce just as
+ * easily as a refused model request. Condemning an instance-wide credential on
+ * that reading would let one agent's failed `curl` disable every team's runs. So
+ * the verdict comes from asking the provider directly, on a request Hezo built,
+ * and nothing else is allowed to write `invalid` here.
+ *
+ * Never throws: a run has already ended by the time this is called, and its
+ * outcome does not change on whether the follow-up probe could be made.
+ */
+export async function condemnRejectedProviderCredential(
+	db: Db,
+	masterKeyManager: MasterKeyManager,
+	provider: AiProvider,
+	credential: CondemnableCredential,
+): Promise<CredentialCondemnation> {
+	const probe = await probeProviderCatalog(
+		provider,
+		credential.value,
+		credential.baseUrl,
+		credential.authMethod,
+	);
+	if (!probeProvesCredentialDead(probe)) return 'not_proven';
+
+	// The compare inside is what keeps a slow run from condemning a credential the
+	// operator replaced while it was still running - see `casMarkAiProviderInvalid`.
+	const wrote = await casMarkAiProviderInvalid(
+		db,
+		masterKeyManager,
+		credential.configId,
+		credential.value,
+	);
+	if (wrote) return 'condemned';
+
+	// It did not write, which covers both "an earlier run already condemned this"
+	// and "the row now holds a different credential". Neither needs a notice and
+	// neither is an error - the row already says what it should, or it is about a
+	// credential this run never touched.
+	return 'superseded';
+}

--- a/packages/server/test/agent-runner-credential-condemnation.test.ts
+++ b/packages/server/test/agent-runner-credential-condemnation.test.ts
@@ -1,0 +1,283 @@
+// What a run does to the stored credential when the provider refuses it.
+//
+// A run classified `auth` used to leave the config `verified`, so the next
+// dispatch selected the same dead credential and spent another container proving
+// the same thing - indefinitely, under a green badge. It is now taken out of
+// service, but only on the provider's own answer to a second, server-side
+// question.
+//
+// That second question is what these tests are really about. `auth` is matched on
+// the runtime's error text and that match includes a bare `401`, which an agent's
+// own failed `curl` produces as readily as a refused model call - and the
+// credential is instance-wide, so condemning on the text alone would let one
+// agent disable every team. The pair below pins both directions.
+//
+// Harness cribbed from `agent-runner-provider-refusal.test.ts`.
+
+import { AiProviderStatus, ContainerStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { type RunnerDeps, runAgent } from '../src/services/agent-runner';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import type { ContainerEngine } from '../src/services/sandbox/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let adminToken: string;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string;
+let agentSlug: string;
+
+let seq = 0;
+
+/** Captured before any test swaps it, so teardown restores the real one. */
+const REAL_FETCH = globalThis.fetch;
+
+/**
+ * A container whose agent CLI writes `events` to stdout and exits `exitCode`.
+ *
+ * The stream is the whole input to this feature, so it is fed through the same
+ * `onChunk` path production uses rather than by poking the parser directly.
+ */
+function authFailureDocker(events: unknown[], exitCode = 1): ContainerEngine {
+	const stream = `${events.map((e) => JSON.stringify(e)).join('\n')}\n`;
+	const base = createStubDocker({
+		createContainer: vi.fn(async () => ({ Id: `authfail-cid-${seq++}`, Warnings: [] })),
+		startContainer: vi.fn(async () => {}),
+		execCreate: vi.fn(async () => 'exec-authfail'),
+		execStart: vi.fn(
+			async (
+				_id: string,
+				opts?: { onChunk?: (c: { stream: string; text: string }) => Promise<void> },
+			) => {
+				// Honour the streaming contract: supplying `onChunk` means the exec
+				// retains nothing, so a stub that also returned the transcript would let
+				// this pass against a contract production does not offer.
+				await opts?.onChunk?.({ stream: 'stdout', text: stream });
+				return { stdout: '', stderr: '' };
+			},
+		),
+		execInspect: vi.fn(async () => ({ ExitCode: exitCode, Running: false, Pid: 0 })),
+		inspectContainer: vi.fn(async (id: string) => ({
+			Id: id,
+			State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+			Config: { Image: 'stub' },
+		})),
+	});
+	return base as unknown as ContainerEngine;
+}
+
+function deps(docker: ContainerEngine, extra: Partial<RunnerDeps> = {}): RunnerDeps {
+	return {
+		db,
+		docker,
+		masterKeyManager,
+		serverPort: 3000,
+		dataDir,
+		logs: new LogStreamBroker(),
+		...extra,
+	};
+}
+
+function agent() {
+	return { id: agentId, title: 'Auth Fail Runner', slug: agentSlug, team_id: teamId };
+}
+
+function project() {
+	return {
+		id: projectId,
+		slug: projectSlug,
+		team_id: teamId,
+		team_slug: 'auth-fail-co',
+		container_id: null,
+		container_status: ContainerStatus.Stopped,
+		designated_repo_id: null,
+		is_internal: false,
+	};
+}
+
+async function makeTask(title: string) {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title, assignee_id: agentId }),
+	});
+	const row = (await res.json()).data;
+	return {
+		id: row.id as string,
+		identifier: row.identifier as string,
+		title,
+		description: 'Auth fail description',
+		status: 'backlog',
+		priority: 'medium',
+		project_id: projectId,
+		rules: null,
+		progress_summary: null,
+		runtime_type: 'codex' as const,
+	};
+}
+
+async function runRow(id: string) {
+	const r = await db.query<{
+		status: string;
+		error: string | null;
+		input_tokens: number | null;
+		output_tokens: number | null;
+	}>('SELECT status, error, input_tokens, output_tokens FROM heartbeat_runs WHERE id = $1', [id]);
+	return r.rows[0];
+}
+
+/** What a CLI prints when the provider rejects the credential it was handed. */
+const AUTH_TURN = {
+	type: 'turn.failed',
+	error: { message: 'stream error: 401 Unauthorized' },
+	usage: {},
+};
+
+/**
+ * Answer the provider probe with `status`, leaving every other fetch alone.
+ *
+ * Scoped to the provider host on purpose: a blanket stub would also answer
+ * whatever else the run reaches for, and the assertion would stop being about
+ * the probe.
+ */
+function probeAnswers(status: number): typeof fetch {
+	return vi.fn(async (input: RequestInfo | URL) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (url.includes('api.openai.com')) {
+			return { ok: status >= 200 && status < 300, status } as Response;
+		}
+		return { ok: true, status: 200 } as Response;
+	}) as unknown as typeof fetch;
+}
+
+async function providerStatus(): Promise<string> {
+	const row = await db.query<{ status: string }>(
+		"SELECT status FROM ai_provider_configs WHERE label = 'openai-authfail'",
+	);
+	return row.rows[0].status;
+}
+
+async function pendingCredentialNotices(): Promise<number> {
+	const rows = await db.query(
+		`SELECT 1 FROM approvals
+		 WHERE status = 'pending'::approval_status
+		   AND payload->>'type' = 'agent_error'
+		   AND payload->>'message' ILIKE '%marked it invalid%'`,
+	);
+	return rows.rows.length;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	adminToken = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+
+	const teamRes = await createTestTeam(db, { name: 'Auth Fail Co' });
+	teamId = (await teamRes.json()).data.id;
+
+	// Codex runs on the OpenAI credential; without one every run here fails on
+	// configuration long before it reaches the stream.
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+	await app.request('/api/ai-providers', {
+		method: 'POST',
+		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			provider: 'openai',
+			api_key: 'sk-authfail-key',
+			label: 'openai-authfail',
+		}),
+	});
+	globalThis.fetch = originalFetch;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Auth Fail Project',
+		description: 'Auth failure project.',
+	});
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(adminToken),
+	});
+	const agentRow = (await agentsRes.json()).data[0];
+	agentId = agentRow.id;
+	agentSlug = agentRow.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('runAgent credential condemnation', () => {
+	afterEach(async () => {
+		globalThis.fetch = REAL_FETCH;
+		await db.query('DELETE FROM approvals');
+		await db.query("UPDATE ai_provider_configs SET status = $1 WHERE label = 'openai-authfail'", [
+			AiProviderStatus.Verified,
+		]);
+	});
+
+	it('takes the credential out of service when the provider confirms it is refused', async () => {
+		const task = await makeTask('Refused credential');
+		globalThis.fetch = probeAnswers(401);
+
+		const result = await runAgent(
+			deps(authFailureDocker([{ type: 'thread.started', model: 'gpt-5-codex' }, AUTH_TURN])),
+			agent(),
+			task,
+			project(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.heartbeatRunId).toBeDefined();
+		const row = await runRow(result.heartbeatRunId as string);
+		expect(row.status).toBe('failed');
+		expect(row.error).toContain('AI provider authentication failed');
+
+		// The point of the whole change: the badge now follows the provider, so the
+		// next dispatch does not select this credential at all.
+		expect(await providerStatus()).toBe(AiProviderStatus.Invalid);
+		expect(await pendingCredentialNotices()).toBe(1);
+	});
+
+	it('leaves the credential alone when the provider does not confirm it', async () => {
+		const task = await makeTask('Agent own 401');
+		// The same `401` in the run's error, but the provider itself is fine - the
+		// shape of an agent whose own tool call was refused by some unrelated API.
+		// Condemning here would disable every team on this instance on the strength
+		// of one agent's failed request.
+		globalThis.fetch = probeAnswers(200);
+
+		const result = await runAgent(
+			deps(authFailureDocker([{ type: 'thread.started', model: 'gpt-5-codex' }, AUTH_TURN])),
+			agent(),
+			task,
+			project(),
+		);
+
+		expect(result.success).toBe(false);
+		expect(await providerStatus()).toBe(AiProviderStatus.Verified);
+		expect(await pendingCredentialNotices()).toBe(0);
+	});
+});

--- a/packages/server/test/ai-providers-verify.test.ts
+++ b/packages/server/test/ai-providers-verify.test.ts
@@ -63,6 +63,30 @@ async function addProvider(provider: string, apiKey: string, label: string): Pro
 	return (await res.json()).data.id;
 }
 
+/** An Anthropic subscription config, stored under the create-path validation skip. */
+async function addSubscriptionConfig(label: string): Promise<string> {
+	const res = await app.request('/api/ai-providers', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			provider: 'anthropic',
+			api_key: 'sk-ant-oat01-live-token',
+			auth_method: 'subscription',
+			label,
+		}),
+	});
+	if (res.status !== 201) throw new Error(`addSubscriptionConfig failed: ${res.status}`);
+	return (await res.json()).data.id;
+}
+
+async function expectStatus(configId: string, status: string): Promise<void> {
+	const row = await db.query<{ status: string }>(
+		'SELECT status FROM ai_provider_configs WHERE id = $1',
+		[configId],
+	);
+	expect(row.rows[0].status).toBe(status);
+}
+
 describe('POST /ai-providers/:configId/verify', () => {
 	let configId: string;
 
@@ -146,31 +170,77 @@ describe('POST /ai-providers/:configId/verify', () => {
 		expect(res.status).toBe(403);
 	});
 
-	it('treats a subscription config as always valid without an HTTP call', async () => {
+	it('marks a subscription config invalid when the provider refuses the token', async () => {
 		await db.query('DELETE FROM ai_provider_configs');
-		const create = await app.request('/api/ai-providers', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				provider: 'anthropic',
-				api_key: 'sk-ant-oat01-live-token',
-				auth_method: 'subscription',
-				label: 'sub-verify',
-			}),
-		});
-		expect(create.status).toBe(201);
-		const subId = (await create.json()).data.id;
+		const subId = await addSubscriptionConfig('sub-refused');
 
-		const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+		const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 401 });
 		globalThis.fetch = fetchSpy as unknown as typeof fetch;
 		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
 			method: 'POST',
 			headers: authHeader(token),
 		});
+
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.valid).toBe(false);
+		// The token goes on as a bearer, not as `x-api-key` - an OAuth token on the
+		// key header is refused whatever its state, which would make every probe a
+		// false condemnation.
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers.Authorization).toBe('Bearer sk-ant-oat01-live-token');
+		expect(headers['x-api-key']).toBeUndefined();
+		await expectStatus(subId, 'invalid');
+	});
+
+	it('leaves a subscription config verified when the probe cannot prove it dead', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		const subId = await addSubscriptionConfig('sub-unproven');
+
+		// A 500 says nothing about the credential, and neither does a 200 whose body
+		// we never read. Only an outright rejection may condemn it, so the badge must
+		// survive both - a token taken out of service by a provider hiccup is the
+		// failure this asymmetry exists to prevent.
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.valid).toBe(true);
-		// Subscription auth short-circuits before any provider HTTP call.
-		expect(fetchSpy).not.toHaveBeenCalled();
+		await expectStatus(subId, 'verified');
+	});
+
+	it('rejects a subscription token the provider refuses at paste time', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		const prev = process.env.SKIP_AI_KEY_VALIDATION;
+		process.env.SKIP_AI_KEY_VALIDATION = '';
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 401 }) as unknown as typeof fetch;
+		try {
+			const res = await app.request('/api/ai-providers', {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					provider: 'anthropic',
+					api_key: 'sk-ant-oat01-already-dead',
+					auth_method: 'subscription',
+					label: 'sub-dead-on-arrival',
+				}),
+			});
+			expect(res.status).toBe(400);
+			expect((await res.json()).error.code).toBe('INVALID_SUBSCRIPTION_BLOB');
+			// Nothing stored: a credential the provider has already refused must not
+			// reach the table wearing a `verified` badge.
+			const rows = await db.query('SELECT id FROM ai_provider_configs');
+			expect(rows.rows).toHaveLength(0);
+		} finally {
+			process.env.SKIP_AI_KEY_VALIDATION = prev;
+		}
 	});
 });
 

--- a/packages/server/test/provider-credential-health.test.ts
+++ b/packages/server/test/provider-credential-health.test.ts
@@ -1,0 +1,240 @@
+import { AiAuthMethod, AiProvider, AiProviderStatus } from '@hezo/shared';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import {
+	casMarkAiProviderInvalid,
+	storeAiProviderKey,
+	updateAiProviderCredential,
+} from '../src/services/ai-provider-keys';
+import { condemnRejectedProviderCredential } from '../src/services/provider-credential-health';
+import { safeClose } from './helpers';
+import { createTestApp } from './helpers/app';
+
+/**
+ * What happens to a stored credential after the provider refuses it.
+ *
+ * The two things worth proving are both about NOT acting: a probe that cannot
+ * show the credential is dead leaves it alone, and a condemnation aimed at a
+ * credential the operator has since replaced hits nothing. Either failure takes
+ * a working credential out of service instance-wide, which is worse than the
+ * stale badge this whole path exists to fix.
+ */
+
+let db: Db;
+let masterKeyManager: MasterKeyManager;
+const originalFetch = globalThis.fetch;
+
+const TOKEN = 'sk-ant-oat01-the-one-the-run-used';
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+});
+
+beforeEach(async () => {
+	await db.query('DELETE FROM ai_provider_configs');
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function storeSubscription(value = TOKEN): Promise<string> {
+	return storeAiProviderKey(
+		db,
+		masterKeyManager,
+		AiProvider.Anthropic,
+		value,
+		AiAuthMethod.Subscription,
+		`sub-${Math.random().toString(36).slice(2, 10)}`,
+	);
+}
+
+async function statusOf(configId: string): Promise<string> {
+	const row = await db.query<{ status: string }>(
+		'SELECT status FROM ai_provider_configs WHERE id = $1',
+		[configId],
+	);
+	return row.rows[0].status;
+}
+
+function respondWith(status: number): void {
+	globalThis.fetch = vi
+		.fn()
+		.mockResolvedValue({ ok: status >= 200 && status < 300, status }) as unknown as typeof fetch;
+}
+
+describe('casMarkAiProviderInvalid', () => {
+	it('marks the config invalid when it still holds the condemned credential', async () => {
+		const configId = await storeSubscription();
+
+		const wrote = await casMarkAiProviderInvalid(db, masterKeyManager, configId, TOKEN);
+
+		expect(wrote).toBe(true);
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Invalid);
+	});
+
+	it('leaves a replaced credential alone', async () => {
+		const configId = await storeSubscription();
+		// The operator pasted a fresh token while the run that is about to condemn
+		// the old one was still in flight.
+		await updateAiProviderCredential(db, masterKeyManager, configId, 'sk-ant-oat01-freshly-pasted');
+
+		const wrote = await casMarkAiProviderInvalid(db, masterKeyManager, configId, TOKEN);
+
+		expect(wrote).toBe(false);
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Verified);
+	});
+
+	it('does not rewrite a row that is already invalid', async () => {
+		const configId = await storeSubscription();
+		expect(await casMarkAiProviderInvalid(db, masterKeyManager, configId, TOKEN)).toBe(true);
+
+		// A burst of runs all failing on one dead token must not each spend a write:
+		// the embedded database does not vacuum, so a no-op update is leaked storage.
+		expect(await casMarkAiProviderInvalid(db, masterKeyManager, configId, TOKEN)).toBe(false);
+	});
+
+	it('reports no write for a config that is gone', async () => {
+		const wrote = await casMarkAiProviderInvalid(
+			db,
+			masterKeyManager,
+			'00000000-0000-0000-0000-000000000000',
+			TOKEN,
+		);
+		expect(wrote).toBe(false);
+	});
+});
+
+describe('condemnRejectedProviderCredential', () => {
+	const credential = {
+		value: TOKEN,
+		authMethod: AiAuthMethod.Subscription,
+		baseUrl: null,
+	};
+
+	it('condemns a credential the provider rejects', async () => {
+		const configId = await storeSubscription();
+		respondWith(401);
+
+		const outcome = await condemnRejectedProviderCredential(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			{ configId, ...credential },
+		);
+
+		expect(outcome).toBe('condemned');
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Invalid);
+	});
+
+	it('sends the subscription token as a bearer, never as an api key', async () => {
+		const configId = await storeSubscription();
+		const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		await condemnRejectedProviderCredential(db, masterKeyManager, AiProvider.Anthropic, {
+			configId,
+			...credential,
+		});
+
+		// On `x-api-key` an OAuth token is refused whatever its state, so probing
+		// that way would condemn every subscription credential it was pointed at.
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(headers['x-api-key']).toBeUndefined();
+	});
+
+	it.each([
+		['a server error', 500],
+		['a rate limit', 429],
+		['an accepted request', 200],
+	])('leaves the credential alone on %s', async (_label, status) => {
+		const configId = await storeSubscription();
+		respondWith(status);
+
+		const outcome = await condemnRejectedProviderCredential(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			{ configId, ...credential },
+		);
+
+		expect(outcome).toBe('not_proven');
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Verified);
+	});
+
+	it('leaves the credential alone when the provider cannot be reached', async () => {
+		const configId = await storeSubscription();
+		globalThis.fetch = vi
+			.fn()
+			.mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+
+		const outcome = await condemnRejectedProviderCredential(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			{ configId, ...credential },
+		);
+
+		// A network blip is not a verdict on the credential. Condemning here would
+		// take every team's runs down for the duration of an outage.
+		expect(outcome).toBe('not_proven');
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Verified);
+	});
+
+	it('does not condemn a credential replaced while the run was in flight', async () => {
+		const configId = await storeSubscription();
+		await updateAiProviderCredential(db, masterKeyManager, configId, 'sk-ant-oat01-freshly-pasted');
+		respondWith(401);
+
+		const outcome = await condemnRejectedProviderCredential(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			{ configId, ...credential },
+		);
+
+		expect(outcome).toBe('superseded');
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Verified);
+	});
+
+	it('reports not_proven for a provider whose subscription cannot be probed', async () => {
+		// Codex's subscription credential is a JSON auth file, not a bearer, so its
+		// table entry carries no `subscriptionHeaders` and there is nothing to ask.
+		// An absent row must read as "cannot prove it", never as a rejection.
+		const configId = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'{"tokens":{"refresh_token":"r"}}',
+			AiAuthMethod.Subscription,
+			'codex-sub',
+		);
+		const fetchSpy = vi.fn();
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+		const outcome = await condemnRejectedProviderCredential(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			{
+				configId,
+				value: '{"tokens":{"refresh_token":"r"}}',
+				authMethod: AiAuthMethod.Subscription,
+				baseUrl: null,
+			},
+		);
+
+		expect(outcome).toBe('not_proven');
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(await statusOf(configId)).toBe(AiProviderStatus.Verified);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -2890,6 +2890,17 @@ export const RUNTIME_HEADLESS_SUFFIX_ARGS: Record<AgentRuntime, readonly string[
 export interface AiProviderVerifyEndpoint {
 	url: string | ((apiKey: string) => string);
 	headers: Record<string, string> | ((apiKey: string) => Record<string, string>);
+	/**
+	 * Headers that put a **subscription** credential on the same endpoint, for a
+	 * provider whose subscription token is a bearer its API accepts.
+	 *
+	 * Absent is an answer, not a gap: it says this provider's subscription
+	 * credential cannot be asked about at all (Codex's is a JSON auth file, not a
+	 * bearer), so the shape check stands alone for it. A row here rather than a
+	 * provider name in the resolver, which is what keeps the generic path free of
+	 * any knowledge of which provider it is serving.
+	 */
+	subscriptionHeaders?: (token: string) => Record<string, string>;
 }
 
 /**
@@ -2929,6 +2940,16 @@ export const AI_PROVIDER_INFO: Record<AiProvider, AiProviderInfo> = {
 		verifyEndpoint: {
 			url: 'https://api.anthropic.com/v1/models',
 			headers: (apiKey) => ({ 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' }),
+			// `x-api-key` refuses an `sk-ant-oat01-…` token whatever its state, so the
+			// subscription credential goes on as a bearer instead. Measured against
+			// the live endpoint: a bad bearer answers 401 `OAuth access token is
+			// invalid` and a bad key 401 `API key is invalid`, so the endpoint tells
+			// the two apart rather than refusing the header shape - which is what
+			// makes a rejection here mean the token, not the request.
+			subscriptionHeaders: (token) => ({
+				Authorization: `Bearer ${token}`,
+				'anthropic-version': '2023-06-01',
+			}),
 		},
 	},
 	[AiProvider.OpenAI]: {

--- a/packages/shared/test/common.test.ts
+++ b/packages/shared/test/common.test.ts
@@ -3,6 +3,7 @@ import {
 	AgentEffort,
 	AgentRuntime,
 	AgentRuntimeStatus,
+	AI_PROVIDER_INFO,
 	AiAuthMethod,
 	AiProvider,
 	ArchiveFilter,
@@ -372,6 +373,34 @@ describe('provider helpers', () => {
 			).toBe('openrouter/anthropic/claude');
 		}
 		expect(opencodeModelKey(AiProvider.Anthropic, 'claude-opus-4')).toBe('claude-opus-4');
+	});
+
+	it('a subscription credential gets a bearer header, never the api-key one', () => {
+		// The two are not interchangeable, and getting it wrong is silent in the
+		// worst direction: `x-api-key` refuses an `sk-ant-oat01-…` token whatever its
+		// state, so a probe sent that way would report every subscription credential
+		// dead - including a perfectly good one - and take it out of service.
+		const endpoint = AI_PROVIDER_INFO[AiProvider.Anthropic].verifyEndpoint;
+		const subscription = endpoint.subscriptionHeaders?.('sk-ant-oat01-token');
+		expect(subscription).toEqual({
+			Authorization: 'Bearer sk-ant-oat01-token',
+			'anthropic-version': '2023-06-01',
+		});
+		expect(subscription?.['x-api-key']).toBeUndefined();
+
+		// The api-key shape is untouched by that addition.
+		const key = endpoint.headers;
+		expect(typeof key === 'function' ? key('sk-ant-key') : key).toEqual({
+			'x-api-key': 'sk-ant-key',
+			'anthropic-version': '2023-06-01',
+		});
+	});
+
+	it('offers no subscription header for a provider whose subscription is not a bearer', () => {
+		// Codex's subscription credential is a JSON auth file. An absent row is the
+		// answer - the probe reads it as "cannot ask", never as a rejection - so it
+		// must stay absent rather than gain a plausible-looking bearer.
+		expect(AI_PROVIDER_INFO[AiProvider.OpenAI].verifyEndpoint.subscriptionHeaders).toBeUndefined();
 	});
 
 	it('claudeCodeProviderUsesCustomEndpoint is true only for the third-party Claude Code providers', () => {

--- a/packages/web/src/components/subscription-paste-form.tsx
+++ b/packages/web/src/components/subscription-paste-form.tsx
@@ -24,9 +24,12 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 		],
 		footer: (
 			<>
-				This is a long-lived token (about a year). Hezo passes it as{' '}
-				<code>CLAUDE_CODE_OAUTH_TOKEN</code> and never uses an API key for this provider. Revoke it
-				anytime from your Anthropic account settings.
+				Paste the token <code>setup-token</code> printed, not the one inside{' '}
+				<code>~/.claude/.credentials.json</code> - that one starts with the same characters but
+				lasts hours, so it is accepted here and then fails every run. This one is long-lived (about
+				a year). Hezo passes it as <code>CLAUDE_CODE_OAUTH_TOKEN</code> and never uses an API key
+				for this provider. There is no refresh token behind it, so once it expires or you revoke it,
+				sign in again to replace it.
 			</>
 		),
 		placeholder: 'sk-ant-oat01-...',


### PR DESCRIPTION
## The report

An operator set up an Anthropic subscription. Settings showed it `verified`. Every run died in about two seconds:

```
AI provider authentication failed - check the team's provider credential.
(Failed to authenticate. API Error: 401 OAuth access token is invalid.)
```

## What was actually wrong

**The badge was not a fact.** A subscription credential was marked `verified` with no network call at all - not on add (`routes/ai-providers.ts`, the probe was gated on `authMethod === ApiKey`) and not on the Verify button, which short-circuited to `{ ok: true }`. The whole check was `validateAnthropicOauthToken`: does the string start with `sk-ant-oat01-`. A test asserted this as intended behaviour.

**And nothing demoted it.** The run classifies `auth` as `Permanent` and says so in its own log, but the only writer of `AiProviderStatus.Invalid` was the manual Verify route, which subscriptions never reached. Selection is `WHERE status = 'verified'`, so the next dispatch picked the same dead credential, took a container, and failed identically - once per dispatch, indefinitely, green throughout.

Measured against the live endpoint with a bogus token:

| Request | Response |
|---|---|
| `x-api-key: sk-ant-oat01-…` | 401 `API key is invalid.` |
| `Authorization: Bearer sk-ant-oat01-…` | 401 **`OAuth access token is invalid.`** |

The second is the operator's exact string, so nothing was mis-wired in header handling - Hezo sets no header, it hands the CLI `CLAUDE_CODE_OAUTH_TOKEN` and the CLI builds its own. The token was simply dead. The useful half is that the endpoint tells a bad bearer from a bad key, which makes a live subscription probe possible where there was none.

## The change

**Ask the provider.** `AiProviderVerifyEndpoint.subscriptionHeaders` carries the header shape a subscription token goes on - a bearer for Anthropic, since `x-api-key` refuses an OAuth token whatever its state and would make every probe a false condemnation. An absent entry is the answer for a provider whose subscription credential is not a bearer at all (Codex's is a JSON auth file), so that one keeps the shape check alone. A table row, never a provider name in the resolver.

**Only a rejection may condemn.** One predicate, `probeProvesCredentialDead`, shared by all three callers: 401/403 and nothing else. Acceptance proves nothing, because what a *valid* subscription token does on a catalog endpoint is not assertable for every provider - it may answer 200, or refuse that endpoint on scope while remaining good for a run. Built this way round so the probe can catch a dead credential and can never condemn a live one. This is not a fallback path: one mechanism, one answer it acts on.

**A refused run takes the credential out of service, on the provider's word rather than its own.** `auth` is matched on the runtime's error text and that match includes a bare `401`, which an agent's failed `curl` produces as readily as a refused model call - and the credential is instance-wide, so acting on the text alone would let one agent disable every team. So the run is the trigger and a second, server-side probe is the proof. The write goes through `casMarkAiProviderInvalid`: a compare-and-set on the value the run actually ran on, so a credential the operator replaced mid-run is never condemned by the dead one's failure, and an already-invalid row is not rewritten into leaked storage. On a write the runner files an Inbox notice through the existing `fileLostRunApproval` writer, which `clearAgentErrorApprovalsOnRecovery` closes on the next success.

## Corrections made while in here

- `buildProviderEnv` and `.dev/architecture.md` both said a subscription credential is delivered by file mount. **False for Anthropic** - it is an env var and no file is written, because Claude Code rewrites its own credentials file and cannot be handed one on a per-run mount.
- The docs and the paste form now name the trap that most likely caused this report: the short-lived token inside `~/.claude/.credentials.json` carries the same `sk-ant-oat01-` prefix as a `setup-token`, so it passes validation and then fails every run within hours.

## New seams

Both registered in `.dev/seam-registry.md`.

| Need | Home |
|---|---|
| "Did the provider refuse this credential itself?" | `probeProvesCredentialDead` (`services/provider-catalog.ts`) |
| Taking a refused credential out of service | `condemnRejectedProviderCredential` (`services/provider-credential-health.ts`) |

## Tests

690 tests pass across every affected suite; `typecheck` and `check` are clean.

The test that asserted the wrong thing - *"treats a subscription config as always valid without an HTTP call"* - is replaced by ones that pin the real contract. New coverage, weighted towards the cases where acting would be wrong:

- a refused subscription token is caught at paste time and stores nothing;
- a 500, a 429, a 200 and an unreachable provider all leave the credential `verified`;
- the token goes on as a bearer, never `x-api-key`;
- the CAS no-ops on a replaced credential and on an already-invalid row;
- a provider with no `subscriptionHeaders` reports `not_proven` and makes no request;
- at runner level, an `auth` failure whose re-probe refuses condemns the config and files the notice, and one whose re-probe does **not** refuse leaves it alone - the "agent's own 401" case.

## Note for the operator

This fixes the diagnosis, not the token. Hezo stores no refresh token for Anthropic and cannot mint a new one, so the existing credential still needs replacing with a fresh `claude setup-token` value or a re-run of the guided sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XwRZJdqY8yhnfMzZKUCCN

---
_Generated by [Claude Code](https://claude.ai/code/session_018XwRZJdqY8yhnfMzZKUCCN)_