### PR TITLE
feat(agents): default new agents to high reasoning effort

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -4088,12 +4088,13 @@ stop-hook judge — 404s on every run while the hook fails open.
 
 **Reasoning effort.** Each run resolves an `agent_effort` level
 (`minimal|low|medium|high|max`) from the wakeup payload → `member_agents.default_effort` →
-global `medium`. Each runtime maps it natively: `claude_code` appends
+global `high`. Each runtime maps it natively: `claude_code` appends
 `think`/`think hard`/`ultrathink`; `codex` passes `-c model_reasoning_effort=`; `antigravity`
-sets `GEMINI_REASONING_EFFORT`; `kimi` sets `KIMI_MODEL_THINKING_EFFORT` (it has no
-`minimal`, which maps to `low`); `opencode` writes `reasoning.effort` onto the run's model in
-its per-run `opencode.json` (see below); `grok` steers effort through the portable prompt
-directive alone. It's also exposed as `HEZO_AGENT_EFFORT`.
+passes `--effort`, folding the five-level ladder onto the `low|medium|high` it accepts; `kimi`
+sets `KIMI_MODEL_THINKING_EFFORT` (it has no `minimal`, which maps to `low`); `opencode`
+writes `reasoning.effort` onto the run's model in its per-run `opencode.json` (see below);
+`grok` steers effort through the portable prompt directive alone. It's also exposed as
+`HEZO_AGENT_EFFORT`.
 
 ### Runtime adapters
 

--- a/agents/app-dev/team.json
+++ b/agents/app-dev/team.json
@@ -81,6 +81,10 @@
 	],
 	"changelog": [
 		{
+			"version": 32,
+			"notes": "Engineer, UI Designer, DevOps Engineer and Marketing Lead now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
+		{
 			"version": 31,
 			"notes": "Reviewing a teammate's finished work now fans out to adversarial sub-agents, one per review dimension, and the reviewer reconciles their reports into one ranked findings list after verifying each finding themselves. That rule reaches every agent on every team, so the QA Engineer's own prompt now carries only what is specific to it: the eight dimensions a code review covers - correctness, security, performance, scalability, maintainability, architectural elegance, testing and documentation - stated once and read by both the post-implementation review and the heartbeat audit, which previously kept two lists that could drift apart."
 		},
@@ -260,7 +264,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 3,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -326,7 +330,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 6,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -348,7 +352,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 7,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -370,7 +374,7 @@
 			},
 			"reports_to_slug": "captain",
 			"sort_order": 8,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/agents/influencer/team.json
+++ b/agents/influencer/team.json
@@ -62,6 +62,10 @@
 	],
 	"changelog": [
 		{
+			"version": 23,
+			"notes": "Content Writer, Media Producer and Distribution Manager now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
+		{
 			"version": 22,
 			"notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
 		},
@@ -208,7 +212,7 @@
 			"role_description": "Drafts posts, scripts, threads, and captions in the creator's voice against the content calendar.",
 			"summary": "The Content Writer drafts posts, captions, scripts, and newsletters in the creator's voice against the content calendar. They report to the Brand Strategist and send every draft to the Content Editor.",
 			"team_context": "You report to the @brand-strategist. You draft posts, captions, scripts, and newsletters in the creator's voice, then hand every draft to the @content-editor. You don't publish.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -230,7 +234,7 @@
 			"role_description": "Generates images, video, and audio for content via connected media-generation providers.",
 			"summary": "The Media Producer generates images, video, and audio for content via connected media-generation providers. They report to the Brand Strategist.",
 			"team_context": "You report to the @brand-strategist. You generate images, video, and audio via connected media providers and send produced media to the @content-editor. You reference credentials by placeholder only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -274,7 +278,7 @@
 			"role_description": "Schedules and publishes approved content through connected platforms, cross-posts, and runs the engagement and analytics loop.",
 			"summary": "The Distribution Manager publishes approved content to connected platforms, cross-posts, and runs the engagement and analytics loop. They report to the Captain and publish only after the admin approves.",
 			"team_context": "You report to the @captain. You publish approved content to connected platforms and run the analytics loop. You publish only after the admin approves, unless the content-approval gate is disabled in team preferences.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/agents/investment/team.json
+++ b/agents/investment/team.json
@@ -68,6 +68,10 @@
 	],
 	"changelog": [
 		{
+			"version": 24,
+			"notes": "Catalyst Monitor and Report Writer now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
+		{
 			"version": 23,
 			"notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
 		},
@@ -218,7 +222,7 @@
 			"role_description": "Sweeps filings, news, and the trade press daily, keeps the stock documents current, and notifies the admin of material events.",
 			"summary": "The Catalyst Monitor runs the standing daily watch: sweeping each watched stock's regulatory filings, news, and industry trade press, keeping each stock document current with targeted edits, and notifying the admin of material events. As the team's earliest detection point, they flag stale progress metrics and material dilutive events to the Equity Analyst. They report to the Captain.",
 			"team_context": "You report to the @captain. You run the standing daily watch task: sweep each watched stock's three channels (the listing jurisdiction's filings, news and press releases, and the industry trade press), make targeted edits to the stock documents in the assets library with dated changelogs, and @admin material events - selectively. Flag stale progress metrics and material dilutive events to the @equity-analyst; you are the team's earliest detection point. Keep the watch task open. Research and analysis only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 1440,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -262,7 +266,7 @@
 			"role_description": "Produces the periodic portfolio and watchlist reviews, maintains the portfolio document and per-stock summary reports, and hands all output to the Captain for review.",
 			"summary": "The Report Writer produces the periodic portfolio and watchlist review, maintains the portfolio overview document, and keeps a one-page summary report per stock in the assets library. Every figure is cross-referenced against its live source document at writing time, and all output passes through the Captain's review before reaching the admin. They report to the Captain.",
 			"team_context": "You report to the @captain, who reviews all your output before it reaches the admin - never deliver a report or portfolio.md update directly. You write the periodic portfolio and watchlist review, maintain portfolio.md (its membership list changes only on explicit admin instruction), and keep the per-stock summary reports current. Cross-reference every figure against the live stock documents at writing time. Research and analysis only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -81,9 +81,9 @@
 				"testing",
 				"security review"
 			],
-			"version": 31,
+			"version": 32,
 			"roster_count": 10,
-			"latest_notes": "Reviewing a teammate's finished work now fans out to adversarial sub-agents, one per review dimension, and the reviewer reconciles their reports into one ranked findings list after verifying each finding themselves. That rule reaches every agent on every team, so the QA Engineer's own prompt now carries only what is specific to it: the eight dimensions a code review covers - correctness, security, performance, scalability, maintainability, architectural elegance, testing and documentation - stated once and read by both the post-implementation review and the heartbeat audit, which previously kept two lists that could drift apart."
+			"latest_notes": "Engineer, UI Designer, DevOps Engineer and Marketing Lead now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
 		},
 		{
 			"slug": "influencer",
@@ -146,9 +146,9 @@
 				"design",
 				"analytics"
 			],
-			"version": 22,
+			"version": 23,
 			"roster_count": 7,
-			"latest_notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
+			"latest_notes": "Content Writer, Media Producer and Distribution Manager now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
 		},
 		{
 			"slug": "investment",
@@ -217,9 +217,9 @@
 				"insider activity",
 				"price target"
 			],
-			"version": 23,
+			"version": 24,
 			"roster_count": 6,
-			"latest_notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
+			"latest_notes": "Catalyst Monitor and Report Writer now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
 		}
 	]
 }

--- a/marketplace/teams/app-dev.json
+++ b/marketplace/teams/app-dev.json
@@ -79,9 +79,13 @@
 		"testing",
 		"security review"
 	],
-	"version": 31,
-	"content_hash": "1179709b955c0a18a8f6d2dec103812335cc1da54c0decb1c7b2abf67bc2bc6d",
+	"version": 32,
+	"content_hash": "3a24c80e2b94c67f3337c95a2efc31dae9e246c59cda1d81ca8d015400ded58f",
 	"changelog": [
+		{
+			"version": 32,
+			"notes": "Engineer, UI Designer, DevOps Engineer and Marketing Lead now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
 		{
 			"version": 31,
 			"notes": "Reviewing a teammate's finished work now fans out to adversarial sub-agents, one per review dimension, and the reviewer reconciles their reports into one ranked findings list after verifying each finding themselves. That rule reaches every agent on every team, so the QA Engineer's own prompt now carries only what is specific to it: the eight dimensions a code review covers - correctness, security, performance, scalability, maintainability, architectural elegance, testing and documentation - stated once and read by both the post-implementation review and the heartbeat audit, which previously kept two lists that could drift apart."
@@ -265,7 +269,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 3,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -334,7 +338,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 6,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -357,7 +361,7 @@
 			},
 			"reports_to_slug": "architect",
 			"sort_order": 7,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -380,7 +384,7 @@
 			},
 			"reports_to_slug": "captain",
 			"sort_order": 8,
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/marketplace/teams/influencer.json
+++ b/marketplace/teams/influencer.json
@@ -60,9 +60,13 @@
 		"design",
 		"analytics"
 	],
-	"version": 22,
-	"content_hash": "47dd1fa72314206b1af38bc49460d238b75e7599db830fea1f982be8e4062d14",
+	"version": 23,
+	"content_hash": "d2be7523775bca96512f1032dd2848bd06d57ca0652ffda024c2824e84fc6feb",
 	"changelog": [
+		{
+			"version": 23,
+			"notes": "Content Writer, Media Producer and Distribution Manager now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
 		{
 			"version": 22,
 			"notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
@@ -213,7 +217,7 @@
 			"role_description": "Drafts posts, scripts, threads, and captions in the creator's voice against the content calendar.",
 			"summary": "The Content Writer drafts posts, captions, scripts, and newsletters in the creator's voice against the content calendar. They report to the Brand Strategist and send every draft to the Content Editor.",
 			"team_context": "You report to the @brand-strategist. You draft posts, captions, scripts, and newsletters in the creator's voice, then hand every draft to the @content-editor. You don't publish.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -236,7 +240,7 @@
 			"role_description": "Generates images, video, and audio for content via connected media-generation providers.",
 			"summary": "The Media Producer generates images, video, and audio for content via connected media-generation providers. They report to the Brand Strategist.",
 			"team_context": "You report to the @brand-strategist. You generate images, video, and audio via connected media providers and send produced media to the @content-editor. You reference credentials by placeholder only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -282,7 +286,7 @@
 			"role_description": "Schedules and publishes approved content through connected platforms, cross-posts, and runs the engagement and analytics loop.",
 			"summary": "The Distribution Manager publishes approved content to connected platforms, cross-posts, and runs the engagement and analytics loop. They report to the Captain and publish only after the admin approves.",
 			"team_context": "You report to the @captain. You publish approved content to connected platforms and run the analytics loop. You publish only after the admin approves, unless the content-approval gate is disabled in team preferences.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/marketplace/teams/investment.json
+++ b/marketplace/teams/investment.json
@@ -66,9 +66,13 @@
 		"insider activity",
 		"price target"
 	],
-	"version": 23,
-	"content_hash": "f5edf455dec9e437fbb87275acf69887bad5002f04889a0812d146620a5827f1",
+	"version": 24,
+	"content_hash": "179d8f2bb75852b9dc3d64cfa3071d4d5087af630ae7610c610b7035212e1163",
 	"changelog": [
+		{
+			"version": 24,
+			"notes": "Catalyst Monitor and Report Writer now reason at high effort instead of medium. They think longer before acting, which catches more before it reaches your review - and costs more per run. Set any role back to medium in its settings if you would rather have the speed."
+		},
 		{
 			"version": 23,
 			"notes": "Agents ship with no monthly spend cap. The old per-role figures were arbitrary, and until cache traffic was priced at real rates they bit several times sooner than they read - so a team could stop working for a reason its operator never set. Set a cap per agent if you want one."
@@ -223,7 +227,7 @@
 			"role_description": "Sweeps filings, news, and the trade press daily, keeps the stock documents current, and notifies the admin of material events.",
 			"summary": "The Catalyst Monitor runs the standing daily watch: sweeping each watched stock's regulatory filings, news, and industry trade press, keeping each stock document current with targeted edits, and notifying the admin of material events. As the team's earliest detection point, they flag stale progress metrics and material dilutive events to the Equity Analyst. They report to the Captain.",
 			"team_context": "You report to the @captain. You run the standing daily watch task: sweep each watched stock's three channels (the listing jurisdiction's filings, news and press releases, and the industry trade press), make targeted edits to the stock documents in the assets library with dated changelogs, and @admin material events - selectively. Flag stale progress metrics and material dilutive events to the @equity-analyst; you are the team's earliest detection point. Keep the watch task open. Research and analysis only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 1440,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,
@@ -269,7 +273,7 @@
 			"role_description": "Produces the periodic portfolio and watchlist reviews, maintains the portfolio document and per-stock summary reports, and hands all output to the Captain for review.",
 			"summary": "The Report Writer produces the periodic portfolio and watchlist review, maintains the portfolio overview document, and keeps a one-page summary report per stock in the assets library. Every figure is cross-referenced against its live source document at writing time, and all output passes through the Captain's review before reaching the admin. They report to the Captain.",
 			"team_context": "You report to the @captain, who reviews all your output before it reaches the admin - never deliver a report or portfolio.md update directly. You write the periodic portfolio and watchlist review, maintain portfolio.md (its membership list changes only on explicit admin instruction), and keep the per-stock summary reports current. Cross-reference every figure against the live stock documents at writing time. Research and analysis only.",
-			"default_effort": "medium",
+			"default_effort": "high",
 			"heartbeat_interval_min": 720,
 			"run_timeout_min": 60,
 			"monthly_budget_cents": 0,

--- a/packages/server/migrations/075_default_effort_high.sql
+++ b/packages/server/migrations/075_default_effort_high.sql
@@ -1,0 +1,22 @@
+-- Raise the column default for agent effort from 'medium' to 'high'.
+--
+-- The global fallback (`DEFAULT_EFFORT` in @hezo/shared) and these two column
+-- defaults are the same fact in two places; the constant moves in this same
+-- commit.
+--
+-- Load-bearing rather than cosmetic. Every other insert into these tables names
+-- the column, but `POST /api/agent-types` (routes/agent-types.ts) omits it, and
+-- team-template-provision then copies an agent type's effort onto every agent
+-- provisioned from that type.
+--
+-- DEFAULT only, no UPDATE. Existing rows keep whatever they hold: an operator
+-- who chose 'medium' for an agent chose it, and rewriting that would raise the
+-- agent's spend without asking. SET DEFAULT is a catalog-only change - no table
+-- rewrite, no row touched.
+--
+-- 'high' is an existing member of `agent_effort` (created in 001), so this does
+-- not run into the "ALTER TYPE ... ADD VALUE cannot be used in the same
+-- transaction" limit the runner's per-migration transaction imposes.
+
+ALTER TABLE agent_types ALTER COLUMN default_effort SET DEFAULT 'high'::agent_effort;
+ALTER TABLE member_agents ALTER COLUMN default_effort SET DEFAULT 'high'::agent_effort;

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -57,7 +57,7 @@ function buildAgentTypeDefs(): AgentTypeDef[] {
 			slug: 'coach',
 			reports_to_slug: null,
 			sort_order: 10,
-			default_effort: AgentEffort.Medium,
+			default_effort: AgentEffort.High,
 			heartbeat_interval_min: DEFAULT_HEARTBEAT_INTERVAL_MIN,
 			run_timeout_min: 60,
 			monthly_budget_cents: 3000,

--- a/packages/server/src/services/approval-handlers/hire.ts
+++ b/packages/server/src/services/approval-handlers/hire.ts
@@ -1,6 +1,7 @@
 import {
 	AgentAdminStatus,
 	ApprovalStatus,
+	DEFAULT_EFFORT,
 	DEFAULT_HEARTBEAT_INTERVAL_MIN,
 	DEFAULT_MONTHLY_BUDGET_CENTS,
 	DocumentType,
@@ -86,7 +87,7 @@ export const hireHandler: ApprovalHandler = {
 				JSON.stringify(buildAgentAvatarSpec({ slug, title, gender, seed: memberId })),
 				(payload.role_description as string) ?? '',
 				reportsToId,
-				(payload.default_effort as string) ?? 'medium',
+				(payload.default_effort as string) ?? DEFAULT_EFFORT,
 				(payload.heartbeat_interval_min as number) ?? DEFAULT_HEARTBEAT_INTERVAL_MIN,
 				(payload.daily_budget_cents as number) ?? 0,
 				(payload.weekly_budget_cents as number) ?? 0,

--- a/packages/server/test/hire-proposal-branches.test.ts
+++ b/packages/server/test/hire-proposal-branches.test.ts
@@ -158,7 +158,9 @@ describe('prepareHireProposal — success branches', () => {
 			role_description: 'does senior things',
 			system_prompt: 'You are a senior bot.',
 			reports_to: CAPTAIN_AGENT_SLUG,
-			default_effort: 'high',
+			// Deliberately not the default: this test proves a supplied effort is
+			// honoured, which a value equal to DEFAULT_EFFORT could not.
+			default_effort: 'low',
 			heartbeat_interval_min: 60,
 			daily_budget_cents: 100,
 			weekly_budget_cents: 1000,
@@ -170,7 +172,7 @@ describe('prepareHireProposal — success branches', () => {
 		const p = r.payload;
 		expect(p.role_description).toBe('does senior things');
 		expect(p.reports_to).toBe(CAPTAIN_AGENT_SLUG);
-		expect(p.default_effort).toBe('high');
+		expect(p.default_effort).toBe('low');
 		expect(p.heartbeat_interval_min).toBe(60);
 		expect(p.touches_code).toBe(true);
 		expect(p.system_prompt).toContain('You are a senior bot.');

--- a/packages/server/test/migrate-075-default-effort-high.test.ts
+++ b/packages/server/test/migrate-075-default-effort-high.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '075_default_effort_high.sql';
+
+describe('075_default_effort_high migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let agentTypeId: string;
+	let memberAgentId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema before 075
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+
+		// An agent type deliberately below the old default, and an agent sitting on
+		// the old default itself - the two shapes the migration must leave alone.
+		const type = await h.db.query<{ id: string }>(
+			`INSERT INTO agent_types (name, slug, default_effort)
+			 VALUES ('Scribe', 'scribe', 'low'::agent_effort) RETURNING id`,
+		);
+		agentTypeId = type.rows[0].id;
+
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Robin') RETURNING id`,
+			[teamId],
+		);
+		memberAgentId = member.rows[0].id;
+		await h.db.query(
+			`INSERT INTO member_agents (id, title, slug, default_effort)
+			 VALUES ($1, 'Scribe', 'scribe', 'medium'::agent_effort)`,
+			[memberAgentId],
+		);
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('moves both column defaults to high', async () => {
+		const r = await h.db.query<{ table_name: string; column_default: string }>(
+			`SELECT table_name, column_default FROM information_schema.columns
+			 WHERE column_name = 'default_effort'
+			   AND table_name IN ('agent_types', 'member_agents')
+			 ORDER BY table_name`,
+		);
+		expect(r.rows.map((row) => row.table_name)).toEqual(['agent_types', 'member_agents']);
+		for (const row of r.rows) {
+			expect(row.column_default).toContain("'high'");
+		}
+	});
+
+	it('leaves every pre-existing row on the effort it was stored with', async () => {
+		const type = await h.db.query<{ default_effort: string }>(
+			'SELECT default_effort FROM agent_types WHERE id = $1',
+			[agentTypeId],
+		);
+		expect(type.rows.length).toBe(1);
+		expect(type.rows[0].default_effort).toBe('low');
+
+		// The one that matters: an agent already on 'medium' keeps it. An operator
+		// who chose the old default chose it, and raising it would raise their spend.
+		const agent = await h.db.query<{ default_effort: string }>(
+			'SELECT default_effort FROM member_agents WHERE id = $1',
+			[memberAgentId],
+		);
+		expect(agent.rows.length).toBe(1);
+		expect(agent.rows[0].default_effort).toBe('medium');
+	});
+
+	it('lands new rows on high when the insert omits the column', async () => {
+		// `POST /api/agent-types` inserts without naming default_effort, and
+		// team-template-provision copies an agent type's effort onto every agent
+		// provisioned from it - so this is the path the default is here to serve.
+		const type = await h.db.query<{ default_effort: string }>(
+			`INSERT INTO agent_types (name, slug) VALUES ('Analyst', 'analyst')
+			 RETURNING default_effort`,
+		);
+		expect(type.rows[0].default_effort).toBe('high');
+
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Sam') RETURNING id`,
+			[teamId],
+		);
+		const agent = await h.db.query<{ default_effort: string }>(
+			`INSERT INTO member_agents (id, title, slug) VALUES ($1, 'Analyst', 'analyst')
+			 RETURNING default_effort`,
+			[member.rows[0].id],
+		);
+		expect(agent.rows[0].default_effort).toBe('high');
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -82,7 +82,7 @@ export const EFFORT_ORDER: Record<AgentEffort, number> = {
 	[AgentEffort.Max]: 4,
 };
 
-export const DEFAULT_EFFORT: AgentEffort = AgentEffort.Medium;
+export const DEFAULT_EFFORT: AgentEffort = AgentEffort.High;
 
 export function isAgentEffort(value: unknown): value is AgentEffort {
 	return typeof value === 'string' && value in EFFORT_ORDER;


### PR DESCRIPTION
Wherever nothing else chooses an effort level, agents now think at `high` instead of `medium`. This raises token spend per run, which is stated in each affected team's changelog note rather than left for operators to discover.

## What moved

| Default | From | To |
|---|---|---|
| `DEFAULT_EFFORT` (`@hezo/shared`) | `medium` | `high` |
| `agent_types.default_effort` column | `medium` | `high` (migration 075) |
| `member_agents.default_effort` column | `medium` | `high` (migration 075) |
| 9 authored marketplace roster roles | `medium` | `high` |
| Seeded built-in Coach | `medium` | `high` |

The Captain and CEO stay forced to `max`. The nine roles are app-dev's Engineer, UI Designer, DevOps Engineer and Marketing Lead; influencer's Content Writer, Media Producer and Distribution Manager; investment's Catalyst Monitor and Report Writer.

## What is deliberately not done

**No row is rewritten.** Migration 075 changes only the column `DEFAULT`, which is a catalog-only change: no table rewrite, no row touched. An agent an operator deliberately set to `medium` keeps it, because nothing can distinguish that from an untouched one and raising it would raise their spend without asking.

The roster half does reach existing installs, but only through the marketplace's own opt-in. The content-hash change bumps app-dev v31 to v32, influencer v22 to v23 and investment v23 to v24; the operator sees "update available" and chooses whether to accept it.

## Why the column default is load-bearing

Every other insert into these tables names the column, but `POST /api/agent-types` (`routes/agent-types.ts`) omits it, and `team-template-provision` then copies an agent type's effort onto every agent provisioned from that type. Migration 075's data-preservation test covers that path alongside preservation:

1. Pre-existing rows at `low` and `medium` still read `low` and `medium` after the migration.
2. `information_schema.columns.column_default` names `high` on both tables.
3. An insert that omits the column lands on `high` - the assertion that would catch a migration touching only one of the two tables.

## Two fixes found in the same code

- `approval-handlers/hire.ts` hardcoded the string `'medium'` instead of reading `DEFAULT_EFFORT`, so a hire approved through that path would have silently kept the old value. Every fallback site now reads the one constant.
- `.dev/architecture.md` claimed antigravity sets `GEMINI_REASONING_EFFORT`. The adapter passes `--effort`, folding the five-level ladder onto the `low|medium|high` agy accepts.

Also changed `hire-proposal-branches.test.ts`'s "keeps supplied values" case from `'high'` to `'low'` - at `'high'` it would now equal the default and pass even if the supplied value were dropped.

## Not touched, on purpose

- **`baseline-schema.snapshot.txt`** stays at `'medium'`. `migrate-baseline-schema.test.ts` introspects only the frozen `001`, never the chain.
- **The twelve i18n catalogs** hold no effort keys; the sidebar's effort labels are hardcoded English.
- **`docs/`** - no page states the default level, so none became false. Adding a sentence naming it would be a fourth copy of the fact with no drift test on it.

## Verification

```
bun run typecheck                                  # 6/6
bunx biome check --diagnostic-level=error .        # clean
bun run --cwd packages/server build:marketplace    # idempotent on rerun
```

Green: `migrate-075` (new), `migrate-baseline-schema`, `effort`, `marketplace-build`, `hire-proposal*`, `team-template*`, `seed`, `startup-seed`, `ceo`, `agent-runner*`, `runtime-adapters`, the four ack-hook suites, `@hezo/shared` (504), and web `task-comments` / `task-detail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6AEYkrdH4gb3HwCCmdvAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6AEYkrdH4gb3HwCCmdvAi)_