### PR TITLE
feat(policy): let a deployer anchor the container-hours window to a billing day

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -192,6 +192,7 @@ pinned unless you say so, so an ordinary instance is unaffected.
 | `policy.pinned.defaultRamCapPerContainerGb` | - | Fixes the per-container RAM cap. |
 | `policy.pinned.defaultContainerDiskGb` | - | Fixes the per-container disk size. |
 | `policy.pinned.monthlyContainerHours` | - | Fixes the monthly container-hours allowance. `0` pins "no limit". |
+| `policy.pinned.containerHoursAnchorDay` | - | The day of the month that allowance resets on, `1`-`31`. Unset, it resets on the 1st. |
 | `policy.pinned.backend` | - | Fixes which container backend runs agent containers (`docker` or `daytona`). |
 | `policyFile` | - | Path to a JSON file holding the `policy` block. The file wins over an inline block, and is re-read when it changes. |
 
@@ -207,6 +208,15 @@ module.exports = {
   },
 };
 ```
+
+**Pin `containerHoursAnchorDay` when you bill on a day other than the 1st.**
+Left unset the allowance resets on the first of the calendar month, which is what
+a self-hosted instance wants. A deployment that bills on the day each instance
+subscribed pins that day here instead, so the hours an instance is capped against
+cover the period it is charged for rather than a calendar month cutting across
+it. A day later than a short month holds - the 31st in February - resets on that
+month's last day, and returns to the anchor the month after; it never walks
+backwards.
 
 **`pinned.backend` is the exception: it takes effect on restart.** The engine
 containers run on is chosen once at startup, so re-pinning it while the instance

--- a/packages/server/src/config/schema.ts
+++ b/packages/server/src/config/schema.ts
@@ -1,5 +1,7 @@
 import type { LocaleSettings } from '@hezo/shared';
 import {
+	CONTAINER_HOURS_ANCHOR_MAX_DAY,
+	CONTAINER_HOURS_ANCHOR_MIN_DAY,
 	parseIssuerPublicKeys,
 	parseLocaleSettingsPatch,
 	parseProjectBrief,
@@ -134,6 +136,11 @@ export const policySchema = z
 				// A deployment can therefore pin "no hours limit" as deliberately as
 				// it pins a number.
 				monthlyContainerHours: z.int().min(0).optional(),
+				containerHoursAnchorDay: z
+					.int()
+					.min(CONTAINER_HOURS_ANCHOR_MIN_DAY)
+					.max(CONTAINER_HOURS_ANCHOR_MAX_DAY)
+					.optional(),
 				// Not a number, unlike its neighbours. A deployment whose containers
 				// run somewhere the instance's own host cannot provide has to be able
 				// to say so: leaving this to the operator lets them switch onto a

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -270,6 +270,16 @@ export interface PolicyConfig {
 		defaultRamCapPerContainerGb?: number;
 		defaultContainerDiskGb?: number;
 		monthlyContainerHours?: number;
+		/**
+		 * The day of the month the hours window resets on, 1-31.
+		 *
+		 * Unset, the window is the calendar month, which is what a local or
+		 * self-hosted instance wants and what this has always done. A control
+		 * plane billing on the day a tenant subscribed pins their own anniversary
+		 * here, so the pool a tenant is capped against covers the period they are
+		 * charged for rather than a calendar month cutting across it.
+		 */
+		containerHoursAnchorDay?: number;
 		/** Which container backend runs agent containers. A name, not a number. */
 		backend?: SandboxBackend;
 	};

--- a/packages/server/src/services/container-hours.ts
+++ b/packages/server/src/services/container-hours.ts
@@ -15,8 +15,9 @@
  * since it merged concurrent runs that shared one container.
  */
 
-import { HOURS_BUCKET_SPAN, type HoursBucket } from '@hezo/shared';
+import { containerHoursWindowStart, HOURS_BUCKET_SPAN, type HoursBucket } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { pinnedSetting } from '../lib/system-meta';
 
 /**
  * Seconds of one interval that fall inside one window, as a SQL expression.
@@ -215,19 +216,33 @@ export async function containerHoursTotals(
 }
 
 /**
- * Instance-wide container-seconds so far this calendar month - what the hours
- * cap is enforced against.
+ * Instance-wide container-seconds so far this window - what the hours cap is
+ * enforced against.
+ *
+ * **The calendar month unless a deployer pinned an anchor day**, which is what
+ * this has always done and what a local or self-hosted instance wants. A control
+ * plane billing on the day a tenant subscribed pins that day instead, so the
+ * pool covers the period the tenant is charged for rather than a calendar month
+ * cutting across it.
+ *
+ * The boundary is computed rather than written into the SQL because the clamp -
+ * a window anchored on the 31st, in a month that has no 31st - is arithmetic
+ * worth testing on its own, and `date_trunc` cannot express it.
  *
  * Its own narrow query rather than a field off {@link containerHoursTotals}:
  * this one runs on the container-admission path, where the other five columns
  * would be work done per dispatch and thrown away.
  */
-export async function monthToDateContainerSeconds(db: Db): Promise<number> {
-	const month = `date_trunc('month', now() AT TIME ZONE 'UTC')`;
+export async function currentWindowContainerSeconds(db: Db): Promise<number> {
+	const start = containerHoursWindowStart(
+		pinnedSetting('containerHoursAnchorDay'),
+		new Date(),
+	).toISOString();
 	const res = await db.query<{ seconds: number }>(
-		`SELECT COALESCE(SUM(${clippedSeconds('e', month, 'now()')}), 0)::int AS seconds
+		`SELECT COALESCE(SUM(${clippedSeconds('e', '$1::timestamptz', 'now()')}), 0)::int AS seconds
 		   FROM container_uptime_entries e
-		  WHERE ${overlapsWindow('e', month, 'now()')}`,
+		  WHERE ${overlapsWindow('e', '$1::timestamptz', 'now()')}`,
+		[start],
 	);
 	return res.rows[0]?.seconds ?? 0;
 }

--- a/packages/server/src/services/run-concurrency.ts
+++ b/packages/server/src/services/run-concurrency.ts
@@ -11,7 +11,7 @@ import {
 	getMaxContainerMemoryGb,
 	getMonthlyContainerHours,
 } from '../lib/system-meta';
-import { monthToDateContainerSeconds } from './container-hours';
+import { currentWindowContainerSeconds } from './container-hours';
 
 import type { ContainerEngine } from './sandbox/types';
 
@@ -291,7 +291,7 @@ export async function getActiveContainers(
 async function hoursQuotaExhausted(db: Db): Promise<boolean> {
 	const capHours = await getMonthlyContainerHours(db);
 	if (capHours <= 0) return false;
-	return (await monthToDateContainerSeconds(db)) >= capHours * 3600;
+	return (await currentWindowContainerSeconds(db)) >= capHours * 3600;
 }
 
 /** Per-project memory caps for the given projects; absent means "inherits the default". */

--- a/packages/server/test/container-uptime-ledger.test.ts
+++ b/packages/server/test/container-uptime-ledger.test.ts
@@ -10,14 +10,15 @@
 
 import { ContainerUptimeEndReason, HoursBucket } from '@hezo/shared';
 import type { Hono } from 'hono';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { resetRuntimeConfig, setPolicy } from '../src/config/runtime';
 import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
 import {
 	containerHoursByProject,
 	containerHoursSeries,
 	containerHoursTotals,
-	monthToDateContainerSeconds,
+	currentWindowContainerSeconds,
 } from '../src/services/container-hours';
 import {
 	claimPoolMember,
@@ -314,7 +315,7 @@ describe('aggregation', () => {
 		// Non-zero, or the equality below would hold for a reader that banked
 		// nothing at all.
 		expect(seeded.rows[0].seconds).toBeGreaterThan(0);
-		expect(await monthToDateContainerSeconds(db)).toBe(seeded.rows[0].seconds);
+		expect(await currentWindowContainerSeconds(db)).toBe(seeded.rows[0].seconds);
 	});
 
 	it('emits every bucket in the window, including the quiet ones', async () => {
@@ -554,5 +555,63 @@ describe('every pool state write moves the ledger', () => {
 		await check('the pool loses confidence in it');
 		await removePoolMember(db, id);
 		await check('it is destroyed');
+	});
+});
+
+/**
+ * The window the hours cap is measured over, when a deployer has anchored it.
+ *
+ * A control plane bills on the day a tenant subscribed, so a pool resetting on
+ * the 1st would cap them against a period they are not charged for — and hand a
+ * tenant who bought on the 20th a third of their first month at full price.
+ */
+describe('an anchored container-hours window', () => {
+	afterEach(() => resetRuntimeConfig());
+
+	/** An entry that ran for an hour, `daysAgo` days back. */
+	async function ran(daysAgo: number, id: string): Promise<void> {
+		await db.query(
+			`INSERT INTO container_uptime_entries (project_id, container_id, started_at, ended_at, backend)
+			 VALUES (NULL, $2,
+			         now() - ($1 || ' days')::interval - interval '1 hour',
+			         now() - ($1 || ' days')::interval,
+			         'docker')`,
+			[String(daysAgo), id],
+		);
+	}
+
+	// **The anchor is read on the admission path, not just stored.** Unanchored,
+	// the window is the calendar month and this has always been so; anchored to
+	// yesterday, everything before it belongs to the window that just closed.
+	it('counts from the anchor rather than from the first of the month', async () => {
+		const now = new Date();
+		// Two days ago and today, both inside this calendar month wherever we are
+		// in it — so the calendar window holds both and an anchor set to yesterday
+		// holds only the later one.
+		const anchorDay = new Date(now.getTime() - 24 * 60 * 60 * 1000).getUTCDate();
+		await ran(2, 'c-before-anchor');
+		await ran(0, 'c-after-anchor');
+
+		setPolicy({ managedBy: 'Acme Cloud', pinned: {} });
+		const calendar = await currentWindowContainerSeconds(db);
+
+		setPolicy({ managedBy: 'Acme Cloud', pinned: { containerHoursAnchorDay: anchorDay } });
+		const anchored = await currentWindowContainerSeconds(db);
+
+		// Only meaningful where the calendar month actually holds both entries:
+		// on the first two days of a month it does not, and the window that just
+		// closed is the previous month either way.
+		if (calendar >= 7200) {
+			expect(anchored).toBeLessThan(calendar);
+			expect(anchored).toBe(3600);
+		}
+	});
+
+	it('is the calendar month when nothing is anchored', async () => {
+		setPolicy({ managedBy: 'Acme Cloud', pinned: {} });
+		const before = await currentWindowContainerSeconds(db);
+		await ran(0, 'c-unanchored');
+
+		expect(await currentWindowContainerSeconds(db)).toBe(before + 3600);
 	});
 });

--- a/packages/shared/src/budget.ts
+++ b/packages/shared/src/budget.ts
@@ -134,3 +134,56 @@ export function normalizeBudgetWindowsUp(w: BudgetWindowsCents): BudgetWindowsCe
 		monthly_budget_cents: monthly,
 	};
 }
+
+/**
+ * The lowest and highest day of the month a container-hours window may be
+ * anchored on.
+ *
+ * 31 is admitted even though seven months are shorter: the anchor is a day the
+ * deployer names, and clamping it to 28 so every month is uniform would move the
+ * anniversary of everyone anchored later in the month.
+ */
+export const CONTAINER_HOURS_ANCHOR_MIN_DAY = 1;
+export const CONTAINER_HOURS_ANCHOR_MAX_DAY = 31;
+
+/**
+ * A day of the month as it falls in one particular month, or that month's last
+ * day where it is too short to hold it.
+ *
+ * **Always from the anchor, never from wherever the last window landed.** Taking
+ * the day off a window that had already been clamped is how an anniversary walks
+ * backwards: the 31st becomes the 28th in February, and every month after that
+ * is the 28th for ever.
+ */
+function occurrenceInMonth(year: number, month: number, day: number): Date {
+	// Day zero of the next month is the last day of this one.
+	const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+	return new Date(Date.UTC(year, month, Math.min(day, lastDay)));
+}
+
+/**
+ * When the container-hours window containing `now` began.
+ *
+ * **The calendar month unless a deployer anchored it**, which is what an unset
+ * anchor gives and what this has always done — a local instance and a
+ * self-hosted one both want the first of the month.
+ *
+ * A hosted instance is billed on the day it subscribed, and a pool resetting on
+ * the 1st would hand a tenant who bought on the 20th a third of their first
+ * month at the full price of it. The anchor is a day rather than a date so it
+ * survives being pinned once and read for ever.
+ */
+export function containerHoursWindowStart(anchorDay: number | undefined, now: Date): Date {
+	const year = now.getUTCFullYear();
+	const month = now.getUTCMonth();
+	if (anchorDay === undefined) return new Date(Date.UTC(year, month, 1));
+
+	const day = Math.min(
+		Math.max(Math.trunc(anchorDay), CONTAINER_HOURS_ANCHOR_MIN_DAY),
+		CONTAINER_HOURS_ANCHOR_MAX_DAY,
+	);
+	const thisMonth = occurrenceInMonth(year, month, day);
+	// Before the anchor has come round this month, the window began last month —
+	// and `Date.UTC` takes month -1 as December of the year before.
+	return thisMonth.getTime() <= now.getTime() ? thisMonth : occurrenceInMonth(year, month - 1, day);
+}

--- a/packages/shared/test/budget.test.ts
+++ b/packages/shared/test/budget.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	centsToDollars,
+	containerHoursWindowStart,
 	dollarsToCents,
 	minMonthlyCents,
 	minWeeklyCents,
@@ -105,5 +106,83 @@ describe('normalizeBudgetWindowsUp', () => {
 			monthly_budget_cents: 3042,
 		};
 		expect(normalizeBudgetWindowsUp(coherent)).toEqual(coherent);
+	});
+});
+
+describe('containerHoursWindowStart', () => {
+	const at = (iso: string) => new Date(iso);
+
+	it('is the first of the calendar month when nothing is anchored', () => {
+		expect(containerHoursWindowStart(undefined, at('2026-09-20T13:00:00Z')).toISOString()).toBe(
+			'2026-09-01T00:00:00.000Z',
+		);
+	});
+
+	it('is this month occurrence of the anchor once it has come round', () => {
+		expect(containerHoursWindowStart(20, at('2026-09-25T00:00:00Z')).toISOString()).toBe(
+			'2026-09-20T00:00:00.000Z',
+		);
+	});
+
+	it('is last month occurrence before the anchor comes round again', () => {
+		expect(containerHoursWindowStart(20, at('2026-09-05T00:00:00Z')).toISOString()).toBe(
+			'2026-08-20T00:00:00.000Z',
+		);
+	});
+
+	// The anchor day itself belongs to the window it opens.
+	it('opens the new window on the anchor day itself', () => {
+		expect(containerHoursWindowStart(20, at('2026-09-20T00:00:00Z')).toISOString()).toBe(
+			'2026-09-20T00:00:00.000Z',
+		);
+	});
+
+	// **The clamp.** February has no 31st, so a window anchored there opens on
+	// the last day it does have rather than rolling into March.
+	it('clamps an anchor the month is too short to hold', () => {
+		expect(containerHoursWindowStart(31, at('2026-02-28T12:00:00Z')).toISOString()).toBe(
+			'2026-02-28T00:00:00.000Z',
+		);
+		expect(containerHoursWindowStart(31, at('2028-02-29T12:00:00Z')).toISOString()).toBe(
+			'2028-02-29T00:00:00.000Z',
+		);
+	});
+
+	// **Always from the anchor, never from where the last window landed.** Taken
+	// off a clamped window, the 31st becomes the 28th and stays there for ever.
+	it('comes back to the anchor day after a short month', () => {
+		expect(containerHoursWindowStart(31, at('2026-03-31T00:00:00Z')).toISOString()).toBe(
+			'2026-03-31T00:00:00.000Z',
+		);
+		expect(containerHoursWindowStart(31, at('2026-03-30T00:00:00Z')).toISOString()).toBe(
+			'2026-02-28T00:00:00.000Z',
+		);
+	});
+
+	it('steps back into the previous year in January', () => {
+		expect(containerHoursWindowStart(15, at('2026-01-05T00:00:00Z')).toISOString()).toBe(
+			'2025-12-15T00:00:00.000Z',
+		);
+	});
+
+	// A stored value outside the range reads as the nearest day rather than
+	// wedging the instance: the cap is a ceiling, not a reason to refuse to run.
+	it('holds a nonsense anchor to a real day of the month', () => {
+		expect(containerHoursWindowStart(0, at('2026-09-05T00:00:00Z')).toISOString()).toBe(
+			'2026-09-01T00:00:00.000Z',
+		);
+		expect(containerHoursWindowStart(99, at('2026-09-05T00:00:00Z')).toISOString()).toBe(
+			'2026-08-31T00:00:00.000Z',
+		);
+	});
+
+	// Whatever the anchor, the window it names has already begun.
+	it('never opens a window that has not started', () => {
+		for (const day of [1, 15, 28, 29, 30, 31]) {
+			for (const now of ['2026-01-01', '2026-02-28', '2026-03-01', '2026-12-31']) {
+				const when = at(`${now}T12:00:00Z`);
+				expect(containerHoursWindowStart(day, when).getTime()).toBeLessThanOrEqual(when.getTime());
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Why

The hours cap has always been measured over the **calendar month**. That is right for a local or self-hosted instance and wrong for a hosted one.

A control plane bills on the day each instance subscribed. An instance bought on the 20th is capped against a month it is not charged for, and its first invoice covers a third of an allowance it was given in full.

## What

`policy.pinned.containerHoursAnchorDay` (1–31) names the day the allowance resets on.

**Unset, nothing changes** — the window is the calendar month, exactly as today. This is additive and optional, so an instance upgrading onto it is capped against precisely the window it was capped against before.

```js
policy: {
  managedBy: 'Acme Cloud',
  pinned: { monthlyContainerHours: 100, containerHoursAnchorDay: 20 },
}
```

## The clamp is the whole difficulty

It is why this is arithmetic in `@hezo/shared` rather than a `date_trunc` in the query.

A window anchored on the 31st has no 31st in February, and the obvious month-step answers **March 3rd** — moving the anniversary permanently, a day at a time, every short month. The day is always taken from the anchor rather than from wherever the last window landed:

| anchor | month | window opens |
|---|---|---|
| 31 | February 2026 | Feb 28 |
| 31 | February 2028 | Feb 29 |
| 31 | March 2026 | **Mar 31**, not Mar 28 |

`date_trunc` cannot express that, and it is arithmetic worth testing on its own.

## One rename

`monthToDateContainerSeconds` → `currentWindowContainerSeconds`. It no longer always measures a month to date, and a name that says it does is a name that will be believed. Two call sites.

## Tested

- **9 cases** on the pure window math: the unanchored default, the anchor before and after it comes round, the anchor day itself, the February clamp in a common and a leap year, the return to the anchor the month after, the step back into the previous year, an out-of-range stored value, and a sweep asserting the window it names has always already begun.
- **2 cases** against a real database in `container-uptime-ledger.test.ts`, proving the anchor is read on the admission path rather than merely stored — an entry inside the calendar month but before the anchor is excluded when anchored and included when not.
- Full `typecheck` and `build` green; `biome` clean on every file touched.

The 20 pre-existing lint errors on `main` are untouched and unrelated.