### PR TITLE
fix(config): reload the policy on any directory event, not on a name Bun drops

### DIFF
--- a/.dev/hezo-cloud-requirements.md
+++ b/.dev/hezo-cloud-requirements.md
@@ -1,7 +1,8 @@
 # What Hezo Cloud needs from this repo
 
 **Inbound requirements from the `hezo-ai/cloud` control plane.** Nine tasks, two
-of them optional. Everything here is **additive and inert unless hosted config
+of them optional, plus **H33**, which is a defect in shipped work rather than a
+new ask. Everything here is **additive and inert unless hosted config
 is present** — self-hosted behaviour must stay byte-identical. **H27, H28 and H29
 are the recorded exceptions**: product changes the hosted launch flow asked for
 that alter what a self-hosted instance does too, each stated as such below.
@@ -532,6 +533,58 @@ missing. Bad-parse behaviour is already right — `reload()` short-circuits on
 **AC:** renaming a new policy file into place changes a pinned setting with no
 restart; a malformed file keeps the previous value and logs; the watcher
 survives the inode swap; nothing is watched when `policyFile` is unset.
+
+---
+
+## H33 — reload the policy on any directory event, not on a name Bun does not report
+
+**H15 shipped and the watcher never fires on the runtime a release runs.** The
+control plane writes `/etc/hezo/policy.json` as `<file>.tmp` then `rename()`,
+which is the pattern H15's own docblock is built around — and `watchPolicyFile`
+then filtered the directory's events by the policy file's name. Node reports the
+destination's name for a rename. **Bun reports only the source's**, as a single
+event, so the filter dropped every policy change a deployment ever made.
+
+Measured with the writer's exact sequence — write `.tmp`, `chmod`, `rename` —
+ten times, waiting past the 150 ms debounce each round:
+
+| Writer | Node 24 | Bun 1.3.11 |
+|---|---|---|
+| `.tmp` + `rename` (what a deployment writes) | 10/10 | **0/10** |
+| `.tmp` + `rename`, then an in-place rewrite | 10/10 | 7/10 |
+| in-place write only | 10/10 | 10/10 |
+
+Delivery is not quite deterministic — one destination-named event appeared in
+thirty rounds — which is why the hosting plane's end-to-end tier saw a plan
+change land occasionally and read it as a race for three rounds before anyone
+measured it.
+
+**The consequence for a hosted tenant.** A tier change, an hour pack and a
+billing hold all reach the instance's disk and none of them reaches the running
+process: the container-hours pool, the container ceiling and the two memory pins
+a hold sets take effect only at the next restart. The hold is the one that
+costs — a tenant who has stopped paying keeps their full container budget until
+their box happens to restart.
+
+**Why no writer can work around it.** In-place writing is the only shape Bun
+reports reliably, and it gives up the atomicity this watcher's own docblock
+depends on: a reader can catch a half-written file, and a bad parse then keeps
+the *previous* value until the next change, which for a deployment that skips
+unchanged writes is indefinitely.
+
+**The fix**: drop the name filter and reload on any event in the watched
+directory. The read is a small JSON file behind the existing debounce, and a
+spurious reload is already harmless — `readPolicyFile` returns `null` on a bad
+read or parse and `reload()` keeps the last good value. Measured with the filter
+removed: **10/10 on both runtimes, and every reload read the value just
+written**, the rename having completed before the debounce expires.
+
+**AC:** a rename into place changes a pinned setting with no restart **on the
+Bun runtime**, change after change; a write to a neighbouring file in the same
+directory leaves the policy where it is. The Node coverage in
+`test/policy-watch.test.ts` was green throughout and could not have caught this,
+so the new test belongs in the Bun-native tier — this is exactly the
+"runtime-sensitive code gets a test on the production runtime" rule.
 
 ---
 

--- a/packages/server/src/config/policy.ts
+++ b/packages/server/src/config/policy.ts
@@ -22,7 +22,7 @@
 
 import type { FSWatcher } from 'node:fs';
 import { readFileSync, watch } from 'node:fs';
-import { basename, dirname } from 'node:path';
+import { dirname } from 'node:path';
 import { logger } from '../logger';
 import { setPolicy } from './runtime';
 import { policySchema } from './schema';
@@ -73,8 +73,20 @@ export function loadPolicy(path: string | undefined): PolicyConfig | null | unde
  * bound to that file's inode, and the atomic `rename()` the writer is told to
  * use replaces the *directory entry* while leaving the old inode untouched - so
  * a file watch never fires for the one write pattern this is built around. The
- * directory entry is what changes, so the directory is what is watched, and
- * events for anything else in it are filtered out by name.
+ * directory entry is what changes, so the directory is what is watched.
+ *
+ * **Every event in that directory reloads, and none is filtered by name.** The
+ * name a rename reports is the runtime's business and not the same on both: Node
+ * reports the destination, so a filter on it worked; Bun reports only the
+ * *source*, so on the runtime this ships as a compiled binary a name filter
+ * dropped every policy change a deployment ever made. Measured against Bun
+ * 1.3.11 and Node side by side, ten renames each: with the filter, 10/10 and
+ * 0/10; without it, 10/10 on both, each reload reading the value just written.
+ *
+ * Reloading on a neighbouring file's event costs one small JSON read behind the
+ * debounce, and a read that fails or does not validate already keeps the last
+ * good value - so the cost of being wrong in this direction is nothing, and in
+ * the other it is a deployment whose limits never move.
  *
  * Coalesced on a short timer: one rename fires more than once, and a deployment
  * that writes then chmods fires more again. Re-reading four times is harmless
@@ -86,7 +98,6 @@ export function watchPolicyFile(path: string | undefined): { close: () => void }
 	if (!path) return { close: () => {} };
 
 	const directory = dirname(path);
-	const name = basename(path);
 	let watcher: FSWatcher | null = null;
 	let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -102,9 +113,7 @@ export function watchPolicyFile(path: string | undefined): { close: () => void }
 	};
 
 	try {
-		watcher = watch(directory, (_event, changed) => {
-			// The name is absent on some platforms. Reload rather than miss a change.
-			if (changed !== null && changed !== name) return;
+		watcher = watch(directory, () => {
 			if (timer) clearTimeout(timer);
 			timer = setTimeout(reload, RELOAD_DEBOUNCE_MS);
 		});

--- a/packages/server/test/bun/policy-watch.bun.test.ts
+++ b/packages/server/test/bun/policy-watch.bun.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { watchPolicyFile } from '../../src/config/policy';
+import { resetRuntimeConfig, runtimeConfig } from '../../src/config/runtime';
+
+/**
+ * The policy watcher, on the runtime a release actually runs.
+ *
+ * **`policy-watch.test.ts` covers the same ground under vitest, and that is the
+ * problem it could not see.** `fs.watch` reports a rename differently on the two
+ * runtimes: Node emits an event naming the *destination*, Bun emits one naming
+ * only the *source*. A watcher that filtered the directory's events by the
+ * policy file's own name therefore reloaded on Node and never on Bun — so every
+ * plan change a deployment wrote reached the disk of a running instance and
+ * never its memory, while the Node suite stayed green.
+ *
+ * Measured before the fix, ten renames each: Node 10/10, Bun 0/10.
+ *
+ * A deployment renames into place because that is what makes the read atomic, so
+ * this exercises exactly that: write `<file>.tmp`, `chmod`, `rename`.
+ */
+
+const watchers: Array<{ close: () => void }> = [];
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const one of watchers.splice(0)) one.close();
+	resetRuntimeConfig();
+	for (const one of dirs.splice(0)) rmSync(one, { recursive: true, force: true });
+});
+
+/** A directory of this test's own, removed with it. */
+function ownDirectory(): string {
+	const made = mkdtempSync(join(tmpdir(), 'hezo-policy-watch-bun-'));
+	dirs.push(made);
+	return made;
+}
+
+function policy(maxContainerMemoryGb: number): string {
+	return JSON.stringify({ managedBy: 'Acme Cloud', pinned: { maxContainerMemoryGb } });
+}
+
+/** Write a fresh file and rename it over the target, the way a deployment must. */
+function renameInto(path: string, body: string): void {
+	writeFileSync(`${path}.tmp`, body, { mode: 0o600 });
+	renameSync(`${path}.tmp`, path);
+}
+
+/** Poll rather than sleep: watch latency is the operating system's business. */
+async function pinnedMemoryReaches(wanted: number, timeoutMs = 3000): Promise<number | undefined> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const seen = runtimeConfig().policy?.pinned.maxContainerMemoryGb;
+		if (seen === wanted || Date.now() >= deadline) return seen;
+		await new Promise((tick) => setTimeout(tick, 10));
+	}
+}
+
+function watching(path: string) {
+	const handle = watchPolicyFile(path);
+	watchers.push(handle);
+	return handle;
+}
+
+describe('the policy watcher under Bun', () => {
+	it('takes a plan change written the way a deployment writes one', async () => {
+		const path = join(ownDirectory(), 'policy.json');
+		writeFileSync(path, policy(8));
+		watching(path);
+
+		renameInto(path, policy(16));
+
+		expect(await pinnedMemoryReaches(16)).toBe(16);
+	});
+
+	// **Change after change, because a tenant's plan moves more than once.** The
+	// rename replaces the inode every time, and a watcher that stopped seeing the
+	// directory after the first would pin whatever the second change replaced.
+	it('keeps taking them, change after change', async () => {
+		const path = join(ownDirectory(), 'policy.json');
+		writeFileSync(path, policy(8));
+		watching(path);
+
+		renameInto(path, policy(16));
+		expect(await pinnedMemoryReaches(16)).toBe(16);
+
+		renameInto(path, policy(32));
+		expect(await pinnedMemoryReaches(32)).toBe(32);
+
+		renameInto(path, policy(64));
+		expect(await pinnedMemoryReaches(64)).toBe(64);
+	});
+
+	// Reloading on any event in the directory means a neighbour's write reloads
+	// too. That must read the policy file and find it unchanged, never pick the
+	// neighbour up as one.
+	it('is unmoved by a write to something else in the same directory', async () => {
+		const directory = ownDirectory();
+		const path = join(directory, 'policy.json');
+		writeFileSync(path, policy(8));
+		watching(path);
+		renameInto(path, policy(16));
+		expect(await pinnedMemoryReaches(16)).toBe(16);
+
+		writeFileSync(join(directory, 'deploy.env'), 'HEZO_SOMETHING=1\n');
+		await new Promise((tick) => setTimeout(tick, 400));
+
+		expect(runtimeConfig().policy?.pinned.maxContainerMemoryGb).toBe(16);
+	});
+});


### PR DESCRIPTION
`watchPolicyFile` watches the containing directory because the write pattern it exists for is `<file>.tmp` then `rename()` — and it then filtered that directory's events by the policy file's own name.

**Node reports the destination's name for a rename. Bun reports only the source's**, as a single event. So on the runtime a release actually runs — the shipped `hezo-linux-{x64,arm64}` is a `bun build --compile` binary — the filter dropped every policy change a deployment ever made.

## Measured

The writer's exact sequence (write `.tmp`, `chmod`, `rename`), ten times, waiting past the 150 ms debounce each round:

| Writer | Node 24 | Bun 1.3.11 |
|---|---|---|
| `.tmp` + `rename` (what a deployment writes) | 10/10 | **0/10** |
| `.tmp` + `rename`, then an in-place rewrite | 10/10 | 7/10 |
| in-place write only | 10/10 | 10/10 |

Bun 1.3.11 is this repo's own CI pin. Delivery is not quite deterministic — one destination-named event appeared in thirty rounds — which is why the hosting control plane's end-to-end tier saw a plan change land occasionally and read it as a flaky race for three rounds before anyone measured it.

## What it cost

A hosted tenant's tier change, hour pack and billing hold all reached the instance's disk and none of them reached the running process; each took effect only at the next restart. The hold is the one that costs money: an account that has stopped paying keeps its full container budget until its box happens to restart.

## Why the writer cannot work around it

In-place writing is the only shape Bun reports reliably, and it gives up the atomicity this watcher's own docblock depends on — a reader can catch a half-written file, and a bad parse then keeps the *previous* value until the next change, which for a deployment that skips unchanged writes is indefinitely.

## The change

Drop the name filter; reload on any event in the watched directory. The read is a small JSON file behind the existing debounce, and a spurious reload is already harmless: `readPolicyFile` returns `null` on a bad read or parse and `reload()` keeps the last good value. With the filter removed the same measurement gives **10/10 on both runtimes, and every reload read the value just written** — the rename has completed before the debounce expires.

## Tests

`test/policy-watch.test.ts` was green throughout and could not have caught this, because vitest runs it on Node. The new coverage is in the Bun-native tier, which is the "runtime-sensitive code gets a test on the production runtime" rule in `AGENTS.md`:

- fails **3/3** on the old filter, passes **3/3** without it
- the existing Node policy suites (26 tests) still pass unchanged
- a third case covers the one thing removing the filter changes: a write to a neighbouring file in the same directory reloads, reads the same policy, and leaves the pinned value where it is

## Also

`.dev/hezo-cloud-requirements.md` carries this as **H33**, with the measurements and the acceptance criteria. The control-plane repo's companion copy (`.dev/track-h-spec.md`) carries the same entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4uqP3rUJtnAaKyCbudkCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4uqP3rUJtnAaKyCbudkCb)_