### PR TITLE
refactor(shared): export the vCPU a sandbox is created with

### DIFF
--- a/packages/server/src/services/sandbox/daytona/engine.ts
+++ b/packages/server/src/services/sandbox/daytona/engine.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { statSync } from 'node:fs';
-import { DEFAULT_CONTAINER_DISK_GB } from '@hezo/shared';
+import { DEFAULT_CONTAINER_DISK_GB, DEFAULT_CONTAINER_VCPU } from '@hezo/shared';
 import { trackBackground } from '../../../lib/background';
 import { logger } from '../../../logger';
 import { ContainerUnreachableError } from '../errors';
@@ -118,7 +118,7 @@ function isHostFile(hostPath: string | undefined): boolean {
  */
 const FALLBACK_DISK_GB = DEFAULT_CONTAINER_DISK_GB;
 /** vCPU per sandbox. */
-const DEFAULT_CPU = 2;
+const DEFAULT_CPU = DEFAULT_CONTAINER_VCPU;
 
 /**
  * Most memory this provider will give one sandbox, in GB.

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -295,6 +295,16 @@ export function projectMemoryFitsBudget(capGb: number, budgetGb: number): boolea
  * needs it - rather than paying for headroom every project holds and none uses.
  */
 export const DEFAULT_CONTAINER_DISK_GB = 5;
+/**
+ * vCPU a sandbox is created with.
+ *
+ * Beside the disk and memory defaults because it is the same kind of fact: what
+ * one container is provisioned with, fixed rather than configurable, and the
+ * third of the three numbers anything costing a container has to know. The
+ * engine that asks the provider for it reads it from here.
+ */
+export const DEFAULT_CONTAINER_VCPU = 2;
+
 /** Below this a checkout plus `node_modules` does not reliably fit. */
 export const CONTAINER_DISK_GB_MIN = 2;
 export const CONTAINER_DISK_GB_MAX = 1024;


### PR DESCRIPTION
`DEFAULT_CPU` sits module-private in the Daytona engine, while the two numbers beside it — the disk and the memory cap a container is provisioned with — are already exported from `@hezo/shared`. They are the same kind of fact: what one container is created with, fixed rather than configurable. Anything that has to *cost* a container needs all three.

Hezo Cloud is that consumer. It prices a tenant's container-hours from vCPU, memory and disk together, and can import two of the three. The third it restates, held to this file by a test that greps the engine source out of a pinned submodule:

```ts
const upstream = /^const DEFAULT_CPU = (\d+);$/m.exec(engine);
expect(Number(upstream?.[1])).toBe(CONTAINER_VCPU);
```

That breaks on any refactor that moves or reformats the line, and — worse — says nothing at all if the value changes in a way the regex still matches. An export turns it into an ordinary import and deletes the test.

## What changes

- `DEFAULT_CONTAINER_VCPU` joins `DEFAULT_CONTAINER_DISK_GB` and `DEFAULT_RAM_CAP_PER_CONTAINER_GB` in `packages/shared/src/constants.ts`.
- The engine's `DEFAULT_CPU` reads it instead of declaring `2`.

No behaviour change: the same number, one import further out. Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wiYTMsGx4UGscKwse4GMt