### PR TITLE
chore(release): 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.61.0 - 2026-09-07
+
+### Breaking Changes
+
+- seed a hosted first run with a language and a project brief (Track H H24-H30) ([#1090](https://github.com/hezo-ai/hezo/pull/1090))
+
+### Features
+
+- seed a hosted first run with a language and a project brief (Track H H24-H30) ([#1090](https://github.com/hezo-ai/hezo/pull/1090))
+- **inbox:** open the failed run from a run-failure notice, and stop calling a queued retry an error ([#1089](https://github.com/hezo-ai/hezo/pull/1089))
+
+### Bug Fixes
+
+- **providers:** a verify that checks, reports what it found, and stays put ([#1088](https://github.com/hezo-ai/hezo/pull/1088))
+
+**Full Changelog**: https://github.com/hezo-ai/hezo/compare/0.60.0...0.61.0
+
 ## 0.60.0 - 2026-09-07
 
 ### Features

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hezo/server",
-	"version": "0.60.0",
+	"version": "0.61.0",
 	"type": "module",
 	"scripts": {
 		"dev": "bun run --hot src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hezo/shared",
-	"version": "0.60.0",
+	"version": "0.61.0",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hezo/ui",
-	"version": "0.60.0",
+	"version": "0.61.0",
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hezo/web",
-	"version": "0.60.0",
+	"version": "0.61.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Automated release for **0.61.0**.

Merging this PR tags the release and publishes the GitHub Release.

Prepared with `bun run release --release-type auto --apply` on main at 572ce74 (CI green), exactly as `release.yml` does; the workflow could not be dispatched from this session's token, so the branch and this PR were opened by hand in its place.

---

## 0.61.0 - 2026-09-07

### Breaking Changes

- seed a hosted first run with a language and a project brief (Track H H24-H30) ([#1090](https://github.com/hezo-ai/hezo/pull/1090))

### Features

- seed a hosted first run with a language and a project brief (Track H H24-H30) ([#1090](https://github.com/hezo-ai/hezo/pull/1090))
- **inbox:** open the failed run from a run-failure notice, and stop calling a queued retry an error ([#1089](https://github.com/hezo-ai/hezo/pull/1089))

### Bug Fixes

- **providers:** a verify that checks, reports what it found, and stays put ([#1088](https://github.com/hezo-ai/hezo/pull/1088))

**Full Changelog**: https://github.com/hezo-ai/hezo/compare/0.60.0...0.61.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SC9VtLNC5atNPcWSorWvtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SC9VtLNC5atNPcWSorWvtc)_