### PR TITLE
fix(providers): a verify that checks, reports what it found, and stays put

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3778,6 +3778,15 @@ shape.** `AiProviderVerifyEndpoint.subscriptionHeaders` carries it (Anthropic: a
 since `x-api-key` refuses an `sk-ant-oat01-…` token whatever its state and would make every
 probe a false condemnation); an absent entry says this provider's subscription credential is
 not a bearer at all (Codex's is a JSON auth file) and leaves it on the shape check alone.
+**A verify has three outcomes, not two, and the same three for both auth methods.**
+Accepted (the provider took it) writes `verified`; refused (`probeProvesCredentialDead`)
+writes `invalid` and relays the provider's own reason through `refusalDetail`, scrubbed of
+the credential; everything else - unreachable, the provider's own 5xx, or a subscription
+with no `subscriptionHeaders` to ask with - is **unknown** and writes nothing, reported as
+`checked: false` so the UI withholds the tick. Expressing only two is where this route's
+bugs lived: a provider answering 500 condemned a working api key, and a Codex subscription
+was written `verified` and reported valid having made no request at all.
+
 **What a probe may conclude is deliberately asymmetric** and lives in one predicate,
 `probeProvesCredentialDead`: only a 401/403 condemns. Acceptance proves nothing, because what
 a *valid* subscription token does on a catalog endpoint is not assertable for every provider -

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -3828,9 +3828,26 @@ screen nobody is watching. `DELETE …/:flowId` cancels. Which runtimes can be d
 (`@hezo/shared`, read by the web to decide whether to offer the button) paired with
 `SUBSCRIPTION_LOGIN_DRIVERS` (the server's argv, output parsers and harvest shape); a test
 asserts the two agree. Codex uses its device flow and needs nothing back; Claude Code needs
-one pasted code; Google has no subscription auth at all (API key only). **The credential never
-reaches the browser** — on success the poll route stores it via `storeAiProviderKey` and
-returns only the config id, coalescing concurrent polls so overlapping requests insert once.
+one pasted code; Google has no subscription auth at all (API key only).
+
+**What the CLI printed is read off a composed screen, never out of the byte stream**
+(`renderTerminalScreen`, `sandbox/terminal-screen.ts`). A TUI repaints only the cells that
+changed, so a value reaches the log as fragments at coordinates: `claude setup-token` writes
+`sk-ant-`, steps the cursor over a character an earlier frame left standing, then writes the
+rest. Deleting the escapes splices the fragments together minus that character, yielding a
+token of the right shape and the wrong value — which passes every shape check, is stored, and
+is then refused by the provider on every run. For the same reason the script sizes the PTY
+with `stty` rather than with `COLUMNS`: `script` opens a terminal that reports `0 0`, so the
+CLI falls back to 80 columns and wraps both the sign-in URL and the token it mints. The
+mechanics and the rest of the traps are `.dev/driving-a-cli-in-a-container.md`.
+
+**The credential never
+reaches the browser** — on success the poll route puts it through `prepareProviderCredential`,
+the same shape check and live provider question a pasted credential answers, then stores it via
+`storeAiProviderKey` and returns only the config id, coalescing concurrent polls so overlapping
+requests insert once. A credential the provider refuses fails the flow as `credential_rejected`
+and stores nothing: a sign-in Hezo drove is not more trustworthy than one the operator pasted,
+because everything between the vendor's screen and the vault is Hezo's own reading of a terminal.
 Every exit path releases the container through `finish`, and `sweepLoginContainers` collects
 anything a mid-flow crash stranded, scoped by an instance-id label value. The login container
 deliberately gets **no egress proxy**: a sign-in emits no `__HEZO_SECRET_*__` placeholders to

--- a/.dev/driving-a-cli-in-a-container.md
+++ b/.dev/driving-a-cli-in-a-container.md
@@ -1,0 +1,70 @@
+# Driving an interactive CLI in a container
+
+The contributor guide for the case where Hezo runs a vendor's own interactive command inside a sandbox, reads what it printed, and types something back. The guided subscription sign-in (`services/subscription-login*.ts`) is the worked example; the traps below are the terminal's, not that feature's, and every one of them was paid for once already.
+
+The rule that binds without reading this is in `AGENTS.md`; everything here is for the person adding or changing such a flow.
+
+## The shape of the problem
+
+A CLI you drive this way is not a program you pipe to. It is a program painting a **screen** through a **terminal**, and both halves have behaviour you have to supply and honour:
+
+- The terminal has a size, and it is not the environment's business.
+- The screen is a grid of cells, and its contents are the composition of every frame, not the concatenation of the bytes.
+- Its input is raw, so no line discipline is translating anything for you.
+
+Get any of these wrong and the flow does not fail. It produces a value that is the right shape and the wrong contents, which is stored and only refused much later, somewhere else.
+
+## Give the PTY a size
+
+`script -qec …` opens a PTY that is **never sized**: `stty size` reports `0 0`. A TUI asks the terminal through `TIOCGWINSZ`, not the environment, so `COLUMNS=1000` in front of the command changes nothing and the CLI falls back to its own default of 80 columns. Everything it prints is then laid out to 80 columns, values included.
+
+Resize the terminal itself, inside the PTY and before the CLI starts:
+
+```sh
+script -qec 'stty cols 400 rows 100; the-cli login' /dev/null
+```
+
+Export `COLUMNS`/`LINES` to match if you like, from the same constant. What you must not do is set only those and believe the terminal is wide.
+
+Set rows too. A zero-height terminal is not a shape a full-screen CLI is written for.
+
+## Read the screen, not the stream
+
+**Never recover a value by deleting escape sequences and keeping the rest.** A repaint writes only the cells that changed, so a single logical value reaches the log as fragments at coordinates, and the fragments are not adjacent to each other in the byte stream:
+
+```
+ESC[2G  sk-ant-    ESC[10G  at01-…
+```
+
+Column 9 is not rewritten, because an earlier frame already put the right character there. Delete the escapes and the two fragments splice together with that character missing — a token one character short, still matching any shape check you wrote.
+
+Compose the cells instead and read the value off the finished screen: `renderTerminalScreen` (`services/sandbox/terminal-screen.ts`). It is the only supported way to read a CLI's output, and it is equally correct on a plain pipe, where there is nothing to compose.
+
+Two things it deliberately does not do:
+
+- **It does not join rows.** A value the CLI wrapped is on two rows, and a row break it chose is indistinguishable from one it meant. Size the PTY so nothing wraps; that is the fix, not a rejoining heuristic.
+- **It does not carry hyperlink targets.** An OSC 8 target occupies no cell. Read a URL from the escape with `parseOsc8Links` rather than off the screen, where it is subject to layout.
+
+## Typing back
+
+- **Terminate with CR, never LF.** A raw-mode prompt has no line discipline turning one into the other, so an LF arrives as an ordinary character: the value lands in the box and sits there unsubmitted until the flow times out.
+- **Frame a paste when the prompt asked for one.** A prompt that enabled bracketed paste (DECSET 2004) groups a burst of bytes into pasted text, and takes a trailing CR as part of the paste rather than as Return. Splitting the CR into a second write does not separate them — the reads coalesce. Wrap the value in the paste markers so the markers end the paste and the CR after them is unambiguously a keypress. Read whether the mode is on from the CLI's own output (`bracketedPasteEnabled`), never from a table: it is a property of the prompt currently on screen.
+- **Hold stdin open.** A FIFO with no writer gives the CLI EOF the moment it opens the pipe, and it abandons its prompt. A `sleep` holding the write end for the flow's lifetime is what lets a code arrive minutes later.
+
+## Launching and watching
+
+- **Detach both background jobs' stdio** (`>/dev/null 2>&1 &` on the subshell, as well as the redirections inside it). An exec does not complete while a child still holds its pipes, so without this the call that starts the flow never returns.
+- **Address every path absolutely and never `cd`.** `&` binds looser than `&&`, so a `cd` at the head of the chain backgrounds with the first subshell and the second one runs somewhere else entirely.
+- **Poll a file, not a byte stream.** `SandboxFiles` behaves identically on every backend; an exec channel's stream semantics do not.
+
+## Do not trust what you read
+
+Scraping is a reading, and a reading can be wrong in ways no shape check catches. **Whatever you harvest, put it through the same validation as the same value arriving by any other route** before you store it — for a credential, that means asking the provider whether it works, exactly as the manual paste path does. A value Hezo scraped deserves *more* suspicion than one a human pasted, not less.
+
+Budget for the vendor's clock too. A one-time code expires on the vendor's schedule, which is shorter than a flow timeout you picked; a sign-in that sat for several minutes between the browser and the paste can fail its exchange with nothing wrong on our side.
+
+## Recording a fixture
+
+Parsers here are written against **recorded** output, because a parser written against prose in a vendor doc is a guess whose failure mode is a flow that hangs with nothing to say. Record from the real CLI at the pinned version, and note the version next to the fixture.
+
+**Never commit a capture containing a real credential.** Substitute the value, then prove the substitution: render the fixture and check what comes back is the synthetic value. A capture of a TUI holds its secret in fragments, so a search-and-replace over the whole value silently misses every one of them.

--- a/.dev/seam-registry.md
+++ b/.dev/seam-registry.md
@@ -15,6 +15,7 @@ rather than here, is how a codebase ends up with two of everything.
 | A container backend | `ContainerEngine` (`services/sandbox/types.ts`), always reached via `SandboxBackendHolder.engine` |
 | "Does this backend class need X?" | `SANDBOX_BACKEND_KIND` (`@hezo/shared`) |
 | An in-container script or its parser | `services/sandbox/proc-scripts.ts` - never an adapter |
+| Reading what a CLI printed to a terminal | `renderTerminalScreen` (`services/sandbox/terminal-screen.ts`) - compose the screen, never strip the escapes out of the stream |
 | What a container was provisioned with | `container_pool_members` (`memory_bytes`, `disk_ceiling_bytes`) - never re-read from the setting |
 | "How long was this container up, and what did it cost?" | `container_uptime_entries`, written only by `services/sandbox/uptime-ledger.ts` from inside `pool-db.ts`'s own state writes; read through `services/container-hours.ts`, never with a second copy of the clipping SQL |
 | A chat platform | `ChatChannelAdapter` (`services/chat-channels/`) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ The rules are here; the detail is there. Prefer reading the guide over rediscove
 | Changing how a run is judged, delivered or priced | `agent-run-hooks.md` |
 | Adding a container backend | `adding-a-container-backend.md` |
 | Adding a chat channel | `adding-a-chat-channel.md` |
+| Driving a vendor CLI inside a container | `driving-a-cli-in-a-container.md` |
 | Working around the Bun runtime | `bun-issues.md` |
 | Looking up where a helper lives | `seam-registry.md` |
 | Checking what else a change must touch | `mirrored-surfaces.md` |
@@ -254,6 +255,14 @@ External chat avenues sit behind a channel adapter plus registry. **Adding one: 
 
 - **The core is channel-agnostic and stays that way** - resolve a channel through the registry, never by branching on a platform name. If a new channel forces a change there, close the gap in the abstraction instead.
 - **One home surface per thread, and replies go where the turn was asked.** No adapter mirrors threads onto another channel. Channel-specific settings live in the adapter's own metadata, never a per-channel column; tokens go in the vault.
+
+### Driving an interactive CLI in a container
+Running a vendor's own command in a sandbox and reading what it printed. **Traps and mechanics: `.dev/driving-a-cli-in-a-container.md`.** Getting these wrong yields a value of the right shape and the wrong contents, stored and refused later somewhere else.
+
+- **Read a CLI's output as a screen, never by deleting escape sequences** - `renderTerminalScreen`. A repaint writes only changed cells, so a value arrives as fragments at coordinates and stripping splices them together minus whatever the cursor stepped over.
+- **Size the PTY with `stty`, inside it.** `COLUMNS` resizes nothing: the terminal reports `0 0` and the CLI lays its output out to 80 columns.
+- **Submit with CR, framed as a paste when the prompt asked for one**, and hold stdin open for the flow's life.
+- **Validate what you scraped as if it arrived any other way** before storing it. A credential Hezo read off a terminal earns more suspicion than one a human pasted, not less.
 
 ### User-facing docs terminology
 

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -175,8 +175,19 @@ immediately instead of starting a container to find out. The credential is share
 team on the instance, so this stops their runs too - replace it to bring them back.
 
 Only an outright refusal changes the badge. If Hezo cannot reach the provider, or the
-provider answers with an error of its own, the credential keeps the status it had: an
-outage must not take a working credential out of service.
+provider answers with an error of its own, **Verify** says it could not check the
+credential and leaves the status exactly as it was: an outage must not take a working
+credential out of service, and it must not claim a pass either.
+
+Where the provider gives a reason, Hezo repeats it back to you. That reason is the useful
+part: Anthropic answers `OAuth access token is invalid.` for a subscription token that has
+expired or been revoked, and `API key is invalid.` when what was pasted is an API key
+rather than a subscription token. The first means sign in again; the second means the
+credential is the wrong kind for the box it went in.
+
+**A Codex subscription cannot be checked this way.** Its credential is a sign-in file, not
+a token any endpoint accepts, so **Verify** tells you it could not check it rather than
+reporting a pass. The first real test is a run.
 
 ## Where to get an API key
 
@@ -224,6 +235,11 @@ say so, naming the connection. Hezo will not quietly move them onto one of your 
 connections: a run billing a provider you didn't pick, while the star still sits on the one
 you did, is the kind of thing that goes unnoticed for weeks. Re-verify the connection, or
 move the star, and runs resume.
+
+Deleting the default is different, because you removed the designation yourself. The star
+moves to another connection rather than leaving your instance with none, preferring a
+verified one and taking the oldest where several qualify. It is visible on the connections
+list straight away, so you can move it if the pick is not the one you wanted.
 
 ## Change a stored key
 

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -139,8 +139,14 @@ long the code has left, and waits while you finish.
   code into Hezo to finish. If the code was mistyped or has expired, Hezo says so and offers
   you a fresh sign-in.
 
+Finish promptly once you have the code. It expires on the provider's clock, which is shorter
+than the window Hezo keeps the sign-in open for, so a code that sat for several minutes can be
+refused with nothing wrong at either end. Start again and it works.
+
 Your credential is created inside the sandbox and stored encrypted without passing
-through your browser, so you never copy an auth file around.
+through your browser, so you never copy an auth file around. Before storing it, Hezo asks the
+provider whether it works, and tells you if the answer is no rather than saving something that
+would fail on your first run.
 
 For any instance where the sandbox cannot reach the provider's sign-in page, use **Paste
 credential manually** instead and follow the steps the form shows.

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -374,44 +374,62 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 	}
 
 	try {
-		// Both auth methods are asked, on their own header shape - the same rule the
-		// create path applies, kept in step with it here. What differs is what an
-		// answer is allowed to conclude: an api key that is refused *or* unreachable
-		// is handled below, while a subscription credential is condemned only by an
-		// outright rejection (`probeProvesCredentialDead`), so the branch is on the
-		// verdict rather than on the auth method.
+		// One question, three answers, and the same three for both auth methods. The
+		// route used to express only two, which is where its bugs lived: a provider
+		// that answered 500 condemned a working api key, and a subscription nothing could
+		// ask about was written `verified` and reported valid - instantly, having made
+		// no request at all, which is the "the badge is not a fact" defect this whole
+		// area exists to remove.
 		const probe = await probeProviderCatalog(
 			cred.provider as AiProvider,
 			cred.value,
 			cred.baseUrl,
 			cred.authMethod,
 		);
-		const subscription = cred.authMethod === AiAuthMethod.Subscription;
-		if (probe.ok || (subscription && !probeProvesCredentialDead(probe))) {
-			// Persist the healthy state so the badge is truthful and a key that was
+		const info = AI_PROVIDER_INFO[cred.provider as AiProvider];
+
+		// Accepted: the provider answered and took it.
+		if (probe.ok) {
+			// Persist the healthy state so the badge is truthful and a credential that was
 			// previously marked `invalid` recovers on a successful re-verify.
 			await db.query(
 				`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`,
 				[AiProviderStatus.Verified, configId],
 			);
-			return ok(c, { valid: true });
+			return ok(c, { valid: true, checked: true });
 		}
-		// An unreachable provider says nothing about the key, so the stored status
-		// is left alone rather than being marked invalid on a network blip - a
-		// badge that flips to "invalid" because the operator's laptop was offline
-		// is worse than no badge.
-		if (probe.reason === 'unreachable') {
-			return ok(c, { valid: false, message: 'Could not reach provider to verify key' });
+
+		// Refused: the provider answered and rejected it. The only answer that writes
+		// `invalid`, and the only one that may - see `probeProvesCredentialDead`.
+		if (probeProvesCredentialDead(probe)) {
+			await db.query(
+				`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`,
+				[AiProviderStatus.Invalid, configId],
+			);
+			// The provider's own words where it gave any: they separate a spent token from
+			// the wrong kind of credential pasted into the right box, which is the whole
+			// question an operator is left holding otherwise.
+			const why = probe.detail ? ` ${info?.name ?? cred.provider} said: ${probe.detail}` : '';
+			return ok(c, {
+				valid: false,
+				checked: true,
+				message:
+					cred.authMethod === AiAuthMethod.Subscription
+						? `Subscription credential was rejected. Sign in again to replace it - an expired or revoked one cannot be renewed.${why}`
+						: `API key was rejected.${why}`,
+			});
 		}
-		await db.query(`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`, [
-			AiProviderStatus.Invalid,
-			configId,
-		]);
+
+		// Unknown: nothing was established, so nothing is written. Reported as such
+		// rather than as either verdict - claiming "valid" here is what put a green
+		// tick beside a credential no one had checked.
 		return ok(c, {
-			valid: false,
-			message: subscription
-				? 'Subscription credential is invalid or expired — mint a fresh one'
-				: 'API key is invalid or expired',
+			valid: true,
+			checked: false,
+			message:
+				probe.reason === 'unsupported'
+					? `A ${info?.runtimeLabel ?? cred.provider} subscription cannot be checked without running it - the credential is a sign-in file, not a token any endpoint accepts. Its status is unchanged.`
+					: `Could not reach ${info?.name ?? cred.provider} to check this credential. Its status is unchanged.`,
 		});
 	} catch {
 		return ok(c, { valid: false, message: 'Could not reach provider to verify key' });

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -10,6 +10,7 @@ import {
 	parseProviderModels,
 	providerRuntimes,
 	providerSupportsRuntime,
+	type SubscriptionLoginFailure,
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
@@ -773,19 +774,31 @@ aiProvidersRoutes.get('/ai-providers/subscription-login/:flowId', async (c) => {
 		const masterKeyManager = c.get('masterKeyManager');
 		if (!masterKeyManager.getKey()) return err(c, 'LOCKED', 'Master key is locked', 401);
 		const db = c.get('db');
-		// Re-validated even though the CLI wrote it: the same tombstone guard the
-		// rotation write-back uses, so a blank file from a failed refresh is never
-		// stored as a credential.
-		const validation = validateSubscriptionBlob(flow.provider, state.credential);
-		if (!validation.ok) {
+		// Put through the same shape check and the same live question a pasted
+		// credential answers. A sign-in Hezo drove is not more trustworthy than one
+		// the operator pasted - it is less, because everything between the vendor's
+		// screen and this line is Hezo's own reading of a terminal. Storing it
+		// unasked is what turns a misread token into a provider that looks
+		// configured and refuses every run.
+		const prepared = await prepareProviderCredential(
+			flow.provider,
+			AiAuthMethod.Subscription,
+			state.credential,
+			undefined,
+		);
+		if (!prepared.ok) {
 			forgetFlow(flowId);
-			return err(c, 'INVALID_CREDENTIAL', validation.error ?? 'Invalid credential', 400);
+			return ok(c, {
+				status: 'failed',
+				error: prepared.message,
+				code: 'credential_rejected' satisfies SubscriptionLoginFailure,
+			});
 		}
 		pending = storeAiProviderKey(
 			db,
 			masterKeyManager,
 			flow.provider,
-			state.credential,
+			prepared.value,
 			AiAuthMethod.Subscription,
 			flowLabels.get(flowId),
 			{},

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -451,12 +451,56 @@ export async function updateAiProviderConfig(
 	return result.rows.length > 0;
 }
 
+/**
+ * Delete a config, handing the instance-wide default on when the deleted row
+ * held it.
+ *
+ * Without the hand-on, deleting the default leaves the instance with no
+ * designated credential at all. Nothing fails loudly - `resolveRuntimeForTask`
+ * falls through to its "no default designated" branch and picks the oldest
+ * verified row - so runs keep working while the settings page shows no Default
+ * on any row, and the operator's next deliberate choice is made against a
+ * designation that quietly stopped existing.
+ *
+ * **The successor is a verified row wherever one exists.** A designated default
+ * that cannot run is not a fallback the resolver forgives: it refuses the run
+ * naming that credential rather than passing to the next in line. So promoting a
+ * rejected row over a working one would take an instance that still had a usable
+ * credential and stop it dead. Only when nothing is verified does the oldest
+ * remaining row take it, which leaves the resolver able to name the credential
+ * the operator has to fix instead of reporting that none is configured.
+ *
+ * Ordering matches `selectProviderConfigRow` and the resolver - oldest first,
+ * `id` breaking a same-millisecond tie - so the row promoted here is the one a
+ * run would have chosen anyway. The whole thing is one transaction: the partial
+ * unique index permits a single default, and a delete that committed without its
+ * successor would leave exactly the state this exists to prevent.
+ */
 export async function deleteAiProviderConfig(db: Db, configId: string): Promise<boolean> {
-	const result = await db.query<{ id: string }>(
-		`DELETE FROM ai_provider_configs WHERE id = $1 RETURNING id`,
-		[configId],
-	);
-	return result.rows.length > 0;
+	return withTransaction(db, async () => {
+		const result = await db.query<{ id: string; is_default: boolean }>(
+			`DELETE FROM ai_provider_configs WHERE id = $1 RETURNING id, is_default`,
+			[configId],
+		);
+		const deleted = result.rows[0];
+		if (!deleted) return false;
+		if (!deleted.is_default) return true;
+
+		const successor = await db.query<{ id: string }>(
+			`SELECT id FROM ai_provider_configs
+			 ORDER BY (status = $1) DESC, created_at ASC, id ASC
+			 LIMIT 1`,
+			[AiProviderStatus.Verified],
+		);
+		const promote = successor.rows[0];
+		if (promote) {
+			await db.query(
+				`UPDATE ai_provider_configs SET is_default = true, updated_at = now() WHERE id = $1`,
+				[promote.id],
+			);
+		}
+		return true;
+	});
 }
 
 export async function setDefaultAiProvider(db: Db, configId: string): Promise<boolean> {
@@ -482,18 +526,34 @@ export async function setDefaultAiProvider(db: Db, configId: string): Promise<bo
 	return true;
 }
 
+/**
+ * Whether the operator has set an AI provider up, and which of them can run.
+ *
+ * **The two are deliberately different questions**, because one consumer gates
+ * the whole app on the first. `configured` asks whether setup has been done at
+ * all - any row, whatever its status - and `providers` asks which providers a
+ * run could actually use, which is the verified ones.
+ *
+ * Answering `configured` from the verified rows is what made a rejected
+ * credential look like a fresh install: the first-run wizard replaces the entire
+ * app shell while `configured` is false, so an operator who pressed Verify on a
+ * credential the provider refused was thrown out of Settings and into onboarding -
+ * away from the one screen where the credential could be replaced, and reading as
+ * though their instance had lost its setup.
+ */
 export async function getAiProviderStatus(
 	db: Db,
 ): Promise<{ configured: boolean; providers: string[] }> {
-	const result = await db.query<{ provider: string }>(
-		`SELECT DISTINCT provider FROM ai_provider_configs WHERE status = $1`,
-		[AiProviderStatus.Verified],
+	const result = await db.query<{ provider: string; status: string }>(
+		`SELECT DISTINCT provider, status FROM ai_provider_configs`,
 	);
 
-	return {
-		configured: result.rows.length > 0,
-		providers: result.rows.map((r) => r.provider),
-	};
+	// A provider holding both a verified and a rejected credential comes back on
+	// two rows, so the usable list is de-duplicated rather than taken as-is.
+	const verified = new Set(
+		result.rows.filter((r) => r.status === AiProviderStatus.Verified).map((r) => r.provider),
+	);
+	return { configured: result.rows.length > 0, providers: [...verified] };
 }
 
 export async function getProviderConfigCredential(

--- a/packages/server/src/services/provider-catalog.ts
+++ b/packages/server/src/services/provider-catalog.ts
@@ -79,13 +79,14 @@ export type CatalogFailure = 'unsupported' | 'unreachable' | 'rejected' | 'error
 
 export type CatalogResult =
 	| { ok: true; json: unknown }
-	| { ok: false; reason: CatalogFailure; status?: number };
+	| { ok: false; reason: CatalogFailure; status?: number; detail?: string };
 
 const CATALOG_TIMEOUT_MS = 10_000;
 
 export type CatalogProbe =
 	| { ok: true; res: Response }
-	| { ok: false; reason: CatalogFailure; status?: number };
+	/** `detail` is the provider's own refusal reason, present only on `rejected`. */
+	| { ok: false; reason: CatalogFailure; status?: number; detail?: string };
 
 /**
  * Call the catalog endpoint and classify the outcome, **without reading the
@@ -120,11 +121,60 @@ export async function probeProviderCatalog(
 
 	if (!res.ok) {
 		if (res.status === 401 || res.status === 403) {
-			return { ok: false, reason: 'rejected', status: res.status };
+			return {
+				ok: false,
+				reason: 'rejected',
+				status: res.status,
+				detail: await refusalDetail(res, credentialValue),
+			};
 		}
 		return { ok: false, reason: 'error', status: res.status };
 	}
 	return { ok: true, res };
+}
+
+/** Cap on the refused body we read. A refusal is a sentence; anything longer is not one. */
+const REFUSAL_DETAIL_LIMIT = 400;
+
+/**
+ * The provider's own reason for refusing, for an operator to read.
+ *
+ * Worth the one extra body read that {@link probeProviderCatalog} otherwise
+ * avoids, because the providers distinguish cases the status code cannot and the
+ * operator cannot act without knowing which they hit: Anthropic answers `OAuth
+ * access token is invalid.` for a spent subscription token and `API key is
+ * invalid.` for a key, so relaying it is the difference between "mint a new
+ * token" and "you pasted the wrong kind of credential".
+ *
+ * **Scrubbed, and never derived from the credential.** Per the credential rules
+ * this must return nothing carrying the secret - no prefix, no masked form - so
+ * the value is stripped from whatever came back rather than trusted not to
+ * appear in it. Read only on a refusal, and only ever `null` on trouble: a
+ * diagnostic that throws would turn a clean verdict into a failed request.
+ */
+async function refusalDetail(res: Response, credentialValue: string): Promise<string | undefined> {
+	let body: string;
+	try {
+		body = (await res.text()).slice(0, REFUSAL_DETAIL_LIMIT);
+	} catch {
+		return undefined;
+	}
+
+	let message: string | undefined;
+	try {
+		const parsed = JSON.parse(body) as { error?: { message?: unknown }; message?: unknown };
+		const raw = typeof parsed.error?.message === 'string' ? parsed.error.message : parsed.message;
+		if (typeof raw === 'string') message = raw;
+	} catch {
+		// Not JSON. A plain-text refusal is still worth relaying.
+		message = body;
+	}
+
+	const cleaned = message?.trim();
+	if (!cleaned) return undefined;
+	// Defensive: no provider observed returns the credential in its refusal, but a
+	// diagnostic is exactly the wrong place to find out that one does.
+	return cleaned.split(credentialValue).join('[redacted]').slice(0, REFUSAL_DETAIL_LIMIT);
 }
 
 /**

--- a/packages/server/src/services/sandbox/proc-scripts.ts
+++ b/packages/server/src/services/sandbox/proc-scripts.ts
@@ -353,15 +353,26 @@ export function shellQuote(arg: string): string {
 }
 
 /**
- * Terminal columns the login PTY is opened at.
+ * The size the login PTY is opened at.
  *
- * A vendor CLI wraps its sign-in URL to the terminal width, and a wrapped URL
- * arrives interleaved with the spinner frames redrawn around it - Claude Code's
- * visible URL text comes back in four overlapping fragments at 80 columns. Wide
- * enough that nothing these CLIs print wraps at all, which is what lets the
- * parsers below read a line rather than reassemble one.
+ * A vendor CLI lays its output out to the terminal width, and anything wider
+ * than that is split across rows - Claude Code's sign-in URL and the token it
+ * mints both arrive in fragments at 80 columns. Wide enough that nothing these
+ * CLIs print wraps at all, which is what lets a parser read a value rather than
+ * reassemble one.
+ *
+ * **Set on the terminal, not in the environment.** A TUI reads its width from
+ * the tty itself, so `COLUMNS` alone changes nothing: `script` opens a PTY whose
+ * size is never initialised, `stty size` reports `0 0`, and the CLI falls back
+ * to its own default of 80. `stty` inside the PTY is what actually resizes it;
+ * the variables are exported alongside so a CLI that prefers them agrees with
+ * the tty rather than contradicting it.
+ *
+ * Rows matter as much as columns - a zero-height terminal is not a shape a
+ * full-screen CLI is written for.
  */
-const LOGIN_PTY_COLUMNS = 1000;
+const LOGIN_PTY_COLUMNS = 400;
+const LOGIN_PTY_ROWS = 100;
 
 /** Per-flow file names under a login flow's own directory. */
 export const LOGIN_STDIN_FIFO = 'in';
@@ -404,8 +415,13 @@ export function buildSubscriptionLoginScript(opts: {
 
 	const d = shellQuote(dir);
 	// `script` needs the command as one string; each argv element is quoted
-	// individually so nothing in it can reach the outer shell.
-	const inner = argv.map(shellQuote).join(' ');
+	// individually so nothing in it can reach the outer shell. The resize runs
+	// inside that string because it has to happen on the PTY `script` allocated,
+	// and it precedes the CLI so the first frame is already painted at the width
+	// the parsers expect.
+	const inner = `stty cols ${LOGIN_PTY_COLUMNS} rows ${LOGIN_PTY_ROWS}; ${argv
+		.map(shellQuote)
+		.join(' ')}`;
 	const envPrefix = Object.entries(env)
 		.map(([k, v]) => {
 			if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) throw new Error(`unsafe env name: ${k}`);
@@ -436,7 +452,7 @@ export function buildSubscriptionLoginScript(opts: {
 		// the call that starts the flow never returns and the flow never begins.
 		// The inner redirections still win for the commands they name.
 		`( sleep ${holdSecs} > ${fifo} ) >/dev/null 2>&1 & ` +
-		`( COLUMNS=${LOGIN_PTY_COLUMNS} ${envPrefix} ` +
+		`( COLUMNS=${LOGIN_PTY_COLUMNS} LINES=${LOGIN_PTY_ROWS} ${envPrefix} ` +
 		`script -qec ${shellQuote(inner)} /dev/null ` +
 		`< ${fifo} > ${log} 2>&1; ` +
 		// Written last and read as the flow's "process is gone" signal.
@@ -529,19 +545,6 @@ export function bracketedPasteEnabled(raw: string): boolean {
 	return enabled;
 }
 
-/**
- * Drop the escape sequences a PTY interleaves with a CLI's own output.
- *
- * Covers CSI (colour, cursor moves, erases), OSC (window title, and the
- * hyperlinks {@link parseOsc8Links} reads first), and the bare two-byte escapes
- * a full-screen redraw emits. Carriage returns become newlines so a redrawn line
- * is its own line to a line-oriented matcher rather than joining the one before.
- */
-export function stripTerminalNoise(raw: string): string {
-	return raw
-		.replace(new RegExp(`${ESC}][^${ESC}${BEL}]*(?:${ST})`, 'g'), '')
-		.replace(new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, 'g'), '')
-		.replace(new RegExp(`${ESC}[()][A-Za-z0-9]`, 'g'), '')
-		.replace(new RegExp(`${ESC}[=><]`, 'g'), '')
-		.replace(/\r/g, '\n');
-}
+// Reading a value back out of what a CLI printed is `renderTerminalScreen`
+// (`./terminal-screen`), which composes the screen rather than deleting the
+// escapes out of the stream. It is imported from there, not re-exported here.

--- a/packages/server/src/services/sandbox/terminal-screen.ts
+++ b/packages/server/src/services/sandbox/terminal-screen.ts
@@ -1,0 +1,278 @@
+/**
+ * Compose a PTY byte stream into the screen it paints.
+ *
+ * A full-screen CLI does not write text, it writes *cells*: it moves the cursor
+ * and repaints only what changed, so a single logical value reaches the stream
+ * as several fragments at coordinates, spread across frames. Reading such a
+ * value by deleting the escape sequences and keeping the rest is unsound in two
+ * ways, and both silently corrupt the result rather than failing:
+ *
+ * - **A skipped column is a lost character.** A redraw that re-writes only the
+ *   changed part jumps the cursor over a character it left standing, so
+ *   deleting the jump splices the fragments either side of it together and the
+ *   untouched character is gone.
+ * - **A wrapped value is a truncated one.** Text laid out to the terminal's
+ *   width arrives as fragments on separate rows, and a matcher that stops at a
+ *   line break takes the first fragment for the whole value.
+ *
+ * Composing the cells answers both: the value is read from the finished screen,
+ * where it sits exactly as an operator would see it.
+ *
+ * Every escape that moves the cursor or erases is honoured; the rest - colour,
+ * mode switches, hyperlinks - is skipped, since none of it changes what
+ * character ends up in which cell. OSC 8 targets are read from the raw stream by
+ * `parseOsc8Links`, which is why they need no representation here.
+ */
+
+/**
+ * How much screen is kept.
+ *
+ * A bound rather than an unbounded canvas because the input is a log that grows
+ * for as long as a sign-in runs, and the cost of composing it is paid on every
+ * poll. Both are far above what any sign-in paints, so clamping never truncates
+ * real output - it only refuses to follow a cursor move into open space.
+ */
+const MAX_ROWS = 4096;
+const MAX_COLS = 4096;
+
+/** A parsed CSI: its numeric parameters and the final byte that names it. */
+interface ControlSequence {
+	params: number[];
+	final: string;
+	end: number;
+}
+
+/**
+ * Read one CSI starting at the `[` after ESC.
+ *
+ * Parameter bytes, then intermediate bytes, then the final byte - the shape ECMA
+ * 48 defines, so a sequence carrying private markers (`?`, `<`) or intermediates
+ * is consumed whole even when nothing below acts on it.
+ */
+function readControlSequence(raw: string, start: number): ControlSequence {
+	let i = start;
+	while (i < raw.length && /[0-9;?<>=!]/.test(raw[i])) i += 1;
+	while (i < raw.length && /[ -/]/.test(raw[i])) i += 1;
+	const params = raw
+		.slice(start, i)
+		.replace(/[^0-9;]/g, '')
+		.split(';')
+		.map((p) => (p === '' ? Number.NaN : Number(p)));
+	return { params, final: raw[i] ?? '', end: i + 1 };
+}
+
+class Screen {
+	private readonly rows: string[][] = [];
+	private row = 0;
+	private col = 0;
+	private savedRow = 0;
+	private savedCol = 0;
+
+	/** The row at the cursor, grown to reach it. */
+	private currentRow(): string[] {
+		while (this.rows.length <= this.row) this.rows.push([]);
+		return this.rows[this.row];
+	}
+
+	write(ch: string): void {
+		if (this.row >= MAX_ROWS || this.col >= MAX_COLS) return;
+		const row = this.currentRow();
+		while (row.length < this.col) row.push(' ');
+		row[this.col] = ch;
+		this.col += 1;
+	}
+
+	moveTo(row: number, col: number): void {
+		this.row = Math.min(Math.max(0, row), MAX_ROWS);
+		this.col = Math.min(Math.max(0, col), MAX_COLS);
+	}
+
+	moveBy(rows: number, cols: number): void {
+		this.moveTo(this.row + rows, this.col + cols);
+	}
+
+	get position(): { row: number; col: number } {
+		return { row: this.row, col: this.col };
+	}
+
+	saveCursor(): void {
+		this.savedRow = this.row;
+		this.savedCol = this.col;
+	}
+
+	restoreCursor(): void {
+		this.moveTo(this.savedRow, this.savedCol);
+	}
+
+	/** Erase within the cursor's row: to its end, to its start, or all of it. */
+	eraseInLine(mode: number): void {
+		const row = this.currentRow();
+		if (mode === 1) {
+			for (let c = 0; c <= this.col && c < row.length; c += 1) row[c] = ' ';
+		} else if (mode === 2) {
+			row.length = 0;
+		} else {
+			row.length = Math.min(row.length, this.col);
+		}
+	}
+
+	/** Erase the display: below the cursor, above it, or the whole screen. */
+	eraseInDisplay(mode: number): void {
+		if (mode === 1) {
+			for (let r = 0; r < this.row && r < this.rows.length; r += 1) this.rows[r].length = 0;
+			this.eraseInLine(1);
+		} else if (mode === 2 || mode === 3) {
+			this.rows.length = 0;
+			this.moveTo(0, 0);
+		} else {
+			this.eraseInLine(0);
+			this.rows.length = Math.min(this.rows.length, this.row + 1);
+		}
+	}
+
+	/** The finished screen, one string per row with trailing blanks dropped. */
+	render(): string {
+		return this.rows.map((row) => row.join('').replace(/\s+$/, '')).join('\n');
+	}
+}
+
+/**
+ * The screen `raw` paints, as text - one line per row.
+ *
+ * Use this, not the raw stream, to read any value a CLI printed. The result is
+ * what the operator sees, so a matcher run over it reads whole values rather
+ * than the fragments the repaint happened to emit.
+ */
+export function renderTerminalScreen(raw: string): string {
+	const screen = new Screen();
+
+	let i = 0;
+	while (i < raw.length) {
+		const ch = raw[i];
+
+		if (ch === '\x1b') {
+			const next = raw[i + 1];
+			if (next === '[') {
+				const { params, final, end } = readControlSequence(raw, i + 2);
+				const n = Number.isNaN(params[0]) ? 1 : params[0];
+				const { row, col } = screen.position;
+				switch (final) {
+					case 'A':
+						screen.moveBy(-n, 0);
+						break;
+					case 'B':
+						screen.moveBy(n, 0);
+						break;
+					case 'C':
+						screen.moveBy(0, n);
+						break;
+					case 'D':
+						screen.moveBy(0, -n);
+						break;
+					case 'E':
+						screen.moveTo(row + n, 0);
+						break;
+					case 'F':
+						screen.moveTo(row - n, 0);
+						break;
+					case 'G':
+					case '`':
+						screen.moveTo(row, n - 1);
+						break;
+					case 'd':
+						screen.moveTo(n - 1, col);
+						break;
+					case 'H':
+					case 'f':
+						screen.moveTo(n - 1, (Number.isNaN(params[1]) ? 1 : params[1]) - 1);
+						break;
+					case 'J':
+						screen.eraseInDisplay(Number.isNaN(params[0]) ? 0 : params[0]);
+						break;
+					case 'K':
+						screen.eraseInLine(Number.isNaN(params[0]) ? 0 : params[0]);
+						break;
+					default:
+						break;
+				}
+				i = end;
+				continue;
+			}
+			if (next === ']') {
+				// OSC, terminated by BEL or by ST. Skipped whole: a window title or a
+				// hyperlink target occupies no cell.
+				let j = i + 2;
+				while (j < raw.length && raw[j] !== '\x07' && !(raw[j] === '\x1b' && raw[j + 1] === '\\')) {
+					j += 1;
+				}
+				i = raw[j] === '\x07' ? j + 1 : j + 2;
+				continue;
+			}
+			if (next === '7') {
+				screen.saveCursor();
+				i += 2;
+				continue;
+			}
+			if (next === '8') {
+				screen.restoreCursor();
+				i += 2;
+				continue;
+			}
+			if (next === 'M') {
+				screen.moveBy(-1, 0);
+				i += 2;
+				continue;
+			}
+			if (next === 'D') {
+				screen.moveBy(1, 0);
+				i += 2;
+				continue;
+			}
+			if (next === 'E') {
+				screen.moveTo(screen.position.row + 1, 0);
+				i += 2;
+				continue;
+			}
+			// Charset and other intermediate-carrying escapes take one more byte.
+			i += next !== undefined && /[()*+#%]/.test(next) ? 3 : 2;
+			continue;
+		}
+
+		if (ch === '\r') {
+			screen.moveTo(screen.position.row, 0);
+			i += 1;
+			continue;
+		}
+		if (ch === '\n') {
+			// Line feed starts the next line, rather than dropping a row and keeping
+			// the column. A PTY pairs it with a carriage return and both readings
+			// agree; a CLI writing to a pipe emits it alone and means a new line. The
+			// other reading would indent each successive line of piped output by the
+			// length of the one before it.
+			screen.moveTo(screen.position.row + 1, 0);
+			i += 1;
+			continue;
+		}
+		if (ch === '\b') {
+			screen.moveBy(0, -1);
+			i += 1;
+			continue;
+		}
+		// Bell, and the shift-in/shift-out charset toggles: no cell, no cursor move.
+		if (ch === '\x07' || ch === '\x0e' || ch === '\x0f') {
+			i += 1;
+			continue;
+		}
+		if (ch === '\t') {
+			const { row, col } = screen.position;
+			screen.moveTo(row, col + 8 - (col % 8));
+			i += 1;
+			continue;
+		}
+
+		screen.write(ch);
+		i += 1;
+	}
+
+	return screen.render();
+}

--- a/packages/server/src/services/subscription-login-drivers.ts
+++ b/packages/server/src/services/subscription-login-drivers.ts
@@ -1,5 +1,6 @@
 import { AgentRuntime } from '@hezo/shared';
-import { parseOsc8Links, stripTerminalNoise } from './sandbox/proc-scripts';
+import { parseOsc8Links } from './sandbox/proc-scripts';
+import { renderTerminalScreen } from './sandbox/terminal-screen';
 
 /**
  * How each coding CLI mints a subscription credential from an interactive
@@ -37,10 +38,10 @@ export interface SubscriptionLoginDriver {
 	 * Proof the installed CLI still offers this flow, run before the operator is
 	 * shown anything.
 	 *
-	 * The three coding CLIs are installed **unpinned** in the agent image, so a
-	 * flag can vanish under a rebuild. Without this the loss would surface as a
-	 * flow that hangs until its challenge timeout with nothing to say; with it,
-	 * the start fails naming the CLI and the flag.
+	 * A pin fixes which version the image installs, not which flags that version
+	 * offers, so a bump can still retire one. Without this the loss would surface
+	 * as a flow that hangs until its challenge timeout with nothing to say; with
+	 * it, the start fails naming the CLI and the flag.
 	 */
 	capabilityProbe?: { argv: readonly string[]; mustContain: string };
 	/** Recognise the challenge in the log so far. Null until the CLI has printed it. */
@@ -96,7 +97,7 @@ const CODEX_DRIVER: SubscriptionLoginDriver = {
 	argv: ['codex', 'login', '--device-auth'],
 	capabilityProbe: { argv: ['codex', 'login', '--help'], mustContain: '--device-auth' },
 	parseChallenge(log) {
-		const text = stripTerminalNoise(log);
+		const text = renderTerminalScreen(log);
 		const url = firstStandaloneUrl(text, 'auth.openai.com');
 		if (!url) return null;
 		// The code is printed alone on its line; matching that rather than
@@ -127,9 +128,17 @@ const CODEX_DRIVER: SubscriptionLoginDriver = {
  * code rather than redirecting to a loopback port - so nothing has to listen
  * anywhere and the operator simply brings the code back.
  *
- * The URL is read from the OSC 8 hyperlink rather than the visible text: the
- * spinner redraws around it, and the on-screen copy comes back interleaved
- * across several overlapping fragments while the escape stays whole.
+ * The URL is read from the OSC 8 hyperlink rather than from the screen: the
+ * hyperlink carries the whole target in one escape, while the visible copy is
+ * laid out to the terminal and would have to be read back off it.
+ *
+ * **The token is read off the composed screen, never out of the byte stream.**
+ * It is printed into a box the CLI repaints, which reaches the log as fragments
+ * at coordinates: one repaint writes `sk-ant-`, jumps the cursor over a
+ * character already standing from an earlier frame, then writes the rest. Delete
+ * the escapes and that character is gone and the fragments splice together, so
+ * the harvest yields a token that is the right shape and the wrong value - which
+ * is stored, and then refused by Anthropic on every run.
  */
 const CLAUDE_CODE_DRIVER: SubscriptionLoginDriver = {
 	argv: ['claude', 'setup-token'],
@@ -140,7 +149,7 @@ const CLAUDE_CODE_DRIVER: SubscriptionLoginDriver = {
 		return null;
 	},
 	completion: 'code',
-	harvest: (log) => stripTerminalNoise(log).match(/sk-ant-oat01-[A-Za-z0-9_-]+/)?.[0] ?? null,
+	harvest: (log) => renderTerminalScreen(log).match(/sk-ant-oat01-[A-Za-z0-9_-]+/)?.[0] ?? null,
 	challengeTimeoutMs: 2 * MINUTE,
 	completionTimeoutMs: 15 * MINUTE,
 };

--- a/packages/server/test/ai-provider-keys.test.ts
+++ b/packages/server/test/ai-provider-keys.test.ts
@@ -1,4 +1,4 @@
-import { AiAuthMethod, AiProvider } from '@hezo/shared';
+import { AiAuthMethod, AiProvider, AiProviderStatus } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
@@ -180,13 +180,178 @@ describe('deleteAiProviderConfig', () => {
 		const result = await deleteAiProviderConfig(db, '00000000-0000-0000-0000-000000000099');
 		expect(result).toBe(false);
 	});
+
+	it('hands the default to the next credential when the default is deleted', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		const first = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-first',
+			AiAuthMethod.ApiKey,
+			'first',
+		);
+		const second = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-second',
+			AiAuthMethod.ApiKey,
+			'second',
+		);
+		// The first config added to an instance auto-takes the default.
+		expect((await listAiProviders(db)).find((c) => c.is_default)?.id).toBe(first);
+
+		expect(await deleteAiProviderConfig(db, first)).toBe(true);
+
+		const remaining = await listAiProviders(db);
+		expect(remaining.filter((c) => c.is_default).map((c) => c.id)).toEqual([second]);
+	});
+
+	it('prefers a verified successor over a rejected one', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		const theDefault = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-default',
+			AiAuthMethod.ApiKey,
+			'the-default',
+		);
+		const rejected = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-rejected',
+			AiAuthMethod.ApiKey,
+			'rejected-but-older',
+		);
+		const working = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.DeepSeek,
+			'sk-working',
+			AiAuthMethod.ApiKey,
+			'verified-but-newer',
+		);
+		await db.query(`UPDATE ai_provider_configs SET status = $1 WHERE id = $2`, [
+			AiProviderStatus.Invalid,
+			rejected,
+		]);
+
+		expect(await deleteAiProviderConfig(db, theDefault)).toBe(true);
+
+		// The rejected row is older, so plain oldest-first would have taken it - and
+		// the resolver refuses a run naming an unusable default rather than passing
+		// to the next in line, which would strand an instance that still works.
+		const remaining = await listAiProviders(db);
+		expect(remaining.filter((c) => c.is_default).map((c) => c.id)).toEqual([working]);
+	});
+
+	it('leaves a non-default deletion alone', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		const theDefault = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-keeps-it',
+			AiAuthMethod.ApiKey,
+			'keeps-it',
+		);
+		const other = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.OpenAI,
+			'sk-other',
+			AiAuthMethod.ApiKey,
+			'other',
+		);
+
+		expect(await deleteAiProviderConfig(db, other)).toBe(true);
+
+		const remaining = await listAiProviders(db);
+		expect(remaining.filter((c) => c.is_default).map((c) => c.id)).toEqual([theDefault]);
+	});
+
+	it('deletes the last config without leaving a default behind', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		const only = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-only',
+			AiAuthMethod.ApiKey,
+			'only',
+		);
+
+		expect(await deleteAiProviderConfig(db, only)).toBe(true);
+		expect(await listAiProviders(db)).toEqual([]);
+	});
 });
 
 describe('getAiProviderStatus', () => {
 	it('returns configured: true when any provider is stored', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-status',
+			AiAuthMethod.ApiKey,
+			'status-verified',
+		);
 		const status = await getAiProviderStatus(db);
 		expect(status.configured).toBe(true);
 		expect(status.providers).toContain(AiProvider.Anthropic);
+	});
+
+	it('stays configured when every credential has been rejected', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-dead',
+			AiAuthMethod.ApiKey,
+			'rejected',
+		);
+		await db.query(`UPDATE ai_provider_configs SET status = $1`, [AiProviderStatus.Invalid]);
+
+		const status = await getAiProviderStatus(db);
+		// Setup has been done; the credential is simply broken. Reporting `false`
+		// here throws the operator into the first-run wizard, which replaces the
+		// whole app shell - taking away the settings page where the credential
+		// would be replaced, on the very click that diagnosed it.
+		expect(status.configured).toBe(true);
+		// It is still not usable, and that is what `providers` reports.
+		expect(status.providers).toEqual([]);
+	});
+
+	it('lists a provider once when it holds both a verified and a rejected credential', async () => {
+		await db.query(`DELETE FROM ai_provider_configs`);
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-good',
+			AiAuthMethod.ApiKey,
+			'good',
+		);
+		const bad = await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.Anthropic,
+			'sk-ant-bad',
+			AiAuthMethod.ApiKey,
+			'bad',
+		);
+		await db.query(`UPDATE ai_provider_configs SET status = $1 WHERE id = $2`, [
+			AiProviderStatus.Invalid,
+			bad,
+		]);
+
+		const status = await getAiProviderStatus(db);
+		expect(status.providers).toEqual([AiProvider.Anthropic]);
 	});
 
 	it('returns configured: false on a fresh DB', async () => {

--- a/packages/server/test/ai-providers-verify.test.ts
+++ b/packages/server/test/ai-providers-verify.test.ts
@@ -116,7 +116,8 @@ describe('POST /ai-providers/:configId/verify', () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.data.valid).toBe(false);
-		expect(body.data.message).toContain('invalid');
+		expect(body.data.checked).toBe(true);
+		expect(body.data.message).toContain('rejected');
 
 		const status = await db.query<{ status: string }>(
 			'SELECT status FROM ai_provider_configs WHERE id = $1',
@@ -142,7 +143,11 @@ describe('POST /ai-providers/:configId/verify', () => {
 		expect(status.rows[0].status).toBe('verified');
 	});
 
-	it('returns valid:false when the provider is unreachable', async () => {
+	it('reports an unreachable provider as unchecked, not as a bad key', async () => {
+		// Reaching nobody says nothing about the credential. Reporting it as invalid
+		// puts the operator on a hunt for a fault that is not theirs, and the status
+		// must not move on it either.
+		await db.query(`UPDATE ai_provider_configs SET status = 'verified' WHERE id = $1`, [configId]);
 		globalThis.fetch = vi.fn().mockRejectedValue(new Error('net')) as unknown as typeof fetch;
 		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
 			method: 'POST',
@@ -150,8 +155,26 @@ describe('POST /ai-providers/:configId/verify', () => {
 		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.data.valid).toBe(false);
-		expect(body.data.message).toContain('Could not reach provider');
+		expect(body.data.valid).toBe(true);
+		expect(body.data.checked).toBe(false);
+		expect(body.data.message).toContain('Could not reach');
+		await expectStatus(configId, 'verified');
+	});
+
+	it('does not blame the key when the provider answers with its own error', async () => {
+		// A 500 is the provider's problem. This used to fall through to the reject
+		// branch and mark a working key invalid.
+		await db.query(`UPDATE ai_provider_configs SET status = 'verified' WHERE id = $1`, [configId]);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		const body = await res.json();
+		expect(body.data.checked).toBe(false);
+		await expectStatus(configId, 'verified');
 	});
 
 	it('returns 404 for an unknown config id', async () => {
@@ -210,8 +233,90 @@ describe('POST /ai-providers/:configId/verify', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect((await res.json()).data.valid).toBe(true);
+		const unproven = (await res.json()).data;
+		expect(unproven.valid).toBe(true);
+		// Not disproven is not the same as checked, and the tick follows `checked`.
+		expect(unproven.checked).toBe(false);
 		await expectStatus(subId, 'verified');
+	});
+
+	it('reports a subscription it cannot check as unchecked, and writes nothing', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		// Codex's subscription credential is a sign-in file, not a token any endpoint
+		// accepts, so its table entry carries no `subscriptionHeaders`. This used to
+		// return `valid: true` instantly having made no request, putting a green tick
+		// beside a credential nobody had checked.
+		const create = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: '{"tokens":{"refresh_token":"r"}}',
+				auth_method: 'subscription',
+				label: 'codex-unverifiable',
+			}),
+		});
+		expect(create.status).toBe(201);
+		const subId = (await create.json()).data.id;
+		await db.query(`UPDATE ai_provider_configs SET status = 'invalid' WHERE id = $1`, [subId]);
+
+		const fetchSpy = vi.fn();
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()).data;
+		expect(body.checked).toBe(false);
+		expect(body.message).toContain('cannot be checked');
+		expect(fetchSpy).not.toHaveBeenCalled();
+		// Nothing was established, so nothing is written - the stored status stands.
+		await expectStatus(subId, 'invalid');
+	});
+
+	it("relays the provider's own reason for refusing", async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		const subId = await addSubscriptionConfig('sub-with-reason');
+
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 401,
+			text: async () => JSON.stringify({ error: { message: 'OAuth access token is invalid.' } }),
+		}) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+
+		const body = (await res.json()).data;
+		expect(body.valid).toBe(false);
+		expect(body.checked).toBe(true);
+		// The distinguishing half: this is what separates a spent token from an api
+		// key pasted into the subscription box, which both fail with a bare 401.
+		expect(body.message).toContain('OAuth access token is invalid.');
+	});
+
+	it('never relays the credential itself in a refusal', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		const subId = await addSubscriptionConfig('sub-echoing-provider');
+
+		// A provider that echoes what it was sent must not turn a diagnostic into a
+		// credential leak.
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 401,
+			text: async () => `token sk-ant-oat01-live-token is not valid`,
+		}) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+
+		const body = (await res.json()).data;
+		expect(body.message).not.toContain('sk-ant-oat01-live-token');
+		expect(body.message).toContain('[redacted]');
 	});
 
 	it('rejects a subscription token the provider refuses at paste time', async () => {

--- a/packages/server/test/ai-providers.test.ts
+++ b/packages/server/test/ai-providers.test.ts
@@ -91,6 +91,24 @@ describe('AI providers CRUD', () => {
 		expect(body.data.providers).toContain('anthropic');
 	});
 
+	it('stays configured after the provider rejects the credential', async () => {
+		// The first-run wizard replaces the whole app shell while this is false, so
+		// reporting an instance with a rejected credential as unconfigured throws the
+		// operator into onboarding on the very click that diagnosed the credential -
+		// away from the settings page where it would be replaced.
+		await db.query(`UPDATE ai_provider_configs SET status = 'invalid' WHERE id = $1`, [configId]);
+
+		const res = await app.request('/api/ai-providers/status', { headers: authHeader(token) });
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.configured).toBe(true);
+		// Still not usable, and that is the field which says so.
+		expect(body.data.providers).not.toContain('anthropic');
+
+		await db.query(`UPDATE ai_provider_configs SET status = 'verified' WHERE id = $1`, [configId]);
+	});
+
 	it('rejects invalid provider name', async () => {
 		const res = await app.request('/api/ai-providers', {
 			method: 'POST',

--- a/packages/server/test/subscription-login-drivers.test.ts
+++ b/packages/server/test/subscription-login-drivers.test.ts
@@ -1,12 +1,14 @@
 import { AgentRuntime, RUNTIMES_WITH_GUIDED_SIGN_IN } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
-import { parseOsc8Links, stripTerminalNoise } from '../src/services/sandbox/proc-scripts';
+import { parseOsc8Links } from '../src/services/sandbox/proc-scripts';
+import { renderTerminalScreen } from '../src/services/sandbox/terminal-screen';
 import { SUBSCRIPTION_LOGIN_DRIVERS } from '../src/services/subscription-login-drivers';
 
 /**
- * The fixtures below are **recorded verbatim** from the real CLIs at the
- * versions an unpinned image build installs, captured with the streams
- * separated and no TTY (Codex) and under a PTY (Claude Code).
+ * The fixtures below are **recorded** from the real CLIs at the versions the
+ * agent image pins, captured with the streams separated and no TTY (Codex) and
+ * under a PTY (Claude Code). Where one carried a credential the value is
+ * substituted and the escape structure kept.
  *
  * They are the whole point of this file: a parser written against prose in a
  * vendor doc is a guess, and the failure mode of a wrong guess is a sign-in that
@@ -57,17 +59,34 @@ const CLAUDE_SETUP_TOKEN_PTY = [
 	'Paste code here if prompted >',
 ].join('\r\n');
 
+/**
+ * A token value of the length and alphabet `claude setup-token` mints, made up
+ * here: a fixture carrying a real one would be a live credential in the repo.
+ */
+const CLAUDE_SYNTHETIC_TOKEN = `sk-ant-oat01-${'A1b2C3d4E5f6G7h8J9k0'.repeat(5).slice(0, 95)}`;
+
+/**
+ * The token printed into the CLI's box, as the repaint leaves it in the stream:
+ * one pass paints the character at column 9, a later pass rewrites the prefix
+ * and jumps the cursor from column 8 to column 10 rather than repainting a cell
+ * that has not changed.
+ *
+ * Recorded from claude-code 2.1.238 under the login PTY. The escape structure is
+ * as captured; only the credential is substituted.
+ */
+const CLAUDE_TOKEN_REPAINT =
+	`${ESC}[1C${ESC}[1BYour${ESC}[7GOAuth${ESC}[13Gtoken${ESC}[19G(valid${ESC}[26Gfor${ESC}[30G1${ESC}[32Gyear):\r\n` +
+	`${ESC}[9G${CLAUDE_SYNTHETIC_TOKEN[7]}\r` +
+	`${ESC}[2G${CLAUDE_SYNTHETIC_TOKEN.slice(0, 7)}${ESC}[10G${CLAUDE_SYNTHETIC_TOKEN.slice(8)}${ESC}[K\r\r\n` +
+	`${ESC}[2GStore${ESC}[8Gthis${ESC}[13Gtoken${ESC}[19Gsecurely.`;
+
 describe('terminal output parsing', () => {
-	it('strips CSI colour runs but keeps the text between them', () => {
-		const text = stripTerminalNoise(CODEX_DEVICE_AUTH_STDOUT);
+	it('drops CSI colour runs but keeps the text between them', () => {
+		const text = renderTerminalScreen(CODEX_DEVICE_AUTH_STDOUT);
 		expect(text).toContain('https://auth.openai.com/codex/device');
 		expect(text).toContain('R314-OEASM');
 		expect(text).not.toContain(ESC);
 		expect(text).not.toContain('[94m');
-	});
-
-	it('turns carriage returns into line breaks so a redrawn line stands alone', () => {
-		expect(stripTerminalNoise('a\rb')).toBe('a\nb');
 	});
 
 	it('recovers an OSC 8 target whose visible text was redrawn into fragments', () => {
@@ -143,6 +162,32 @@ describe('claude setup-token driver', () => {
 		);
 		expect(harvest('sk-ant-api03-not-a-subscription-token')).toBeNull();
 		expect(harvest('Paste code here if prompted >')).toBeNull();
+	});
+
+	/**
+	 * The token is printed into a box the CLI repaints, and a repaint writes only
+	 * the cells that changed: one pass leaves a character standing, the next
+	 * rewrites the prefix and steps the cursor over it. The value therefore never
+	 * appears in the byte stream in one piece, which is what
+	 * {@link CLAUDE_TOKEN_REPAINT} reproduces.
+	 *
+	 * This is the whole reason the harvest reads a composed screen. Deleting the
+	 * escapes instead yields a token of the right shape and the wrong value - and
+	 * a wrong value is not a failure anyone sees here: it is stored, and then
+	 * refused by Anthropic on every run the credential is used for.
+	 */
+	it('composes a token the repaint left in pieces', () => {
+		const harvest = driver?.harvest;
+		if (typeof harvest !== 'function') throw new Error('expected a function harvest');
+		expect(harvest(CLAUDE_TOKEN_REPAINT)).toBe(CLAUDE_SYNTHETIC_TOKEN);
+	});
+
+	it('is not satisfied by deleting the escapes, which loses a character', () => {
+		const stripped = CLAUDE_TOKEN_REPAINT.replace(
+			new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, 'g'),
+			'',
+		).replace(/\r/g, '\n');
+		expect(stripped).not.toContain(CLAUDE_SYNTHETIC_TOKEN);
 	});
 });
 

--- a/packages/server/test/subscription-login-routes.test.ts
+++ b/packages/server/test/subscription-login-routes.test.ts
@@ -158,7 +158,17 @@ async function pollUntil(flowId: string, want: string, t = token) {
 	throw new Error(`flow never reached ${want}`);
 }
 
+/**
+ * The store step asks the provider whether the harvested credential works, and
+ * these tests are about the flow rather than about a real token. Skipped here so
+ * nothing in this file reaches the network; the one test that is about the
+ * question turns it back on and answers it itself.
+ */
+let prevSkipValidation: string | undefined;
+
 beforeAll(async () => {
+	prevSkipValidation = process.env.SKIP_AI_KEY_VALIDATION;
+	process.env.SKIP_AI_KEY_VALIDATION = '1';
 	const ctx = await createTestApp({ docker: scriptedDocker() });
 	app = ctx.app;
 	db = ctx.db;
@@ -185,6 +195,8 @@ afterEach(() => {
 });
 
 afterAll(async () => {
+	if (prevSkipValidation === undefined) delete process.env.SKIP_AI_KEY_VALIDATION;
+	else process.env.SKIP_AI_KEY_VALIDATION = prevSkipValidation;
 	await safeClose(db);
 });
 
@@ -405,6 +417,43 @@ describe('submitting a code', () => {
 		);
 		expect(stored.rows[0].auth_method).toBe('subscription');
 		expect(liveContainers.size).toBe(0);
+	});
+
+	/**
+	 * A sign-in Hezo drove is not more trustworthy than a credential the operator
+	 * pasted: everything between the vendor's screen and the vault is Hezo's own
+	 * reading of a terminal. Storing what it read without asking is what turns a
+	 * misread token into a provider that looks configured and refuses every run,
+	 * so the same live question the paste path asks is asked here.
+	 */
+	it('refuses to store a credential the provider will not accept', async () => {
+		delete process.env.SKIP_AI_KEY_VALIDATION;
+		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ error: { message: 'OAuth access token is invalid.' } }), {
+				status: 401,
+			}),
+		);
+		try {
+			const start = await post('/api/ai-providers/subscription-login/start', {
+				provider: AiProvider.Anthropic,
+			});
+			const { flow_id } = (await start.json()).data;
+
+			log = CLAUDE_CHALLENGE;
+			await pollUntil(flow_id, 'awaiting_user');
+			await post(`/api/ai-providers/subscription-login/${flow_id}/code`, { code: 'callback-code' });
+			log += CLAUDE_TOKEN_LINE;
+
+			const { body } = await pollUntil(flow_id, 'failed');
+			expect(body.code).toBe('credential_rejected');
+			expect(fetchSpy).toHaveBeenCalled();
+
+			const stored = await db.query('SELECT id FROM ai_provider_configs');
+			expect(stored.rows).toHaveLength(0);
+		} finally {
+			fetchSpy.mockRestore();
+			process.env.SKIP_AI_KEY_VALIDATION = '1';
+		}
 	});
 
 	it('sends no paste markers to a prompt that never asked for them', async () => {

--- a/packages/server/test/subscription-login-script.test.ts
+++ b/packages/server/test/subscription-login-script.test.ts
@@ -98,8 +98,22 @@ describe('buildSubscriptionLoginScript', () => {
 		expect(script).toContain(`'\\''codex'\\'' '\\''login'\\'' '\\''--device-auth'\\''`);
 	});
 
-	it('opens the PTY wide enough that a sign-in URL cannot wrap', () => {
-		expect(buildSubscriptionLoginScript(base)).toContain('COLUMNS=1000');
+	/**
+	 * The variables alone are what this used to do, and they size nothing: the
+	 * PTY `script` opens is never initialised, so it reports `0 0` and a CLI that
+	 * asks the terminal falls back to 80 columns and lays its output out to that.
+	 * The `stty` is the part that resizes, so it is the part asserted on.
+	 */
+	it('resizes the PTY itself, not just the environment describing it', () => {
+		const script = buildSubscriptionLoginScript(base);
+		expect(script).toContain('stty cols 400 rows 100');
+		expect(script).toContain('COLUMNS=400');
+		expect(script).toContain('LINES=100');
+	});
+
+	it('resizes before the CLI starts, so its first frame is already at that width', () => {
+		const script = buildSubscriptionLoginScript(base);
+		expect(script.indexOf('stty cols')).toBeLessThan(script.indexOf(`'\\''codex'\\''`));
 	});
 
 	it('holds the stdin FIFO open for the whole flow', () => {

--- a/packages/server/test/terminal-screen.test.ts
+++ b/packages/server/test/terminal-screen.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { renderTerminalScreen } from '../src/services/sandbox/terminal-screen';
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+/**
+ * The sequences below are the shapes a real repaint emits, taken from
+ * `claude setup-token` under the login PTY. They are here because deleting
+ * escape sequences and keeping the rest - which is what this replaced - reads
+ * several of them wrong while looking right, and a token that is the right shape
+ * and the wrong value is stored and then refused on every run.
+ */
+describe('renderTerminalScreen', () => {
+	/**
+	 * The prefix lands in columns 2..8 and the cursor is then sent to column 10,
+	 * so column 9 keeps whatever an earlier pass left there. That character is in
+	 * the stream nowhere near the fragments either side of it.
+	 */
+	const REPAINT = `${ESC}[9Go\r${ESC}[2Gsk-ant-${ESC}[10Gat01-BBB`;
+
+	it('keeps a character the repaint jumped over', () => {
+		expect(renderTerminalScreen(REPAINT)).toBe(' sk-ant-oat01-BBB');
+	});
+
+	it('splices fragments together when the escapes are merely deleted', () => {
+		// The same stream read the way this replaced, kept as the statement of what
+		// breaks: a value of the right shape, missing a character.
+		const stripped = REPAINT.replace(new RegExp(`${ESC}\\[[0-9;?]*[ -/]*[@-~]`, 'g'), '').replace(
+			/\r/g,
+			'\n',
+		);
+		expect(stripped).toContain('sk-ant-at01-BBB');
+		expect(renderTerminalScreen(REPAINT)).not.toContain('sk-ant-at01-');
+	});
+
+	it('returns a carriage return to the start of its own row, not to a new one', () => {
+		// The old tail survives because nothing erased it - which is why the erase
+		// below has to be honoured rather than skipped as decoration.
+		expect(renderTerminalScreen('loading…\rdone')).toBe('doneing…');
+	});
+
+	it('leaves a value the CLI wrapped on two rows, because that is where it put it', () => {
+		// Not joined: a row break the CLI chose is indistinguishable here from one
+		// it meant. The PTY is sized so nothing these CLIs print reaches this case.
+		expect(renderTerminalScreen('sk-ant-oat01-AAA\nBBB')).toBe('sk-ant-oat01-AAA\nBBB');
+	});
+
+	it('honours erase-to-end-of-line, so a shortened line does not keep its old tail', () => {
+		expect(renderTerminalScreen(`abcdefgh\r${ESC}[3Cxy${ESC}[K`)).toBe('abcxy');
+	});
+
+	it('honours cursor up and down, so a box repainted in place composes', () => {
+		const painted = `one\ntwo\nthree${ESC}[2A\rONE`;
+		expect(renderTerminalScreen(painted)).toBe('ONE\ntwo\nthree');
+	});
+
+	it('drops OSC sequences, which occupy no cell', () => {
+		expect(renderTerminalScreen(`a${ESC}]8;;https://example.com${BEL}b${ESC}]8;;${BEL}c`)).toBe(
+			'abc',
+		);
+		expect(renderTerminalScreen(`a${ESC}]0;window title${ESC}\\b`)).toBe('ab');
+	});
+
+	it('drops colour and mode switches without eating the text around them', () => {
+		expect(renderTerminalScreen(`${ESC}[?25l${ESC}[32mgreen${ESC}[0m${ESC}[?25h`)).toBe('green');
+	});
+
+	it('restores a saved cursor, so a frame that parks and returns lands where it left', () => {
+		expect(renderTerminalScreen(`abc${ESC}7\rxy${ESC}8Z`)).toBe('xycZ');
+	});
+
+	it('reads a value back whole from a stream with no escapes at all', () => {
+		// A CLI writing to a pipe rather than a PTY paints nothing, and must come
+		// back unchanged - the same function serves both.
+		const plain = '1. Open this link\n   https://auth.openai.com/codex/device\n\n   R314-OEASM\n';
+		expect(renderTerminalScreen(plain)).toContain('https://auth.openai.com/codex/device');
+		expect(renderTerminalScreen(plain)).toContain('R314-OEASM');
+	});
+
+	it('stops following a cursor driven past its bound instead of growing without limit', () => {
+		const runaway = `${ESC}[999999B${ESC}[999999Cx`;
+		expect(renderTerminalScreen(runaway).length).toBeLessThan(10_000);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -2320,6 +2320,12 @@ export const RUNTIMES_WITH_GUIDED_SIGN_IN: readonly AgentRuntime[] = [
  * the sign-in failed either way, and the operator reads them from the same
  * place. `internal` is the one whose message is a diagnostic rather than a
  * sentence, so it is shown alongside a fixed lead rather than replaced by one.
+ *
+ * `credential_rejected` is the sign-in that produced something the provider then
+ * refused. It is distinct from `code_rejected`, which is the operator's code
+ * being refused: here the exchange worked and what came out of it does not
+ * authenticate, so the fault is in the credential rather than in anything the
+ * operator typed.
  */
 export type SubscriptionLoginFailure =
 	| 'unsupported'
@@ -2328,6 +2334,7 @@ export type SubscriptionLoginFailure =
 	| 'completion_timeout'
 	| 'code_rejected'
 	| 'exited_without_credential'
+	| 'credential_rejected'
 	| 'cancelled'
 	| 'internal'
 	| 'poll_failed'

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -153,7 +153,13 @@ export function AiProvidersSection() {
 					<span className="flex items-center gap-2 justify-end">
 						{verifiedOk[c.id] && (
 							<Tooltip content="Key is valid">
-								<ShieldCheck className="w-3.5 h-3.5 text-success-soft-fg" />
+								{/* Tagged because the tooltip's text only exists while hovered, so
+								    absence of the tick - the thing that used to claim a check that
+								    never happened - is otherwise not assertable. */}
+								<ShieldCheck
+									data-testid={`credential-verified-${c.id}`}
+									className="w-3.5 h-3.5 text-success-soft-fg"
+								/>
 							</Tooltip>
 						)}
 						<Tooltip content={t('settings.provider.edit')}>

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -37,7 +37,10 @@ export function AiProvidersSection() {
 	const [addOpen, setAddOpen] = useState(false);
 	const [editing, setEditing] = useState<AiProviderConfig | null>(null);
 	// Per-row transient "verified OK" marker — failures surface as a toast and a
-	// refetched `invalid` status badge, so only successes need an inline cue.
+	// refetched `invalid` status badge, so only successes need an inline cue. Set
+	// only where the provider actually answered and accepted: a credential nothing
+	// could ask about must not wear the tick, which is the whole complaint about a
+	// Verify that returned instantly having checked nothing.
 	const [verifiedOk, setVerifiedOk] = useState<Record<string, boolean>>({});
 	const [verifyingId, setVerifyingId] = useState<string | null>(null);
 
@@ -47,9 +50,14 @@ export function AiProvidersSection() {
 		setVerifyingId(configId);
 		try {
 			const result = await verifyProvider.mutateAsync(configId);
-			setVerifiedOk((prev) => ({ ...prev, [configId]: result.valid }));
+			const confirmed = result.valid && result.checked !== false;
+			setVerifiedOk((prev) => ({ ...prev, [configId]: confirmed }));
 			if (!result.valid) {
 				toast.error(result.message ?? result.error ?? 'Key is invalid or expired');
+			} else if (!confirmed) {
+				// Not a failure and not a pass. Saying nothing here is what made the
+				// button look like it had silently succeeded.
+				toast.info(result.message ?? 'Could not check this credential');
 			}
 		} catch (e) {
 			toast.error(e instanceof Error ? e.message : 'Could not verify key');

--- a/packages/web/src/components/subscription-login-panel.tsx
+++ b/packages/web/src/components/subscription-login-panel.tsx
@@ -35,6 +35,7 @@ const FAILURE_MESSAGE: Record<SubscriptionLoginFailure, MessageKey> = {
 	completion_timeout: 'settings.provider.signIn.error.expired',
 	code_rejected: 'settings.provider.signIn.error.codeRejected',
 	exited_without_credential: 'settings.provider.signIn.error.noCredential',
+	credential_rejected: 'settings.provider.signIn.error.credentialRejected',
 	cancelled: 'settings.provider.signIn.error.cancelled',
 	internal: 'settings.provider.signIn.error.internal',
 	poll_failed: 'settings.provider.signIn.error.unreachable',

--- a/packages/web/src/hooks/use-ai-providers.ts
+++ b/packages/web/src/hooks/use-ai-providers.ts
@@ -83,10 +83,13 @@ export function useSetDefaultAiProvider() {
 
 export function useVerifyAiProvider() {
 	return useMutation({
-		// The server returns `{ valid, message }` on failure; `error` is kept for
-		// back-compat with any caller still reading it.
+		// `checked` says whether the provider actually answered. It is separate from
+		// `valid` because the two disagree in the case that matters: a credential
+		// nothing can ask about is not known to be bad, but showing it as verified
+		// claims a check that never happened. `error` is kept for back-compat with
+		// any caller still reading it.
 		mutationFn: (configId: string) =>
-			api.post<{ valid: boolean; message?: string; error?: string }>(
+			api.post<{ valid: boolean; checked?: boolean; message?: string; error?: string }>(
 				`/api/ai-providers/${configId}/verify`,
 			),
 		onSuccess: invalidateAll,

--- a/packages/web/src/lib/i18n/catalog/de.json
+++ b/packages/web/src/lib/i18n/catalog/de.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo öffnet die Anmeldung für Sie. Sie erhalten einen Link und einen kurzen Code, den Sie auf einem beliebigen Gerät eingeben können.",
 	"settings.provider.signIn.error.cancelled": "Die Anmeldung wurde abgebrochen.",
 	"settings.provider.signIn.error.codeRejected": "{provider} hat diesen Code nicht akzeptiert. Er wurde möglicherweise falsch eingegeben oder ist abgelaufen.",
+	"settings.provider.signIn.error.credentialRejected": "Die Anmeldung wurde abgeschlossen, aber {provider} hat die dabei ausgestellten Zugangsdaten abgelehnt. Starten Sie sie erneut.",
 	"settings.provider.signIn.error.expired": "Die Anmeldung ist abgelaufen, bevor sie abgeschlossen wurde. Starten Sie sie erneut.",
 	"settings.provider.signIn.error.internal": "Die Anmeldung konnte nicht abgeschlossen werden.",
 	"settings.provider.signIn.error.noCredential": "Die Anmeldung endete, bevor {provider} Zugangsdaten ausgestellt hat.",

--- a/packages/web/src/lib/i18n/catalog/en.json
+++ b/packages/web/src/lib/i18n/catalog/en.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo opens the sign-in for you. You'll get a link and a short code to enter on any device.",
 	"settings.provider.signIn.error.cancelled": "The sign-in was cancelled.",
 	"settings.provider.signIn.error.codeRejected": "{provider} did not accept that code. It may have been mistyped, or it may have expired.",
+	"settings.provider.signIn.error.credentialRejected": "The sign-in finished, but {provider} refused the credential it produced. Start it again.",
 	"settings.provider.signIn.error.expired": "The sign-in expired before it was finished. Start it again.",
 	"settings.provider.signIn.error.internal": "The sign-in could not be completed.",
 	"settings.provider.signIn.error.noCredential": "The sign-in ended before {provider} issued a credential.",

--- a/packages/web/src/lib/i18n/catalog/es.json
+++ b/packages/web/src/lib/i18n/catalog/es.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo abre el inicio de sesión por ti. Recibirás un enlace y un código corto para introducir en cualquier dispositivo.",
 	"settings.provider.signIn.error.cancelled": "El inicio de sesión se canceló.",
 	"settings.provider.signIn.error.codeRejected": "{provider} no aceptó ese código. Puede que lo hayas escrito mal o que haya caducado.",
+	"settings.provider.signIn.error.credentialRejected": "El inicio de sesión terminó, pero {provider} rechazó la credencial que generó. Vuelve a empezar.",
 	"settings.provider.signIn.error.expired": "El inicio de sesión caducó antes de completarse. Vuelve a empezar.",
 	"settings.provider.signIn.error.internal": "No se pudo completar el inicio de sesión.",
 	"settings.provider.signIn.error.noCredential": "El inicio de sesión terminó antes de que {provider} emitiera una credencial.",

--- a/packages/web/src/lib/i18n/catalog/fr.json
+++ b/packages/web/src/lib/i18n/catalog/fr.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo ouvre la connexion pour vous. Vous recevrez un lien et un code court à saisir sur n'importe quel appareil.",
 	"settings.provider.signIn.error.cancelled": "La connexion a été annulée.",
 	"settings.provider.signIn.error.codeRejected": "{provider} n'a pas accepté ce code. Il a peut-être été mal saisi ou il a expiré.",
+	"settings.provider.signIn.error.credentialRejected": "La connexion a abouti, mais {provider} a refusé les identifiants produits. Recommencez.",
 	"settings.provider.signIn.error.expired": "La connexion a expiré avant d'être terminée. Recommencez.",
 	"settings.provider.signIn.error.internal": "La connexion n'a pas pu aboutir.",
 	"settings.provider.signIn.error.noCredential": "La connexion s'est terminée avant que {provider} n'émette d'identifiants.",

--- a/packages/web/src/lib/i18n/catalog/it.json
+++ b/packages/web/src/lib/i18n/catalog/it.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo apre l'accesso per te. Riceverai un link e un codice breve da inserire su qualsiasi dispositivo.",
 	"settings.provider.signIn.error.cancelled": "L'accesso è stato annullato.",
 	"settings.provider.signIn.error.codeRejected": "{provider} non ha accettato quel codice. Potrebbe essere stato digitato male o essere scaduto.",
+	"settings.provider.signIn.error.credentialRejected": "L'accesso è andato a buon fine, ma {provider} ha rifiutato le credenziali prodotte. Ricomincia.",
 	"settings.provider.signIn.error.expired": "L'accesso è scaduto prima di essere completato. Ricomincia.",
 	"settings.provider.signIn.error.internal": "Non è stato possibile completare l'accesso.",
 	"settings.provider.signIn.error.noCredential": "L'accesso è terminato prima che {provider} rilasciasse le credenziali.",

--- a/packages/web/src/lib/i18n/catalog/ja.json
+++ b/packages/web/src/lib/i18n/catalog/ja.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo がログイン画面を開きます。リンクと短いコードが表示されるので、どの端末でも入力できます。",
 	"settings.provider.signIn.error.cancelled": "ログインはキャンセルされました。",
 	"settings.provider.signIn.error.codeRejected": "{provider} はこのコードを受け付けませんでした。入力に誤りがあるか、有効期限が切れている可能性があります。",
+	"settings.provider.signIn.error.credentialRejected": "ログインは完了しましたが、発行された認証情報を {provider} が受け付けませんでした。もう一度やり直してください。",
 	"settings.provider.signIn.error.expired": "ログインは完了する前に有効期限が切れました。もう一度やり直してください。",
 	"settings.provider.signIn.error.internal": "ログインを完了できませんでした。",
 	"settings.provider.signIn.error.noCredential": "{provider} が認証情報を発行する前にログインが終了しました。",

--- a/packages/web/src/lib/i18n/catalog/ko.json
+++ b/packages/web/src/lib/i18n/catalog/ko.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo가 로그인 화면을 열어 드려요. 링크와 짧은 코드를 받아 어떤 기기에서든 입력할 수 있어요.",
 	"settings.provider.signIn.error.cancelled": "로그인이 취소되었어요.",
 	"settings.provider.signIn.error.codeRejected": "{provider}에서 이 코드를 받아들이지 않았어요. 잘못 입력했거나 만료되었을 수 있어요.",
+	"settings.provider.signIn.error.credentialRejected": "로그인은 끝났지만 {provider}에서 발급된 인증 정보를 받아들이지 않았어요. 다시 시작해 주세요.",
 	"settings.provider.signIn.error.expired": "로그인이 완료되기 전에 만료되었어요. 다시 시작해 주세요.",
 	"settings.provider.signIn.error.internal": "로그인을 완료하지 못했어요.",
 	"settings.provider.signIn.error.noCredential": "{provider}가 인증 정보를 발급하기 전에 로그인이 끝났어요.",

--- a/packages/web/src/lib/i18n/catalog/nl.json
+++ b/packages/web/src/lib/i18n/catalog/nl.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo opent de aanmelding voor je. Je krijgt een link en een korte code die je op elk apparaat kunt invoeren.",
 	"settings.provider.signIn.error.cancelled": "De aanmelding is geannuleerd.",
 	"settings.provider.signIn.error.codeRejected": "{provider} heeft die code niet geaccepteerd. Mogelijk is de code verkeerd ingevoerd of verlopen.",
+	"settings.provider.signIn.error.credentialRejected": "De aanmelding is voltooid, maar {provider} heeft de afgegeven inloggegevens geweigerd. Begin opnieuw.",
 	"settings.provider.signIn.error.expired": "De aanmelding is verlopen voordat die klaar was. Begin opnieuw.",
 	"settings.provider.signIn.error.internal": "De aanmelding kon niet worden voltooid.",
 	"settings.provider.signIn.error.noCredential": "De aanmelding is geëindigd voordat {provider} inloggegevens had afgegeven.",

--- a/packages/web/src/lib/i18n/catalog/pl.json
+++ b/packages/web/src/lib/i18n/catalog/pl.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo otworzy logowanie za Ciebie. Otrzymasz link i krótki kod do wpisania na dowolnym urządzeniu.",
 	"settings.provider.signIn.error.cancelled": "Logowanie zostało anulowane.",
 	"settings.provider.signIn.error.codeRejected": "{provider} nie przyjął tego kodu. Mógł zostać wpisany błędnie lub wygasnąć.",
+	"settings.provider.signIn.error.credentialRejected": "Logowanie zakończyło się, ale {provider} odrzucił wydane dane logowania. Zacznij od nowa.",
 	"settings.provider.signIn.error.expired": "Logowanie wygasło, zanim zostało ukończone. Zacznij od nowa.",
 	"settings.provider.signIn.error.internal": "Nie udało się ukończyć logowania.",
 	"settings.provider.signIn.error.noCredential": "Logowanie zakończyło się, zanim {provider} wydał dane logowania.",

--- a/packages/web/src/lib/i18n/catalog/pt-BR.json
+++ b/packages/web/src/lib/i18n/catalog/pt-BR.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "O Hezo abre o login para você. Você vai receber um link e um código curto para digitar em qualquer dispositivo.",
 	"settings.provider.signIn.error.cancelled": "O login foi cancelado.",
 	"settings.provider.signIn.error.codeRejected": "O {provider} não aceitou esse código. Ele pode ter sido digitado errado ou ter expirado.",
+	"settings.provider.signIn.error.credentialRejected": "O login foi concluído, mas o {provider} recusou a credencial gerada. Comece de novo.",
 	"settings.provider.signIn.error.expired": "O login expirou antes de ser concluído. Comece de novo.",
 	"settings.provider.signIn.error.internal": "Não foi possível concluir o login.",
 	"settings.provider.signIn.error.noCredential": "O login terminou antes de o {provider} emitir uma credencial.",

--- a/packages/web/src/lib/i18n/catalog/sv.json
+++ b/packages/web/src/lib/i18n/catalog/sv.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo öppnar inloggningen åt dig. Du får en länk och en kort kod som du kan ange på vilken enhet som helst.",
 	"settings.provider.signIn.error.cancelled": "Inloggningen avbröts.",
 	"settings.provider.signIn.error.codeRejected": "{provider} godtog inte koden. Den kan ha skrivits fel eller ha gått ut.",
+	"settings.provider.signIn.error.credentialRejected": "Inloggningen blev klar, men {provider} godtog inte uppgifterna som utfärdades. Börja om.",
 	"settings.provider.signIn.error.expired": "Inloggningen gick ut innan den blev klar. Börja om.",
 	"settings.provider.signIn.error.internal": "Inloggningen kunde inte slutföras.",
 	"settings.provider.signIn.error.noCredential": "Inloggningen tog slut innan {provider} utfärdade några uppgifter.",

--- a/packages/web/src/lib/i18n/catalog/zh-Hans.json
+++ b/packages/web/src/lib/i18n/catalog/zh-Hans.json
@@ -650,6 +650,7 @@
 	"settings.provider.signIn.blurb": "Hezo 会为您打开登录页面。您将获得一个链接和一个短代码，可在任意设备上输入。",
 	"settings.provider.signIn.error.cancelled": "登录已取消。",
 	"settings.provider.signIn.error.codeRejected": "{provider} 未接受该代码。可能输入有误，或者代码已过期。",
+	"settings.provider.signIn.error.credentialRejected": "登录已完成，但 {provider} 拒绝了签发的凭据。请重新开始。",
 	"settings.provider.signIn.error.expired": "登录在完成前已过期。请重新开始。",
 	"settings.provider.signIn.error.internal": "无法完成登录。",
 	"settings.provider.signIn.error.noCredential": "{provider} 尚未签发凭据，登录就结束了。",

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -1091,3 +1091,34 @@ test('the providers list marks only the credential whose runs serialise', async 
 	expect(markers.length).toBe(1);
 	expect(markers[0].closest('tr')?.textContent).toContain('codex-sub');
 });
+
+test('Verify withholds the tick for a credential it could not check', async () => {
+	// The reported complaint: Verify "returns instantly" and reports success. A
+	// Codex subscription is a sign-in file, not a token any endpoint accepts, so
+	// nothing is asked - and the button used to write `verified` and show the green
+	// tick anyway. Deterministic without stubbing the network precisely because no
+	// request is made.
+	const { findByRole, findByText, queryByTestId, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'openai',
+				api_key: JSON.stringify({ tokens: { refresh_token: 'rt-unverifiable' } }),
+				label: 'codex-unverifiable',
+				auth_method: 'subscription',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(
+		await findByRole('button', { name: 'Verify codex-unverifiable' }, { timeout: 15_000 }),
+	);
+
+	// It says so, rather than passing silently.
+	await findByText(/cannot be checked/, undefined, { timeout: 15_000 });
+	// And no claim is made on the row: the tick is the thing that lied.
+	expect(queryByTestId(/^credential-verified-/)).toBeNull();
+});


### PR DESCRIPTION
Follow-up to #1081, from three things an operator hit on it.

> whenever i try to verify anthropic credential it says something went wrong and then immediately shows me the onboarding ai provider setup screen (it shouldn't do this)
> looks like the verify button doesn't do a real verification? it seems to return instantly
> if i delete the default ai provider it should auto-make next one as default

## The verify route had three outcomes and expressed two

That is where all of it lived.

**Verify returned instantly having checked nothing.** A subscription whose provider has no `subscriptionHeaders` to ask with — Codex, whose credential is a sign-in file rather than a token any endpoint accepts — probed as `unsupported` **without making a request**, failed the "proven dead" test, and fell into the accepting branch: `verified` written, `valid: true` returned, green tick shown. Exactly the "badge is not a fact" defect #1081 set out to remove, still standing in the place nobody looked. The same branch also wrote `verified` when the provider was merely unreachable.

**And its mirror:** an API key whose provider answered 500 fell *past* the `unreachable` check into the reject branch and was marked `invalid`. A provider hiccup condemned a working key. `probeProvesCredentialDead` exists to prevent precisely this and was only being applied to subscriptions.

The route now answers **accepted / refused / unknown**, identically for both auth methods:

| Outcome | Writes | Returns |
|---|---|---|
| Provider accepted it | `verified` | `valid: true, checked: true` |
| Provider refused it (401/403) | `invalid` | `valid: false, checked: true`, with the provider's reason |
| Anything else | nothing | `valid: true, checked: false`, saying so |

`checked` is new, and the web reads it: no tick for a credential nothing asked about, and a neutral toast instead of silence.

## Rejecting a credential threw the operator into onboarding

`getAiProviderStatus` answered `configured` from the **verified** rows, and `SetupGate` replaces the entire app shell while that is false. So pressing Verify on a credential the provider refused took away the settings page where it would be replaced — on the very click that diagnosed it — and read as an instance that had lost its setup.

`configured` now asks whether setup was done at all. `providers` still reports what can actually run, so nothing that needs a usable credential got looser.

## Verify now says why

`refusalDetail` reads the refused body and relays the provider's own message, scrubbed of the credential per the credential rules (`data/users`-style secrets never appear; the value is stripped rather than trusted not to be there, and the read is bounded).

This is the half an operator cannot get anywhere else:

- `OAuth access token is invalid.` — the subscription token expired or was revoked. Sign in again.
- `API key is invalid.` — an API key was pasted into the subscription box. Wrong kind of credential.

Both are a bare 401 without it.

## Deleting the default handed it to nobody

A bare `DELETE` left the instance with no designated credential. Nothing failed loudly, because `resolveRuntimeForTask` falls through to the oldest verified row — so the star just vanished from the settings page and the operator's next deliberate choice was made against a designation that had quietly stopped existing.

It now moves to another credential in the same transaction, **preferring a verified one**. That preference is load-bearing: the resolver refuses a run naming an unusable default rather than passing to the next in line, so promoting a rejected row over a working one would stop an instance that still had a usable credential.

## Tests

`typecheck` and `check` clean; 156 provider tests, plus the credential-health, model-pins and docs suites.

New coverage is weighted at the cases where acting is wrong:

- a subscription that cannot be checked reports `checked: false`, **makes no request**, and leaves the stored status untouched;
- an unreachable provider and a provider 500 both leave the credential's badge exactly as it was;
- the provider's reason is relayed, and a provider that echoes the credential back gets it redacted;
- deleting the default promotes the successor, prefers a verified one over an older rejected one, leaves a non-default deletion alone, and deleting the last config leaves no default behind;
- `/ai-providers/status` stays `configured` when every credential has been rejected, and lists a provider once when it holds both a verified and a rejected credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XwRZJdqY8yhnfMzZKUCCN

---
_Generated by [Claude Code](https://claude.ai/code/session_018XwRZJdqY8yhnfMzZKUCCN)_