### PR TITLE
ci(test-s3): pull MinIO from quay.io, pinned by digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,12 +425,23 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       # A plain docker run, not a service container: services can't override
-      # the image command and minio/minio requires `server /data`.
+      # the image command and MinIO requires `server /data`.
+      #
+      # Pulled from quay.io, which is MinIO's own registry. The Docker Hub
+      # mirror this used to name was withdrawn between 2026-09-11 and
+      # 2026-09-12 - an anonymous pull of `minio/minio` now answers 401 and
+      # docker reports it as "pull access denied", so every run failed here.
+      #
+      # Pinned by digest, tag alongside it for readability: the server under
+      # test is the one thing in this job with no lockfile behind it, and an
+      # image that moves on its own changes what the S3 driver is proved
+      # against with no commit and no signal. Bump it as its own change.
       - name: Start MinIO
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=hezo -e MINIO_ROOT_PASSWORD=hezo-secret-key \
-            minio/minio:latest server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            server /data
           timeout 60 bash -c 'until curl -sf http://127.0.0.1:9000/minio/health/ready; do sleep 1; done'
       - name: Create test bucket
         env:


### PR DESCRIPTION
Fixes the `test-s3` failure on [run 34660117354](https://github.com/hezo-ai/hezo/actions/runs/34660117354), the only red job on that run.

## What broke

Docker Hub withdrew the `minio/minio` repository between run 3203 (green, 2026-09-11) and run 3204. The `Start MinIO` step exits 125 before a single assertion runs:

```
docker: Error response from daemon: pull access denied for minio/minio,
repository does not exist or may require 'docker login': denied:
requested access to the resource is denied
```

Nothing in the tree caused it and no re-run recovers it. Verified against the registries directly:

| Check | Result |
|---|---|
| `GET hub.docker.com/v2/repositories/minio/minio/` | `404 {"message":"object not found"}` |
| Anonymous manifest pull of `minio/minio:latest` from `registry-1.docker.io` | `401` (docker surfaces this as "pull access denied") |
| Anonymous manifest pull from `quay.io/minio/minio` | `200` |

## The fix

quay.io is MinIO's own registry and still carries the image, so the job pulls from there, pinned by digest with the tag kept alongside it for readability:

```
quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
```

The pin is the second half of the fix, not incidental tidying. The MinIO server is the only thing this job runs that no lockfile covers, and `:latest` let what the S3 driver is proved against move with no commit and no signal behind it. Bump it deliberately, as its own change.

## Behaviour under test is unchanged

`RELEASE.2025-09-07T16-13-09Z` is the release quay's `latest` resolves to and the newest community release - every tag published above it there is an enterprise `.hotfix.` build - so it is the same image Docker Hub's `latest` was serving. Read off the pinned amd64 config blob:

- `Entrypoint: ["/usr/bin/docker-entrypoint.sh"]`, `Cmd: ["minio"]` - `server /data` still arrives as args exactly as before
- `ExposedPorts: ["9000/tcp"]` - the `-p 9000:9000` mapping and the `/minio/health/ready` readiness poll are untouched
- `version` / `release` labels: `RELEASE.2025-09-07T16-13-09Z`, `vendor: MinIO Inc`
- manifest list covers linux/amd64, which `ubuntu-latest` runners are

## Verification

No Docker daemon is available in this session, so the container was not started end to end here - CI is the proof. What was checked locally: the workflow YAML parses and the `Start MinIO` step renders as intended; the image reference is valid per the distribution grammar; both the manifest list and the amd64 manifest resolve anonymously from quay.io at the pinned digest. The full pre-commit gate (biome, typecheck, build) and all four trailer hooks ran on the commit - no bypass.

## Scope

One line of `.github/workflows/ci.yml`, plus its comment. Nothing else in the repo names the image: `postgres:16` is a Docker Official Image, the Playwright image comes from `mcr.microsoft.com`, and the agent base image is our own GHCR. `docs/` and `.dev/ci-and-commands.md` mention MinIO only as an example S3-compatible store, never a registry or tag, so no doc surface moved. CI config is outside every trailer hook's bearing-path list, so the commit carries none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KK9oPrmS7JZCFLHacnQijp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KK9oPrmS7JZCFLHacnQijp)_