### PR TITLE
fix(web): render generated avatars in Budget rows

### DIFF
--- a/packages/web/src/hooks/use-costs.ts
+++ b/packages/web/src/hooks/use-costs.ts
@@ -52,9 +52,8 @@ export interface AgentBudgetStatus extends EntityBudgetStatus {
 	agent_name: string | null;
 	agent_slug: string;
 	runtime_status: string;
-	/** Uploaded avatar (signed URL); null when unset. Built-in CEO/Coach defaults
-	 *  are resolved client-side from the slug. */
-	agent_icon_url: string | null;
+	/** Generated avatar spec; built-in CEO/Coach defaults resolve from the slug. */
+	agent_avatar_spec: unknown;
 	agent_over_budget: boolean;
 	project_over_budget: boolean;
 }

--- a/packages/web/src/routes/projects/$projectId/budget/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget/index.tsx
@@ -25,7 +25,7 @@ import {
 	useBudgetStatus,
 	type WindowStatus,
 } from '../../../../hooks/use-costs';
-import { defaultAvatarForSlug } from '../../../../lib/default-avatars';
+import { agentAvatarUrl } from '../../../../lib/agent-avatar';
 import { formatDuration } from '../../../../lib/format-duration';
 import { useI18n } from '../../../../lib/i18n';
 
@@ -164,7 +164,10 @@ function BudgetPage() {
 										<div className="flex min-w-0 items-center gap-2.5">
 											<Avatar
 												initials={getInitials(agentLabel(agent))}
-												imageUrl={agent.agent_icon_url ?? defaultAvatarForSlug(agent.agent_slug)}
+												imageUrl={agentAvatarUrl({
+													slug: agent.agent_slug,
+													avatar_spec: agent.agent_avatar_spec,
+												})}
 												size="sm"
 												running={agent.runtime_status === 'running'}
 											/>

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -3,6 +3,35 @@ import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedWorkspace } from './helpers/seed';
 
+test("Budget page renders a named agent's generated avatar instead of initials", async () => {
+	let teamSlug = '';
+	let agentSlug = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const { apiBase } = getTestContext();
+			const agent = ws.agents.find((candidate) => candidate.slug === 'engineer') ?? ws.agents[0];
+			agentSlug = agent.slug;
+			teamSlug = ws.internalSlug;
+
+			const res = await apiBase(`/api/projects/${ws.internalSlug}/agents/${agent.id}`, {
+				method: 'PATCH',
+				headers: ws.headers,
+				body: JSON.stringify({ human_name: 'Rowan', avatar_seed: 'budget-rowan' }),
+			});
+			if (!res.ok) throw new Error(`seed: setting agent identity failed (${res.status})`);
+		},
+	});
+
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+
+	const row = await findByTestId(`agent-budget-row-${agentSlug}`, undefined, { timeout: 15_000 });
+	expect(row.textContent).toContain('Rowan');
+	expect(row.querySelector('img')?.getAttribute('src')).toMatch(/^data:image\/svg\+xml/);
+});
+
 test('Budgets page shows per-agent windows and flags an over-budget agent', async () => {
 	let teamSlug = '';
 	let overAgentSlug = '';


### PR DESCRIPTION
## What changed

- Align the Budget client contract with the existing `agent_avatar_spec` API response.
- Resolve Budget row images through the shared `agentAvatarUrl` path used by other agent surfaces.
- Add a component regression that renames the non-fallback Engineer agent to Rowan, generates a new avatar through the real PATCH route, and requires an SVG image in Rowan's Budget row.

This addresses HM-787 and unblocks HM-785.

## Contract decision

The API continues to return `agent_avatar_spec`. The client treats that field as `unknown` and the existing shared resolver validates it with `isAvatarSpec` before generating a data URI. The retired and explicitly forbidden `agent_icon_url` field is not restored.

## Verification

- Red observation on current main: the new Rowan regression failed because the Budget row contained no image.
- `bun run test --package web --pattern budget-page` - 7 tests passed. The suite emitted its pre-existing Recharts zero-size warnings under happy-dom.
- `bun run test --package server --pattern budget.test` - 30 tests passed across 3 matched files.
- `bun run check` - exited 0; reported 330 pre-existing warnings and 3 informational diagnostics across the repository.
- `bun run typecheck` - 6 tasks passed.
- `bun run build` - passed. Vite retained its existing chunk-size warning.
- Commit hooks reran repository check, typecheck, and build successfully.
- GitHub CI - 28 checks succeeded, 1 intentional architecture verification was skipped, and 0 failed.

## Deployment impact

Web-only rendering and type-contract correction. No API, database, migration, configuration, or translation change.

## Exact commits

- Base: `67d8df5ff50eddcc9aaba38553bc236abc14af0d`
- Head: `78be9fb4c351231abd41de8c4dca6412495f3d66`

The remote head matches the clean local branch, the merge base is current `main`, and GitHub reports the PR mergeable. Repository policy keeps it blocked until exact-head QA, Marketing, Captain, and admin approvals complete.